### PR TITLE
[Dubbo 5052] Fix executes param takes no effect when using generic call #5052

### DIFF
--- a/dubbo-rpc/dubbo-rpc-api/src/test/java/org/apache/dubbo/rpc/filter/ExecuteLimitFilterTest.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/test/java/org/apache/dubbo/rpc/filter/ExecuteLimitFilterTest.java
@@ -18,6 +18,7 @@ package org.apache.dubbo.rpc.filter;
 
 import org.apache.dubbo.common.URL;
 import org.apache.dubbo.rpc.AppResponse;
+import org.apache.dubbo.rpc.Constants;
 import org.apache.dubbo.rpc.Invocation;
 import org.apache.dubbo.rpc.Invoker;
 import org.apache.dubbo.rpc.Result;
@@ -128,5 +129,59 @@ public class ExecuteLimitFilterTest {
         }
 
         Assertions.assertEquals(totalExecute - maxExecute, failed.get());
+    }
+
+    @Test
+    public void testGenericExecuteLimitInvoke() throws Exception {
+        int maxExecute = 10;
+        int totalExecute = 20;
+        final AtomicInteger failed = new AtomicInteger(0);
+        final String methodName = "testGenericExecuteLimitInvoke";
+
+        URL url = URL.valueOf("test://test:11/test?accesslog=true&group=dubbo&version=1.1&executes=" + maxExecute);
+        final Invoker<ExecuteLimitFilter> invoker = new BlockMyInvoker<>(url, 1000);
+
+        //generic invocation mock object
+        final Invocation genericInv = Mockito.mock(Invocation.class);
+        when(genericInv.getParameterTypes()).thenReturn(new Class[]{String.class, String.class, Object.class});
+        when(genericInv.getArguments()).thenReturn(new Object[]{methodName, String.class, "hello"});
+        when(genericInv.getAttachment(Constants.GENERIC_KEY, "false")).thenReturn("true");
+
+        //mock when filtered by generic filter, methodName will be real method
+        when(genericInv.getMethodName()).thenReturn(methodName);
+        Result genericResult = executeLimitFilter.invoke(invoker, genericInv);
+        genericResult = executeLimitFilter.invoke(invoker, genericInv);
+
+        final Invocation invocation = Mockito.mock(Invocation.class);
+        when(invocation.getMethodName()).thenReturn(methodName);
+
+        final CountDownLatch latch = new CountDownLatch(1);
+        for (int i = 0; i < totalExecute; i++) {
+            Thread thread = new Thread(() -> {
+                try {
+                    latch.await();
+                } catch (InterruptedException e) {
+                    e.printStackTrace();
+                }
+                try {
+                    executeLimitFilter.invoke(invoker, invocation);
+                } catch (RpcException expected) {
+                    failed.incrementAndGet();
+                }
+            });
+            thread.start();
+        }
+        //But on the callback onResponse, the invocation object is the one before all filters
+        when(genericInv.getMethodName()).thenReturn(Constants.$INVOKE);
+        executeLimitFilter.listener().onResponse(genericResult, invoker, genericInv);//release generic call's active count
+        executeLimitFilter.listener().onError(null, invoker, genericInv);//release generic call's active count
+        latch.countDown();
+
+        try {
+            Thread.sleep(1000);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+        Assertions.assertEquals(totalExecute - maxExecute, failed.get());//
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

Fix issue #5052. When generic invokes, the beginning `invocation` object (before any filters) will be used to be a callback method's parameter, such as like `onResponse`, `onError` of interface `org.apache.dubbo.rpc.Filter.Listener`. However, `invocation`'s function `getMethodName` will return value:`$invoke` when it is a generic invoke.

Thus, it will cause `endCount` method not counting the origin method status. Then the `executes` limit is not accurate enough.


Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a [GITHUB_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [x] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Run `mvn clean install -DskipTests=false` & `mvn clean test-compile failsafe:integration-test` to make sure unit-test and integration-test pass.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
