### PR TITLE
修复 CollectionUtils类toStringMap方法没有检查 pairs 参数是否为空.

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/utils/CollectionUtils.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/utils/CollectionUtils.java
@@ -173,6 +173,10 @@ public class CollectionUtils {
 
     public static Map<String, String> toStringMap(String... pairs) {
         Map<String, String> parameters = new HashMap<>();
+        if (pairs == null || pairs.length == 0) {
+            return parameters;
+        }
+
         if (pairs.length > 0) {
             if (pairs.length % 2 != 0) {
                 throw new IllegalArgumentException("pairs must be even.");


### PR DESCRIPTION
CollectionUtils类toStringMap方法没有检查 pairs 参数是否为空 in apache#5100.

添加如下代码

if (pairs == null || pairs.length == 0) {
            return parameters;
 }

resolve apache#5100