### PR TITLE
Fixes a bug in gson's deserialization feature

### DIFF
--- a/dubbo-rpc/dubbo-rpc-dubbo/src/main/java/org/apache/dubbo/rpc/protocol/dubbo/DecodeableRpcResult.java
+++ b/dubbo-rpc/dubbo-rpc-dubbo/src/main/java/org/apache/dubbo/rpc/protocol/dubbo/DecodeableRpcResult.java
@@ -141,7 +141,7 @@ public class DecodeableRpcResult extends AppResponse implements Codec, Decodeabl
 
     private void handleException(ObjectInput in) throws IOException {
         try {
-            Object obj = in.readObject();
+            Object obj = in.readObject(Throwable.class);
             if (!(obj instanceof Throwable)) {
                 throw new IOException("Response data error, expect Throwable, but get " + obj);
             }

--- a/dubbo-serialization/dubbo-serialization-gson/src/main/java/org/apache/dubbo/common/serialize/gson/GsonJsonObjectInput.java
+++ b/dubbo-serialization/dubbo-serialization-gson/src/main/java/org/apache/dubbo/common/serialize/gson/GsonJsonObjectInput.java
@@ -90,7 +90,7 @@ public class GsonJsonObjectInput implements ObjectInput {
     @Override
     public Object readObject() throws IOException, ClassNotFoundException {
         String json = readLine();
-        return gson.fromJson(json, String.class);
+        return gson.fromJson(json, Object.class);
     }
 
     @Override


### PR DESCRIPTION
+ gson 协议处理异常的时候会有bug
    -  GsonJsonObjectInput->public Object readObject() throws IOException->return gson.fromJson(json, String.class);
    -  gson 并不具备fastjson的异常解析能力,可以通过反序列化直接得到Throwable,并且这里序列话的直接是String
    -  到处理异常结果的时候DecodeableRpcResult->handleException
          *  Object obj = in.readObject();  这里会直接出错,因为反序列化的是个json
          *  就算上边不出错,等到if (!(obj instanceof Throwable) 这个判断也会直接抛错