### PR TITLE
[Dubbo-3629]fix set generic method error

### DIFF
--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/ServiceConfig.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/ServiceConfig.java
@@ -1011,7 +1011,7 @@ public class ServiceConfig<T> extends AbstractServiceConfig {
         if (StringUtils.isEmpty(generic)) {
             return;
         }
-        if (ProtocolUtils.isGeneric(generic)) {
+        if (Boolean.FALSE.toString().equals(generic) || ProtocolUtils.isGeneric(generic)) {
             this.generic = generic;
         } else {
             throw new IllegalArgumentException("Unsupported generic type " + generic);

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/support/ProtocolUtils.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/support/ProtocolUtils.java
@@ -53,12 +53,10 @@ public class ProtocolUtils {
     }
 
     public static boolean isGeneric(String generic) {
-        return generic != null
-                && !"".equals(generic)
-                && (GENERIC_SERIALIZATION_DEFAULT.equalsIgnoreCase(generic)  /* Normal generalization cal */
+        return GENERIC_SERIALIZATION_DEFAULT.equalsIgnoreCase(generic)  /* Normal generalization cal */
                 || GENERIC_SERIALIZATION_NATIVE_JAVA.equalsIgnoreCase(generic) /* Streaming generalization call supporting jdk serialization */
                 || GENERIC_SERIALIZATION_BEAN.equalsIgnoreCase(generic)
-                || GENERIC_SERIALIZATION_PROTOBUF.equalsIgnoreCase(generic));
+                || GENERIC_SERIALIZATION_PROTOBUF.equalsIgnoreCase(generic);
     }
 
     public static boolean isDefaultGenericSerialization(String generic) {


### PR DESCRIPTION
## What is the purpose of the change
fix #3629, #4926
1.fix ServiceConfig's setGeneric log error when set "false" to generic field
2.simplify ProtocolUtils.isGeneric method

## Brief changelog

ServiceConfig.java
ProtocolUtils.java

## Verifying this change

has been test

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a [GITHUB_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Run `mvn clean install -DskipTests=false` & `mvn clean test-compile failsafe:integration-test` to make sure unit-test and integration-test pass.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
