### PR TITLE
fix-dubbo SPI config service when separated names with ","

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/extension/ExtensionLoader.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/extension/ExtensionLoader.java
@@ -742,7 +742,7 @@ public class ExtensionLoader<T> {
                 cacheActivateClass(clazz, names[0]);
                 for (String n : names) {
                     cacheName(clazz, n);
-                    saveInExtensionClass(extensionClasses, clazz, name);
+                    saveInExtensionClass(extensionClasses, clazz, n);
                 }
             }
         }

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/extension/ExtensionLoaderTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/extension/ExtensionLoaderTest.java
@@ -28,6 +28,7 @@ import org.apache.dubbo.common.extension.activate.impl.ValueActivateExtImpl;
 import org.apache.dubbo.common.extension.ext1.SimpleExt;
 import org.apache.dubbo.common.extension.ext1.impl.SimpleExtImpl1;
 import org.apache.dubbo.common.extension.ext1.impl.SimpleExtImpl2;
+import org.apache.dubbo.common.extension.ext10.Ext10MultiNames;
 import org.apache.dubbo.common.extension.ext2.Ext2;
 import org.apache.dubbo.common.extension.ext6_wrap.WrappedExt;
 import org.apache.dubbo.common.extension.ext6_wrap.impl.Ext5Wrapper1;
@@ -437,4 +438,9 @@ public class ExtensionLoaderTest {
         Assertions.assertNull(injectExtImpl.getGenericType());
     }
 
+    @Test
+    void testMultiNames() {
+        Ext10MultiNames ext10MultiNames = ExtensionLoader.getExtensionLoader(Ext10MultiNames.class).getExtension("impl");
+        Assertions.assertNotNull(ext10MultiNames);
+    }
 }

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/extension/ExtensionLoaderTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/extension/ExtensionLoaderTest.java
@@ -18,13 +18,7 @@ package org.apache.dubbo.common.extension;
 
 import org.apache.dubbo.common.URL;
 import org.apache.dubbo.common.extension.activate.ActivateExt1;
-import org.apache.dubbo.common.extension.activate.impl.ActivateExt1Impl1;
-import org.apache.dubbo.common.extension.activate.impl.GroupActivateExtImpl;
-import org.apache.dubbo.common.extension.activate.impl.OldActivateExt1Impl2;
-import org.apache.dubbo.common.extension.activate.impl.OldActivateExt1Impl3;
-import org.apache.dubbo.common.extension.activate.impl.OrderActivateExtImpl1;
-import org.apache.dubbo.common.extension.activate.impl.OrderActivateExtImpl2;
-import org.apache.dubbo.common.extension.activate.impl.ValueActivateExtImpl;
+import org.apache.dubbo.common.extension.activate.impl.*;
 import org.apache.dubbo.common.extension.ext1.SimpleExt;
 import org.apache.dubbo.common.extension.ext1.impl.SimpleExtImpl1;
 import org.apache.dubbo.common.extension.ext1.impl.SimpleExtImpl2;
@@ -38,18 +32,11 @@ import org.apache.dubbo.common.extension.ext8_add.AddExt1;
 import org.apache.dubbo.common.extension.ext8_add.AddExt2;
 import org.apache.dubbo.common.extension.ext8_add.AddExt3;
 import org.apache.dubbo.common.extension.ext8_add.AddExt4;
-import org.apache.dubbo.common.extension.ext8_add.impl.AddExt1Impl1;
-import org.apache.dubbo.common.extension.ext8_add.impl.AddExt1_ManualAdaptive;
-import org.apache.dubbo.common.extension.ext8_add.impl.AddExt1_ManualAdd1;
-import org.apache.dubbo.common.extension.ext8_add.impl.AddExt1_ManualAdd2;
-import org.apache.dubbo.common.extension.ext8_add.impl.AddExt2_ManualAdaptive;
-import org.apache.dubbo.common.extension.ext8_add.impl.AddExt3_ManualAdaptive;
-import org.apache.dubbo.common.extension.ext8_add.impl.AddExt4_ManualAdaptive;
+import org.apache.dubbo.common.extension.ext8_add.impl.*;
 import org.apache.dubbo.common.extension.ext9_empty.Ext9Empty;
 import org.apache.dubbo.common.extension.ext9_empty.impl.Ext9EmptyImpl;
 import org.apache.dubbo.common.extension.injection.InjectExt;
 import org.apache.dubbo.common.extension.injection.impl.InjectExtImpl;
-
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -58,16 +45,10 @@ import java.util.List;
 import java.util.Set;
 
 import static org.apache.dubbo.common.constants.CommonConstants.GROUP_KEY;
-import static org.hamcrest.CoreMatchers.allOf;
-import static org.hamcrest.CoreMatchers.anyOf;
-import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class ExtensionLoaderTest {
     @Test

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/extension/ext10/Ext10MultiNames.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/extension/ext10/Ext10MultiNames.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.common.extension.ext10;
+
+import org.apache.dubbo.common.extension.SPI;
+
+@SPI
+public interface Ext10MultiNames {
+    void names();
+}

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/extension/ext10/Ext10MultiNames.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/extension/ext10/Ext10MultiNames.java
@@ -20,5 +20,4 @@ import org.apache.dubbo.common.extension.SPI;
 
 @SPI
 public interface Ext10MultiNames {
-    void names();
 }

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/extension/ext10/impl/Ext10MultiNamesImpl.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/extension/ext10/impl/Ext10MultiNamesImpl.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.common.extension.ext10.impl;
+
+import org.apache.dubbo.common.extension.ext10.Ext10MultiNames;
+
+public class Ext10MultiNamesImpl implements Ext10MultiNames {
+    @Override
+    public void names() {
+    }
+}

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/extension/ext10/impl/Ext10MultiNamesImpl.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/extension/ext10/impl/Ext10MultiNamesImpl.java
@@ -19,7 +19,4 @@ package org.apache.dubbo.common.extension.ext10.impl;
 import org.apache.dubbo.common.extension.ext10.Ext10MultiNames;
 
 public class Ext10MultiNamesImpl implements Ext10MultiNames {
-    @Override
-    public void names() {
-    }
 }

--- a/dubbo-common/src/test/resources/META-INF/dubbo/internal/org.apache.dubbo.common.extension.ext10.Ext10MultiNames
+++ b/dubbo-common/src/test/resources/META-INF/dubbo/internal/org.apache.dubbo.common.extension.ext10.Ext10MultiNames
@@ -1,0 +1,1 @@
+impl,implMultiName=org.apache.dubbo.common.extension.ext10.impl.Ext10MultiNamesImpl


### PR DESCRIPTION
## What is the purpose of the change
just fix bug as title