### PR TITLE
fix NacosRegistry weight missing issue

### DIFF
--- a/dubbo-registry/dubbo-registry-nacos/src/main/java/com/alibaba/dubbo/registry/nacos/NacosRegistry.java
+++ b/dubbo-registry/dubbo-registry-nacos/src/main/java/com/alibaba/dubbo/registry/nacos/NacosRegistry.java
@@ -433,6 +433,7 @@ public class NacosRegistry extends FailbackRegistry {
         Instance instance = new Instance();
         instance.setIp(ip);
         instance.setPort(port);
+        instance.setWeight(newURL.getParameter(Constants.WEIGHT_KEY, Constants.DEFAULT_WEIGHT));
         instance.setMetadata(new HashMap<String, String>(newURL.getParameters()));
         return instance;
     }

--- a/dubbo-registry/dubbo-registry-nacos/src/main/java/com/alibaba/dubbo/registry/nacos/NacosRegistryFactory.java
+++ b/dubbo-registry/dubbo-registry-nacos/src/main/java/com/alibaba/dubbo/registry/nacos/NacosRegistryFactory.java
@@ -93,7 +93,6 @@ public class NacosRegistryFactory extends AbstractRegistryFactory {
         putPropertyIfAbsent(url, properties, NAMESPACE);
         putPropertyIfAbsent(url, properties, NACOS_NAMING_LOG_NAME);
         putPropertyIfAbsent(url, properties, ENDPOINT);
-        putPropertyIfAbsent(url, properties, NAMESPACE);
         putPropertyIfAbsent(url, properties, ACCESS_KEY);
         putPropertyIfAbsent(url, properties, SECRET_KEY);
         putPropertyIfAbsent(url, properties, CLUSTER_NAME);


### PR DESCRIPTION
nacos客户端默认设置weight=1.0
而dubbo权重默认设置的是100,
dubbo通过``NacosRegistry``注册服务时没有设置,导致权重获取bug
![image](https://user-images.githubusercontent.com/13413715/66375502-225d5980-e9e0-11e9-87c9-78a5bd18e31f.png)
