### PR TITLE
BUG FIX: #3420

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/utils/IOUtils.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/utils/IOUtils.java
@@ -35,6 +35,7 @@ import java.util.List;
 
 public class IOUtils {
     private static final int BUFFER_SIZE = 1024 * 8;
+    public static final int EOF = -1;
 
     private IOUtils() {
     }
@@ -61,18 +62,21 @@ public class IOUtils {
      * @throws IOException
      */
     public static long write(InputStream is, OutputStream os, int bufferSize) throws IOException {
-        int read;
-        long total = 0;
         byte[] buff = new byte[bufferSize];
-        while (is.available() > 0) {
-            read = is.read(buff, 0, buff.length);
-            if (read > 0) {
-                os.write(buff, 0, read);
-                total += read;
-            }
-        }
-        return total;
+        return write(is, os, buff);
     }
+
+    public static long write(
+            final InputStream input, final OutputStream output, final byte[] buffer) throws IOException {
+        long count = 0;
+        int n;
+        while (EOF != (n = input.read(buffer))) {
+            output.write(buffer, 0, n);
+            count += n;
+        }
+        return count;
+    }
+
 
     /**
      * read string.
@@ -131,7 +135,7 @@ public class IOUtils {
     public static long write(Reader reader, Writer writer, int bufferSize) throws IOException {
         int read;
         long total = 0;
-        char[] buf = new char[BUFFER_SIZE];
+        char[] buf = new char[bufferSize];
         while ((read = reader.read(buf)) != -1) {
             writer.write(buf, 0, read);
             total += read;


### PR DESCRIPTION
1. `IOUtils.write(InputStream, OutputStream, int)` BUG#3420;
2. `IOUtils.write(Reader, Writer, int)` not using `bufferSize` parameter.

`org.apache.dubbo.common.io.Bytes#unzip()` is now using fixed `write()` method so it is worth running a `BytesTest#testZip()` test.