### PR TITLE
upgrade fastjson to 1.2.60

### DIFF
--- a/dependencies-bom/pom.xml
+++ b/dependencies-bom/pom.xml
@@ -94,7 +94,7 @@
         <mina_version>1.1.7</mina_version>
         <grizzly_version>2.1.4</grizzly_version>
         <httpclient_version>4.5.3</httpclient_version>
-        <fastjson_version>1.2.58</fastjson_version>
+        <fastjson_version>1.2.60</fastjson_version>
         <zookeeper_version>3.4.9</zookeeper_version>
         <zkclient_version>0.2</zkclient_version>
         <curator_version>2.12.0</curator_version>


### PR DESCRIPTION
upgrade fastjson to 1.2.60 for security problem
https://help.aliyun.com/noticelist/articleid/1060052050.html?spm=a2c4g.789213612.n2.8.ddd861419LgwrZ
https://github.com/qixiaobo/fastjson-oom