### PR TITLE
[Dubbo-4248]fix getmetadata have multy function to get same member param make the default value wrong bug #4248

### DIFF
--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/AbstractConfig.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/AbstractConfig.java
@@ -491,13 +491,24 @@ public abstract class AbstractConfig implements Serializable {
                 String name = method.getName();
                 if (isMetaMethod(method)) {
                     String prop = calculateAttributeFromGetter(name);
-                    String key;
+                    String key = null;
                     Parameter parameter = method.getAnnotation(Parameter.class);
-                    if (parameter != null && parameter.key().length() > 0 && parameter.useKeyAsProperty()) {
-                        key = parameter.key();
-                    } else {
-                        key = prop;
+                    if (parameter != null ) {
+                        // exist multi get or is function to get same member param
+                        // ex: AbstractReferenceConfig isGeneric and getGeneric, if getmethods isGeneric after getGeneric, the default value is change from null to false, it will be wrong
+                        // centos compile isGeneric after getGeneric, so it default value is false(wrong)
+                        // windows compile isGeneric before getGeneric, so it default value is null(correct)
+                        // this function is to get res member param value
+                        // i think the best way is add Parameter Annotation atti(excludeMetadata), but the more atti the different to understand
+                        // invisible rules future maybe have bugs
+                        if(parameter.excludedMetadata())
+                            continue;
+                        if(parameter.key().length() > 0 && parameter.useKeyAsProperty())
+                            key = parameter.key();
                     }
+                    if(key == null)
+                        key = prop;
+
                     // treat url and configuration differently, the value should always present in configuration though it may not need to present in url.
                     //if (method.getReturnType() == Object.class || parameter != null && parameter.excluded()) {
                     if (method.getReturnType() == Object.class) {

--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/AbstractReferenceConfig.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/AbstractReferenceConfig.java
@@ -102,7 +102,7 @@ public abstract class AbstractReferenceConfig extends AbstractInterfaceConfig {
         this.init = init;
     }
 
-    @Parameter(excluded = true)
+    @Parameter(excluded = true, excludedMetadata = true)
     public Boolean isGeneric() {
         return ProtocolUtils.isGeneric(generic);
     }

--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/support/Parameter.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/support/Parameter.java
@@ -42,6 +42,8 @@ public @interface Parameter {
 
     boolean append() default false;
 
+    boolean excludedMetadata() default false;
+
     /**
      * if {@link #key()} is specified, it will be used as the key for the annotated property when generating url.
      * by default, this key will also be used to retrieve the config value:

--- a/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/AbstractConfigTest.java
+++ b/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/AbstractConfigTest.java
@@ -456,13 +456,19 @@ public class AbstractConfigTest {
         overrideConfig.setAddress("override-config://127.0.0.1:2181");
         overrideConfig.setProtocol("override-config");
         overrideConfig.setEscape("override-config://");
+        overrideConfig.setExcludeMetaData("override-config-metadata");
+        Map<String, String> metaData = overrideConfig.getMetaData();
+        Assertions.assertEquals(null, metaData.get("exclude"));
+        Assertions.assertEquals(null, metaData.get("excludeMetaData"));
+
         overrideConfig.setExclude("override-config");
 
-        Map<String, String> metaData = overrideConfig.getMetaData();
+        metaData = overrideConfig.getMetaData();
         Assertions.assertEquals("override-config://127.0.0.1:2181", metaData.get("address"));
         Assertions.assertEquals("override-config", metaData.get("protocol"));
         Assertions.assertEquals("override-config://", metaData.get("escape"));
         Assertions.assertEquals("override-config", metaData.get("exclude"));
+        Assertions.assertEquals(null, metaData.get("excludeMetaData"));
         Assertions.assertNull(metaData.get("key"));
         Assertions.assertNull(metaData.get("key2"));
     }
@@ -518,6 +524,7 @@ public class AbstractConfigTest {
         public String key;
         public String useKeyAsProperty;
         public String escape;
+        public String excludeMetaData;
 
         public String getAddress() {
             return address;
@@ -569,6 +576,15 @@ public class AbstractConfigTest {
 
         public void setEscape(String escape) {
             this.escape = escape;
+        }
+
+        @Parameter(excludedMetadata = true)
+        public String getExcludeMetaData() {
+            return excludeMetaData;
+        }
+
+        public void setExcludeMetaData(String excludeMetaData) {
+            this.excludeMetaData = excludeMetaData;
         }
     }
 

--- a/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/AbstractReferenceConfigTest.java
+++ b/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/AbstractReferenceConfigTest.java
@@ -19,6 +19,7 @@ package org.apache.dubbo.config;
 
 import org.apache.dubbo.remoting.Constants;
 
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
@@ -53,6 +54,9 @@ public class AbstractReferenceConfigTest {
     @Test
     public void testGeneric() throws Exception {
         ReferenceConfig referenceConfig = new ReferenceConfig();
+        Map<String, String> metaData = referenceConfig.getMetaData();
+        Assertions.assertEquals(null, metaData.get("generic"));
+
         referenceConfig.setGeneric(true);
         assertThat(referenceConfig.isGeneric(), is(true));
         Map<String, String> parameters = new HashMap<String, String>();


### PR DESCRIPTION

## What is the purpose of the change

fix getmetadata have multy function to get same member param make the default value wrong bug

## Brief changelog
1. Parameter Annotation add atti excludedMetadata default false
`
boolean excludedMetadata() default false;
`
2. AbstractConfig::getMetaData support excludedMetadata Parameter Annotation
3. AbstractReferenceConfig::isGeneric set  Parameter Annotation excludedMetadata = true
`    @Parameter(excluded = true, excludedMetadata = true)
    public Boolean isGeneric() {
        return ProtocolUtils.isGeneric(generic);
    }
`

## Verifying this change

centos compile AbstractConfig::getmetadata the get generic key default value is null. 

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a [GITHUB_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [x] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Run `mvn clean install -DskipTests=false` & `mvn clean test-compile failsafe:integration-test` to make sure unit-test and integration-test pass.
- [x] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
