### PR TITLE
[Dubbo] Fix StringIndexOutOfBoundsException when len=0 #4402

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/io/Bytes.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/io/Bytes.java
@@ -711,6 +711,9 @@ public class Bytes {
         if (len < 0) {
             throw new IndexOutOfBoundsException("base642bytes: length < 0, length is " + len);
         }
+        if (len == 0) {
+            return new byte[0];
+        }
         if (off + len > str.length()) {
             throw new IndexOutOfBoundsException("base642bytes: offset + length > string length.");
         }

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/io/Bytes.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/io/Bytes.java
@@ -620,6 +620,9 @@ public class Bytes {
         if (len < 0) {
             throw new IndexOutOfBoundsException("base642bytes: length < 0, length is " + len);
         }
+        if (len == 0) {
+            return new byte[0];
+        }
         if (off + len > str.length()) {
             throw new IndexOutOfBoundsException("base642bytes: offset + length > string length.");
         }

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/io/BytesTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/io/BytesTest.java
@@ -60,6 +60,9 @@ public class BytesTest {
 
         byte[] emptyBytes = Bytes.base642bytes("dubbo", 0, 0);
         assertThat(emptyBytes, is("".getBytes()));
+
+        assertThat(Bytes.base642bytes("dubbo", 0, 0, ""), is("".getBytes()));
+        assertThat(Bytes.base642bytes("dubbo", 0, 0, new char[0]), is("".getBytes()));
     }
 
     @Test

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/io/BytesTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/io/BytesTest.java
@@ -57,6 +57,9 @@ public class BytesTest {
 
         byte[] bytesWithC64 = Bytes.base642bytes(str, C64);
         assertThat(bytesWithC64, is(bytes));
+
+        byte[] emptyBytes = Bytes.base642bytes("dubbo", 0, 0);
+        assertThat(emptyBytes, is("".getBytes()));
     }
 
     @Test


### PR DESCRIPTION
## What is the purpose of the change

fix https://github.com/apache/dubbo/issues/4402

## Brief changelog

add guard clause for len=0 in method `base642bytes`

## Verifying this change

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a [GITHUB_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [x] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Run `mvn clean install -DskipTests=false` & `mvn clean test-compile failsafe:integration-test` to make sure unit-test and integration-test pass.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
