### PR TITLE
considering methodStatus.active == Integer.MAX_VALUE

### DIFF
--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/RpcStatus.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/RpcStatus.java
@@ -112,6 +112,9 @@ public class RpcStatus {
         max = (max <= 0) ? Integer.MAX_VALUE : max;
         RpcStatus appStatus = getStatus(url);
         RpcStatus methodStatus = getStatus(url, methodName);
+        if (methodStatus.active.get() == Integer.MAX_VALUE) {
+            return false;
+        }
         if (methodStatus.active.incrementAndGet() > max) {
             methodStatus.active.decrementAndGet();
             return false;


### PR DESCRIPTION
## What is the purpose of the change

in case of methodStatus.active is already equals Integer.MAX_VALUE, methodStatus.active.incrementAndGet() will become Integer.MIN_VALUE

## Brief changelog

avoid potential value out of bounds