### PR TITLE
[*] fix 泛化调用:referenceconfig(null) is not destroyed when finalize 问题

### DIFF
--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/utils/ReferenceConfigCache.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/utils/ReferenceConfigCache.java
@@ -45,20 +45,29 @@ public class ReferenceConfigCache {
             Class<?> clazz = referenceConfig.getInterfaceClass();
             iName = clazz.getName();
         }
-        if (StringUtils.isBlank(iName)) {
-            throw new IllegalArgumentException("No interface info in ReferenceConfig" + referenceConfig);
-        }
-
-        StringBuilder ret = new StringBuilder();
-        if (!StringUtils.isBlank(referenceConfig.getGroup())) {
-            ret.append(referenceConfig.getGroup()).append("/");
-        }
-        ret.append(iName);
-        if (!StringUtils.isBlank(referenceConfig.getVersion())) {
-            ret.append(":").append(referenceConfig.getVersion());
-        }
-        return ret.toString();
+        return getKey(iName, referenceConfig.getGroup(), referenceConfig.getVersion());
     };
+
+
+
+    public static final String getKey(String iName, String group, String version) {
+        if (StringUtils.isBlank(iName)) {
+            throw new IllegalArgumentException("No interface info in ReferenceConfig" + iName);
+        } else {
+            StringBuilder ret = new StringBuilder();
+            if (!StringUtils.isBlank(group)) {
+                ret.append(group).append("/");
+            }
+            ret.append(iName);
+            if (!StringUtils.isBlank(version)) {
+                ret.append(":").append(version);
+            }
+            return ret.toString();
+        }
+    }
+
+
+
     static final ConcurrentMap<String, ReferenceConfigCache> CACHE_HOLDER = new ConcurrentHashMap<String, ReferenceConfigCache>();
     private final String name;
     private final KeyGenerator generator;


### PR DESCRIPTION
+ 泛化调用会使用ReferenceConfigCache.get(ReferenceConfig<T> referenceConfig)接口
+ 然后会自己新建ReferenceConfig,但自己创建的ReferenceConfig并不会调用destroy接口
+ 这就造成了ReferenceConfig析构的时候会疯狂输出:Unexpected err when destroy invoker of ReferenceConfig
+ logger.warn("Unexpected err when destroy invoker of ReferenceConfig(" + this.url + ").", var2);
+ 我们需要做的就是重构下ReferenceConfigCache,新增一个不需要创建ReferenceConfig 就能获取key的方法即可