### PR TITLE
[Dubbo-1899] Fix mergeable cluster invoke when throw exception

### DIFF
--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/support/MergeableClusterInvoker.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/support/MergeableClusterInvoker.java
@@ -114,7 +114,7 @@ public class MergeableClusterInvoker<T> extends AbstractClusterInvoker<T> {
                     resultList.add(r);
                 }
             } catch (Exception e) {
-                throw new RpcException("Failed to invoke service " + entry.getKey() + ": " + e.getMessage(), e);
+                log.error("Failed to invoke service " + entry.getKey() + ": " + e.getMessage(), e);
             }
         }
 


### PR DESCRIPTION
## What is the purpose of the change

fix #1899 

## Brief changelog

when throw exception on execute, just log it, don't throw it !
