### PR TITLE
 fix issue#1597 

### DIFF
--- a/dubbo-filter/dubbo-filter-cache/src/main/java/com/alibaba/dubbo/cache/filter/CacheFilter.java
+++ b/dubbo-filter/dubbo-filter-cache/src/main/java/com/alibaba/dubbo/cache/filter/CacheFilter.java
@@ -52,7 +52,7 @@ public class CacheFilter implements Filter {
                     return new RpcResult(value);
                 }
                 Result result = invoker.invoke(invocation);
-                if (!result.hasException()) {
+                if (!result.hasException() && result.getValue() != null) {
                     cache.put(key, result.getValue());
                 }
                 return result;

--- a/dubbo-filter/dubbo-filter-cache/src/test/java/com/alibaba/dubbo/cache/filter/CacheFilterTest.java
+++ b/dubbo-filter/dubbo-filter-cache/src/test/java/com/alibaba/dubbo/cache/filter/CacheFilterTest.java
@@ -44,6 +44,8 @@ public class CacheFilterTest {
     private Invoker<?> invoker = mock(Invoker.class);
     private Invoker<?> invoker1 = mock(Invoker.class);
     private Invoker<?> invoker2 = mock(Invoker.class);
+    private Invoker<?> invoker3 = mock(Invoker.class);
+    private Invoker<?> invoker4 = mock(Invoker.class);
     private String cacheType;
     private CacheFactory cacheFactory;
 
@@ -77,6 +79,11 @@ public class CacheFilterTest {
         given(invoker2.invoke(invocation)).willReturn(new RpcResult("value2"));
         given(invoker2.getUrl()).willReturn(url);
 
+        given(invoker3.invoke(invocation)).willReturn(new RpcResult(new RuntimeException()));
+        given(invoker3.getUrl()).willReturn(url);
+
+        given(invoker4.invoke(invocation)).willReturn(new RpcResult());
+        given(invoker4.getUrl()).willReturn(url);
     }
 
     @Test
@@ -89,6 +96,7 @@ public class CacheFilterTest {
         RpcResult rpcResult1 = (RpcResult) cacheFilter.invoke(invoker1, invocation);
         RpcResult rpcResult2 = (RpcResult) cacheFilter.invoke(invoker2, invocation);
         Assert.assertEquals(rpcResult1.getValue(), rpcResult2.getValue());
+        Assert.assertEquals(rpcResult1.getValue(), "value");
     }
 
     @Test
@@ -101,5 +109,30 @@ public class CacheFilterTest {
         RpcResult rpcResult1 = (RpcResult) cacheFilter.invoke(invoker1, invocation);
         RpcResult rpcResult2 = (RpcResult) cacheFilter.invoke(invoker2, invocation);
         Assert.assertEquals(rpcResult1.getValue(), rpcResult2.getValue());
+        Assert.assertEquals(rpcResult1.getValue(), "value");
+    }
+
+    @Test
+    public void testException() {
+        invocation.setMethodName("echo1");
+        invocation.setParameterTypes(new Class<?>[]{String.class});
+        invocation.setArguments(new Object[]{"arg2"});
+
+        cacheFilter.invoke(invoker3, invocation);
+        RpcResult rpcResult = (RpcResult) cacheFilter.invoke(invoker2, invocation);
+        Assert.assertEquals(rpcResult.getValue(), "value2");
+    }
+
+    @Test
+    public void testNull() {
+        invocation.setMethodName("echo1");
+        invocation.setParameterTypes(new Class<?>[]{String.class});
+        invocation.setArguments(new Object[]{"arg3"});
+
+        cacheFilter.invoke(invoker4, invocation);
+        RpcResult rpcResult1 = (RpcResult) cacheFilter.invoke(invoker1, invocation);
+        RpcResult rpcResult2 = (RpcResult) cacheFilter.invoke(invoker2, invocation);
+        Assert.assertEquals(rpcResult1.getValue(), "value1");
+        Assert.assertEquals(rpcResult2.getValue(), "value1");
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

fix issue#1597: CacheFilter,when value is null,it will throw NPE(if use ehcache for jcache),why not check null here

## Brief changelog

com.alibaba.dubbo.cache.filter.CacheFilter
com.alibaba.dubbo.cache.filter.CacheFilterTest

## Verifying this change

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a [GITHUB_issue](https://github.com/apache/incubator-dubbo/issues) filed for the change (usually before you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/alibaba/dubbo/tree/master/dubbo-test).
- [ ] Run `mvn clean install -DskipTests` & `mvn clean test-compile failsafe:integration-test` to make sure unit-test and integration-test pass.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/incubator-dubbo/wiki/Software-donation-guide).