### PR TITLE
[Dubbo-4760]config center timeout key convert to zk transporter timeout key

### DIFF
--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/AbstractInterfaceConfig.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/AbstractInterfaceConfig.java
@@ -50,6 +50,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 import static org.apache.dubbo.common.config.ConfigurationUtils.parseProperties;
@@ -624,6 +625,7 @@ public abstract class AbstractInterfaceConfig extends AbstractMethodConfig {
                 cc.setProtocol(rc.getProtocol());
                 cc.setAddress(rc.getAddress());
                 cc.setHighestPriority(false);
+                Optional.ofNullable(rc.getTimeout()).ifPresent(timeout -> cc.setTimeout(Long.valueOf(timeout)));
                 setConfigCenter(cc);
                 startConfigCenter();
                 return null;

--- a/dubbo-configcenter/dubbo-configcenter-api/src/main/java/org/apache/dubbo/configcenter/Constants.java
+++ b/dubbo-configcenter/dubbo-configcenter-api/src/main/java/org/apache/dubbo/configcenter/Constants.java
@@ -21,4 +21,5 @@ public interface Constants {
     String CONFIG_NAMESPACE_KEY = "config.namespace";
     String CONFIG_GROUP_KEY = "config.group";
     String CONFIG_CHECK_KEY = "config.check";
+    String CONFIG_TIMEOUT_KEY = "config.timeout";
 }


### PR DESCRIPTION
## What is the purpose of the change

1.Set the timeout of ConfigCenterConfig according to Zookeeper Registry when no config-center set
2.Convert the timeout key of ConfigCenterConfig "config.timeout" to "timeout" before connect Zookeeper registry

## Brief changelog
fix #4760
1.AbstractInterfaceConfig.java
2.ZookeeperDynamicConfiguration.java

## Verifying this change

XXXXX

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a [GITHUB_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Run `mvn clean install -DskipTests=false` & `mvn clean test-compile failsafe:integration-test` to make sure unit-test and integration-test pass.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
