### PR TITLE
[CI] Add enforce maven plugin to do snapshot version check

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -120,6 +120,7 @@
         <maven_checkstyle_version>3.0.0</maven_checkstyle_version>
         <maven_jacoco_version>0.8.2</maven_jacoco_version>
         <maven_flatten_version>1.1.0</maven_flatten_version>
+        <maven_enforce_version>3.0.0-M2</maven_enforce_version>
         <apache-rat-plugin.version>0.12</apache-rat-plugin.version>
         <arguments />
         <checkstyle.skip>true</checkstyle.skip>
@@ -196,6 +197,35 @@
     </dependencies>
 
     <profiles>
+        <profile>
+            <id>snapshot-ci-deploy</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-enforcer-plugin</artifactId>
+                        <version>${maven_enforce_version}</version>
+                        <executions>
+                            <execution>
+                                <id>enforce-no-releases</id>
+                                <goals>
+                                    <goal>enforce</goal>
+                                </goals>
+                                <configuration>
+                                    <rules>
+                                        <requireSnapshotVersion>
+                                            <message>No Releases Allowed!</message>
+                                            <failWhenParentIsRelease>false</failWhenParentIsRelease>
+                                        </requireSnapshotVersion>
+                                    </rules>
+                                    <fail>true</fail>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
         <profile>
             <id>javadoc-lint</id>
             <activation>


### PR DESCRIPTION
## What is the purpose of the change

Creating [a jenkins job](https://builds.apache.org/job/Apache%20Dubbo/job/apache-dubbo-snapshot-deployment/) for deploying snapshot version to apache maven repo.

In order to make everything works well, we need prevent release deploy for this job, so try to add a enforce plugin rule to check all version is snapshot version.

## Brief changelog

modify pom.xml and add new enforce plugin

## Verifying this change

CI pass with
```
./mvnw clean validate -Psnapshot-ci-deploy
```

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a [GITHUB_issue](https://github.com/apache/incubator-dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [x] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/incubator-dubbo-samples) project.
- [x] Run `mvn clean install -DskipTests=false` & `mvn clean test-compile failsafe:integration-test` to make sure unit-test and integration-test pass.
- [x] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/incubator-dubbo/wiki/Software-donation-guide).
