### PR TITLE
I think it is better to remove the key ,when the corresponding listeners is empty in AbstractEventDispatcher.java

### DIFF
--- a/dubbo-event/src/main/java/org/apache/dubbo/event/AbstractEventDispatcher.java
+++ b/dubbo-event/src/main/java/org/apache/dubbo/event/AbstractEventDispatcher.java
@@ -134,7 +134,7 @@ public abstract class AbstractEventDispatcher implements EventDispatcher {
                 List<EventListener> listeners = listenersCache.computeIfAbsent(eventType, e -> new LinkedList<>());
                 // consume
                 consumer.accept(listeners);
-                if (CollectionUtils.isEmpty(listeners)) {
+                if (listeners.size() == 0) {
                     listenersCache.remove(eventType);
                 } else {// sort
                     sort(listeners);

--- a/dubbo-event/src/main/java/org/apache/dubbo/event/AbstractEventDispatcher.java
+++ b/dubbo-event/src/main/java/org/apache/dubbo/event/AbstractEventDispatcher.java
@@ -134,8 +134,11 @@ public abstract class AbstractEventDispatcher implements EventDispatcher {
                 List<EventListener> listeners = listenersCache.computeIfAbsent(eventType, e -> new LinkedList<>());
                 // consume
                 consumer.accept(listeners);
-                // sort
-                sort(listeners);
+                if (CollectionUtils.isEmpty(listeners)) {
+                    listenersCache.remove(eventType);
+                } else {// sort
+                    sort(listeners);
+                }
             }
         }
     }


### PR DESCRIPTION
rt