### PR TITLE
修复tag路由在多次rpc调用中无效的bug

### DIFF
--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/filter/ConsumerContextFilter.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/filter/ConsumerContextFilter.java
@@ -54,7 +54,14 @@ public class ConsumerContextFilter implements Filter {
             return invoker.invoke(invocation);
         } finally {
             // TODO removeContext? but we need to save future for RpcContext.getFuture() API. If clear attachments here, attachments will not available when postProcessResult is invoked.
+            String tag = null;
+            if (RpcContext.getContext().getAttachments() != null && RpcContext.getContext().getAttachment(Constants.TAG_KEY) != null) {
+                tag = RpcContext.getContext().getAttachment(Constants.TAG_KEY);
+            }
             RpcContext.getContext().clearAttachments();
+            if (tag != null) {
+                RpcContext.getContext().setAttachment(Constants.TAG_KEY, tag);
+            }
         }
     }
 

--- a/dubbo-rpc/dubbo-rpc-api/src/test/java/org/apache/dubbo/rpc/filter/ConsumerContextFilterTest.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/test/java/org/apache/dubbo/rpc/filter/ConsumerContextFilterTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.dubbo.rpc.filter;
 
+import org.apache.dubbo.common.Constants;
 import org.apache.dubbo.common.URL;
 import org.apache.dubbo.common.utils.NetUtils;
 import org.apache.dubbo.rpc.Filter;
@@ -29,6 +30,7 @@ import org.apache.dubbo.rpc.support.MyInvoker;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 /**
  * ConsumerContextFilterTest.java
@@ -40,12 +42,15 @@ public class ConsumerContextFilterTest {
     public void testSetContext() {
         URL url = URL.valueOf("test://test:11/test?group=dubbo&version=1.1");
         Invoker<DemoService> invoker = new MyInvoker<DemoService>(url);
+        RpcContext.getContext().setAttachment(Constants.TAG_KEY, "red");
+        RpcContext.getContext().setAttachment("any_key", "any_value");
         Invocation invocation = new MockInvocation();
         consumerContextFilter.invoke(invoker, invocation);
         assertEquals(invoker, RpcContext.getContext().getInvoker());
         assertEquals(invocation, RpcContext.getContext().getInvocation());
         assertEquals(NetUtils.getLocalHost() + ":0", RpcContext.getContext().getLocalAddressString());
         assertEquals("test:11", RpcContext.getContext().getRemoteAddressString());
-
+        assertEquals("red", RpcContext.getContext().getAttachment(Constants.TAG_KEY));
+        assertNull(RpcContext.getContext().getAttachment("any_key"));
     }
 }


### PR DESCRIPTION
## 修复tag路由在多次rpc调用中无效的bug

BUG描述：假设A调用B，B先调用C再调用D，B、C均打上了相同dubbo.provider.tag=test，A打上request.tag=test，请求时A调用B，B调用C均正常，但是B调用D时，B的RpcContext attachments被清空，无法正常路由

## Brief changelog

ConsumerContextFilter保留attachments中的dubbo.tag
