### PR TITLE
Fix name type for FailedNotifiedTask

### DIFF
--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/retry/FailedNotifiedTask.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/retry/FailedNotifiedTask.java
@@ -31,7 +31,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
  */
 public final class FailedNotifiedTask extends AbstractRetryTask {
 
-    private static final String NAME = "retry subscribe";
+    private static final String NAME = "retry notify";
 
     private final NotifyListener listener;
 


### PR DESCRIPTION
## What is the purpose of the change

- Fix name of FailedNotifiedTask, The purpose is to repair the log like:
`Final failed to execute task  retry subscribe...` to `Final failed to execute task  retry notify...` while the FailedNotifiedTask run at https://github.com/apache/dubbo/blob/1173b400949ceccc76182f7df9b39d35290d9148/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/retry/AbstractRetryTask.java#L109-L130.
## Brief changelog

Fix name of FailedNotifiedTask

## Verifying this change

unnecessary

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a [GITHUB_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [x] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Run `mvn clean install -DskipTests=false` & `mvn clean test-compile failsafe:integration-test` to make sure unit-test and integration-test pass.
- [x] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
