### PR TITLE
Stabilize EtcdMetadataReportTest

### DIFF
--- a/dubbo-metadata-report/dubbo-metadata-report-etcd/src/test/java/org/apache/dubbo/metadata/store/etcd/EtcdMetadataReportTest.java
+++ b/dubbo-metadata-report/dubbo-metadata-report-etcd/src/test/java/org/apache/dubbo/metadata/store/etcd/EtcdMetadataReportTest.java
@@ -32,7 +32,6 @@ import io.etcd.jetcd.launcher.EtcdClusterFactory;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.net.URI;
@@ -44,6 +43,7 @@ import java.util.concurrent.CompletableFuture;
 
 import static org.apache.dubbo.common.constants.CommonConstants.CONSUMER_SIDE;
 import static org.apache.dubbo.common.constants.CommonConstants.PROVIDER_SIDE;
+import static org.apache.dubbo.metadata.support.Constants.SYNC_REPORT_KEY;
 
 /**
  * Unit test for etcd metadata report
@@ -63,7 +63,7 @@ public class EtcdMetadataReportTest {
         etcdCluster.start();
         etcdClientForTest = Client.builder().endpoints(etcdCluster.getClientEndpoints()).build();
         List<URI> clientEndPoints = etcdCluster.getClientEndpoints();
-        this.registryUrl = URL.valueOf("etcd://" + clientEndPoints.get(0).getHost() + ":" + clientEndPoints.get(0).getPort());
+        this.registryUrl = URL.valueOf("etcd://" + clientEndPoints.get(0).getHost() + ":" + clientEndPoints.get(0).getPort()).addParameter(SYNC_REPORT_KEY, true);
         etcdMetadataReportFactory = new EtcdMetadataReportFactory();
         this.etcdMetadataReport = (EtcdMetadataReport) etcdMetadataReportFactory.createMetadataReport(registryUrl);
     }
@@ -74,7 +74,6 @@ public class EtcdMetadataReportTest {
     }
 
     @Test
-    @Disabled("Disabled because https://github.com/apache/dubbo/issues/4185")
     public void testStoreProvider() throws Exception {
         String version = "1.0.0";
         String group = null;
@@ -120,7 +119,6 @@ public class EtcdMetadataReportTest {
                 ServiceDefinitionBuilder.buildFullDefinition(interfaceClass, url.getParameters());
 
         etcdMetadataReport.storeProviderMetadata(providerMetadataIdentifier, fullServiceDefinition);
-        Thread.sleep(1000);
         return providerMetadataIdentifier;
     }
 
@@ -131,7 +129,6 @@ public class EtcdMetadataReportTest {
         Map<String, String> tmp = new HashMap<>();
         tmp.put("paramConsumerTest", "etcdConsumer");
         etcdMetadataReport.storeConsumerMetadata(consumerIdentifier, tmp);
-        Thread.sleep(1000);
         return consumerIdentifier;
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

both `testStoreProvider()` and `testStoreConsumer()` are unstable, and it is more likely failed in travis.
The assumption we made that the operation should be done in 1s in async mode may fail.

## Brief changelog

Bring back `testStoreProvider()`
Use EtcdMetadataReport in sync mode for UT

## Verifying this change

ut pass

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a [GITHUB_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Run `mvn clean install -DskipTests=false` & `mvn clean test-compile failsafe:integration-test` to make sure unit-test and integration-test pass.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).