### PR TITLE
[Dubbo-5257] trim .properties for apollo namespaces

### DIFF
--- a/dubbo-configcenter/dubbo-configcenter-apollo/src/main/java/org/apache/dubbo/configcenter/support/apollo/ApolloDynamicConfiguration.java
+++ b/dubbo-configcenter/dubbo-configcenter-apollo/src/main/java/org/apache/dubbo/configcenter/support/apollo/ApolloDynamicConfiguration.java
@@ -152,9 +152,9 @@ public class ApolloDynamicConfiguration implements DynamicConfiguration {
 
     @Override
     public String getProperties(String key, String group, long timeout) throws IllegalStateException {
-        // Apollo does not allow namespace ends with '.properties', '.yaml', ...
-        if (key.endsWith(".properties")) {
-            key = key.replace(".properties", "-properties");
+        // Apollo namespaces won't end with file formats, e.g. '.properties', '.yaml', so we could safely trim them here
+        if (key.toLowerCase().endsWith(".properties")) {
+            key = key.substring(0, key.length() - ".properties".length());
         }
         ConfigFile configFile = ConfigService.getConfigFile(key, ConfigFileFormat.Properties);
         if (configFile == null) {


### PR DESCRIPTION
## What is the purpose of the change

Fixes #5257

## Brief changelog

Apollo namespaces won't end with file formats, e.g. `.properties`, `.yaml`, so we could safely trim them(and we'd better do that) before passing to methods like `ConfigService.getConfigFile(key, ConfigFileFormat.Properties)`.

## Verifying this change

Passing `dubbo.properties` as key to `org.apache.dubbo.configcenter.support.apollo.ApolloDynamicConfiguration#getProperties` will return the configurations of namespace `dubbo` with format `properties`.

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a [GITHUB_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [x] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Run `mvn clean install -DskipTests=false` & `mvn clean test-compile failsafe:integration-test` to make sure unit-test and integration-test pass.
- [x] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
