### PR TITLE
support mixed xml reference config and annotation dubbo config

### DIFF
--- a/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/beans/factory/annotation/DubboConfigBindingBeanPostProcessor.java
+++ b/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/beans/factory/annotation/DubboConfigBindingBeanPostProcessor.java
@@ -30,6 +30,7 @@ import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.config.BeanPostProcessor;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
+import org.springframework.core.PriorityOrdered;
 import org.springframework.core.env.Environment;
 
 /**
@@ -40,7 +41,8 @@ import org.springframework.core.env.Environment;
  * @since 2.5.8
  */
 
-public class DubboConfigBindingBeanPostProcessor implements BeanPostProcessor, ApplicationContextAware, InitializingBean {
+public class DubboConfigBindingBeanPostProcessor implements BeanPostProcessor, ApplicationContextAware,
+        PriorityOrdered {
 
     private final Log log = LogFactory.getLog(getClass());
 
@@ -77,6 +79,8 @@ public class DubboConfigBindingBeanPostProcessor implements BeanPostProcessor, A
     public Object postProcessBeforeInitialization(Object bean, String beanName) throws BeansException {
 
         if (beanName != null && beanName.equals(this.beanName) && bean instanceof AbstractConfig) {
+
+            init();
 
             AbstractConfig dubboConfig = (AbstractConfig) bean;
 
@@ -126,8 +130,7 @@ public class DubboConfigBindingBeanPostProcessor implements BeanPostProcessor, A
         this.applicationContext = applicationContext;
     }
 
-    @Override
-    public void afterPropertiesSet() throws Exception {
+    public void init() {
 
         if (dubboConfigBinder == null) {
             try {
@@ -158,4 +161,8 @@ public class DubboConfigBindingBeanPostProcessor implements BeanPostProcessor, A
         return defaultDubboConfigBinder;
     }
 
+    @Override
+    public int getOrder() {
+        return Integer.MIN_VALUE;
+    }
 }

--- a/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/beans/factory/annotation/DubboConfigBindingBeanPostProcessor.java
+++ b/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/beans/factory/annotation/DubboConfigBindingBeanPostProcessor.java
@@ -16,17 +16,15 @@
  */
 package org.apache.dubbo.config.spring.beans.factory.annotation;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.apache.dubbo.common.utils.Assert;
 import org.apache.dubbo.config.AbstractConfig;
 import org.apache.dubbo.config.spring.context.annotation.DubboConfigBindingRegistrar;
 import org.apache.dubbo.config.spring.context.annotation.EnableDubboConfigBinding;
 import org.apache.dubbo.config.spring.context.properties.DefaultDubboConfigBinder;
 import org.apache.dubbo.config.spring.context.properties.DubboConfigBinder;
-
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.springframework.beans.BeansException;
-import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.config.BeanPostProcessor;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;

--- a/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/beans/factory/annotation/DubboConfigBindingBeanPostProcessor.java
+++ b/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/beans/factory/annotation/DubboConfigBindingBeanPostProcessor.java
@@ -128,7 +128,7 @@ public class DubboConfigBindingBeanPostProcessor implements BeanPostProcessor, A
         this.applicationContext = applicationContext;
     }
 
-    public void init() {
+    private void init() {
 
         if (dubboConfigBinder == null) {
             try {

--- a/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/beans/factory/annotation/DubboConfigBindingBeanPostProcessor.java
+++ b/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/beans/factory/annotation/DubboConfigBindingBeanPostProcessor.java
@@ -161,6 +161,6 @@ public class DubboConfigBindingBeanPostProcessor implements BeanPostProcessor, A
 
     @Override
     public int getOrder() {
-        return Integer.MIN_VALUE;
+        return PriorityOrdered.HIGHEST_PRECEDENCE;
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

support mixed xml reference config and annotation dubbo config

## Brief changelog

1. DubboConfigBindingBeanPostProcessor

## For the Issue requirements

- [ ] I have searched the [issues](https://github.com/apache/incubator-dubbo/issues) of this repository and believe that this is not a duplicate.
- [ ] I have checked the [FAQ](https://github.com/apache/incubator-dubbo/blob/master/FAQ.md) of this repository and believe that this is not a duplicate.

### Environment

* Dubbo version: 2.6.5
* Operating System version: mac os 10.13.1
* Java version: 1.8

### Steps to reproduce this issue

It is easy to reproduce this problem

1. following is my config(here use the multiple config, but it does not cause the problem, it is same with single config)

```
dubbo.applications.my-application.logger=slf4j
dubbo.protocols.protocol.accesslog=true
dubbo.protocols.protocol.id=dubbo
dubbo.protocols.protocol.name=dubbo

dubbo.registries.unitRegistry.id=unitRegistry
dubbo.registries.unitRegistry.address=zookeeper://192.168.1.1:2181
dubbo.registries.baseRegistry.id=baseRegistry
dubbo.registries.baseRegistry.address=zookeeper://192.168.1.1:2285
dubbo.registries.commonRegistry.id=commonRegistry
dubbo.registries.commonRegistry.address=zookeeper://192.168.1.1:2185

server.port=13164
dubbo.applications.my-application.id=xxx-service
dubbo.applications.my-application.name=xxx-service
dubbo.applications.my-application.qosPort=13166
dubbo.protocols.protocol.port=13165
```

2. with the config before, then load reference config in xml, it cause exception

### Expected Result

start normally. 

### Actual Result
cannot start application and throws exception: 

```
Caused by: java.lang.IllegalStateException: ApplicationConfig.application == null
  at com.alibaba.dubbo.config.AbstractConfig.appendParameters(AbstractConfig.java:222) ~[dubbo-2.6.5.jar:2.6.5]
  at com.alibaba.dubbo.config.AbstractConfig.appendParameters(AbstractConfig.java:172) ~[dubbo-2.6.5.jar:2.6.5]
  at com.alibaba.dubbo.config.ReferenceConfig.init(ReferenceConfig.java:303) ~[dubbo-2.6.5.jar:2.6.5]
  at com.alibaba.dubbo.config.ReferenceConfig.get(ReferenceConfig.java:163) ~[dubbo-2.6.5.jar:2.6.5]
  at com.alibaba.dubbo.config.spring.beans.factory.annotation.ReferenceAnnotationBeanPostProcessor$ReferenceBeanInvocationHandler.init(ReferenceAnnotationBeanPostProcessor.java:163) ~[dubbo-2.6.5.jar:2.6.5]
  at com.alibaba.dubbo.config.spring.beans.factory.annotation.ReferenceAnnotationBeanPostProcessor$ReferenceBeanInvocationHandler.access$100(ReferenceAnnotationBeanPostProcessor.java:147) ~[dubbo-2.6.5.jar:2.6.5]
  at com.alibaba.dubbo.config.spring.beans.factory.annotation.ReferenceAnnotationBeanPostProcessor.buildInvocationHandler(ReferenceAnnotationBeanPostProcessor.java:141) ~[dubbo-2.6.5.jar:2.6.5]
  at com.alibaba.dubbo.config.spring.beans.factory.annotation.ReferenceAnnotationBeanPostProcessor.buildProxy(ReferenceAnnotationBeanPostProcessor.java:123) ~[dubbo-2.6.5.jar:2.6.5]
  at com.alibaba.dubbo.config.spring.beans.factory.annotation.ReferenceAnnotationBeanPostProcessor.doGetInjectedBean(ReferenceAnnotationBeanPostProcessor.java:117) ~[dubbo-2.6.5.jar:2.6.5]
  at com.alibaba.dubbo.config.spring.beans.factory.annotation.ReferenceAnnotationBeanPostProcessor.doGetInjectedBean(ReferenceAnnotationBeanPostProcessor.java:50) ~[dubbo-2.6.5.jar:2.6.5]
  at com.alibaba.spring.beans.factory.annotation.AnnotationInjectedBeanPostProcessor.getInjectedObject(AnnotationInjectedBeanPostProcessor.java:340) ~[spring-context-support-1.0.2.jar:?]
  at com.alibaba.spring.beans.factory.annotation.AnnotationInjectedBeanPostProcessor$AnnotatedFieldElement.inject(AnnotationInjectedBeanPostProcessor.java:520) ~[spring-context-support-1.0.2.jar:?]
  at org.springframework.beans.factory.annotation.InjectionMetadata.inject(InjectionMetadata.java:88) ~[spring-beans-4.3.2.RELEASE.jar:4.3.2.RELEASE]
  at com.alibaba.spring.beans.factory.annotation.AnnotationInjectedBeanPostProcessor.postProcessPropertyValues(AnnotationInjectedBeanPostProcessor.java:128) ~[spring-context-support-1.0.2.jar:?]
  ... 15 more
```

### what cause this problem 

```
for (String beanName : beanNames) {
    registerDubboConfigBean(beanName, configClass, registry);
    registerDubboConfigBindingBeanPostProcessor(prefix, beanName, multiple, registry);
}
```

dubbo 2.6.5 register a DubboConfigBindingBeanPostProcessor for each DubboConfigBean to binding properties with the config. But config reference in xml may cause the ApplicationConfig or other config initialize before DubboConfigBindingBeanPostProcessor register. So the DubboConfigBean have no chance to binding properties. 

And I try to give the most priority to the DubboConfigBindingBeanPostProcessor. But it is also failed. Because of the `afterPropertiesSet` method: `applicationContext.getBean(DubboConfigBinder.class)` this will cause the beanDefinitions traverse and the ReferenceBean will initialize. So cause the same problem. 
