### PR TITLE
[Dubbo-2.7.2] Fix `StringIndexOutOfBoundsException` when calling base642bytes(String, int, int)

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/io/Bytes.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/io/Bytes.java
@@ -633,6 +633,10 @@ public class Bytes {
             throw new IllegalArgumentException("base642bytes: base64 string length % 4 == 1.");
         }
 
+        if (off == 0 && len == 0) {
+            return new byte[0];
+        }
+
         int num = len / 4, size = num * 3;
         if (code.length() > 64) {
             if (rem != 0) {
@@ -719,6 +723,10 @@ public class Bytes {
         int rem = len % 4;
         if (rem == 1) {
             throw new IllegalArgumentException("base642bytes: base64 string length % 4 == 1.");
+        }
+
+        if (off == 0 && len == 0) {
+            return new byte[0];
         }
 
         int num = len / 4, size = num * 3;

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/io/Bytes.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/io/Bytes.java
@@ -633,7 +633,7 @@ public class Bytes {
             throw new IllegalArgumentException("base642bytes: base64 string length % 4 == 1.");
         }
 
-        if (off == 0 && len == 0) {
+        if (len == 0) {
             return new byte[0];
         }
 
@@ -725,7 +725,7 @@ public class Bytes {
             throw new IllegalArgumentException("base642bytes: base64 string length % 4 == 1.");
         }
 
-        if (off == 0 && len == 0) {
+        if (len == 0) {
             return new byte[0];
         }
 

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/io/BytesTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/io/BytesTest.java
@@ -91,6 +91,11 @@ public class BytesTest {
     }
 
     @Test
+    public void testBase642bytes0Off0Len() {
+        assertThat(Bytes.base642bytes("dubbo", 0, 0).length, is(0));
+    }
+
+    @Test
     public void testHex() {
         String str = Bytes.bytes2hex(b1);
         assertThat(b1, is(Bytes.hex2bytes(str)));


### PR DESCRIPTION
## What is the purpose of the change

Fixes #4402

## Brief changelog

Calling `base642bytes(String, int, int)` from `org.apache.dubbo.common.io` or any similar method with `len = 0` now returns an empty `byte[]`

## Verifying this change

A new test case was added in `BytesTest.java`

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a [GITHUB_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [x] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Run `mvn clean install -DskipTests=false` & `mvn clean test-compile failsafe:integration-test` to make sure unit-test and integration-test pass.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
