### PR TITLE
fix register config not take effect because of url simplified

### DIFF
--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/integration/RegistryProtocol.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/integration/RegistryProtocol.java
@@ -215,7 +215,7 @@ public class RegistryProtocol implements Protocol {
         ProviderInvokerWrapper<T> providerInvokerWrapper = ProviderConsumerRegTable.registerProvider(originInvoker,
                 registryUrl, registeredProviderUrl);
         //to judge if we need to delay publish
-        boolean register = registeredProviderUrl.getParameter("register", true);
+        boolean register = providerUrl.getParameter(REGISTER_KEY, true);
         if (register) {
             register(registryUrl, registeredProviderUrl);
             providerInvokerWrapper.setReg(true);


### PR DESCRIPTION
fix #4341

when set dubbo.registry.simplified true. the dubbo.service.register won't take effect because of the register key was simplified and will use default value true;

boolean register = **registeredProviderUrl**.getParameter("register", true);

change providerUrl here