### PR TITLE
optimize some code styles

### DIFF
--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/support/wrapper/MockClusterInvoker.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/support/wrapper/MockClusterInvoker.java
@@ -73,7 +73,7 @@ public class MockClusterInvoker<T> implements Invoker<T> {
         Result result = null;
 
         String value = directory.getUrl().getMethodParameter(invocation.getMethodName(), MOCK_KEY, Boolean.FALSE.toString()).trim();
-        if (value.length() == 0 || value.equalsIgnoreCase("false")) {
+        if (value.length() == 0 || "false".equalsIgnoreCase(value)) {
             //no mock
             result = this.invoker.invoke(invocation);
         } else if (value.startsWith("force")) {

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/compiler/support/JdkCompiler.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/compiler/support/JdkCompiler.java
@@ -73,7 +73,7 @@ public class JdkCompiler extends AbstractCompiler {
         StandardJavaFileManager manager = compiler.getStandardFileManager(diagnosticCollector, null, null);
         final ClassLoader loader = Thread.currentThread().getContextClassLoader();
         if (loader instanceof URLClassLoader
-                && (!loader.getClass().getName().equals("sun.misc.Launcher$AppClassLoader"))) {
+                && (!"sun.misc.Launcher$AppClassLoader".equals(loader.getClass().getName()))) {
             try {
                 URLClassLoader urlClassLoader = (URLClassLoader) loader;
                 List<File> files = new ArrayList<File>();

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/utils/NetUtils.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/utils/NetUtils.java
@@ -422,7 +422,7 @@ public class NetUtils {
             throw new IllegalArgumentException("Illegal Argument pattern or hostName. Pattern:" + pattern + ", Host:" + host);
         }
         pattern = pattern.trim();
-        if (pattern.equals("*.*.*.*") || pattern.equals("*")) {
+        if ("*.*.*.*".equals(pattern) || "*".equals(pattern)) {
             return true;
         }
 
@@ -458,7 +458,7 @@ public class NetUtils {
             }
         }
         for (int i = 0; i < mask.length; i++) {
-            if (mask[i].equals("*") || mask[i].equals(ipAddress[i])) {
+            if ("*".equals(mask[i]) || mask[i].equals(ipAddress[i])) {
                 continue;
             } else if (mask[i].contains("-")) {
                 String[] rangeNumStrs = mask[i].split("-");

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/utils/PojoUtils.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/utils/PojoUtils.java
@@ -561,10 +561,10 @@ public class PojoUtils {
      * @return
      */
     private static Object getDefaultValue(Class<?> parameterType) {
-        if (parameterType.getName().equals("char")) {
+        if ("char".equals(parameterType.getName())) {
             return Character.MIN_VALUE;
         }
-        if (parameterType.getName().equals("bool")) {
+        if ("bool".equals(parameterType.getName())) {
             return false;
         }
         return parameterType.isPrimitive() ? 0 : null;

--- a/dubbo-compatible/src/main/java/com/alibaba/dubbo/rpc/protocol/dubbo/FutureAdapter.java
+++ b/dubbo-compatible/src/main/java/com/alibaba/dubbo/rpc/protocol/dubbo/FutureAdapter.java
@@ -17,13 +17,13 @@
 
 package com.alibaba.dubbo.rpc.protocol.dubbo;
 
-import org.apache.dubbo.rpc.AppResponse;
-import org.apache.dubbo.rpc.Result;
-
 import com.alibaba.dubbo.remoting.RemotingException;
 import com.alibaba.dubbo.remoting.exchange.ResponseCallback;
 import com.alibaba.dubbo.remoting.exchange.ResponseFuture;
 import com.alibaba.dubbo.rpc.RpcException;
+
+import org.apache.dubbo.rpc.AppResponse;
+import org.apache.dubbo.rpc.Result;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
@@ -106,18 +106,22 @@ public class FutureAdapter<V> implements Future<V> {
         future.whenComplete(biConsumer);
     }
 
+    @Override
     public boolean cancel(boolean mayInterruptIfRunning) {
         return false;
     }
 
+    @Override
     public boolean isCancelled() {
         return false;
     }
 
+    @Override
     public boolean isDone() {
         return future.isDone();
     }
 
+    @Override
     @SuppressWarnings("unchecked")
     public V get() throws InterruptedException, ExecutionException {
         try {
@@ -129,6 +133,7 @@ public class FutureAdapter<V> implements Future<V> {
         }
     }
 
+    @Override
     @SuppressWarnings("unchecked")
     public V get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
         try {

--- a/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/SimpleRegistryExporter.java
+++ b/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/SimpleRegistryExporter.java
@@ -39,7 +39,7 @@ public class SimpleRegistryExporter {
 
     private static final Protocol protocol = ExtensionLoader.getExtensionLoader(Protocol.class).getAdaptiveExtension();
 
-    private static final ProxyFactory proxyFactory = ExtensionLoader.getExtensionLoader(ProxyFactory.class).getAdaptiveExtension();
+    private static final ProxyFactory PROXY_FACTORY = ExtensionLoader.getExtensionLoader(ProxyFactory.class).getAdaptiveExtension();
 
     public synchronized static Exporter<RegistryService> exportIfAbsent(int port) {
         try {
@@ -55,7 +55,7 @@ public class SimpleRegistryExporter {
     }
 
     public static Exporter<RegistryService> export(int port, RegistryService registryService) {
-        return protocol.export(proxyFactory.getInvoker(registryService, RegistryService.class,
+        return protocol.export(PROXY_FACTORY.getInvoker(registryService, RegistryService.class,
                 new URLBuilder(DUBBO_PROTOCOL, NetUtils.getLocalHost(), port, RegistryService.class.getName())
                         .setPath(RegistryService.class.getName())
                         .addParameter(INTERFACE_KEY, RegistryService.class.getName())

--- a/dubbo-metadata-report/dubbo-metadata-definition-protobuf/src/main/java/org/apache/dubbo/metadata/definition/protobuf/ProtobufTypeBuilder.java
+++ b/dubbo-metadata-report/dubbo-metadata-definition-protobuf/src/main/java/org/apache/dubbo/metadata/definition/protobuf/ProtobufTypeBuilder.java
@@ -227,9 +227,9 @@ public class ProtobufTypeBuilder implements TypeBuilder {
         // 1. - setUnknownFields( com.google.protobuf.UnknownFieldSet unknownFields)
         // 2. - setField(com.google.protobuf.Descriptors.FieldDescriptor field,java.lang.Object value)
         // 3. - setRepeatedField(com.google.protobuf.Descriptors.FieldDescriptor field,int index,java.lang.Object value）
-        if (methodName.equals("setField") && types[0].equals(Descriptors.FieldDescriptor.class)
-                || methodName.equals("setUnknownFields") && types[0].equals(UnknownFieldSet.class)
-                || methodName.equals("setRepeatedField") && types[0].equals(Descriptors.FieldDescriptor.class)) {
+        if ("setField".equals(methodName) && types[0].equals(Descriptors.FieldDescriptor.class)
+                || "setUnknownFields".equals(methodName) && types[0].equals(UnknownFieldSet.class)
+                || "setRepeatedField".equals(methodName) && types[0].equals(Descriptors.FieldDescriptor.class)) {
             return false;
         }
 

--- a/dubbo-registry/dubbo-registry-default/src/test/java/org/apache/dubbo/registry/dubbo/SimpleRegistryExporter.java
+++ b/dubbo-registry/dubbo-registry-default/src/test/java/org/apache/dubbo/registry/dubbo/SimpleRegistryExporter.java
@@ -40,7 +40,7 @@ public class SimpleRegistryExporter {
 
     private static final Protocol protocol = ExtensionLoader.getExtensionLoader(Protocol.class).getAdaptiveExtension();
 
-    private static final ProxyFactory proxyFactory = ExtensionLoader.getExtensionLoader(ProxyFactory.class).getAdaptiveExtension();
+    private static final ProxyFactory PROXY_FACTORY = ExtensionLoader.getExtensionLoader(ProxyFactory.class).getAdaptiveExtension();
 
     public synchronized static Exporter<RegistryService> exportIfAbsent(int port) {
         try {
@@ -56,7 +56,7 @@ public class SimpleRegistryExporter {
     }
 
     public static Exporter<RegistryService> export(int port, RegistryService registryService) {
-        return protocol.export(proxyFactory.getInvoker(registryService, RegistryService.class,
+        return protocol.export(PROXY_FACTORY.getInvoker(registryService, RegistryService.class,
                 new URLBuilder(DUBBO_PROTOCOL, NetUtils.getLocalHost(), port, RegistryService.class.getName())
                         .setPath(RegistryService.class.getName())
                         .addParameter(INTERFACE_KEY, RegistryService.class.getName())

--- a/dubbo-registry/dubbo-registry-nacos/src/main/java/org/apache/dubbo/registry/nacos/NacosServiceName.java
+++ b/dubbo-registry/dubbo-registry-nacos/src/main/java/org/apache/dubbo/registry/nacos/NacosServiceName.java
@@ -222,8 +222,12 @@ public class NacosServiceName {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof NacosServiceName)) return false;
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof NacosServiceName)) {
+            return false;
+        }
         NacosServiceName that = (NacosServiceName) o;
         return Objects.equals(getValue(), that.getValue());
     }
@@ -233,6 +237,7 @@ public class NacosServiceName {
         return Objects.hash(getValue());
     }
 
+    @Override
     public String toString() {
         return getValue();
     }

--- a/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/telnet/support/command/StatusTelnetHandler.java
+++ b/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/telnet/support/command/StatusTelnetHandler.java
@@ -45,7 +45,7 @@ public class StatusTelnetHandler implements TelnetHandler {
 
     @Override
     public String telnet(Channel channel, String message) {
-        if (message.equals("-l")) {
+        if ("-l".equals(message)) {
             List<StatusChecker> checkers = extensionLoader.getActivateExtension(channel.getUrl(), "status");
             String[] header = new String[]{"resource", "status", "message"};
             List<List<String>> table = new ArrayList<List<String>>();

--- a/dubbo-rpc/dubbo-rpc-dubbo/src/main/java/org/apache/dubbo/rpc/protocol/dubbo/CallbackServiceCodec.java
+++ b/dubbo-rpc/dubbo-rpc-dubbo/src/main/java/org/apache/dubbo/rpc/protocol/dubbo/CallbackServiceCodec.java
@@ -68,9 +68,9 @@ class CallbackServiceCodec {
         if (url != null) {
             String callback = url.getParameter(methodName + "." + argIndex + ".callback");
             if (callback != null) {
-                if (callback.equalsIgnoreCase("true")) {
+                if ("true".equalsIgnoreCase(callback)) {
                     isCallback = CALLBACK_CREATE;
-                } else if (callback.equalsIgnoreCase("false")) {
+                } else if ("false".equalsIgnoreCase(callback)) {
                     isCallback = CALLBACK_DESTROY;
                 }
             }

--- a/dubbo-rpc/dubbo-rpc-dubbo/src/main/java/org/apache/dubbo/rpc/protocol/dubbo/telnet/ChangeTelnetHandler.java
+++ b/dubbo-rpc/dubbo-rpc-dubbo/src/main/java/org/apache/dubbo/rpc/protocol/dubbo/telnet/ChangeTelnetHandler.java
@@ -38,7 +38,7 @@ public class ChangeTelnetHandler implements TelnetHandler {
             return "Please input service name, eg: \r\ncd XxxService\r\ncd com.xxx.XxxService";
         }
         StringBuilder buf = new StringBuilder();
-        if (message.equals("/") || message.equals("..")) {
+        if ("/".equals(message) || "..".equals(message)) {
             String service = (String) channel.getAttribute(SERVICE_KEY);
             channel.removeAttribute(SERVICE_KEY);
             buf.append("Cancelled default service " + service + ".");

--- a/dubbo-rpc/dubbo-rpc-dubbo/src/main/java/org/apache/dubbo/rpc/protocol/dubbo/telnet/ShutdownTelnetHandler.java
+++ b/dubbo-rpc/dubbo-rpc-dubbo/src/main/java/org/apache/dubbo/rpc/protocol/dubbo/telnet/ShutdownTelnetHandler.java
@@ -36,7 +36,7 @@ public class ShutdownTelnetHandler implements TelnetHandler {
         int sleepMilliseconds = 0;
         if (StringUtils.isNotEmpty(message)) {
             String[] parameters = message.split("\\s+");
-            if (parameters.length == 2 && parameters[0].equals("-t") && StringUtils.isInteger(parameters[1])) {
+            if (parameters.length == 2 && "-t".equals(parameters[0]) && StringUtils.isInteger(parameters[1])) {
                 sleepMilliseconds = Integer.parseInt(parameters[1]);
             } else {
                 return "Invalid parameter,please input like shutdown -t 10000";

--- a/dubbo-rpc/dubbo-rpc-hessian/src/main/java/org/apache/dubbo/rpc/protocol/hessian/HessianProtocol.java
+++ b/dubbo-rpc/dubbo-rpc-hessian/src/main/java/org/apache/dubbo/rpc/protocol/hessian/HessianProtocol.java
@@ -176,7 +176,7 @@ public class HessianProtocol extends AbstractProxyProtocol {
                 throws IOException, ServletException {
             String uri = request.getRequestURI();
             HessianSkeleton skeleton = skeletonMap.get(uri);
-            if (!request.getMethod().equalsIgnoreCase("POST")) {
+            if (!"POST".equalsIgnoreCase(request.getMethod())) {
                 response.setStatus(500);
             } else {
                 RpcContext.getContext().setRemoteAddress(request.getRemoteAddr(), request.getRemotePort());

--- a/dubbo-rpc/dubbo-rpc-http/src/main/java/org/apache/dubbo/rpc/protocol/http/HttpProtocol.java
+++ b/dubbo-rpc/dubbo-rpc-http/src/main/java/org/apache/dubbo/rpc/protocol/http/HttpProtocol.java
@@ -208,7 +208,7 @@ public class HttpProtocol extends AbstractProxyProtocol {
                 throws IOException, ServletException {
             String uri = request.getRequestURI();
             HttpInvokerServiceExporter skeleton = skeletonMap.get(uri);
-            if (!request.getMethod().equalsIgnoreCase("POST")) {
+            if (!"POST".equalsIgnoreCase(request.getMethod())) {
                 response.setStatus(500);
             } else {
                 RpcContext.getContext().setRemoteAddress(request.getRemoteAddr(), request.getRemotePort());

--- a/dubbo-rpc/dubbo-rpc-jsonrpc/src/main/java/org/apache/dubbo/rpc/protocol/jsonrpc/JsonRpcProtocol.java
+++ b/dubbo-rpc/dubbo-rpc-jsonrpc/src/main/java/org/apache/dubbo/rpc/protocol/jsonrpc/JsonRpcProtocol.java
@@ -82,9 +82,9 @@ public class JsonRpcProtocol extends AbstractProxyProtocol {
                 response.setHeader(ACCESS_CONTROL_ALLOW_METHODS_HEADER, "POST");
                 response.setHeader(ACCESS_CONTROL_ALLOW_HEADERS_HEADER, "*");
             }
-            if (request.getMethod().equalsIgnoreCase("OPTIONS")) {
+            if ("OPTIONS".equalsIgnoreCase(request.getMethod())) {
                 response.setStatus(200);
-            } else if (request.getMethod().equalsIgnoreCase("POST")) {
+            } else if ("POST".equalsIgnoreCase(request.getMethod())) {
 
                 RpcContext.getContext().setRemoteAddress(request.getRemoteAddr(), request.getRemotePort());
                 try {

--- a/dubbo-rpc/dubbo-rpc-xml/src/main/java/org/apache/dubbo/xml/rpc/protocol/xmlrpc/XmlRpcProtocol.java
+++ b/dubbo-rpc/dubbo-rpc-xml/src/main/java/org/apache/dubbo/xml/rpc/protocol/xmlrpc/XmlRpcProtocol.java
@@ -84,9 +84,9 @@ public class XmlRpcProtocol extends AbstractProxyProtocol {
                 response.setHeader(ACCESS_CONTROL_ALLOW_METHODS_HEADER, "POST");
                 response.setHeader(ACCESS_CONTROL_ALLOW_HEADERS_HEADER, "*");
             }
-            if (request.getMethod().equalsIgnoreCase("OPTIONS")) {
+            if ("OPTIONS".equalsIgnoreCase(request.getMethod())) {
                 response.setStatus(200);
-            } else if (request.getMethod().equalsIgnoreCase("POST")) {
+            } else if ("POST".equalsIgnoreCase(request.getMethod())) {
 
                 RpcContext.getContext().setRemoteAddress(request.getRemoteAddr(), request.getRemotePort());
                 try {

--- a/dubbo-rpc/dubbo-rpc-xml/src/main/java/org/apache/dubbo/xml/rpc/protocol/xmlrpc/XmlRpcProxyFactoryBean.java
+++ b/dubbo-rpc/dubbo-rpc-xml/src/main/java/org/apache/dubbo/xml/rpc/protocol/xmlrpc/XmlRpcProxyFactoryBean.java
@@ -80,7 +80,7 @@ public class XmlRpcProxyFactoryBean extends UrlBasedRemoteAccessor
 
         // handle toString()
         Method method = invocation.getMethod();
-        if (method.getDeclaringClass() == Object.class && method.getName().equals("toString")) {
+        if (method.getDeclaringClass() == Object.class && "toString".equals(method.getName())) {
             return proxyObject.getClass().getName() + "@" + System.identityHashCode(proxyObject);
         }
 

--- a/dubbo-serialization/dubbo-serialization-protobuf-json/src/main/java/org/apache/dubbo/common/serialize/protobuf/support/MapValue.java
+++ b/dubbo-serialization/dubbo-serialization-protobuf-json/src/main/java/org/apache/dubbo/common/serialize/protobuf/support/MapValue.java
@@ -187,6 +187,7 @@ public final class MapValue {
       return attachments_;
     }
 
+    @Override
     public int getAttachmentsCount() {
       return internalGetAttachments().getMap().size();
     }
@@ -194,6 +195,7 @@ public final class MapValue {
      * <code>map&lt;string, string&gt; attachments = 1;</code>
      */
 
+    @Override
     public boolean containsAttachments(
         String key) {
       if (key == null) { throw new NullPointerException(); }
@@ -202,6 +204,7 @@ public final class MapValue {
     /**
      * Use {@link #getAttachmentsMap()} instead.
      */
+    @Override
     @Deprecated
     public java.util.Map<String, String> getAttachments() {
       return getAttachmentsMap();
@@ -210,6 +213,7 @@ public final class MapValue {
      * <code>map&lt;string, string&gt; attachments = 1;</code>
      */
 
+    @Override
     public java.util.Map<String, String> getAttachmentsMap() {
       return internalGetAttachments().getMap();
     }
@@ -217,6 +221,7 @@ public final class MapValue {
      * <code>map&lt;string, string&gt; attachments = 1;</code>
      */
 
+    @Override
     public String getAttachmentsOrDefault(
         String key,
         String defaultValue) {
@@ -229,6 +234,7 @@ public final class MapValue {
      * <code>map&lt;string, string&gt; attachments = 1;</code>
      */
 
+    @Override
     public String getAttachmentsOrThrow(
         String key) {
       if (key == null) { throw new NullPointerException(); }
@@ -244,8 +250,12 @@ public final class MapValue {
     @Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
-      if (isInitialized == 1) return true;
-      if (isInitialized == 0) return false;
+      if (isInitialized == 1) {
+          return true;
+      }
+      if (isInitialized == 0) {
+          return false;
+      }
 
       memoizedIsInitialized = 1;
       return true;
@@ -266,7 +276,9 @@ public final class MapValue {
     @Override
     public int getSerializedSize() {
       int size = memoizedSize;
-      if (size != -1) return size;
+      if (size != -1) {
+          return size;
+      }
 
       size = 0;
       for (java.util.Map.Entry<String, String> entry
@@ -419,6 +431,7 @@ public final class MapValue {
         return MapValue.internal_static_Map_descriptor;
       }
 
+      @Override
       @SuppressWarnings({"rawtypes"})
       protected com.google.protobuf.MapField internalGetMapField(
           int number) {
@@ -430,6 +443,7 @@ public final class MapValue {
                 "Invalid map field number: " + number);
         }
       }
+      @Override
       @SuppressWarnings({"rawtypes"})
       protected com.google.protobuf.MapField internalGetMutableMapField(
           int number) {
@@ -544,7 +558,9 @@ public final class MapValue {
       }
 
       public Builder mergeFrom(Map other) {
-        if (other == Map.getDefaultInstance()) return this;
+        if (other == Map.getDefaultInstance()) {
+            return this;
+        }
         internalGetMutableAttachments().mergeFrom(
             other.internalGetAttachments());
         this.mergeUnknownFields(other.unknownFields);
@@ -600,6 +616,7 @@ public final class MapValue {
         return attachments_;
       }
 
+      @Override
       public int getAttachmentsCount() {
         return internalGetAttachments().getMap().size();
       }
@@ -607,6 +624,7 @@ public final class MapValue {
        * <code>map&lt;string, string&gt; attachments = 1;</code>
        */
 
+      @Override
       public boolean containsAttachments(
           String key) {
         if (key == null) { throw new NullPointerException(); }
@@ -615,6 +633,7 @@ public final class MapValue {
       /**
        * Use {@link #getAttachmentsMap()} instead.
        */
+      @Override
       @Deprecated
       public java.util.Map<String, String> getAttachments() {
         return getAttachmentsMap();
@@ -623,6 +642,7 @@ public final class MapValue {
        * <code>map&lt;string, string&gt; attachments = 1;</code>
        */
 
+      @Override
       public java.util.Map<String, String> getAttachmentsMap() {
         return internalGetAttachments().getMap();
       }
@@ -630,6 +650,7 @@ public final class MapValue {
        * <code>map&lt;string, string&gt; attachments = 1;</code>
        */
 
+      @Override
       public String getAttachmentsOrDefault(
           String key,
           String defaultValue) {
@@ -642,6 +663,7 @@ public final class MapValue {
        * <code>map&lt;string, string&gt; attachments = 1;</code>
        */
 
+      @Override
       public String getAttachmentsOrThrow(
           String key) {
         if (key == null) { throw new NullPointerException(); }
@@ -779,6 +801,7 @@ public final class MapValue {
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
         new com.google.protobuf.Descriptors.FileDescriptor.    InternalDescriptorAssigner() {
+          @Override
           public com.google.protobuf.ExtensionRegistry assignDescriptors(
               com.google.protobuf.Descriptors.FileDescriptor root) {
             descriptor = root;


### PR DESCRIPTION
optimize some code styles
1.Object 的 equals 方法容易抛出空指针异常，方法的调用方需使用确定值的对象（或常量）来调用 equals 方法
2.所有的覆写方法，必须加@Override 注解

