### PR TITLE
fix GenericServiceTest failing on Travis

### DIFF
--- a/dubbo-rpc/dubbo-rpc-dubbo/src/test/java/org/apache/dubbo/rpc/service/GenericServiceTest.java
+++ b/dubbo-rpc/dubbo-rpc-dubbo/src/test/java/org/apache/dubbo/rpc/service/GenericServiceTest.java
@@ -29,9 +29,7 @@ import org.apache.dubbo.config.ProtocolConfig;
 import org.apache.dubbo.config.ReferenceConfig;
 import org.apache.dubbo.config.RegistryConfig;
 import org.apache.dubbo.config.ServiceConfig;
-
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayInputStream;
@@ -42,21 +40,24 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 
-import static org.apache.dubbo.rpc.Constants.GENERIC_SERIALIZATION_NATIVE_JAVA;
 import static org.apache.dubbo.rpc.Constants.GENERIC_SERIALIZATION_BEAN;
+import static org.apache.dubbo.rpc.Constants.GENERIC_SERIALIZATION_NATIVE_JAVA;
 
 /**
  * GenericServiceTest
  */
-@Disabled("Keeps failing on Travis, but can not be reproduced locally.")
 public class GenericServiceTest {
+
+    private ApplicationConfig application = new ApplicationConfig("genericService-test");
+    private RegistryConfig registryNA = new RegistryConfig("N/A");
+    private ProtocolConfig protocolDubbo29581 = new ProtocolConfig("dubbo", 29581);
 
     @Test
     public void testGenericServiceException() {
         ServiceConfig<GenericService> service = new ServiceConfig<GenericService>();
-        service.setApplication(new ApplicationConfig("generic-provider"));
-        service.setRegistry(new RegistryConfig("N/A"));
-        service.setProtocol(new ProtocolConfig("dubbo", 29581));
+        service.setApplication(application);
+        service.setRegistry(registryNA);
+        service.setProtocol(protocolDubbo29581);
         service.setInterface(DemoService.class.getName());
         service.setRef(new GenericService() {
 
@@ -77,7 +78,7 @@ public class GenericServiceTest {
         service.export();
         try {
             ReferenceConfig<DemoService> reference = new ReferenceConfig<DemoService>();
-            reference.setApplication(new ApplicationConfig("generic-consumer"));
+            service.setApplication(application);
             reference.setInterface(DemoService.class);
             reference.setUrl("dubbo://127.0.0.1:29581?generic=true&timeout=3000");
             DemoService demoService = reference.get();
@@ -108,15 +109,15 @@ public class GenericServiceTest {
     @Test
     public void testGenericReferenceException() {
         ServiceConfig<DemoService> service = new ServiceConfig<DemoService>();
-        service.setApplication(new ApplicationConfig("generic-provider"));
-        service.setRegistry(new RegistryConfig("N/A"));
-        service.setProtocol(new ProtocolConfig("dubbo", 29581));
+        service.setApplication(application);
+        service.setRegistry(registryNA);
+        service.setProtocol(protocolDubbo29581);
         service.setInterface(DemoService.class.getName());
         service.setRef(new DemoServiceImpl());
         service.export();
         try {
             ReferenceConfig<GenericService> reference = new ReferenceConfig<GenericService>();
-            reference.setApplication(new ApplicationConfig("generic-consumer"));
+            service.setApplication(application);
             reference.setInterface(DemoService.class);
             reference.setUrl("dubbo://127.0.0.1:29581?scope=remote&timeout=3000");
             reference.setGeneric(true);
@@ -141,16 +142,16 @@ public class GenericServiceTest {
     @Test
     public void testGenericSerializationJava() throws Exception {
         ServiceConfig<DemoService> service = new ServiceConfig<DemoService>();
-        service.setApplication(new ApplicationConfig("generic-provider"));
-        service.setRegistry(new RegistryConfig("N/A"));
-        service.setProtocol(new ProtocolConfig("dubbo", 29581));
+        service.setApplication(application);
+        service.setRegistry(registryNA);
+        service.setProtocol(protocolDubbo29581);
         service.setInterface(DemoService.class.getName());
         DemoServiceImpl ref = new DemoServiceImpl();
         service.setRef(ref);
         service.export();
         try {
             ReferenceConfig<GenericService> reference = new ReferenceConfig<GenericService>();
-            reference.setApplication(new ApplicationConfig("generic-consumer"));
+            service.setApplication(application);
             reference.setInterface(DemoService.class);
             reference.setUrl("dubbo://127.0.0.1:29581?scope=remote&timeout=3000");
             reference.setGeneric(GENERIC_SERIALIZATION_NATIVE_JAVA);
@@ -209,17 +210,17 @@ public class GenericServiceTest {
     @Test
     public void testGenericInvokeWithBeanSerialization() throws Exception {
         ServiceConfig<DemoService> service = new ServiceConfig<DemoService>();
-        service.setApplication(new ApplicationConfig("bean-provider"));
+        service.setApplication(application);
+        service.setRegistry(registryNA);
+        service.setProtocol(protocolDubbo29581);
         service.setInterface(DemoService.class);
-        service.setRegistry(new RegistryConfig("N/A"));
         DemoServiceImpl impl = new DemoServiceImpl();
         service.setRef(impl);
-        service.setProtocol(new ProtocolConfig("dubbo", 29581));
         service.export();
         ReferenceConfig<GenericService> reference = null;
         try {
             reference = new ReferenceConfig<GenericService>();
-            reference.setApplication(new ApplicationConfig("bean-consumer"));
+            service.setApplication(application);
             reference.setInterface(DemoService.class);
             reference.setUrl("dubbo://127.0.0.1:29581?scope=remote&timeout=3000");
             reference.setGeneric(GENERIC_SERIALIZATION_BEAN);
@@ -248,9 +249,9 @@ public class GenericServiceTest {
     public void testGenericImplementationWithBeanSerialization() throws Exception {
         final AtomicReference reference = new AtomicReference();
         ServiceConfig<GenericService> service = new ServiceConfig<GenericService>();
-        service.setApplication(new ApplicationConfig("bean-provider"));
-        service.setRegistry(new RegistryConfig("N/A"));
-        service.setProtocol(new ProtocolConfig("dubbo", 29581));
+        service.setApplication(application);
+        service.setRegistry(registryNA);
+        service.setProtocol(protocolDubbo29581);
         service.setInterface(DemoService.class.getName());
         service.setRef(new GenericService() {
 
@@ -273,7 +274,7 @@ public class GenericServiceTest {
         ReferenceConfig<DemoService> ref = null;
         try {
             ref = new ReferenceConfig<DemoService>();
-            ref.setApplication(new ApplicationConfig("bean-consumer"));
+            service.setApplication(application);
             ref.setInterface(DemoService.class);
             ref.setUrl("dubbo://127.0.0.1:29581?scope=remote&generic=bean&timeout=3000");
             DemoService demoService = ref.get();

--- a/dubbo-rpc/dubbo-rpc-dubbo/src/test/java/org/apache/dubbo/rpc/validation/ValidationTest.java
+++ b/dubbo-rpc/dubbo-rpc-dubbo/src/test/java/org/apache/dubbo/rpc/validation/ValidationTest.java
@@ -46,7 +46,7 @@ import java.util.Set;
 public class ValidationTest {
     private ApplicationConfig application = new ApplicationConfig("validation-test");
     private RegistryConfig registryNA = new RegistryConfig("N/A");
-    private ProtocolConfig protocolDubo29582 = new ProtocolConfig("dubbo", 29582);
+    private ProtocolConfig protocolDubbo29582 = new ProtocolConfig("dubbo", 29582);
 
     @BeforeEach
     public void setUp() {
@@ -63,7 +63,7 @@ public class ValidationTest {
         ServiceConfig<ValidationService> service = new ServiceConfig<ValidationService>();
         service.setApplication(application);
         service.setRegistry(registryNA);
-        service.setProtocol(protocolDubo29582);
+        service.setProtocol(protocolDubbo29582);
         service.setInterface(ValidationService.class.getName());
         service.setRef(new ValidationServiceImpl());
         service.setValidation(String.valueOf(true));
@@ -189,7 +189,7 @@ public class ValidationTest {
         ServiceConfig<ValidationService> service = new ServiceConfig<ValidationService>();
         service.setApplication(application);
         service.setRegistry(registryNA);
-        service.setProtocol(protocolDubo29582);
+        service.setProtocol(protocolDubbo29582);
         service.setInterface(ValidationService.class.getName());
         service.setRef(new ValidationServiceImpl());
         service.setValidation(String.valueOf(true));
@@ -254,7 +254,7 @@ public class ValidationTest {
         ServiceConfig<ValidationService> service = new ServiceConfig<ValidationService>();
         service.setApplication(application);
         service.setRegistry(registryNA);
-        service.setProtocol(protocolDubo29582);
+        service.setProtocol(protocolDubbo29582);
         service.setInterface(ValidationService.class.getName());
         service.setRef(new ValidationServiceImpl());
         service.setValidation(String.valueOf(true));


### PR DESCRIPTION
## What is the purpose of the change
在GenericServiceTest 发现有此描述
@Disabled("Keeps failing on Travis, but can not be reproduced locally."

## Brief changelog

原因是Application是全局变量，在不同的test里 同时set不同的Application会产生错误。
此类对泛型应用和泛型实现有一定测试回归价值，所以去掉了@Disabled，并都使用同一个Application

修复ValidationTest中dubbo的拼写错误

## Verifying this change

XXXXX

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a [GITHUB_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [x] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Run `mvn clean install -DskipTests=false` & `mvn clean test-compile failsafe:integration-test` to make sure unit-test and integration-test pass.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
