### PR TITLE
 #4470 fix referenceAnnotation config not work when a dubbo service wa…

### DIFF
--- a/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/beans/factory/annotation/ReferenceAnnotationBeanPostProcessor.java
+++ b/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/beans/factory/annotation/ReferenceAnnotationBeanPostProcessor.java
@@ -123,7 +123,7 @@ public class ReferenceAnnotationBeanPostProcessor extends AnnotationInjectedBean
     protected Object doGetInjectedBean(AnnotationAttributes attributes, Object bean, String beanName, Class<?> injectedType,
                                        InjectionMetadata.InjectedElement injectedElement) throws Exception {
 
-        String referencedBeanName = buildReferencedBeanName(attributes, injectedType);
+        String referencedBeanName = buildInjectedObjectCacheKey(attributes, bean, beanName, injectedType, injectedElement);
 
         ReferenceBean referenceBean = buildReferenceBeanIfAbsent(referencedBeanName, attributes, injectedType);
 


### PR DESCRIPTION

## What is the purpose of the change

#4470 fix referenceAnnotation config not work when a dubbo service was referenced multi times

@mercyblitz have tried to fix this issue at 2.6.6 but not work. and I found the `referencedBeanName` was not really changed.

