### PR TITLE
add excluded when get metadata

### DIFF
--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/AbstractConfig.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/AbstractConfig.java
@@ -493,8 +493,13 @@ public abstract class AbstractConfig implements Serializable {
                     String prop = calculateAttributeFromGetter(name);
                     String key;
                     Parameter parameter = method.getAnnotation(Parameter.class);
-                    if (parameter != null && parameter.key().length() > 0 && parameter.useKeyAsProperty()) {
-                        key = parameter.key();
+                    if (parameter != null) {
+                        if(parameter.excluded())
+                            continue;
+                        if(parameter.key().length() > 0 && parameter.useKeyAsProperty())
+                            key = parameter.key();
+                        else
+                            key = prop;
                     } else {
                         key = prop;
                     }


### PR DESCRIPTION
## What is the purpose of the change

different platform compile the java file have the different methods sequence 
when get metadata, null will be set to false(like generic have getGeneric and isGeneric, getGeneric before isGeneric, the default value is set to false, it will be wrong)
