### PR TITLE
move AbstractConfig.class method isMetaMethod to MethodUtils.class

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/utils/MethodUtils.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/utils/MethodUtils.java
@@ -38,4 +38,27 @@ public class MethodUtils {
                 && method.getParameterTypes().length == 0
                 && ClassUtils.isPrimitive(method.getReturnType());
     }
+
+    public static boolean isMetaMethod(Method method) {
+        String name = method.getName();
+        if (!(name.startsWith("get") || name.startsWith("is"))) {
+            return false;
+        }
+        if ("get".equals(name)) {
+            return false;
+        }
+        if ("getClass".equals(name)) {
+            return false;
+        }
+        if (!Modifier.isPublic(method.getModifiers())) {
+            return false;
+        }
+        if (method.getParameterTypes().length != 0) {
+            return false;
+        }
+        if (!ClassUtils.isPrimitive(method.getReturnType())) {
+            return false;
+        }
+        return true;
+    }
 }

--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/AbstractConfig.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/AbstractConfig.java
@@ -489,7 +489,7 @@ public abstract class AbstractConfig implements Serializable {
         for (Method method : methods) {
             try {
                 String name = method.getName();
-                if (isMetaMethod(method)) {
+                if (MethodUtils.isMetaMethod(method)) {
                     String prop = calculateAttributeFromGetter(name);
                     String key;
                     Parameter parameter = method.getAnnotation(Parameter.class);
@@ -619,28 +619,6 @@ public abstract class AbstractConfig implements Serializable {
         return true;
     }
 
-    private boolean isMetaMethod(Method method) {
-        String name = method.getName();
-        if (!(name.startsWith("get") || name.startsWith("is"))) {
-            return false;
-        }
-        if ("get".equals(name)) {
-            return false;
-        }
-        if ("getClass".equals(name)) {
-            return false;
-        }
-        if (!Modifier.isPublic(method.getModifiers())) {
-            return false;
-        }
-        if (method.getParameterTypes().length != 0) {
-            return false;
-        }
-        if (!ClassUtils.isPrimitive(method.getReturnType())) {
-            return false;
-        }
-        return true;
-    }
 
     @Override
     public boolean equals(Object obj) {


### PR DESCRIPTION
## What is the purpose of the change

isMetaMethod can be a public method using in all module, there is already a class MethodUtils,
so it may be useful moving isMetaMethod to MethodUtils.class

## Brief changelog

move AbstractConfig.class method isMetaMethod to MethodUtils.class

## Verifying this change


Follow this checklist to help us incorporate your contribution quickly and easily:

- [] Make sure there is a [GITHUB_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Run `mvn clean install -DskipTests=false` & `mvn clean test-compile failsafe:integration-test` to make sure unit-test and integration-test pass.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
