### PR TITLE
[Dubbo-5004] Performance tuning: Reduce object allocation

### DIFF
--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/model/ApplicationModel.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/model/ApplicationModel.java
@@ -110,12 +110,12 @@ public class ApplicationModel {
         return serviceModel;
     }
 
-    public static Optional<ServiceModel> getServiceModel (String interfaceName) {
-        return Optional.ofNullable(SERVICES.get(interfaceName));
+    public static ServiceModel getServiceModel(String interfaceName) {
+        return SERVICES.get(interfaceName);
     }
 
-    public static Optional<ServiceModel> getServiceModel (Class<?> interfaceClass) {
-        return Optional.ofNullable(SERVICES.get(interfaceClass.getName()));
+    public static ServiceModel getServiceModel(Class<?> interfaceClass) {
+        return SERVICES.get(interfaceClass.getName());
     }
 
     public static String getApplication() {

--- a/dubbo-rpc/dubbo-rpc-api/src/test/java/org/apache/dubbo/rpc/support/RpcUtilsTest.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/test/java/org/apache/dubbo/rpc/support/RpcUtilsTest.java
@@ -21,10 +21,12 @@ import org.apache.dubbo.rpc.Invocation;
 import org.apache.dubbo.rpc.Invoker;
 import org.apache.dubbo.rpc.RpcInvocation;
 
+import org.apache.dubbo.rpc.model.ApplicationModel;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -108,46 +110,60 @@ public class RpcUtilsTest {
 
     @Test
     public void testGetReturnTypes() throws Exception {
+        Class<?> demoServiceClass = DemoService.class;
+        ApplicationModel.registerServiceModel(demoServiceClass);
+        String serviceName = demoServiceClass.getName();
         Invoker invoker = mock(Invoker.class);
-        String service = "org.apache.dubbo.rpc.support.DemoService";
         given(invoker.getUrl()).willReturn(URL.valueOf("test://127.0.0.1:1/org.apache.dubbo.rpc.support.DemoService?interface=org.apache.dubbo.rpc.support.DemoService"));
-        Invocation inv = new RpcInvocation("testReturnType", service, new Class<?>[]{String.class}, null, null, invoker);
 
-        java.lang.reflect.Type[] types = RpcUtils.getReturnTypes(inv);
+        RpcInvocation inv = new RpcInvocation("testReturnType", serviceName, new Class<?>[]{String.class}, null, null, invoker);
+        Type[] types = RpcUtils.getReturnTypes(inv);
+        Assertions.assertNotNull(types);
         Assertions.assertEquals(2, types.length);
         Assertions.assertEquals(String.class, types[0]);
         Assertions.assertEquals(String.class, types[1]);
+        Assertions.assertArrayEquals(types, inv.getReturnTypes());
 
-        Invocation inv1 = new RpcInvocation("testReturnType1", service, new Class<?>[]{String.class}, null, null, invoker);
+        RpcInvocation inv1 = new RpcInvocation("testReturnType1", serviceName, new Class<?>[]{String.class}, null, null, invoker);
         java.lang.reflect.Type[] types1 = RpcUtils.getReturnTypes(inv1);
+        Assertions.assertNotNull(types1);
         Assertions.assertEquals(2, types1.length);
         Assertions.assertEquals(List.class, types1[0]);
-        Assertions.assertEquals(DemoService.class.getMethod("testReturnType1", new Class<?>[]{String.class}).getGenericReturnType(), types1[1]);
+        Assertions.assertEquals(demoServiceClass.getMethod("testReturnType1", String.class).getGenericReturnType(), types1[1]);
+        Assertions.assertArrayEquals(types1, inv1.getReturnTypes());
 
-        Invocation inv2 = new RpcInvocation("testReturnType2", service, new Class<?>[]{String.class}, null, null, invoker);
+        RpcInvocation inv2 = new RpcInvocation("testReturnType2", serviceName, new Class<?>[]{String.class}, null, null, invoker);
         java.lang.reflect.Type[] types2 = RpcUtils.getReturnTypes(inv2);
+        Assertions.assertNotNull(types2);
         Assertions.assertEquals(2, types2.length);
         Assertions.assertEquals(String.class, types2[0]);
         Assertions.assertEquals(String.class, types2[1]);
+        Assertions.assertArrayEquals(types2, inv2.getReturnTypes());
 
-        Invocation inv3 = new RpcInvocation("testReturnType3", service, new Class<?>[]{String.class}, null, null, invoker);
+        RpcInvocation inv3 = new RpcInvocation("testReturnType3", serviceName, new Class<?>[]{String.class}, null, null, invoker);
         java.lang.reflect.Type[] types3 = RpcUtils.getReturnTypes(inv3);
+        Assertions.assertNotNull(types3);
         Assertions.assertEquals(2, types3.length);
         Assertions.assertEquals(List.class, types3[0]);
-        java.lang.reflect.Type genericReturnType3 = DemoService.class.getMethod("testReturnType3", new Class<?>[]{String.class}).getGenericReturnType();
+        java.lang.reflect.Type genericReturnType3 = demoServiceClass.getMethod("testReturnType3", String.class).getGenericReturnType();
         Assertions.assertEquals(((ParameterizedType) genericReturnType3).getActualTypeArguments()[0], types3[1]);
+        Assertions.assertArrayEquals(types3, inv3.getReturnTypes());
 
-        Invocation inv4 = new RpcInvocation("testReturnType4", service, new Class<?>[]{String.class}, null, null, invoker);
+        RpcInvocation inv4 = new RpcInvocation("testReturnType4", serviceName, new Class<?>[]{String.class}, null, null, invoker);
         java.lang.reflect.Type[] types4 = RpcUtils.getReturnTypes(inv4);
+        Assertions.assertNotNull(types4);
         Assertions.assertEquals(2, types4.length);
         Assertions.assertNull(types4[0]);
         Assertions.assertNull(types4[1]);
+        Assertions.assertArrayEquals(types4, inv4.getReturnTypes());
 
-        Invocation inv5 = new RpcInvocation("testReturnType5", service, new Class<?>[]{String.class}, null, null, invoker);
+        RpcInvocation inv5 = new RpcInvocation("testReturnType5", serviceName, new Class<?>[]{String.class}, null, null, invoker);
         java.lang.reflect.Type[] types5 = RpcUtils.getReturnTypes(inv5);
+        Assertions.assertNotNull(types5);
         Assertions.assertEquals(2, types5.length);
         Assertions.assertEquals(Map.class, types5[0]);
-        java.lang.reflect.Type genericReturnType5 = DemoService.class.getMethod("testReturnType5", new Class<?>[]{String.class}).getGenericReturnType();
+        java.lang.reflect.Type genericReturnType5 = demoServiceClass.getMethod("testReturnType5", String.class).getGenericReturnType();
         Assertions.assertEquals(((ParameterizedType) genericReturnType5).getActualTypeArguments()[0], types5[1]);
+        Assertions.assertArrayEquals(types5, inv5.getReturnTypes());
     }
 }

--- a/dubbo-rpc/dubbo-rpc-dubbo/pom.xml
+++ b/dubbo-rpc/dubbo-rpc-dubbo/pom.xml
@@ -61,6 +61,11 @@
         </dependency>
         <dependency>
             <groupId>org.apache.dubbo</groupId>
+            <artifactId>dubbo-config-api</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.dubbo</groupId>
             <artifactId>dubbo-remoting-netty4</artifactId>
             <version>${project.parent.version}</version>
             <scope>test</scope>

--- a/dubbo-rpc/dubbo-rpc-dubbo/src/main/java/org/apache/dubbo/rpc/protocol/dubbo/DecodeableRpcInvocation.java
+++ b/dubbo-rpc/dubbo-rpc-dubbo/src/main/java/org/apache/dubbo/rpc/protocol/dubbo/DecodeableRpcInvocation.java
@@ -38,7 +38,6 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Optional;
 
 import static org.apache.dubbo.common.constants.CommonConstants.PATH_KEY;
 import static org.apache.dubbo.common.constants.CommonConstants.VERSION_KEY;
@@ -114,11 +113,11 @@ public class DecodeableRpcInvocation extends RpcInvocation implements Codec, Dec
             Class<?>[] pts = DubboCodec.EMPTY_CLASS_ARRAY;
             if (desc.length() > 0) {
                 // TODO, lambda function requires variables to be final.
-                Optional<ServiceModel> serviceModel = ApplicationModel.getServiceModel(path);
-                if (serviceModel.isPresent()) {
-                    Optional<MethodModel> methodOptional = serviceModel.get().getMethod(getMethodName(), desc);
-                    if (methodOptional.isPresent()) {
-                        pts = methodOptional.get().getParameterClasses();
+                ServiceModel serviceModel = ApplicationModel.getServiceModel(path);
+                if (serviceModel != null) {
+                    MethodModel methodModel = serviceModel.getMethod(getMethodName(), desc);
+                    if (methodModel != null) {
+                        pts = methodModel.getParameterClasses();
                         args = new Object[pts.length];
                         for (int i = 0; i < args.length; i++) {
                             try {
@@ -130,7 +129,7 @@ public class DecodeableRpcInvocation extends RpcInvocation implements Codec, Dec
                             }
                         }
 
-                        this.setReturnTypes(methodOptional.get().getReturnTypes());
+                        this.setReturnTypes(methodModel.getReturnTypes());
                     }
                 }
             }


### PR DESCRIPTION
## What is the purpose of the change

Reduce object allocation when get `Method` returnTypes.
The original code allocate 2 `Optional` objects, 2 `Consumer` objects and 1 `Iterator` object each time it gets `Method` returnTypes, it will increase GC pressure.

## Brief changelog

* Use ` != null` instead of  `Optional.ifPresent(Consumer)`
* Use `Map<String, List<MethodModel>>`  instead of  `Map<String, Set<MethodModel>>` in `ServiceModel`

## Verifying this change

XXXXX

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a [GITHUB_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [x] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Run `mvn clean install -DskipTests=false` & `mvn clean test-compile failsafe:integration-test` to make sure unit-test and integration-test pass.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
