### PR TITLE
Apollo config center should be initialized via XML

### DIFF
--- a/dubbo-configcenter/dubbo-configcenter-apollo/src/main/java/org/apache/dubbo/configcenter/support/apollo/ApolloDynamicConfiguration.java
+++ b/dubbo-configcenter/dubbo-configcenter-apollo/src/main/java/org/apache/dubbo/configcenter/support/apollo/ApolloDynamicConfiguration.java
@@ -69,6 +69,7 @@ public class ApolloDynamicConfiguration implements DynamicConfiguration {
     private static final String APOLLO_CLUSTER_KEY = "apollo.cluster";
     private static final String APOLLO_PROTOCOL_PREFIX = "http://";
     private static final String APOLLO_APPLICATION_KEY = "application";
+    private static final String APOLLO_APPID_KEY = "app.id";
 
     private URL url;
     private Config dubboConfig;
@@ -81,14 +82,18 @@ public class ApolloDynamicConfiguration implements DynamicConfiguration {
         String configEnv = url.getParameter(APOLLO_ENV_KEY);
         String configAddr = getAddressWithProtocolPrefix(url);
         String configCluster = url.getParameter(CLUSTER_KEY);
-        if (configEnv != null) {
+        String configAppId = url.getParameter(APOLLO_APPID_KEY);
+        if (StringUtils.isEmpty(System.getProperty(APOLLO_ENV_KEY)) && configEnv != null) {
             System.setProperty(APOLLO_ENV_KEY, configEnv);
         }
-        if (StringUtils.isEmpty(System.getProperty(APOLLO_ENV_KEY)) && !ANYHOST_VALUE.equals(configAddr)) {
+        if (StringUtils.isEmpty(System.getProperty(APOLLO_ADDR_KEY)) && !ANYHOST_VALUE.equals(url.getHost())) {
             System.setProperty(APOLLO_ADDR_KEY, configAddr);
         }
-        if (configCluster != null) {
+        if (StringUtils.isEmpty(System.getProperty(APOLLO_CLUSTER_KEY)) && configCluster != null) {
             System.setProperty(APOLLO_CLUSTER_KEY, configCluster);
+        }
+        if (StringUtils.isEmpty(System.getProperty(APOLLO_APPID_KEY)) && configAppId != null) {
+            System.setProperty(APOLLO_APPID_KEY, configAppId);
         }
 
         String namespace = url.getParameter(CONFIG_NAMESPACE_KEY, DEFAULT_GROUP);


### PR DESCRIPTION
## What is the purpose of the change

Apollo config center should be initialized via XML

## Brief changelog

/dubbo-configcenter/dubbo-configcenter-apollo/src/main/java/org/apache/dubbo/configcenter/support/apollo/ApolloDynamicConfiguration.java

## Verifying this change

declare apollo config center via XML only:

```
<dubbo:config-center protocol="apollo" address="127.0.0.1:8080" namespace="dubbo">
    <dubbo:parameter key="env" value="DEV"/>
    <dubbo:parameter key="app.id" value="ABC"/>
</dubbo:config-center>
```

Or var XML with System Properties:
Add Properties:"-Dapp.id=ABC -Denv=DEV -Dapollo.meta=http://127.0.0.1:8080"
And then declare in XML:
```
<dubbo:config-center protocol="apollo" namespace="dubbo"/>
```