### PR TITLE
Properties configuration should not query value from system properties

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/config/PropertiesConfiguration.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/config/PropertiesConfiguration.java
@@ -18,7 +18,12 @@ package org.apache.dubbo.common.config;
 
 import org.apache.dubbo.common.logger.Logger;
 import org.apache.dubbo.common.logger.LoggerFactory;
-import org.apache.dubbo.common.utils.ConfigUtils;
+
+import java.util.Map;
+import java.util.Properties;
+
+import static org.apache.dubbo.common.utils.ConfigUtils.getProperties;
+import static org.apache.dubbo.common.utils.ConfigUtils.replaceProperty;
 
 /**
  * Configuration from system properties and dubbo.properties
@@ -36,6 +41,7 @@ public class PropertiesConfiguration extends AbstractPrefixConfiguration {
 
     @Override
     public Object getInternalProperty(String key) {
-        return ConfigUtils.getProperty(key);
+        Properties properties = getProperties();
+        return replaceProperty(properties.getProperty(key, null), (Map) properties);
     }
 }

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/config/PropertiesConfigurationTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/config/PropertiesConfigurationTest.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.common.config;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+public class PropertiesConfigurationTest {
+    private static PropertiesConfiguration noPrefixConfig;
+    private static PropertiesConfiguration configuration;
+
+    @BeforeAll
+    public static void init() {
+        noPrefixConfig = new PropertiesConfiguration();
+        configuration = new PropertiesConfiguration("properties", "identity");
+    }
+
+    @Test
+    public void testGetProperty() {
+        assertEquals("properties", noPrefixConfig.getProperty("dubbo"));
+        assertEquals("value", configuration.getString("key"));
+        assertNotEquals("properties2", noPrefixConfig.getProperty("dubbo"));
+        assertNotEquals("value2", configuration.getString("key"));
+        assertNotEquals("properties", noPrefixConfig.getProperty("dubbo2"));
+        assertNotEquals("value", configuration.getString("key2"));
+    }
+}

--- a/dubbo-common/src/test/resources/dubbo.properties
+++ b/dubbo-common/src/test/resources/dubbo.properties
@@ -16,3 +16,4 @@
 #
 
 dubbo=properties
+properties.identity.key=value


### PR DESCRIPTION
## What is the purpose of the change

Properties configuration should not query value from system properties

## Brief changelog

modify:
PropertiesConfiguration.java

add:
PropertiesConfigurationTest.java

## Verifying this change

XXXXX

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a [GITHUB_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Run `mvn clean install -DskipTests=false` & `mvn clean test-compile failsafe:integration-test` to make sure unit-test and integration-test pass.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
