### PR TITLE
[Dubbo-3990] Fix dubbo和openfeign一起用报错 #3990

### DIFF
--- a/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/ServiceBean.java
+++ b/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/ServiceBean.java
@@ -72,6 +72,8 @@ public class ServiceBean<T> extends ServiceConfig<T> implements InitializingBean
 
     private transient boolean supportedApplicationListener;
 
+    private transient boolean ready;
+
     private ApplicationEventPublisher applicationEventPublisher;
 
     public ServiceBean() {
@@ -107,7 +109,16 @@ public class ServiceBean<T> extends ServiceConfig<T> implements InitializingBean
 
     @Override
     public void onApplicationEvent(ContextRefreshedEvent event) {
+        if (event.getApplicationContext() != applicationContext) {
+            return;
+        }
         if (!isExported() && !isUnexported()) {
+            if(!ready) {
+                if (logger.isWarnEnabled()) {
+                    logger.warn("The service unready. service: " + getInterface());
+                }
+                return;
+            }
             if (logger.isInfoEnabled()) {
                 logger.info("The service ready on spring started. service: " + getInterface());
             }
@@ -313,6 +324,7 @@ public class ServiceBean<T> extends ServiceConfig<T> implements InitializingBean
                 setPath(beanName);
             }
         }
+        ready = true;
         if (!supportedApplicationListener) {
             export();
         }


### PR DESCRIPTION
## What is the purpose of the change

fix compatible with openfeign

## Brief changelog

ServiceBean
1. ignore ContextRefreshedEvent fired by FeignContext(child spring context) 
2. onApplicationEvent check if ServiceBean is ready(all properties are set, updated on afterPropertiesSet)

## Verifying this change

mvn clean install -pl dubbo-config/dubbo-config-spring
passed
