### PR TITLE
[Dubbo] Fixed IndexOutOfBoundsException in base642bytes(String, int, int, char[])

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/io/Bytes.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/io/Bytes.java
@@ -730,8 +730,12 @@ public class Bytes {
             char pc = code[64];
             if (str.charAt(off + len - 2) == pc) {
                 size -= 2;
+                --num;
+                rem = 2;
             } else if (str.charAt(off + len - 1) == pc) {
                 size--;
+                --num;
+                rem = 3;
             }
         } else {
             if (rem == 2) {

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/io/BytesTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/io/BytesTest.java
@@ -91,6 +91,14 @@ public class BytesTest {
     }
 
     @Test
+    public void testBase642bCharArrCall() {
+        byte[] stringCall = Bytes.base642bytes("ZHViYm8=", C64);
+        byte[] charArrCall = Bytes.base642bytes("ZHViYm8=", C64.toCharArray());
+
+        assertThat(stringCall, is(charArrCall));
+    }
+
+    @Test
     public void testHex() {
         String str = Bytes.bytes2hex(b1);
         assertThat(b1, is(Bytes.hex2bytes(str)));


### PR DESCRIPTION
## What is the purpose of the change

Fixes #4514

## Brief changelog

This change fixes `Bytes.base642bytes(String, int, int, char[])` by adjusting `num` and `rem` variables when required, similar to `Bytes.base642bytes(String, int, int, String)`.

## Verifying this change

A new test case was added in `BytesTest.java`

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a [GITHUB_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [x] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Run `mvn clean install -DskipTests=false` & `mvn clean test-compile failsafe:integration-test` to make sure unit-test and integration-test pass.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
