### PR TITLE
concurrent cache bug fix

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/bytecode/Wrapper.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/bytecode/Wrapper.java
@@ -113,12 +113,7 @@ public abstract class Wrapper {
             return OBJECT_WRAPPER;
         }
 
-        Wrapper ret = WRAPPER_MAP.get(c);
-        if (ret == null) {
-            ret = makeWrapper(c);
-            WRAPPER_MAP.put(c, ret);
-        }
-        return ret;
+        return WRAPPER_MAP.computeIfAbsent(c, key -> makeWrapper(key));
     }
 
     private static Wrapper makeWrapper(Class<?> c) {


### PR DESCRIPTION
## What is the purpose of the change

The codes are not thread-safe, 
"
ret = makeWrapper(c);
WRAPPER_MAP.put(c, ret);
"
should be replaced by
"            
WRAPPER_MAP.putIfAbsent(c, makeWrapper(c));
ret = WRAPPER_MAP.get(c);
"
as the key may be put into the map twice.
Futuhermore,the codes can also be replaced by lambda expression
