### PR TITLE
调整ServiceBean关闭顺序.

### DIFF
--- a/dubbo-config/dubbo-config-spring/src/main/java/com/alibaba/dubbo/config/spring/ServiceBean.java
+++ b/dubbo-config/dubbo-config-spring/src/main/java/com/alibaba/dubbo/config/spring/ServiceBean.java
@@ -28,6 +28,7 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
 import org.springframework.context.ApplicationEvent;
 import org.springframework.context.ApplicationListener;
+import org.springframework.context.event.ContextClosedEvent;
 import org.springframework.context.event.ContextRefreshedEvent;
 import org.springframework.context.support.AbstractApplicationContext;
 
@@ -108,6 +109,9 @@ public class ServiceBean<T> extends ServiceConfig<T> implements InitializingBean
                 }
                 export();
             }
+        }
+        if (event instanceof ContextClosedEvent) {
+            unexport();
         }
     }
     


### PR DESCRIPTION
现在ServiceBean通过实现DisposableBean接口来销毁Provider,大多数情况下,这样的做好工作得很好.

但是,当spring容器里依赖很多后,就会出现这样的情况:provider1依赖service1,在容器关闭时,service1比provider
1先销毁.在这种情况下,外部请求到provider1,但是provider1也不能正确处理请求了.

通过监听ContextClosedEvent事件来实现需要让ServiceBean比spring容器内的其他服务先销毁.
