### PR TITLE
fix:make sure attribute exists

### DIFF
--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/AbstractConfig.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/AbstractConfig.java
@@ -590,6 +590,15 @@ public abstract class AbstractConfig implements Serializable {
                     if (MethodUtils.isGetter(method)) {
                         String name = method.getName();
                         String key = calculateAttributeFromGetter(name);
+                        /**
+                         * make sure attribute exists
+                         */
+                        try {
+                            getClass().getField(key);
+                        } catch (NoSuchFieldException e) {
+                            logger.warn(e.getMessage(), e);
+                            continue;
+                        }
                         Object value = method.invoke(this);
                         if (value != null) {
                             buf.append(" ");


### PR DESCRIPTION
## What is the purpose of the change

make sure attribute exists

## Brief changelog

when dubug or call toString method of AbstractConfig,the field may not exist.For example, when getClass refer to ReferenceBean,it will call getObject() and init method in ReferenceConfig,when it is not initialized,interfaceName is null and throws an Exception, but initialized set to be true.this will lead to service bean cannot be created successfully.

## Verifying this change



Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a [GITHUB_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Run `mvn clean install -DskipTests=false` & `mvn clean test-compile failsafe:integration-test` to make sure unit-test and integration-test pass.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
