### PR TITLE
Fix MulticastSocket setInterface choose an unreachable address

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/utils/NetUtils.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/utils/NetUtils.java
@@ -371,13 +371,25 @@ public class NetUtils {
             while (addresses.hasMoreElements()) {
                 InetAddress address = (InetAddress) addresses.nextElement();
                 if (preferIpv6 && address instanceof Inet6Address) {
-                    multicastSocket.setInterface(address);
-                    interfaceSet = true;
-                    break;
+                    try {
+                        if(address.isReachable(100)){
+                            multicastSocket.setInterface(address);
+                            interfaceSet = true;
+                            break;
+                        }
+                    } catch (IOException e) {
+                        // ignore
+                    }
                 } else if (!preferIpv6 && address instanceof Inet4Address) {
-                    multicastSocket.setInterface(address);
-                    interfaceSet = true;
-                    break;
+                    try {
+                        if(address.isReachable(100)){
+                            multicastSocket.setInterface(address);
+                            interfaceSet = true;
+                            break;
+                        }
+                    } catch (IOException e) {
+                        // ignore
+                    }
                 }
             }
             if (interfaceSet) {


### PR DESCRIPTION
## What is the purpose of the change

Fix MulticastSocket setInterface choose an unreachable address

Try with multicast demo, get an exception as follow

```
/Library/Java/JavaVirtualMachines/adoptopenjdk-11.jdk/Contents/Home/bin/java -agentlib:jdwp=transport=dt_socket,address=127.0.0.1:58390,suspend=y,server=n -javaagent:/Users/hsk/Library/Caches/IntelliJIdea2018.2/captureAgent/debugger-agent.jar=file:/private/var/folders/68/y1kr9bfs183b887sz8tmqm_c0000gn/T/capture.props -Dfile.encoding=UTF-8 -classpath "/Users/hsk/githome/github/dubbo/dubbo-demo/dubbo-demo-api/dubbo-demo-api-consumer/target/classes:/Users/hsk/githome/github/dubbo/dubbo-demo/dubbo-demo-interface/target/classes:/Users/hsk/githome/github/dubbo/dubbo-registry/dubbo-registry-multicast/target/classes:/Users/hsk/githome/github/dubbo/dubbo-registry/dubbo-registry-api/target/classes:/Users/hsk/githome/github/dubbo/dubbo-cluster/target/classes:/Users/hsk/.m2/repository/org/yaml/snakeyaml/1.20/snakeyaml-1.20.jar:/Users/hsk/githome/github/dubbo/dubbo-rpc/dubbo-rpc-dubbo/target/classes:/Users/hsk/githome/github/dubbo/dubbo-rpc/dubbo-rpc-api/target/classes:/Users/hsk/githome/github/dubbo/dubbo-common/target/classes:/Users/hsk/.m2/repository/commons-logging/commons-logging/1.2/commons-logging-1.2.jar:/Users/hsk/.m2/repository/log4j/log4j/1.2.16/log4j-1.2.16.jar:/Users/hsk/.m2/repository/org/javassist/javassist/3.20.0-GA/javassist-3.20.0-GA.jar:/Users/hsk/.m2/repository/com/alibaba/fastjson/1.2.46/fastjson-1.2.46.jar:/Users/hsk/.m2/repository/com/esotericsoftware/kryo/4.0.1/kryo-4.0.1.jar:/Users/hsk/.m2/repository/com/esotericsoftware/reflectasm/1.11.3/reflectasm-1.11.3.jar:/Users/hsk/.m2/repository/org/ow2/asm/asm/5.0.4/asm-5.0.4.jar:/Users/hsk/.m2/repository/com/esotericsoftware/minlog/1.3.0/minlog-1.3.0.jar:/Users/hsk/.m2/repository/de/javakaffee/kryo-serializers/0.42/kryo-serializers-0.42.jar:/Users/hsk/.m2/repository/de/ruedigermoeller/fst/2.48-jdk-6/fst-2.48-jdk-6.jar:/Users/hsk/.m2/repository/com/fasterxml/jackson/core/jackson-core/2.8.6/jackson-core-2.8.6.jar:/Users/hsk/.m2/repository/com/cedarsoftware/java-util/1.9.0/java-util-1.9.0.jar:/Users/hsk/.m2/repository/com/cedarsoftware/json-io/2.5.1/json-io-2.5.1.jar:/Users/hsk/githome/github/dubbo/dubbo-remoting/dubbo-remoting-api/target/classes:/Users/hsk/githome/github/dubbo/dubbo-config/dubbo-config-api/target/classes:/Users/hsk/githome/github/dubbo/dubbo-metadata-report/dubbo-metadata-report-api/target/classes:/Users/hsk/githome/github/dubbo/dubbo-metadata-report/dubbo-metadata-definition/target/classes:/Users/hsk/.m2/repository/com/google/code/gson/gson/2.8.5/gson-2.8.5.jar:/Users/hsk/githome/github/dubbo/dubbo-monitor/dubbo-monitor-api/target/classes:/Users/hsk/githome/github/dubbo/dubbo-rpc/dubbo-rpc-injvm/target/classes:/Users/hsk/githome/github/dubbo/dubbo-filter/dubbo-filter-validation/target/classes:/Users/hsk/.m2/repository/javax/validation/validation-api/1.1.0.Final/validation-api-1.1.0.Final.jar:/Users/hsk/githome/github/dubbo/dubbo-filter/dubbo-filter-cache/target/classes:/Users/hsk/.m2/repository/javax/cache/cache-api/1.0.0/cache-api-1.0.0.jar:/Users/hsk/githome/github/dubbo/dubbo-container/dubbo-container-api/target/classes:/Users/hsk/githome/github/dubbo/dubbo-configcenter/dubbo-configcenter-api/target/classes:/Users/hsk/githome/github/dubbo/dubbo-remoting/dubbo-remoting-netty4/target/classes:/Users/hsk/.m2/repository/io/netty/netty-all/4.1.25.Final/netty-all-4.1.25.Final.jar:/Users/hsk/githome/github/dubbo/dubbo-serialization/dubbo-serialization-hessian2/target/classes:/Users/hsk/githome/github/dubbo/dubbo-serialization/dubbo-serialization-api/target/classes:/Users/hsk/.m2/repository/com/alibaba/hessian-lite/3.2.5/hessian-lite-3.2.5.jar:/Users/hsk/.m2/repository/org/objenesis/objenesis/2.6/objenesis-2.6.jar:/Applications/IntelliJ IDEA.app/Contents/lib/idea_rt.jar" org.apache.dubbo.demo.consumer.Application
Connected to the target VM, address: '127.0.0.1:58390', transport: 'socket'
[29/06/19 16:29:09:905 CST] main  INFO logger.LoggerFactory: using logger: org.apache.dubbo.common.logger.log4j.Log4jLoggerAdapter
WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by javassist.ClassPool (file:/Users/hsk/.m2/repository/org/javassist/javassist/3.20.0-GA/javassist-3.20.0-GA.jar) to method java.lang.ClassLoader.defineClass(java.lang.String,byte[],int,int,java.security.ProtectionDomain)
WARNING: Please consider reporting this to the maintainers of javassist.ClassPool
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release
[29/06/19 16:29:10:508 CST] main  WARN config.AbstractConfig:  [DUBBO] There's no valid metadata config found, if you are using the simplified mode of registry url, please make sure you have a metadata address configured properly., dubbo version: , current host: 10.3.18.53
[29/06/19 16:29:10:598 CST] main  INFO config.AbstractConfig:  [DUBBO] There's no valid monitor config found, if you want to open monitor statistics for Dubbo, please make sure your monitor is configured properly., dubbo version: , current host: 10.3.18.53
[29/06/19 16:29:10:764 CST] main  INFO multicast.MulticastRegistry:  [DUBBO] Register: consumer://10.3.18.53/org.apache.dubbo.demo.DemoService?application=dubbo-demo-api-consumer&category=consumers&check=false&dubbo=2.0.2&interface=org.apache.dubbo.demo.DemoService&lazy=false&methods=sayHello&pid=52461&side=consumer&sticky=false&timestamp=1561796950508, dubbo version: , current host: 10.3.18.53
[29/06/19 16:29:10:764 CST] main  INFO multicast.MulticastRegistry:  [DUBBO] Send multicast message: register consumer://10.3.18.53/org.apache.dubbo.demo.DemoService?application=dubbo-demo-api-consumer&category=consumers&check=false&dubbo=2.0.2&interface=org.apache.dubbo.demo.DemoService&lazy=false&methods=sayHello&pid=52461&side=consumer&sticky=false&timestamp=1561796950508 to /224.5.6.7:1234, dubbo version: , current host: 10.3.18.53
[29/06/19 16:29:10:778 CST] main  INFO multicast.MulticastRegistry:  [DUBBO] Subscribe: consumer://10.3.18.53/org.apache.dubbo.demo.DemoService?application=dubbo-demo-api-consumer&category=providers,configurators,routers&dubbo=2.0.2&interface=org.apache.dubbo.demo.DemoService&lazy=false&methods=sayHello&pid=52461&side=consumer&sticky=false&timestamp=1561796950508, dubbo version: , current host: 10.3.18.53
[29/06/19 16:29:10:780 CST] main  INFO multicast.MulticastRegistry:  [DUBBO] Send multicast message: subscribe consumer://10.3.18.53/org.apache.dubbo.demo.DemoService?application=dubbo-demo-api-consumer&category=providers,configurators,routers&dubbo=2.0.2&interface=org.apache.dubbo.demo.DemoService&lazy=false&methods=sayHello&pid=52461&side=consumer&sticky=false&timestamp=1561796950508 to /224.5.6.7:1234, dubbo version: , current host: 10.3.18.53
[29/06/19 16:29:11:783 CST] main  WARN multicast.MulticastRegistry:  [DUBBO] Ignore empty notify urls for subscribe url consumer://10.3.18.53/org.apache.dubbo.demo.DemoService?application=dubbo-demo-api-consumer&category=providers,configurators,routers&dubbo=2.0.2&interface=org.apache.dubbo.demo.DemoService&lazy=false&methods=sayHello&pid=52461&side=consumer&sticky=false&timestamp=1561796950508, dubbo version: , current host: 10.3.18.53
Exception in thread "main" java.lang.IllegalStateException: Failed to check the status of the service org.apache.dubbo.demo.DemoService. No provider available for the service org.apache.dubbo.demo.DemoService from the url multicast://224.5.6.7:1234/org.apache.dubbo.registry.RegistryService?application=dubbo-demo-api-consumer&dubbo=2.0.2&interface=org.apache.dubbo.demo.DemoService&lazy=false&methods=sayHello&pid=52461&register.ip=10.3.18.53&side=consumer&sticky=false&timestamp=1561796950508 to the consumer 10.3.18.53 use dubbo version 
	at org.apache.dubbo.config.ReferenceConfig.createProxy(ReferenceConfig.java:418)
	at org.apache.dubbo.config.ReferenceConfig.init(ReferenceConfig.java:329)
	at org.apache.dubbo.config.ReferenceConfig.get(ReferenceConfig.java:250)
	at org.apache.dubbo.demo.consumer.Application.main(Application.java:36)
[29/06/19 16:29:11:791 CST] DubboShutdownHook  INFO config.DubboShutdownHook:  [DUBBO] Run shutdown hook now., dubbo version: , current host: 10.3.18.53
[29/06/19 16:29:11:792 CST] DubboShutdownHook  INFO support.AbstractRegistryFactory:  [DUBBO] Close all registries [multicast://224.5.6.7:1234/org.apache.dubbo.registry.RegistryService?application=dubbo-demo-api-consumer&dubbo=2.0.2&interface=org.apache.dubbo.registry.RegistryService&pid=52461&timestamp=1561796950592], dubbo version: , current host: 10.3.18.53
[29/06/19 16:29:11:792 CST] DubboShutdownHook  INFO multicast.MulticastRegistry:  [DUBBO] Destroy registry:multicast://224.5.6.7:1234/org.apache.dubbo.registry.RegistryService?application=dubbo-demo-api-consumer&dubbo=2.0.2&interface=org.apache.dubbo.registry.RegistryService&pid=52461&timestamp=1561796950592, dubbo version: , current host: 10.3.18.53
[29/06/19 16:29:11:792 CST] DubboShutdownHook  INFO multicast.MulticastRegistry:  [DUBBO] Unregister: consumer://10.3.18.53/org.apache.dubbo.demo.DemoService?application=dubbo-demo-api-consumer&category=consumers&check=false&dubbo=2.0.2&interface=org.apache.dubbo.demo.DemoService&lazy=false&methods=sayHello&pid=52461&side=consumer&sticky=false&timestamp=1561796950508, dubbo version: , current host: 10.3.18.53
[29/06/19 16:29:11:792 CST] DubboShutdownHook  INFO multicast.MulticastRegistry:  [DUBBO] Send multicast message: unregister consumer://10.3.18.53/org.apache.dubbo.demo.DemoService?application=dubbo-demo-api-consumer&category=consumers&check=false&dubbo=2.0.2&interface=org.apache.dubbo.demo.DemoService&lazy=false&methods=sayHello&pid=52461&side=consumer&sticky=false&timestamp=1561796950508 to /224.5.6.7:1234, dubbo version: , current host: 10.3.18.53
[29/06/19 16:29:11:792 CST] DubboShutdownHook  INFO multicast.MulticastRegistry:  [DUBBO] Destroy unregister url consumer://10.3.18.53/org.apache.dubbo.demo.DemoService?application=dubbo-demo-api-consumer&category=consumers&check=false&dubbo=2.0.2&interface=org.apache.dubbo.demo.DemoService&lazy=false&methods=sayHello&pid=52461&side=consumer&sticky=false&timestamp=1561796950508, dubbo version: , current host: 10.3.18.53
[29/06/19 16:29:11:793 CST] DubboShutdownHook  INFO multicast.MulticastRegistry:  [DUBBO] Unsubscribe: consumer://10.3.18.53/org.apache.dubbo.demo.DemoService?application=dubbo-demo-api-consumer&category=providers,configurators,routers&dubbo=2.0.2&interface=org.apache.dubbo.demo.DemoService&lazy=false&methods=sayHello&pid=52461&side=consumer&sticky=false&timestamp=1561796950508, dubbo version: , current host: 10.3.18.53
[29/06/19 16:29:11:793 CST] DubboShutdownHook  INFO multicast.MulticastRegistry:  [DUBBO] Unregister: consumer://10.3.18.53/org.apache.dubbo.demo.DemoService?application=dubbo-demo-api-consumer&category=providers,configurators,routers&dubbo=2.0.2&interface=org.apache.dubbo.demo.DemoService&lazy=false&methods=sayHello&pid=52461&side=consumer&sticky=false&timestamp=1561796950508, dubbo version: , current host: 10.3.18.53
[29/06/19 16:29:11:793 CST] DubboShutdownHook  INFO multicast.MulticastRegistry:  [DUBBO] Send multicast message: unregister consumer://10.3.18.53/org.apache.dubbo.demo.DemoService?application=dubbo-demo-api-consumer&category=providers,configurators,routers&dubbo=2.0.2&interface=org.apache.dubbo.demo.DemoService&lazy=false&methods=sayHello&pid=52461&side=consumer&sticky=false&timestamp=1561796950508 to /224.5.6.7:1234, dubbo version: , current host: 10.3.18.53
[29/06/19 16:29:11:793 CST] DubboShutdownHook  INFO multicast.MulticastRegistry:  [DUBBO] Send multicast message: unsubscribe consumer://10.3.18.53/org.apache.dubbo.demo.DemoService?application=dubbo-demo-api-consumer&category=providers,configurators,routers&dubbo=2.0.2&interface=org.apache.dubbo.demo.DemoService&lazy=false&methods=sayHello&pid=52461&side=consumer&sticky=false&timestamp=1561796950508 to /224.5.6.7:1234, dubbo version: , current host: 10.3.18.53
[29/06/19 16:29:11:793 CST] DubboShutdownHook  INFO multicast.MulticastRegistry:  [DUBBO] Destroy unsubscribe url consumer://10.3.18.53/org.apache.dubbo.demo.DemoService?application=dubbo-demo-api-consumer&category=providers,configurators,routers&dubbo=2.0.2&interface=org.apache.dubbo.demo.DemoService&lazy=false&methods=sayHello&pid=52461&side=consumer&sticky=false&timestamp=1561796950508, dubbo version: , current host: 10.3.18.53
Disconnected from the target VM, address: '127.0.0.1:58390', transport: 'socket'

Process finished with exit code 1

```
analysis provider, multiicastSocket get an unreachable ip address .

![](http://skblog.duiduiche.com/d9d468ef3a2643bc605e5b811d35a1de.jpg)

unreachable ip 

![](http://skblog.duiduiche.com/45a70e1003c501fae0ec47079abc3ef8.jpg)

NetUtils setInterface() methode doesn't check reacheable like getLocalAddress0() 

![](http://skblog.duiduiche.com/b1ae7387c421fc92a8f3361174cf98f3.jpg)

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a [GITHUB_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Run `mvn clean install -DskipTests=false` & `mvn clean test-compile failsafe:integration-test` to make sure unit-test and integration-test pass.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
