### PR TITLE
fix RpcContext compatible problem

### DIFF
--- a/dubbo-compatible/src/main/java/com/alibaba/dubbo/rpc/RpcContext.java
+++ b/dubbo-compatible/src/main/java/com/alibaba/dubbo/rpc/RpcContext.java
@@ -35,9 +35,7 @@ public class RpcContext extends org.apache.dubbo.rpc.RpcContext {
         RpcContext copy = new RpcContext();
         copy.getAttachments().putAll(rpcContext.getAttachments());
         copy.get().putAll(rpcContext.get());
-        if (rpcContext.getCompletableFuture() != null) {
-            copy.setFuture(rpcContext.getCompletableFuture());
-        }
+
         copy.setUrls(rpcContext.getUrls());
         copy.setUrl(rpcContext.getUrl());
         copy.setMethodName(rpcContext.getMethodName());


### PR DESCRIPTION
## What is the purpose of the change

Fix `Future<?> future = com.alibaba.xxx.RpcContext.getFuture(); ` can not get the right Future instance.
