### PR TITLE
[Dubbo-5215] get & set & remove in org.apache.dubbo.common.utils.Stack take no consideration that index plus mSize is negative

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/utils/Stack.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/utils/Stack.java
@@ -77,7 +77,7 @@ public class Stack<E> {
      * @return element.
      */
     public E get(int index) {
-        if (index >= mSize) {
+        if (index >= mSize || index + mSize < 0) {
             throw new IndexOutOfBoundsException("Index: " + index + ", Size: " + mSize);
         }
 
@@ -92,7 +92,7 @@ public class Stack<E> {
      * @return old element.
      */
     public E set(int index, E value) {
-        if (index >= mSize) {
+        if (index >= mSize || index + mSize < 0) {
             throw new IndexOutOfBoundsException("Index: " + index + ", Size: " + mSize);
         }
 
@@ -106,7 +106,7 @@ public class Stack<E> {
      * @return element
      */
     public E remove(int index) {
-        if (index >= mSize) {
+        if (index >= mSize || index + mSize < 0) {
             throw new IndexOutOfBoundsException("Index: " + index + ", Size: " + mSize);
         }
 

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/utils/StackTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/utils/StackTest.java
@@ -83,6 +83,17 @@ public class StackTest {
     }
 
     @Test
+    public void testIllegalGetNegative() throws Exception {
+        Stack<String> stack = new Stack<String>();
+        stack.push("one");
+        stack.get(-1);
+
+        Assertions.assertThrows(IndexOutOfBoundsException.class, () -> {
+            stack.get(-10);
+        });
+    }
+
+    @Test
     public void testIllegalSet() throws Exception {
         Assertions.assertThrows(IndexOutOfBoundsException.class, () -> {
             Stack<String> stack = new Stack<String>();
@@ -91,10 +102,28 @@ public class StackTest {
     }
 
     @Test
+    public void testIllegalSetNegative() throws Exception {
+        Assertions.assertThrows(IndexOutOfBoundsException.class, () -> {
+            Stack<String> stack = new Stack<String>();
+            stack.set(-1, "illegal");
+        });
+    }
+
+    @Test
     public void testIllegalRemove() throws Exception {
         Assertions.assertThrows(IndexOutOfBoundsException.class, () -> {
             Stack<String> stack = new Stack<String>();
             stack.remove(1);
+        });
+    }
+
+    @Test
+    public void testIllegalRemoveNegative() throws Exception {
+        Stack<String> stack = new Stack<String>();
+        stack.push("one");
+
+        Assertions.assertThrows(IndexOutOfBoundsException.class, () -> {
+            stack.remove(-1);
         });
     }
 }

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/utils/StackTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/utils/StackTest.java
@@ -123,7 +123,7 @@ public class StackTest {
         stack.push("one");
 
         Assertions.assertThrows(IndexOutOfBoundsException.class, () -> {
-            stack.remove(-1);
+            stack.remove(-2);
         });
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

fix #5215

## Brief changelog

XXXXX

## Verifying this change

XXXXX

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a [GITHUB_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Run `mvn clean install -DskipTests=false` & `mvn clean test-compile failsafe:integration-test` to make sure unit-test and integration-test pass.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
