### PR TITLE
throw exception when data bind from properties file encounter error

### DIFF
--- a/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/context/properties/DefaultDubboConfigBinder.java
+++ b/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/context/properties/DefaultDubboConfigBinder.java
@@ -19,9 +19,13 @@ package org.apache.dubbo.config.spring.context.properties;
 import org.apache.dubbo.config.AbstractConfig;
 
 import org.springframework.beans.MutablePropertyValues;
+import org.springframework.validation.BindingResult;
 import org.springframework.validation.DataBinder;
+import org.springframework.validation.FieldError;
 
+import java.util.List;
 import java.util.Map;
+import java.util.stream.IntStream;
 
 import static org.apache.dubbo.config.spring.util.PropertySourcesUtils.getSubProperties;
 
@@ -42,7 +46,25 @@ public class DefaultDubboConfigBinder extends AbstractDubboConfigBinder {
         MutablePropertyValues propertyValues = new MutablePropertyValues(properties);
         // Bind
         dataBinder.bind(propertyValues);
+        BindingResult bindingResult = dataBinder.getBindingResult();
+        if (bindingResult.hasGlobalErrors()) {
+            throw new RuntimeException("Data bind global error, please check config. config: " + bindingResult.getGlobalError() + "");
+        }
+        if (bindingResult.hasFieldErrors()) {
+            throw new RuntimeException(buildErrorMsg(bindingResult.getFieldErrors(), prefix, dubboConfig.getClass().getSimpleName()));
+        }
     }
 
+    private String buildErrorMsg(List<FieldError> errors, String prefix, String config) {
+        StringBuilder builder = new StringBuilder("Data bind error, please check config. config: " + config + ", prefix: " + prefix
+                + " , error fields: [" + errors.get(0).getField());
+        if (errors.size() > 1) {
+            IntStream.range(1, errors.size()).forEach(i -> {
+                builder.append(", " + errors.get(i).getField());
+            });
+        }
+        builder.append("]");
+        return builder.toString();
+    }
 }
 


### PR DESCRIPTION
## What is the purpose of the change

When there are errors in properties file and data bind encounter error, dubbo now will not throw exception but ignore the errors.
The errors should be thrown to users.

## Brief changelog

DefaultDubboConfigBinder.java

## Verifying this change

XXXXX

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a [GITHUB_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Run `mvn clean install -DskipTests=false` & `mvn clean test-compile failsafe:integration-test` to make sure unit-test and integration-test pass.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
