### PR TITLE
[Dubbo-4218] Fix NPE when the TagRouterRule addresses config is null (#4218)

### DIFF
--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/router/tag/model/TagRouterRule.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/router/tag/model/TagRouterRule.java
@@ -16,12 +16,10 @@
  */
 package org.apache.dubbo.rpc.cluster.router.tag.model;
 
+import org.apache.dubbo.common.utils.CollectionUtils;
 import org.apache.dubbo.rpc.cluster.router.AbstractRouterRule;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.stream.Collectors;
 
 /**
@@ -50,7 +48,7 @@ public class TagRouterRule extends AbstractRouterRule {
             return;
         }
 
-        tags.forEach(tag -> {
+        tags.stream().filter(tag -> CollectionUtils.isNotEmpty(tag.getAddresses())).forEach(tag -> {
             tagnameToAddresses.put(tag.getName(), tag.getAddresses());
             tag.getAddresses().forEach(addr -> {
                 List<String> tagNames = addressToTagnames.computeIfAbsent(addr, k -> new ArrayList<>());
@@ -60,7 +58,10 @@ public class TagRouterRule extends AbstractRouterRule {
     }
 
     public List<String> getAddresses() {
-        return tags.stream().flatMap(tag -> tag.getAddresses().stream()).collect(Collectors.toList());
+        return tags.stream()
+                .filter(tag -> CollectionUtils.isNotEmpty(tag.getAddresses()))
+                .flatMap(tag -> tag.getAddresses().stream())
+                .collect(Collectors.toList());
     }
 
     public List<String> getTagNames() {

--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/router/tag/model/TagRouterRule.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/router/tag/model/TagRouterRule.java
@@ -19,7 +19,10 @@ package org.apache.dubbo.rpc.cluster.router.tag.model;
 import org.apache.dubbo.common.utils.CollectionUtils;
 import org.apache.dubbo.rpc.cluster.router.AbstractRouterRule;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 /**

--- a/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/router/TagRouterTest.java
+++ b/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/router/TagRouterTest.java
@@ -19,6 +19,8 @@ package org.apache.dubbo.rpc.cluster.router;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.retry.ExponentialBackoffRetry;
+import org.apache.dubbo.rpc.cluster.router.tag.model.TagRouterRule;
+import org.apache.dubbo.rpc.cluster.router.tag.model.TagRuleParser;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -62,5 +64,47 @@ public class TagRouterTest {
 
     private void setData(String path, String data) throws Exception {
         client.setData().forPath(path, data.getBytes());
+    }
+
+    /**
+     * TagRouterRule parse test when the tags addresses is null
+     *
+     * <pre>
+     *     ~ -> null
+     *     null -> null
+     * </pre>
+     */
+    @Test
+    public void tagRouterRuleParseTest(){
+        String tagRouterRuleConfig = "---\n" +
+                "force: false\n" +
+                "runtime: true\n" +
+                "enabled: false\n" +
+                "priority: 1\n" +
+                "key: demo-provider\n" +
+                "tags:\n" +
+                "  - name: tag1\n" +
+                "    addresses: null\n" +
+                "  - name: tag2\n" +
+                "    addresses: [\"30.5.120.37:20880\"]\n" +
+                "  - name: tag3\n" +
+                "    addresses: []\n" +
+                "  - name: tag4\n" +
+                "    addresses: ~\n" +
+                "...";
+
+        TagRouterRule tagRouterRule = TagRuleParser.parse(tagRouterRuleConfig);
+
+        // assert tags
+        assert tagRouterRule.getTagNames().contains("tag1");
+        assert tagRouterRule.getTagNames().contains("tag2");
+        assert tagRouterRule.getTagNames().contains("tag3");
+        assert tagRouterRule.getTagNames().contains("tag4");
+        // assert addresses
+        assert tagRouterRule.getAddresses().contains("30.5.120.37:20880");
+        assert tagRouterRule.getTagnameToAddresses().get("tag1")==null;
+        assert tagRouterRule.getTagnameToAddresses().get("tag2").size()==1;
+        assert tagRouterRule.getTagnameToAddresses().get("tag3")==null;
+        assert tagRouterRule.getTagnameToAddresses().get("tag4")==null;
     }
 }

--- a/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/router/TagRouterTest.java
+++ b/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/router/TagRouterTest.java
@@ -106,5 +106,6 @@ public class TagRouterTest {
         assert tagRouterRule.getTagnameToAddresses().get("tag2").size()==1;
         assert tagRouterRule.getTagnameToAddresses().get("tag3")==null;
         assert tagRouterRule.getTagnameToAddresses().get("tag4")==null;
+        assert tagRouterRule.getAddresses().size()==1;
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

Fix NPE when the TagRouterRule addresses config is null #4218

## Brief changelog

Fix NPE when the TagRouterRule addresses config is null #4218

## Verifying this change

XXXXX

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a [GITHUB_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [x] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Run `mvn clean install -DskipTests=false` & `mvn clean test-compile failsafe:integration-test` to make sure unit-test and integration-test pass.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
