### PR TITLE
Dubbo throws IoException with error message while decoding fail

### DIFF
--- a/dubbo-rpc/dubbo-rpc-dubbo/src/main/java/com/alibaba/dubbo/rpc/protocol/dubbo/DecodeableRpcResult.java
+++ b/dubbo-rpc/dubbo-rpc-dubbo/src/main/java/com/alibaba/dubbo/rpc/protocol/dubbo/DecodeableRpcResult.java
@@ -128,7 +128,7 @@ public class DecodeableRpcResult extends RpcResult implements Codec, Decodeable 
                 }
                 break;
             default:
-                throw new IOException("Unknown result flag, expect '0' '1' '2', get " + flag);
+                throw new IOException("Unknown result flag, expect '0' '1' '2' '3' '4' '5', get " + flag);
         }
         if (in instanceof Cleanable) {
             ((Cleanable) in).cleanup();


### PR DESCRIPTION
 have searched the issues of this repository and believe that this is not a duplicate.
  I have checked the FAQ of this repository and believe that this is not a duplicate.
Environment
Dubbo version: 2.6.6
Operating System version: *nix
Java version: 1.7+
Expected Result
throw new IOException("Unknown result flag, expect '0' '1' '2' '3' '4' '5', get " + flag);

Actual Result
throw new IOException("Unknown result flag, expect '0' '1' '2', get " + flag);

since dubbo add new type for class dubbocodec for issue #1843
we should also change the exception message .

For example, if dubbo provides new protocol version(higher than 2.0.2) .then the high version dubbo invoke the lower version dubbo[2.0.2] with no support codec ,then the lower version dubbo throws ioexception with incorrect message.
So we need fix it