### PR TITLE
Remove unnecessary extend.

### DIFF
--- a/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/Client.java
+++ b/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/Client.java
@@ -25,7 +25,7 @@ import org.apache.dubbo.common.Resetable;
  *
  * @see org.apache.dubbo.remoting.Transporter#connect(org.apache.dubbo.common.URL, ChannelHandler)
  */
-public interface Client extends Endpoint, Channel, Resetable, IdleSensible {
+public interface Client extends Channel, Resetable, IdleSensible {
 
     /**
      * reconnect.


### PR DESCRIPTION
## What is the purpose of the change
Remove Endpoint from Client, because Client extend Channel which extend Endpoint. so i think we can remove it.