### PR TITLE
make metadata key contain : when version and group is empty

### DIFF
--- a/dubbo-metadata-report/dubbo-metadata-report-api/src/main/java/org/apache/dubbo/metadata/identifier/MetadataIdentifier.java
+++ b/dubbo-metadata-report/dubbo-metadata-report-api/src/main/java/org/apache/dubbo/metadata/identifier/MetadataIdentifier.java
@@ -67,7 +67,7 @@ public class MetadataIdentifier {
     }
 
     public String getIdentifierKey() {
-        return serviceInterface + SEPARATOR + (version == null ? "" : version + SEPARATOR) + (group == null ? "" : group + SEPARATOR) + side + SEPARATOR + application;
+        return serviceInterface + SEPARATOR + (version == null ? "" : version) + SEPARATOR + (group == null ? "" : group) + SEPARATOR + side + SEPARATOR + application;
     }
 
     private String getFilePathKey() {

--- a/dubbo-metadata-report/dubbo-metadata-report-api/src/test/java/org/apache/dubbo/metadata/identifier/MetadataIdentifierTest.java
+++ b/dubbo-metadata-report/dubbo-metadata-report-api/src/test/java/org/apache/dubbo/metadata/identifier/MetadataIdentifierTest.java
@@ -37,12 +37,12 @@ public class MetadataIdentifierTest {
         Assertions.assertEquals(providerMetadataIdentifier.getUniqueKey(MetadataIdentifier.KeyTypeEnum.PATH),
                 "metadata" + PATH_SEPARATOR + interfaceName + PATH_SEPARATOR +
                         (version == null ? "" : (version + PATH_SEPARATOR))
-                + (group == null ? "" : (group + PATH_SEPARATOR)) + PROVIDER_SIDE
+                        + (group == null ? "" : (group + PATH_SEPARATOR)) + PROVIDER_SIDE
                         + PATH_SEPARATOR + application);
         Assertions.assertEquals(providerMetadataIdentifier.getUniqueKey(MetadataIdentifier.KeyTypeEnum.UNIQUE_KEY),
                 interfaceName + MetadataIdentifier.SEPARATOR +
-                        (version == null ? "" : version + MetadataIdentifier.SEPARATOR)
-                        + (group == null ? "" : group + MetadataIdentifier.SEPARATOR)
+                        (version == null ? "" : version) + MetadataIdentifier.SEPARATOR
+                        + (group == null ? "" : group) + MetadataIdentifier.SEPARATOR
                         + PROVIDER_SIDE + MetadataIdentifier.SEPARATOR + application);
     }
 }


### PR DESCRIPTION
Make sure metadata key contain ":" when version and group is empty.