### PR TITLE
optimize generic invoke

### DIFF
--- a/dubbo-dependencies-bom/pom.xml
+++ b/dubbo-dependencies-bom/pom.xml
@@ -142,7 +142,7 @@
         <activation_version>1.2.0</activation_version>
         <test_container_version>1.11.2</test_container_version>
         <etcd_launcher_version>0.3.0</etcd_launcher_version>
-        <hessian_lite_version>3.2.5</hessian_lite_version>
+        <hessian_lite_version>3.2.6</hessian_lite_version>
         <swagger_version>1.5.19</swagger_version>
         <spring_test_version>4.3.16.RELEASE</spring_test_version>
 

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/Constants.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/Constants.java
@@ -49,6 +49,8 @@ public interface Constants {
 
     String GENERIC_SERIALIZATION_DEFAULT = "true";
 
+    String GENERIC_RAW_RETURN = "raw.return";
+
     String GENERIC_SERIALIZATION_BEAN = "bean";
 
     String GENERIC_SERIALIZATION_PROTOBUF = "protobuf-json";

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/filter/GenericFilter.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/filter/GenericFilter.java
@@ -77,7 +77,8 @@ public class GenericFilter implements Filter {
                 }
 
                 if (StringUtils.isEmpty(generic)
-                        || ProtocolUtils.isDefaultGenericSerialization(generic)) {
+                        || ProtocolUtils.isDefaultGenericSerialization(generic)
+                        || ProtocolUtils.isGenericReturnRawResult(generic)) {
                     args = PojoUtils.realize(args, params, method.getGenericParameterTypes());
                 } else if (ProtocolUtils.isJavaGenericSerialization(generic)) {
                     for (int i = 0; i < args.length; i++) {
@@ -166,6 +167,8 @@ public class GenericFilter implements Filter {
                                 GENERIC_SERIALIZATION_PROTOBUF +
                                 "] serialize result failed.", e);
                     }
+                } else if(ProtocolUtils.isGenericReturnRawResult(generic)) {
+                    return result;
                 } else {
                     return new RpcResult(PojoUtils.generalize(result.getValue()));
                 }

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/support/ProtocolUtils.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/support/ProtocolUtils.java
@@ -25,6 +25,7 @@ import static org.apache.dubbo.rpc.Constants.GENERIC_SERIALIZATION_NATIVE_JAVA;
 import static org.apache.dubbo.rpc.Constants.GENERIC_SERIALIZATION_DEFAULT;
 import static org.apache.dubbo.rpc.Constants.GENERIC_SERIALIZATION_BEAN;
 import static org.apache.dubbo.rpc.Constants.GENERIC_SERIALIZATION_PROTOBUF;
+import static org.apache.dubbo.rpc.Constants.GENERIC_RAW_RETURN;
 
 public class ProtocolUtils {
 
@@ -58,7 +59,9 @@ public class ProtocolUtils {
                 && (GENERIC_SERIALIZATION_DEFAULT.equalsIgnoreCase(generic)  /* Normal generalization cal */
                 || GENERIC_SERIALIZATION_NATIVE_JAVA.equalsIgnoreCase(generic) /* Streaming generalization call supporting jdk serialization */
                 || GENERIC_SERIALIZATION_BEAN.equalsIgnoreCase(generic)
-                || GENERIC_SERIALIZATION_PROTOBUF.equalsIgnoreCase(generic));
+                || GENERIC_SERIALIZATION_PROTOBUF.equalsIgnoreCase(generic)
+                || GENERIC_RAW_RETURN.equalsIgnoreCase(generic));
+
     }
 
     public static boolean isDefaultGenericSerialization(String generic) {
@@ -77,5 +80,9 @@ public class ProtocolUtils {
 
     public static boolean isProtobufGenericSerialization(String generic) {
         return isGeneric(generic) && GENERIC_SERIALIZATION_PROTOBUF.equals(generic);
+    }
+
+    public static boolean isGenericReturnRawResult(String generic) {
+        return GENERIC_RAW_RETURN.equals(generic);
     }
 }


### PR DESCRIPTION
add a new generic type "raw.return" to reduce  unnecessary result convert. effective for hessian serialization only