### PR TITLE
fix #4635 provider throw RpcException custom retry not correct times

### DIFF
--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/support/FailoverClusterInvoker.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/support/FailoverClusterInvoker.java
@@ -92,7 +92,7 @@ public class FailoverClusterInvoker<T> extends AbstractClusterInvoker<T> {
                             + le.getMessage(), le);
                 }
 
-                if(result.getException() != null && result.getException() instanceof RpcException){
+                if(result != null && result.getException() != null && result.getException() instanceof RpcException){
                     throw result.getException();
                 }
 

--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/support/FailoverClusterInvoker.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/support/FailoverClusterInvoker.java
@@ -91,6 +91,11 @@ public class FailoverClusterInvoker<T> extends AbstractClusterInvoker<T> {
                             + " using the dubbo version " + Version.getVersion() + ". Last error is: "
                             + le.getMessage(), le);
                 }
+
+                if(result.getException() != null && result.getException() instanceof RpcException){
+                    throw result.getException();
+                }
+
                 return result;
             } catch (RpcException e) {
                 if (e.isBiz()) { // biz exception.

--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/support/FailoverClusterInvoker.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/support/FailoverClusterInvoker.java
@@ -92,7 +92,7 @@ public class FailoverClusterInvoker<T> extends AbstractClusterInvoker<T> {
                             + le.getMessage(), le);
                 }
 
-                if(result != null && result.getException() != null && result.getException() instanceof RpcException){
+                if (result != null && result.hasException() && result.getException() instanceof RpcException) {
                     throw result.getException();
                 }
 

--- a/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/support/FailoverRpcExceptionTest.java
+++ b/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/support/FailoverRpcExceptionTest.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.dubbo.rpc.cluster.support;
 
 import org.apache.dubbo.common.URL;

--- a/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/support/FailoverRpcExceptionTest.java
+++ b/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/support/FailoverRpcExceptionTest.java
@@ -29,11 +29,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 
-/**
- * @description:
- * @author: chengang6
- * @create: 2019/7/22 19:40
- **/
 public class FailoverRpcExceptionTest {
     private List<Invoker<FailoverClusterInvokerTest>> invokers = new ArrayList<Invoker<FailoverClusterInvokerTest>>();
     private int retries = 3;

--- a/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/support/FailoverRpcExceptionTest.java
+++ b/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/support/FailoverRpcExceptionTest.java
@@ -1,0 +1,64 @@
+package org.apache.dubbo.rpc.cluster.support;
+
+import org.apache.dubbo.common.URL;
+import org.apache.dubbo.rpc.*;
+import org.apache.dubbo.rpc.cluster.Directory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+/**
+ * @description:
+ * @author: chengang6
+ * @create: 2019/7/22 19:40
+ **/
+public class FailoverRpcExceptionTest {
+    private List<Invoker<FailoverClusterInvokerTest>> invokers = new ArrayList<Invoker<FailoverClusterInvokerTest>>();
+    private int retries = 3;
+    private URL url = URL.valueOf("test://test:11/test?retries=" + 3);
+    private Invoker<FailoverClusterInvokerTest> invoker1 = mock(Invoker.class);
+    private RpcInvocation invocation = new RpcInvocation();
+    private Directory<FailoverClusterInvokerTest> dic;
+    private Result result = new AppResponse();
+
+    /**
+     * @throws java.lang.Exception
+     */
+    @BeforeEach
+    public void setUp() throws Exception {
+
+        dic = mock(Directory.class);
+
+        given(dic.getUrl()).willReturn(url);
+        given(dic.list(invocation)).willReturn(invokers);
+        given(dic.getInterface()).willReturn(FailoverClusterInvokerTest.class);
+        invocation.setMethodName("method1");
+
+        invokers.add(invoker1);
+
+        result.setException(new RpcException("FailoverRpcExceptionTest|RpcException"));
+    }
+
+    @Test()
+    public void testInvokeWithRPCException() {
+        given(invoker1.invoke(invocation)).willReturn(result);
+        given(invoker1.isAvailable()).willReturn(true);
+        given(invoker1.getUrl()).willReturn(url);
+        given(invoker1.getInterface()).willReturn(FailoverClusterInvokerTest.class);
+        FailoverClusterInvoker<FailoverClusterInvokerTest> invoker = new FailoverClusterInvoker<FailoverClusterInvokerTest>(dic);
+
+        try {
+            Result ret = invoker.invoke(invocation);
+        } catch (RpcException expected) {
+            assertTrue((expected.isTimeout() || expected.getCode() == 0));
+            assertTrue(expected.getMessage().indexOf("Tried "+(retries + 1) + " times") > 0);
+        }
+    }
+
+}

--- a/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/support/FailoverRpcExceptionTest.java
+++ b/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/support/FailoverRpcExceptionTest.java
@@ -73,6 +73,7 @@ public class FailoverRpcExceptionTest {
             Result ret = invoker.invoke(invocation);
         } catch (RpcException expected) {
             assertTrue((expected.isTimeout() || expected.getCode() == 0));
+            //assert retries times
             assertTrue(expected.getMessage().indexOf("Tried "+(retries + 1) + " times") > 0);
         }
     }


### PR DESCRIPTION
## What is the purpose of the change

fix #4635  provider throw RpcException custom retry not correct times

## Brief changelog

FailoverClusterInvoker;
FailoverRpcExceptionTest;

## Verifying this change

org.apache.dubbo.rpc.cluster.support.FailoverRpcExceptionTest;

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a [GITHUB_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [x] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Run `mvn clean install -DskipTests=false` & `mvn clean test-compile failsafe:integration-test` to make sure unit-test and integration-test pass.
- [x] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
