### PR TITLE
[Dubbo-4694] Fix consumer can't return quickly, when the provider interrupts abnormally #4694

### DIFF
--- a/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/exchange/support/header/HeaderExchangeChannel.java
+++ b/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/exchange/support/header/HeaderExchangeChannel.java
@@ -131,6 +131,8 @@ final class HeaderExchangeChannel implements ExchangeChannel {
     @Override
     public void close() {
         try {
+            // graceful close
+            DefaultFuture.closeChannel(channel);
             channel.close();
         } catch (Throwable e) {
             logger.warn(e.getMessage(), e);


### PR DESCRIPTION
## What is the purpose of the change

1. run provider
2. debug consumer
3. let the provider offline in registry center
4. in consumer, just org.apache.dubbo.remoting.exchange.support.header.HeaderExchangeChannel#close() get called

fix #4694 

## Brief changelog

consumer return quickly, when the provider interrupts abnormally

## Verifying this change


Follow this checklist to help us incorporate your contribution quickly and easily:

- [√] Make sure there is a [GITHUB_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [√] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Run `mvn clean install -DskipTests=false` & `mvn clean test-compile failsafe:integration-test` to make sure unit-test and integration-test pass.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).