### PR TITLE
dubbo:registry标签 username & password 生效

### DIFF
--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/AbstractInterfaceConfig.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/AbstractInterfaceConfig.java
@@ -624,6 +624,8 @@ public abstract class AbstractInterfaceConfig extends AbstractMethodConfig {
                 cc.getParameters().put(org.apache.dubbo.remoting.Constants.CLIENT_KEY,rc.getClient());
                 cc.setProtocol(rc.getProtocol());
                 cc.setAddress(rc.getAddress());
+                cc.setUsername(rc.getUsername());
+                cc.setPassword(rc.getPassword());
                 cc.setHighestPriority(false);
                 setConfigCenter(cc);
                 startConfigCenter();


### PR DESCRIPTION
生效
```
    <dubbo:registry
            address="zookeeper://username:pwd@ip:port"
            group="xxx"/>
    

```
不生效
```
    <dubbo:registry
            address="zookeeper://ip:port"
            username="username"
            password="pwd"/>
```

resolve https://github.com/apache/dubbo/issues/5076
