### PR TITLE
Failover executor for failover request.

### DIFF
--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/support/FailoverClusterInvoker.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/support/FailoverClusterInvoker.java
@@ -33,6 +33,7 @@ import org.apache.dubbo.rpc.support.RpcUtils;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 /**
@@ -40,7 +41,6 @@ import java.util.Set;
  * Note that retry causes latency.
  * <p>
  * <a href="http://en.wikipedia.org/wiki/Failover">Failover</a>
- *
  */
 public class FailoverClusterInvoker<T> extends AbstractClusterInvoker<T> {
 
@@ -95,6 +95,13 @@ public class FailoverClusterInvoker<T> extends AbstractClusterInvoker<T> {
                     throw e;
                 }
                 le = e;
+                if (e.getCode() == RpcException.TIMEOUT_EXCEPTION) {
+                    // FIXME Shell we set this request as a failover request in any exception situation?
+                    Map<String, String> attachments = invocation.getAttachments();
+                    if (attachments != null) {
+                        attachments.put(Constants.FAILOVER_REQUEST, "true");
+                    }
+                }
             } catch (Throwable e) {
                 le = new RpcException(e.getMessage(), e);
             } finally {

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/Constants.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/Constants.java
@@ -829,4 +829,5 @@ public class Constants {
      * private Constants(){ }
      */
 
+    public static final String FAILOVER_REQUEST = "failoverRequest";
 }

--- a/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/exchange/Request.java
+++ b/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/exchange/Request.java
@@ -41,11 +41,6 @@ public class Request {
 
     private boolean mBroken = false;
 
-    /**
-     * whether this request is a failover request.
-     */
-    private boolean failover = false;
-
     private Object mData;
 
     public Request() {
@@ -132,14 +127,6 @@ public class Request {
         if (isHeartbeat) {
             setEvent(HEARTBEAT_EVENT);
         }
-    }
-
-    public boolean isFailover() {
-        return failover;
-    }
-
-    public void setFailover(boolean failover) {
-        this.failover = failover;
     }
 
     @Override

--- a/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/exchange/Request.java
+++ b/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/exchange/Request.java
@@ -41,6 +41,11 @@ public class Request {
 
     private boolean mBroken = false;
 
+    /**
+     * whether this request is a failover request.
+     */
+    private boolean failover = false;
+
     private Object mData;
 
     public Request() {
@@ -127,6 +132,14 @@ public class Request {
         if (isHeartbeat) {
             setEvent(HEARTBEAT_EVENT);
         }
+    }
+
+    public boolean isFailover() {
+        return failover;
+    }
+
+    public void setFailover(boolean failover) {
+        this.failover = failover;
     }
 
     @Override

--- a/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/exchange/support/ExchangeHandlerAdapter.java
+++ b/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/exchange/support/ExchangeHandlerAdapter.java
@@ -16,17 +16,30 @@
  */
 package org.apache.dubbo.remoting.exchange.support;
 
+import org.apache.dubbo.common.threadlocal.NamedInternalThreadFactory;
 import org.apache.dubbo.remoting.RemotingException;
 import org.apache.dubbo.remoting.exchange.ExchangeChannel;
 import org.apache.dubbo.remoting.exchange.ExchangeHandler;
 import org.apache.dubbo.remoting.telnet.support.TelnetHandlerAdapter;
 
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 
 /**
  * ExchangeHandlerAdapter
  */
 public abstract class ExchangeHandlerAdapter extends TelnetHandlerAdapter implements ExchangeHandler {
+
+    // FIXME shell we make this pool config-able and is this place suitable?
+    protected final Executor failoverExecutor = new ThreadPoolExecutor(20,
+            40,
+            10,
+            TimeUnit.MINUTES,
+            new LinkedBlockingQueue<>(),
+            new NamedInternalThreadFactory("failoverExecutor", true));
 
     @Override
     public CompletableFuture<Object> reply(ExchangeChannel channel, Object msg) throws RemotingException {

--- a/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/exchange/support/header/HeaderExchangeHandler.java
+++ b/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/exchange/support/header/HeaderExchangeHandler.java
@@ -96,6 +96,10 @@ public class HeaderExchangeHandler implements ChannelHandlerDelegate {
             channel.send(res);
             return;
         }
+        reply(channel, req, res);
+    }
+
+    private void reply(final ExchangeChannel channel, Request req, Response res) throws RemotingException {
         // find handler by message class.
         Object msg = req.getData();
         try {

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/filter/ContextFilter.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/filter/ContextFilter.java
@@ -52,6 +52,7 @@ public class ContextFilter implements Filter {
             attachments.remove(Constants.TIMEOUT_KEY);
             // Remove async property to avoid being passed to the following invoke chain.
             attachments.remove(Constants.ASYNC_KEY);
+            attachments.remove(Constants.FAILOVER_REQUEST);
             attachments.remove(Constants.TAG_KEY);
             attachments.remove(Constants.FORCE_USE_TAG);
         }


### PR DESCRIPTION
Add a tag to the failover request. When the Provider receives such a request, it often means that the previous request is a failure/timeout. We need to open a new thread pool to execute these requests, preventing the failover request from filling our Provider side business thread pool.

If we accept this pr, there are still some things to decide:
- Whether to make the failover pool configurable
- The location of the failover pool
- Shell we set this request as a failover request in any exception situation?