### PR TITLE
[Dubbo-5049]support @Bean on Config class to config id as alias

### DIFF
--- a/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/beans/factory/annotation/DubboConfigBindingBeanPostProcessor.java
+++ b/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/beans/factory/annotation/DubboConfigBindingBeanPostProcessor.java
@@ -17,6 +17,7 @@
 package org.apache.dubbo.config.spring.beans.factory.annotation;
 
 import org.apache.dubbo.common.utils.Assert;
+import org.apache.dubbo.common.utils.StringUtils;
 import org.apache.dubbo.config.AbstractConfig;
 import org.apache.dubbo.config.spring.context.annotation.DubboConfigBindingRegistrar;
 import org.apache.dubbo.config.spring.context.annotation.EnableDubboConfigBinding;
@@ -29,6 +30,10 @@ import org.apache.commons.logging.LogFactory;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.config.BeanPostProcessor;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.beans.factory.support.BeanDefinitionRegistry;
+import org.springframework.beans.factory.support.BeanDefinitionRegistryPostProcessor;
+import org.springframework.beans.factory.support.DefaultListableBeanFactory;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
 import org.springframework.core.annotation.AnnotationAwareOrderComparator;
@@ -49,7 +54,8 @@ import static org.springframework.beans.factory.BeanFactoryUtils.beansOfTypeIncl
  * @since 2.5.8
  */
 
-public class DubboConfigBindingBeanPostProcessor implements BeanPostProcessor, ApplicationContextAware, InitializingBean {
+public class DubboConfigBindingBeanPostProcessor implements BeanPostProcessor, ApplicationContextAware, InitializingBean
+        , BeanDefinitionRegistryPostProcessor {
 
     private final Log log = LogFactory.getLog(getClass());
 
@@ -66,6 +72,8 @@ public class DubboConfigBindingBeanPostProcessor implements BeanPostProcessor, A
     private DubboConfigBinder dubboConfigBinder;
 
     private ApplicationContext applicationContext;
+
+    private BeanDefinitionRegistry beanDefinitionRegistry;
 
     private boolean ignoreUnknownFields = true;
 
@@ -145,6 +153,15 @@ public class DubboConfigBindingBeanPostProcessor implements BeanPostProcessor, A
 
     @Override
     public Object postProcessAfterInitialization(Object bean, String beanName) throws BeansException {
+        if (bean instanceof AbstractConfig) {
+            String id = ((AbstractConfig) bean).getId();
+            if (beanDefinitionRegistry != null && beanDefinitionRegistry instanceof DefaultListableBeanFactory) {
+                DefaultListableBeanFactory factory = (DefaultListableBeanFactory) beanDefinitionRegistry;
+                if (!StringUtils.isBlank(id) && !factory.hasAlias(beanName, id)) {
+                    beanDefinitionRegistry.registerAlias(beanName, id);
+                }
+            }
+        }
         return bean;
     }
 
@@ -203,4 +220,15 @@ public class DubboConfigBindingBeanPostProcessor implements BeanPostProcessor, A
         return defaultDubboConfigBinder;
     }
 
+    @Override
+    public void postProcessBeanDefinitionRegistry(BeanDefinitionRegistry registry) throws BeansException {
+        if (this.beanDefinitionRegistry == null) {
+            this.beanDefinitionRegistry = registry;
+        }
+    }
+
+    @Override
+    public void postProcessBeanFactory(ConfigurableListableBeanFactory beanFactory) throws BeansException {
+        //do nothing here
+    }
 }

--- a/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/beans/factory/annotation/DubboConfigBindingBeanPostProcessorTest.java
+++ b/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/beans/factory/annotation/DubboConfigBindingBeanPostProcessorTest.java
@@ -17,6 +17,7 @@
 package org.apache.dubbo.config.spring.beans.factory.annotation;
 
 import org.apache.dubbo.config.ApplicationConfig;
+import org.apache.dubbo.config.ProtocolConfig;
 import org.apache.dubbo.config.spring.context.config.NamePropertyDefaultValueDubboConfigBeanCustomizer;
 import org.apache.dubbo.config.spring.context.properties.DefaultDubboConfigBinder;
 
@@ -52,6 +53,14 @@ public class DubboConfigBindingBeanPostProcessorTest {
         return new ApplicationConfig();
     }
 
+    @Bean("dubbo-demo-protocol")
+    public ProtocolConfig protocolConfig() {
+        ProtocolConfig protocolConfig = new ProtocolConfig();
+        protocolConfig.setName("dubbo");
+        protocolConfig.setId("customConfigAlias");
+        return protocolConfig;
+    }
+
     @Bean
     public DubboConfigBindingBeanPostProcessor bindingBeanPostProcessor() {
         return new DubboConfigBindingBeanPostProcessor("dubbo.application", "dubbo-demo-application");
@@ -65,8 +74,15 @@ public class DubboConfigBindingBeanPostProcessorTest {
 
         ApplicationConfig applicationConfig = applicationContext.getBean(ApplicationConfig.class);
 
+        String[] aliases = applicationContext.getAliases("dubbo-demo-protocol");
+        ProtocolConfig protocolConfigByName = applicationContext.getBean("dubbo-demo-protocol", ProtocolConfig.class);
+        ProtocolConfig protocolConfigById = applicationContext.getBean(protocolConfigByName.getId(), ProtocolConfig.class);
+
         Assert.assertEquals("dubbo-demo-application", applicationConfig.getName());
         Assert.assertEquals("mercyblitz", applicationConfig.getOwner());
         Assert.assertEquals("Apache", applicationConfig.getOrganization());
+
+        Assert.assertArrayEquals(new String[]{"customConfigAlias"}, aliases);
+        Assert.assertEquals(protocolConfigByName, protocolConfigById);
     }
 }


### PR DESCRIPTION
as #5049 mentioned, when `@Service(protocol = "dubbo1")` is annotated on a class, the provider starts failed, `dubbo1` is the `id` property of `ProtocolConfig`.
```java
@Bean
  public ProtocolConfig config1() {
    ProtocolConfig config = new ProtocolConfig();
    config.setId("dubbo1");
    config.setName("dubbo");
    config.setPort(20880);
    return config;
  }
```
The failure cause is `dubbo1` is not an name or alias of `ProtocolConfig` bean.

When using xml way:
```xml
<dubbo:application name="demo-provider"/>

    <dubbo:registry address="zookeeper://127.0.0.1:2181"/>

    <dubbo:protocol name="dubbo" id="dubbo1"/>

    <bean id="demoService" class="org.apache.dubbo.demo.provider.DemoServiceImpl"/>

    <dubbo:service interface="org.apache.dubbo.demo.DemoService" ref="demoService" protocol="dubbo1"/>
```
xml config with` id` property assigned with `dubbo1`, the provider starts successfully.

I think the annotation way should work fine as well.

### My suggestion approach
Use spring extension interfaces, such as:
1. BeanDefinitionRegistry: can do the registry alias stuff
2. BeanPostProcessor: can do `1`  after config beans's  initialization by implementing method `postProcessAfterInitialization`, which is already implemented by class `DubboConfigBindingBeanPostProcessor` with an empty method.

Actually, @haiyang1985 has a PR #5051 solving this issue:
But I think using `getBean` in `postProcessBeanDefinitionRegistry` method cause the initialization of ProtocolConfig's bean too early (bean registry phase in spring) as @mercyblitz mentioned 