### PR TITLE
remove duplicated references from ServiceConfig and ReferenceConfig, keep them in ConfigManager

### DIFF
--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/AbstractConfig.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/AbstractConfig.java
@@ -551,10 +551,10 @@ public abstract class AbstractConfig implements Serializable {
             CompositeConfiguration compositeConfiguration = Environment.getInstance().getConfiguration(getPrefix(), getId());
             Configuration config = new ConfigConfigurationAdapter(this);
             if (Environment.getInstance().isConfigCenterFirst()) {
-                // The sequence would be: SystemConfiguration -> AppExternalConfiguration -> ExternalConfiguration -> AbstractConfig -> PropertiesConfiguration
+                // The sequence would be: SystemConfiguration -> EnvironmentConfiguration -> AppExternalConfiguration -> ExternalConfiguration -> AbstractConfig -> PropertiesConfiguration
                 compositeConfiguration.addConfiguration(4, config);
             } else {
-                // The sequence would be: SystemConfiguration -> AbstractConfig -> AppExternalConfiguration -> ExternalConfiguration -> PropertiesConfiguration
+                // The sequence would be: SystemConfiguration -> EnvironmentConfiguration -> AbstractConfig -> AppExternalConfiguration -> ExternalConfiguration -> PropertiesConfiguration
                 compositeConfiguration.addConfiguration(2, config);
             }
 

--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/ReferenceConfig.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/ReferenceConfig.java
@@ -56,24 +56,24 @@ import java.util.Map;
 import java.util.Properties;
 
 import static org.apache.dubbo.common.constants.CommonConstants.ANY_VALUE;
+import static org.apache.dubbo.common.constants.CommonConstants.CLUSTER_KEY;
 import static org.apache.dubbo.common.constants.CommonConstants.COMMA_SEPARATOR;
 import static org.apache.dubbo.common.constants.CommonConstants.CONSUMER_SIDE;
 import static org.apache.dubbo.common.constants.CommonConstants.DUBBO;
 import static org.apache.dubbo.common.constants.CommonConstants.INTERFACE_KEY;
 import static org.apache.dubbo.common.constants.CommonConstants.LOCALHOST_VALUE;
 import static org.apache.dubbo.common.constants.CommonConstants.METHODS_KEY;
+import static org.apache.dubbo.common.constants.CommonConstants.MONITOR_KEY;
 import static org.apache.dubbo.common.constants.CommonConstants.REVISION_KEY;
 import static org.apache.dubbo.common.constants.CommonConstants.SEMICOLON_SPLIT_PATTERN;
 import static org.apache.dubbo.common.constants.CommonConstants.SIDE_KEY;
-import static org.apache.dubbo.common.constants.CommonConstants.CLUSTER_KEY;
-import static org.apache.dubbo.config.Constants.DUBBO_IP_TO_REGISTRY;
-import static org.apache.dubbo.rpc.cluster.Constants.REFER_KEY;
-import static org.apache.dubbo.registry.Constants.REGISTER_IP_KEY;
-import static org.apache.dubbo.common.constants.CommonConstants.MONITOR_KEY;
-import static org.apache.dubbo.registry.Constants.CONSUMER_PROTOCOL;
 import static org.apache.dubbo.common.constants.RegistryConstants.REGISTRY_PROTOCOL;
-import static org.apache.dubbo.rpc.Constants.LOCAL_PROTOCOL;
 import static org.apache.dubbo.common.utils.NetUtils.isInvalidLocalHost;
+import static org.apache.dubbo.config.Constants.DUBBO_IP_TO_REGISTRY;
+import static org.apache.dubbo.registry.Constants.CONSUMER_PROTOCOL;
+import static org.apache.dubbo.registry.Constants.REGISTER_IP_KEY;
+import static org.apache.dubbo.rpc.Constants.LOCAL_PROTOCOL;
+import static org.apache.dubbo.rpc.cluster.Constants.REFER_KEY;
 
 /**
  * ReferenceConfig
@@ -295,9 +295,9 @@ public class ReferenceConfig<T> extends AbstractReferenceConfig {
             }
         }
         map.put(INTERFACE_KEY, interfaceName);
-        appendParameters(map, metrics);
-        appendParameters(map, application);
-        appendParameters(map, module);
+        appendParameters(map, getMetrics());
+        appendParameters(map, getApplication());
+        appendParameters(map, getModule());
         // remove 'default.' prefix for configs from ConsumerConfig
         // appendParameters(map, consumer, Constants.DEFAULT_KEY);
         appendParameters(map, consumer);
@@ -495,33 +495,33 @@ public class ReferenceConfig<T> extends AbstractReferenceConfig {
 
     private void completeCompoundConfigs() {
         if (consumer != null) {
-            if (application == null) {
+            if (getApplication() == null) {
                 setApplication(consumer.getApplication());
             }
-            if (module == null) {
+            if (getModule() == null) {
                 setModule(consumer.getModule());
             }
             if (registries == null) {
                 setRegistries(consumer.getRegistries());
             }
-            if (monitor == null) {
+            if (getMonitor() == null) {
                 setMonitor(consumer.getMonitor());
             }
         }
-        if (module != null) {
+        if (getModule() != null) {
             if (registries == null) {
-                setRegistries(module.getRegistries());
+                setRegistries(getModule().getRegistries());
             }
-            if (monitor == null) {
-                setMonitor(module.getMonitor());
+            if (getMonitor() == null) {
+                setMonitor(getModule().getMonitor());
             }
         }
-        if (application != null) {
+        if (getApplication() != null) {
             if (registries == null) {
-                setRegistries(application.getRegistries());
+                setRegistries(getApplication().getRegistries());
             }
-            if (monitor == null) {
-                setMonitor(application.getMonitor());
+            if (getMonitor() == null) {
+                setMonitor(getApplication().getMonitor());
             }
         }
     }

--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/context/ConfigManager.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/context/ConfigManager.java
@@ -23,6 +23,8 @@ import org.apache.dubbo.config.AbstractConfig;
 import org.apache.dubbo.config.ApplicationConfig;
 import org.apache.dubbo.config.ConfigCenterConfig;
 import org.apache.dubbo.config.ConsumerConfig;
+import org.apache.dubbo.config.MetadataReportConfig;
+import org.apache.dubbo.config.MetricsConfig;
 import org.apache.dubbo.config.ModuleConfig;
 import org.apache.dubbo.config.MonitorConfig;
 import org.apache.dubbo.config.ProtocolConfig;
@@ -64,12 +66,6 @@ import static org.apache.dubbo.common.constants.CommonConstants.DEFAULT_KEY;
  *  }
  *  }
  * </pre>
- * </p>
- * TODO
- * The properties defined here are duplicate with that in ReferenceConfig/ServiceConfig,
- * the properties here are currently only used for duplication check but are still not being used in the export/refer process yet.
- * Maybe we can remove the property definition in ReferenceConfig/ServiceConfig and only keep the setXxxConfig() as an entrance.
- * All workflow internally can rely on ConfigManager.
  */
 public class ConfigManager {
     private static final Logger logger = LoggerFactory.getLogger(ConfigManager.class);
@@ -79,6 +75,12 @@ public class ConfigManager {
     private MonitorConfig monitor;
     private ModuleConfig module;
     private ConfigCenterConfig configCenter;
+
+    /**
+     * The metrics configuration
+     */
+    protected MetricsConfig metrics;
+    protected MetadataReportConfig metadataReportConfig;
 
     private Map<String, ProtocolConfig> protocols = new ConcurrentHashMap<>();
     private Map<String, RegistryConfig> registries = new ConcurrentHashMap<>();
@@ -134,6 +136,28 @@ public class ConfigManager {
         if (configCenter != null) {
             checkDuplicate(this.configCenter, configCenter);
             this.configCenter = configCenter;
+        }
+    }
+
+    public Optional<MetricsConfig> getMetrics() {
+        return Optional.ofNullable(metrics);
+    }
+
+    public void setMetrics(MetricsConfig metrics) {
+        if (metrics != null) {
+            checkDuplicate(this.metrics, metrics);
+            this.metrics = metrics;
+        }
+    }
+
+    public Optional<MetadataReportConfig> getMetadataReportConfig() {
+        return Optional.ofNullable(metadataReportConfig);
+    }
+
+    public void setMetadataReportConfig(MetadataReportConfig metadataReportConfig) {
+        if (metadataReportConfig != null) {
+            checkDuplicate(this.metadataReportConfig, metadataReportConfig);
+            this.metadataReportConfig = metadataReportConfig;
         }
     }
 
@@ -302,6 +326,8 @@ public class ConfigManager {
         getApplication().ifPresent(ApplicationConfig::refresh);
         getMonitor().ifPresent(MonitorConfig::refresh);
         getModule().ifPresent(ModuleConfig::refresh);
+        getMetrics().ifPresent(MetricsConfig::refresh);
+        getMetadataReportConfig().ifPresent(MetadataReportConfig::refresh);
 
         getProtocols().values().forEach(ProtocolConfig::refresh);
         getRegistries().values().forEach(RegistryConfig::refresh);
@@ -322,6 +348,8 @@ public class ConfigManager {
         this.configCenter = null;
         this.monitor = null;
         this.module = null;
+        this.metrics = null;
+        this.metadataReportConfig = null;
         this.registries.clear();
         this.protocols.clear();
         this.providers.clear();


### PR DESCRIPTION
## What is the purpose of the change

Some global unique configuration references in ServiceConfig and ReferenceConfig is now duplicated from what's defined in ConfigManager, we can remove those.