### PR TITLE
[Dubbo-4340]Throws exception whenever SPI extensions are in abnormal status during loading.

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/extension/ExtensionLoader.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/extension/ExtensionLoader.java
@@ -492,12 +492,15 @@ public class ExtensionLoader<T> {
         return (T) instance;
     }
 
-    private IllegalStateException findException(String name) {
+    private void findException(String name) {
         for (Map.Entry<String, IllegalStateException> entry : exceptions.entrySet()) {
             if (entry.getKey().toLowerCase().contains(name.toLowerCase())) {
-                return entry.getValue();
+                throw entry.getValue();
             }
         }
+    }
+
+    private IllegalStateException noExtensionException(String name) {
         StringBuilder buf = new StringBuilder("No such extension " + type.getName() + " by name " + name);
 
 
@@ -519,9 +522,11 @@ public class ExtensionLoader<T> {
 
     @SuppressWarnings("unchecked")
     private T createExtension(String name) {
+        // throws any possible exception in loading period.
+        findException(name);
         Class<?> clazz = getExtensionClasses().get(name);
         if (clazz == null) {
-            throw findException(name);
+            throw noExtensionException(name);
         }
         try {
             T instance = (T) EXTENSION_INSTANCES.get(clazz);


### PR DESCRIPTION
## What is the purpose of the change

Fixes #4340 

## Brief changelog

Split `findException` into two sperate functions, with one called before loading and another called after loading.