### PR TITLE
Update AbstractClient.java

### DIFF
--- a/dubbo-remoting/dubbo-remoting-api/src/main/java/com/alibaba/dubbo/remoting/transport/AbstractClient.java
+++ b/dubbo-remoting/dubbo-remoting-api/src/main/java/com/alibaba/dubbo/remoting/transport/AbstractClient.java
@@ -109,7 +109,7 @@ public abstract class AbstractClient extends AbstractEndpoint implements Client 
                 close();
                 throw t;
             } else {
-                logger.error("Failed to start " + getClass().getSimpleName() + " " + NetUtils.getLocalAddress()
+                logger.warn("Failed to start " + getClass().getSimpleName() + " " + NetUtils.getLocalAddress()
                              + " connect to the server " + getRemoteAddress() + " (check == false, ignore and retry later!), cause: " + t.getMessage(), t);
             }
         } catch (Throwable t){


### PR DESCRIPTION
当配置check=false时，如果connect服务端失败，日志级别调整为warn，不需要为error
