### PR TITLE
support epoll

### DIFF
--- a/dubbo-remoting/dubbo-remoting-netty4/src/main/java/org/apache/dubbo/remoting/transport/netty4/NettyClient.java
+++ b/dubbo-remoting/dubbo-remoting-netty4/src/main/java/org/apache/dubbo/remoting/transport/netty4/NettyClient.java
@@ -16,6 +16,7 @@
  */
 package org.apache.dubbo.remoting.transport.netty4;
 
+import io.netty.channel.socket.nio.NioSocketChannel;
 import org.apache.dubbo.common.Constants;
 import org.apache.dubbo.common.URL;
 import org.apache.dubbo.common.Version;
@@ -40,8 +41,7 @@ import io.netty.channel.epoll.Epoll;
 import io.netty.channel.epoll.EpollMode;
 import io.netty.channel.epoll.EpollChannelOption;
 import io.netty.channel.epoll.EpollEventLoopGroup;
-import io.netty.channel.epoll.EpollServerSocketChannel;
-import io.netty.channel.socket.nio.NioServerSocketChannel;
+import io.netty.channel.epoll.EpollSocketChannel;
 import io.netty.handler.proxy.Socks5ProxyHandler;
 import io.netty.handler.timeout.IdleStateHandler;
 import io.netty.util.concurrent.DefaultThreadFactory;
@@ -60,7 +60,7 @@ public class NettyClient extends AbstractClient {
     private static final EventLoopGroup eventLoopGroup = Epoll.isAvailable()?
             new EpollEventLoopGroup(Constants.DEFAULT_IO_THREADS, new DefaultThreadFactory("NettyClientWorker", true)):
             new NioEventLoopGroup(Constants.DEFAULT_IO_THREADS, new DefaultThreadFactory("NettyClientWorker", true));
-    
+
     private static final String SOCKS_PROXY_HOST = "socksProxyHost";
 
     private static final String SOCKS_PROXY_PORT = "socksProxyPort";
@@ -85,10 +85,10 @@ public class NettyClient extends AbstractClient {
                 //.option(ChannelOption.CONNECT_TIMEOUT_MILLIS, getTimeout())
                 .option(ChannelOption.ALLOCATOR, PooledByteBufAllocator.DEFAULT);
         if (Epoll.isAvailable()) {
-            bootstrap.channel(EpollServerSocketChannel.class)
+            bootstrap.channel(EpollSocketChannel.class)
                 .option(EpollChannelOption.EPOLL_MODE, EpollMode.EDGE_TRIGGERED);
         } else {
-            bootstrap.channel(NioServerSocketChannel.class);
+            bootstrap.channel(NioSocketChannel.class);
         }
 
         if (getConnectTimeout() < 3000) {

--- a/dubbo-remoting/dubbo-remoting-netty4/src/test/java/org/apache/dubbo/remoting/transport/netty4/ClientReconnectTest.java
+++ b/dubbo-remoting/dubbo-remoting-netty4/src/test/java/org/apache/dubbo/remoting/transport/netty4/ClientReconnectTest.java
@@ -33,9 +33,6 @@ import org.junit.jupiter.api.Test;
  * Client reconnect test
  */
 public class ClientReconnectTest {
-//    public static void main(String[] args) {
-//        System.out.println(3 % 1);
-//    }
 
     @BeforeEach
     public void clear() {

--- a/dubbo-remoting/dubbo-remoting-netty4/src/test/java/org/apache/dubbo/remoting/transport/netty4/ClientReconnectTest.java
+++ b/dubbo-remoting/dubbo-remoting-netty4/src/test/java/org/apache/dubbo/remoting/transport/netty4/ClientReconnectTest.java
@@ -33,9 +33,9 @@ import org.junit.jupiter.api.Test;
  * Client reconnect test
  */
 public class ClientReconnectTest {
-    public static void main(String[] args) {
-        System.out.println(3 % 1);
-    }
+//    public static void main(String[] args) {
+//        System.out.println(3 % 1);
+//    }
 
     @BeforeEach
     public void clear() {


### PR DESCRIPTION
## What is the purpose of the change

This is an improvement of netty native transport, inspired by grpc and netty. Please check this issue https://github.com/apache/incubator-dubbo/issues/2737 .  We can find some transport enhancement from this upgrade, What's more, with default Epoll, we can have more transport advantages, such as TCP_USER_TIME,  choice between ET mode and LT mode, and so on.

## Brief changelog

change default transport to Epoll if available, otherwise using Nio.

## Verifying this change

XXXXX

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a [GITHUB_issue](https://github.com/apache/incubator-dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/incubator-dubbo-samples) project.
- [x] Run `mvn clean install -DskipTests=false` & `mvn clean test-compile failsafe:integration-test` to make sure unit-test and integration-test pass.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/incubator-dubbo/wiki/Software-donation-guide).
