### PR TITLE
fix #4898: Dubbo-Attachments header in REST protocol doesn't allow '=

### DIFF
--- a/dubbo-rpc/dubbo-rpc-rest/src/main/java/org/apache/dubbo/rpc/protocol/rest/RpcContextFilter.java
+++ b/dubbo-rpc/dubbo-rpc-rest/src/main/java/org/apache/dubbo/rpc/protocol/rest/RpcContextFilter.java
@@ -72,7 +72,7 @@ public class RpcContextFilter implements ContainerRequestFilter, ClientRequestFi
         for (Map.Entry<String, String> entry : RpcContext.getContext().getAttachments().entrySet()) {
             String key = entry.getKey();
             String value = entry.getValue();
-            if (illegalForRest(key) || illegalForRest(value)) {
+            if (illegalHttpHeaderKey(key) || illegalHttpHeaderValue(value)) {
                 throw new IllegalArgumentException("The attachments of " + RpcContext.class.getSimpleName() + " must not contain ',' or '=' when using rest protocol");
             }
 
@@ -89,15 +89,16 @@ public class RpcContextFilter implements ContainerRequestFilter, ClientRequestFi
         }
     }
 
-    /**
-     * If a string value illegal for rest protocol(',' and '=' is illegal for rest protocol).
-     *
-     * @param v string value
-     * @return true for illegal
-     */
-    private boolean illegalForRest(String v) {
-        if (StringUtils.isNotEmpty(v)) {
-            return v.contains(",") || v.contains("=");
+    private boolean illegalHttpHeaderKey(String key) {
+        if (StringUtils.isNotEmpty(key)) {
+            return key.contains(",") || key.contains("=");
+        }
+        return false;
+    }
+
+    private boolean illegalHttpHeaderValue(String value) {
+        if (StringUtils.isNotEmpty(value)) {
+            return value.contains(",");
         }
         return false;
     }

--- a/dubbo-rpc/dubbo-rpc-rest/src/test/java/org/apache/dubbo/rpc/protocol/rest/DemoServiceImpl.java
+++ b/dubbo-rpc/dubbo-rpc-rest/src/test/java/org/apache/dubbo/rpc/protocol/rest/DemoServiceImpl.java
@@ -17,7 +17,12 @@
 package org.apache.dubbo.rpc.protocol.rest;
 
 
+import org.apache.dubbo.rpc.RpcContext;
+
+import java.util.Map;
+
 public class DemoServiceImpl implements DemoService {
+    private static Map<String, String> context;
     private boolean called;
 
     public String sayHello(String name) {
@@ -32,11 +37,16 @@ public class DemoServiceImpl implements DemoService {
 
     @Override
     public Integer hello(Integer a, Integer b) {
+        context = RpcContext.getContext().getAttachments();
         return a + b;
     }
 
     @Override
     public String error() {
         throw new RuntimeException();
+    }
+
+    public static Map<String, String> getAttachments() {
+        return context;
     }
 }

--- a/dubbo-rpc/dubbo-rpc-rest/src/test/java/org/apache/dubbo/rpc/protocol/rest/RestProtocolTest.java
+++ b/dubbo-rpc/dubbo-rpc-rest/src/test/java/org/apache/dubbo/rpc/protocol/rest/RestProtocolTest.java
@@ -35,8 +35,12 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.util.Map;
+
 import static org.apache.dubbo.remoting.Constants.SERVER_KEY;
+import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 import static org.apache.dubbo.rpc.protocol.rest.Constants.EXTENSION_KEY;
@@ -94,8 +98,8 @@ public class RestProtocolTest {
     @Test
     public void testExport() {
         DemoService server = new DemoServiceImpl();
-        ProviderModel providerModel = new ProviderModel(exportUrl.getServiceKey(), server, DemoService.class);
-        ApplicationModel.initProviderModel(exportUrl.getServiceKey(), providerModel);
+        ProviderModel providerModel = new ProviderModel(exportUrl.getPathKey(), server, DemoService.class);
+        ApplicationModel.initProviderModel(exportUrl.getPathKey(), providerModel);
 
         RpcContext.getContext().setAttachment("timeout", "200");
         Exporter<DemoService> exporter = protocol.export(proxy.getInvoker(server, DemoService.class, exportUrl));
@@ -111,8 +115,8 @@ public class RestProtocolTest {
     @Test
     public void testNettyServer() {
         DemoService server = new DemoServiceImpl();
-        ProviderModel providerModel = new ProviderModel(exportUrl.getServiceKey(), server, DemoService.class);
-        ApplicationModel.initProviderModel(exportUrl.getServiceKey(), providerModel);
+        ProviderModel providerModel = new ProviderModel(exportUrl.getPathKey(), server, DemoService.class);
+        ApplicationModel.initProviderModel(exportUrl.getPathKey(), providerModel);
 
         URL nettyUrl = exportUrl.addParameter(SERVER_KEY, "netty");
         Exporter<DemoService> exporter = protocol.export(proxy.getInvoker(new DemoServiceImpl(), DemoService.class, nettyUrl));
@@ -129,7 +133,7 @@ public class RestProtocolTest {
     public void testServletWithoutWebConfig() {
         Assertions.assertThrows(RpcException.class, () -> {
             DemoService server = new DemoServiceImpl();
-            ProviderModel providerModel = new ProviderModel(exportUrl.getServiceKey(), server, DemoService.class);
+            ProviderModel providerModel = new ProviderModel(exportUrl.getPathKey(), server, DemoService.class);
             ApplicationModel.initProviderModel(exportUrl.getPathKey(), providerModel);
 
             URL servletUrl = exportUrl.addParameter(SERVER_KEY, "servlet");
@@ -142,8 +146,8 @@ public class RestProtocolTest {
     public void testErrorHandler() {
         Assertions.assertThrows(RpcException.class, () -> {
             DemoService server = new DemoServiceImpl();
-            ProviderModel providerModel = new ProviderModel(exportUrl.getServiceKey(), server, DemoService.class);
-            ApplicationModel.initProviderModel(exportUrl.getServiceKey(), providerModel);
+            ProviderModel providerModel = new ProviderModel(exportUrl.getPathKey(), server, DemoService.class);
+            ApplicationModel.initProviderModel(exportUrl.getPathKey(), providerModel);
 
             URL nettyUrl = exportUrl.addParameter(SERVER_KEY, "netty");
             Exporter<DemoService> exporter = protocol.export(proxy.getInvoker(server, DemoService.class, nettyUrl));
@@ -157,8 +161,8 @@ public class RestProtocolTest {
     @Test
     public void testInvoke() {
         DemoService server = new DemoServiceImpl();
-        ProviderModel providerModel = new ProviderModel(exportUrl.getServiceKey(), server, DemoService.class);
-        ApplicationModel.initProviderModel(exportUrl.getServiceKey(), providerModel);
+        ProviderModel providerModel = new ProviderModel(exportUrl.getPathKey(), server, DemoService.class);
+        ApplicationModel.initProviderModel(exportUrl.getPathKey(), providerModel);
 
 
         Exporter<DemoService> exporter = protocol.export(proxy.getInvoker(server, DemoService.class, exportUrl));
@@ -172,8 +176,8 @@ public class RestProtocolTest {
     @Test
     public void testFilter() {
         DemoService server = new DemoServiceImpl();
-        ProviderModel providerModel = new ProviderModel(exportUrl.getServiceKey(), server, DemoService.class);
-        ApplicationModel.initProviderModel(exportUrl.getServiceKey(), providerModel);
+        ProviderModel providerModel = new ProviderModel(exportUrl.getPathKey(), server, DemoService.class);
+        ApplicationModel.initProviderModel(exportUrl.getPathKey(), providerModel);
 
         URL nettyUrl = exportUrl.addParameter(SERVER_KEY, "netty")
                 .addParameter(EXTENSION_KEY, "org.apache.dubbo.rpc.protocol.rest.support.LoggingFilter");
@@ -191,8 +195,8 @@ public class RestProtocolTest {
     @Test
     public void testRpcContextFilter() {
         DemoService server = new DemoServiceImpl();
-        ProviderModel providerModel = new ProviderModel(exportUrl.getServiceKey(), server, DemoService.class);
-        ApplicationModel.initProviderModel(exportUrl.getServiceKey(), providerModel);
+        ProviderModel providerModel = new ProviderModel(exportUrl.getPathKey(), server, DemoService.class);
+        ApplicationModel.initProviderModel(exportUrl.getPathKey(), providerModel);
 
         // use RpcContextFilter
         URL nettyUrl = exportUrl.addParameter(SERVER_KEY, "netty")
@@ -201,12 +205,22 @@ public class RestProtocolTest {
 
         DemoService demoService = this.proxy.getProxy(protocol.refer(DemoService.class, nettyUrl));
 
-        String value = null;
-        // put a null value into attachment.
-        RpcContext.getContext().setAttachment("key", value);
+        // make sure null and base64 encoded string can work
+        RpcContext.getContext().setAttachment("key1", null);
+        RpcContext.getContext().setAttachment("key2", "value");
+        RpcContext.getContext().setAttachment("key3", "=value");
+        RpcContext.getContext().setAttachment("key4", "YWJjZGVmCg==");
+        RpcContext.getContext().setAttachment("key5", "val=ue");
         Integer result = demoService.hello(1, 2);
 
         assertThat(result, is(3));
+
+        Map<String, String> attachment = DemoServiceImpl.getAttachments();
+        assertThat(attachment.get("key1"), nullValue());
+        assertThat(attachment.get("key2"), equalTo("value"));
+        assertThat(attachment.get("key3"), equalTo("=value"));
+        assertThat(attachment.get("key4"), equalTo("YWJjZGVmCg=="));
+        assertThat(attachment.get("key5"), equalTo("val=ue"));
 
         exporter.unexport();
     }
@@ -215,8 +229,8 @@ public class RestProtocolTest {
     public void testRegFail() {
         Assertions.assertThrows(RuntimeException.class, () -> {
             DemoService server = new DemoServiceImpl();
-            ProviderModel providerModel = new ProviderModel(exportUrl.getServiceKey(), server, DemoService.class);
-            ApplicationModel.initProviderModel(exportUrl.getServiceKey(), providerModel);
+            ProviderModel providerModel = new ProviderModel(exportUrl.getPathKey(), server, DemoService.class);
+            ApplicationModel.initProviderModel(exportUrl.getPathKey(), providerModel);
 
             URL nettyUrl = exportUrl.addParameter(EXTENSION_KEY, "com.not.existing.Filter");
             protocol.export(proxy.getInvoker(server, DemoService.class, nettyUrl));


### PR DESCRIPTION
## What is the purpose of the change

fix #4898

## Brief changelog

XXXXX

## Verifying this change

XXXXX

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a [GITHUB_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Run `mvn clean install -DskipTests=false` & `mvn clean test-compile failsafe:integration-test` to make sure unit-test and integration-test pass.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
