### PR TITLE
Adjust the default log priority order,  use slf4j first

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/logger/LoggerFactory.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/logger/LoggerFactory.java
@@ -60,8 +60,8 @@ public class LoggerFactory {
                 break;
             default:
                 List<Class<? extends LoggerAdapter>> candidates = Arrays.asList(
-                        Log4jLoggerAdapter.class,
                         Slf4jLoggerAdapter.class,
+                        Log4jLoggerAdapter.class,
                         Log4j2LoggerAdapter.class,
                         JclLoggerAdapter.class,
                         JdkLoggerAdapter.class


### PR DESCRIPTION
## What is the purpose of the change

Adjust the default log priority order,  use slf4j first.

Currently using slf4j most.
Due to the priority log4j, dubbo has no log output.
`dubbo.application.logger` must be configured to take effect.