### PR TITLE
README: Fix typo in example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ There's a [README](https://github.com/apache/dubbo-samples/tree/master/dubbo-sam
 package org.apache.dubbo.samples.api;
 
 public interface GreetingService {
-    String sayHello(String name);
+    String sayHi(String name);
 }
 ```
 


### PR DESCRIPTION
The example service method name is `sayHi` everywhere in the example except in the interface where it is `sayHello`.

The Java sample source is already correct, so the typo seems to only be in the README: https://github.com/apache/dubbo-samples/blob/master/dubbo-samples-api/src/main/java/org/apache/dubbo/samples/api/GreetingsService.java