### PR TITLE
protosubff : heartbeat data is null causes connect close

### DIFF
--- a/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/exchange/codec/ExchangeCodec.java
+++ b/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/exchange/codec/ExchangeCodec.java
@@ -152,8 +152,7 @@ public class ExchangeCodec extends TelnetCodec {
                 if (status == Response.OK) {
                     Object data;
                     if (res.isHeartbeat()) {
-                        // data = decodeHeartbeatData(channel, in);
-                        data = null;
+                        data = decodeHeartbeatData(channel, in);
                     } else if (res.isEvent()) {
                         data = decodeEventData(channel, in);
                     } else {
@@ -414,11 +413,7 @@ public class ExchangeCodec extends TelnetCodec {
 
     @Deprecated
     protected Object decodeHeartbeatData(Channel channel, ObjectInput in) throws IOException {
-        try {
-            return in.readObject();
-        } catch (ClassNotFoundException e) {
-            throw new IOException(StringUtils.toString("Read object failed.", e));
-        }
+        return Response.HEARTBEAT_EVENT;
     }
 
     protected Object decodeRequestData(Channel channel, ObjectInput in) throws IOException {

--- a/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/exchange/codec/ExchangeCodec.java
+++ b/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/exchange/codec/ExchangeCodec.java
@@ -152,7 +152,8 @@ public class ExchangeCodec extends TelnetCodec {
                 if (status == Response.OK) {
                     Object data;
                     if (res.isHeartbeat()) {
-                        data = decodeHeartbeatData(channel, in);
+                        // data = decodeHeartbeatData(channel, in);
+                        data = null;
                     } else if (res.isEvent()) {
                         data = decodeEventData(channel, in);
                     } else {
@@ -378,7 +379,11 @@ public class ExchangeCodec extends TelnetCodec {
     }
 
     private void encodeEventData(ObjectOutput out, Object data) throws IOException {
-        out.writeObject(data);
+        if(data != null) {
+            out.writeObject(data);
+        }else{
+            logger.warn("encodeEventData  data is null");
+        }
     }
 
     @Deprecated

--- a/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/exchange/codec/ExchangeCodec.java
+++ b/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/exchange/codec/ExchangeCodec.java
@@ -378,11 +378,7 @@ public class ExchangeCodec extends TelnetCodec {
     }
 
     private void encodeEventData(ObjectOutput out, Object data) throws IOException {
-        if(data != null) {
-            out.writeObject(data);
-        }else{
-            logger.warn("encodeEventData  data is null");
-        }
+        out.writeObject(data);
     }
 
     @Deprecated


### PR DESCRIPTION
## What is the purpose of the change

repair protosubff heartbeat data is null causes connect close

## Brief changelog

```java
ExchangeCodec. decodeBody
     -->if (res.isHeartbeat()) {
                        // data = decodeHeartbeatData(channel, in);
                        data = null;
                    }
ExchangeCodec.encodeEventData(ObjectOutput out, Object data)
if(data != null) {
            out.writeObject(data);
        }else{
            logger.warn("encodeEventData  data is null");
        }
```

## Verifying this change

Dubbo version: 2.7.1
Operating System version: mac
Java version: 1.8


