### PR TITLE
Fixed the router problem of application condition router does not take effect.

### DIFF
--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/router/condition/config/AppRouter.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/router/condition/config/AppRouter.java
@@ -69,9 +69,6 @@ public class AppRouter extends ListenableRouter {
         }
         synchronized (this) {
             if (!Objects.equals(remoteApplication, application)) {
-                if (!StringUtils.isEmpty(application)) {
-                    ruleRepository.removeListener(application + RULE_SUFFIX, this);
-                }
                 String routerKey = remoteApplication + RULE_SUFFIX;
                 ruleRepository.addListener(routerKey, this);
                 application = remoteApplication;

--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/router/condition/config/AppRouter.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/router/condition/config/AppRouter.java
@@ -17,7 +17,17 @@
 package org.apache.dubbo.rpc.cluster.router.condition.config;
 
 import org.apache.dubbo.common.URL;
+import org.apache.dubbo.common.config.configcenter.ConfigChangedEvent;
+import org.apache.dubbo.common.config.configcenter.DynamicConfiguration;
 import org.apache.dubbo.common.constants.CommonConstants;
+import org.apache.dubbo.common.logger.Logger;
+import org.apache.dubbo.common.logger.LoggerFactory;
+import org.apache.dubbo.common.utils.CollectionUtils;
+import org.apache.dubbo.common.utils.StringUtils;
+import org.apache.dubbo.rpc.Invoker;
+
+import java.util.List;
+import java.util.Objects;
 
 /**
  * Application level router, "application.condition-router"
@@ -29,8 +39,47 @@ public class AppRouter extends ListenableRouter {
      */
     private static final int APP_ROUTER_DEFAULT_PRIORITY = 150;
 
+    private static final Logger logger = LoggerFactory.getLogger(AppRouter.class);
+
+    private String application;
+
     public AppRouter(URL url) {
-        super(url, url.getParameter(CommonConstants.APPLICATION_KEY));
+        super(url);
         this.priority = APP_ROUTER_DEFAULT_PRIORITY;
+    }
+
+    public void setApplication(String application) {
+        this.application = application;
+    }
+
+    @Override
+    public <T> void notify(List<Invoker<T>> invokers) {
+        if (CollectionUtils.isEmpty(invokers)) {
+            return;
+        }
+
+        Invoker<T> invoker = invokers.get(0);
+        URL url = invoker.getUrl();
+        String remoteApplication = url.getParameter(CommonConstants.REMOTE_APPLICATION_KEY);
+
+        if (StringUtils.isEmpty(remoteApplication)) {
+            logger.error("AppRouter must getConfig from or subscribe to a specific application, but the application " +
+                    "in this AppRouter is not specified.");
+            return;
+        }
+        synchronized (this) {
+            if (!Objects.equals(remoteApplication, application)) {
+                if (!StringUtils.isEmpty(application)) {
+                    ruleRepository.removeListener(application + RULE_SUFFIX, this);
+                }
+                String routerKey = remoteApplication + RULE_SUFFIX;
+                ruleRepository.addListener(routerKey, this);
+                application = remoteApplication;
+                String rule = ruleRepository.getRule(routerKey, DynamicConfiguration.DEFAULT_GROUP);
+                if (StringUtils.isNotEmpty(rule)) {
+                    this.process(new ConfigChangedEvent(routerKey, DynamicConfiguration.DEFAULT_GROUP, rule));
+                }
+            }
+        }
     }
 }

--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/router/condition/config/ListenableRouter.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/router/condition/config/ListenableRouter.java
@@ -20,11 +20,9 @@ import org.apache.dubbo.common.URL;
 import org.apache.dubbo.common.config.configcenter.ConfigChangeType;
 import org.apache.dubbo.common.config.configcenter.ConfigChangedEvent;
 import org.apache.dubbo.common.config.configcenter.ConfigurationListener;
-import org.apache.dubbo.common.config.configcenter.DynamicConfiguration;
 import org.apache.dubbo.common.logger.Logger;
 import org.apache.dubbo.common.logger.LoggerFactory;
 import org.apache.dubbo.common.utils.CollectionUtils;
-import org.apache.dubbo.common.utils.StringUtils;
 import org.apache.dubbo.rpc.Invocation;
 import org.apache.dubbo.rpc.Invoker;
 import org.apache.dubbo.rpc.RpcException;
@@ -43,16 +41,15 @@ import java.util.stream.Collectors;
  */
 public abstract class ListenableRouter extends AbstractRouter implements ConfigurationListener {
     public static final String NAME = "LISTENABLE_ROUTER";
-    private static final String RULE_SUFFIX = ".condition-router";
+    protected static final String RULE_SUFFIX = ".condition-router";
 
     private static final Logger logger = LoggerFactory.getLogger(ListenableRouter.class);
     private ConditionRouterRule routerRule;
     private List<ConditionRouter> conditionRouters = Collections.emptyList();
 
-    public ListenableRouter(URL url, String ruleKey) {
+    public ListenableRouter(URL url) {
         super(url);
         this.force = false;
-        this.init(ruleKey);
     }
 
     @Override
@@ -110,18 +107,6 @@ public abstract class ListenableRouter extends AbstractRouter implements Configu
                     .stream()
                     .map(condition -> new ConditionRouter(condition, rule.isForce(), rule.isEnabled()))
                     .collect(Collectors.toList());
-        }
-    }
-
-    private synchronized void init(String ruleKey) {
-        if (StringUtils.isEmpty(ruleKey)) {
-            return;
-        }
-        String routerKey = ruleKey + RULE_SUFFIX;
-        ruleRepository.addListener(routerKey, this);
-        String rule = ruleRepository.getRule(routerKey, DynamicConfiguration.DEFAULT_GROUP);
-        if (StringUtils.isNotEmpty(rule)) {
-            this.process(new ConfigChangedEvent(routerKey, DynamicConfiguration.DEFAULT_GROUP, rule));
         }
     }
 }

--- a/dubbo-common/src/main/java/org/apache/dubbo/config/context/ConfigManager.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/config/context/ConfigManager.java
@@ -400,10 +400,10 @@ public class ConfigManager extends LifecycleAdapter implements FrameworkExt {
 //                throw new IllegalStateException("No such " + configType.getName() + " is found");
                 return null;
             } else if (size > 1) {
-                throw new IllegalStateException("The expected single matching " + configType + " but found " + size + " instances");
-            } else {
-                return configsMap.values().iterator().next();
+                logger.warn("Expected single matching of " + configType + ", but found " + size + " instances, will randomly pick the first one.");
             }
+
+            return configsMap.values().iterator().next();
         });
     }
 


### PR DESCRIPTION
## What is the purpose of the change

修复应用路由不生效问题 #4779 

## Brief changelog

AppRouter 读取路径是以consumer application name 为基础的（consumer.condition-router），但是dubbo-admin写入是以provider application name 为基础 (provider.condition-router) 所以在注册的时候读取不到admin设置的应用路由条件 现在修复为 注册的时候通过 provider application name 读取， 可以正常工作。

## Verifying this change

example https://github.com/challengeof/dubbo-demo

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a [GITHUB_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [x] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Run `mvn clean install -DskipTests=false` & `mvn clean test-compile failsafe:integration-test` to make sure unit-test and integration-test pass.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
