### PR TITLE
fix: method name spelling error

### DIFF
--- a/dubbo-compatible/src/test/java/org/apache/dubbo/config/MethodConfigTest.java
+++ b/dubbo-compatible/src/test/java/org/apache/dubbo/config/MethodConfigTest.java
@@ -103,12 +103,12 @@ public class MethodConfigTest {
     }
 
     @Test
-    public void testConverMethodConfig2AsyncInfo() throws Exception{
+    public void testConvertMethodConfig2AsyncInfo() throws Exception{
         org.apache.dubbo.config.MethodConfig methodConfig = new org.apache.dubbo.config.MethodConfig();
         methodConfig.setOninvokeMethod("setName");
         methodConfig.setOninvoke(new Person());
 
-        ConsumerMethodModel.AsyncMethodInfo methodInfo = org.apache.dubbo.config.MethodConfig.convertMethodConfig2AyncInfo(methodConfig);
+        ConsumerMethodModel.AsyncMethodInfo methodInfo = org.apache.dubbo.config.MethodConfig.convertMethodConfig2AsyncInfo(methodConfig);
 
         assertTrue(methodInfo.getOninvokeMethod().equals( Person.class.getMethod("setName", String.class)));
     }

--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/AbstractConfig.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/AbstractConfig.java
@@ -245,7 +245,7 @@ public abstract class AbstractConfig implements Serializable {
         }
     }
 
-    protected static ConsumerMethodModel.AsyncMethodInfo convertMethodConfig2AyncInfo(MethodConfig methodConfig) {
+    protected static ConsumerMethodModel.AsyncMethodInfo convertMethodConfig2AsyncInfo(MethodConfig methodConfig) {
         if (methodConfig == null || (methodConfig.getOninvoke() == null && methodConfig.getOnreturn() == null && methodConfig.getOnthrow() == null)) {
             return null;
         }

--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/ReferenceConfig.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/ReferenceConfig.java
@@ -321,7 +321,7 @@ public class ReferenceConfig<T> extends AbstractReferenceConfig {
                         map.put(methodConfig.getName() + ".retries", "0");
                     }
                 }
-                ConsumerMethodModel.AsyncMethodInfo asyncMethodInfo = convertMethodConfig2AyncInfo(methodConfig);
+                ConsumerMethodModel.AsyncMethodInfo asyncMethodInfo = convertMethodConfig2AsyncInfo(methodConfig);
                 if (asyncMethodInfo != null) {
                     consumerModel.getMethodModel(methodConfig.getName()).addAttribute(Constants.ASYNC_KEY, asyncMethodInfo);
                 }


### PR DESCRIPTION
## What is the purpose of the change

fix convertMethodConfig2AyncInfo method name spelling error 

## Brief changelog

rename convertMethodConfig2AyncInfo
