### PR TITLE
Revert "change attachment type from Map<String,String> to Map<String,Object> (#4311)

### DIFF
--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/router/mock/MockInvokersSelector.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/router/mock/MockInvokersSelector.java
@@ -52,7 +52,7 @@ public class MockInvokersSelector extends AbstractRouter {
         if (invocation.getAttachments() == null) {
             return getNormalInvokers(invokers);
         } else {
-            String value = (String) invocation.getAttachments().get(INVOCATION_NEED_MOCK);
+            String value = invocation.getAttachments().get(INVOCATION_NEED_MOCK);
             if (value == null) {
                 return getNormalInvokers(invokers);
             } else if (Boolean.TRUE.toString().equalsIgnoreCase(value)) {

--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/router/tag/TagRouter.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/router/tag/TagRouter.java
@@ -97,8 +97,8 @@ public class TagRouter extends AbstractRouter implements ConfigurationListener {
         }
 
         List<Invoker<T>> result = invokers;
-        String tag = StringUtils.isEmpty((String) invocation.getAttachment(TAG_KEY)) ? url.getParameter(TAG_KEY) :
-                (String) invocation.getAttachment(TAG_KEY);
+        String tag = StringUtils.isEmpty(invocation.getAttachment(TAG_KEY)) ? url.getParameter(TAG_KEY) :
+                invocation.getAttachment(TAG_KEY);
 
         // if we are requesting for a Provider with a specific tag
         if (StringUtils.isNotEmpty(tag)) {
@@ -163,8 +163,8 @@ public class TagRouter extends AbstractRouter implements ConfigurationListener {
     private <T> List<Invoker<T>> filterUsingStaticTag(List<Invoker<T>> invokers, URL url, Invocation invocation) {
         List<Invoker<T>> result = invokers;
         // Dynamic param
-        String tag = StringUtils.isEmpty((String) invocation.getAttachment(TAG_KEY)) ? url.getParameter(TAG_KEY) :
-                (String) invocation.getAttachment(TAG_KEY);
+        String tag = StringUtils.isEmpty(invocation.getAttachment(TAG_KEY)) ? url.getParameter(TAG_KEY) :
+                invocation.getAttachment(TAG_KEY);
         // Tag request
         if (!StringUtils.isEmpty(tag)) {
             result = filterInvoker(invokers, invoker -> tag.equals(invoker.getUrl().getParameter(TAG_KEY)));
@@ -189,7 +189,7 @@ public class TagRouter extends AbstractRouter implements ConfigurationListener {
     }
 
     private boolean isForceUseTag(Invocation invocation) {
-        return Boolean.valueOf((String) invocation.getAttachment(FORCE_USE_TAG, url.getParameter(FORCE_USE_TAG, "false")));
+        return Boolean.valueOf(invocation.getAttachment(FORCE_USE_TAG, url.getParameter(FORCE_USE_TAG, "false")));
     }
 
     private <T> List<Invoker<T>> filterInvoker(List<Invoker<T>> invokers, Predicate<Invoker<T>> predicate) {

--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/support/AbstractClusterInvoker.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/support/AbstractClusterInvoker.java
@@ -244,7 +244,7 @@ public abstract class AbstractClusterInvoker<T> implements Invoker<T> {
         checkWhetherDestroyed();
 
         // binding attachments into invocation.
-        Map<String, Object> contextAttachments = RpcContext.getContext().getAttachments();
+        Map<String, String> contextAttachments = RpcContext.getContext().getAttachments();
         if (contextAttachments != null && contextAttachments.size() != 0) {
             ((RpcInvocation) invocation).addAttachments(contextAttachments);
         }

--- a/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/directory/MockDirInvocation.java
+++ b/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/directory/MockDirInvocation.java
@@ -56,8 +56,8 @@ public class MockDirInvocation implements Invocation {
         return new Object[]{"aa"};
     }
 
-    public Map<String, Object> getAttachments() {
-        Map<String, Object> attachments = new HashMap<String, Object>();
+    public Map<String, String> getAttachments() {
+        Map<String, String> attachments = new HashMap<>();
         attachments.put(PATH_KEY, "dubbo");
         attachments.put(GROUP_KEY, "dubbo");
         attachments.put(VERSION_KEY, "1.0.0");
@@ -68,12 +68,12 @@ public class MockDirInvocation implements Invocation {
     }
 
     @Override
-    public void setAttachment(String key, Object value) {
+    public void setAttachment(String key, String value) {
 
     }
 
     @Override
-    public void setAttachmentIfAbsent(String key, Object value) {
+    public void setAttachmentIfAbsent(String key, String value) {
 
     }
 
@@ -96,11 +96,11 @@ public class MockDirInvocation implements Invocation {
         return null;
     }
 
-    public Object getAttachment(String key) {
+    public String getAttachment(String key) {
         return getAttachments().get(key);
     }
 
-    public Object getAttachment(String key, Object defaultValue) {
+    public String getAttachment(String key, String defaultValue) {
         return getAttachments().get(key);
     }
 

--- a/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/support/AbstractClusterInvokerTest.java
+++ b/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/support/AbstractClusterInvokerTest.java
@@ -150,7 +150,7 @@ public class AbstractClusterInvokerTest {
 
         // setup attachment
         RpcContext.getContext().setAttachment(attachKey, attachValue);
-        Map<String, Object> attachments = RpcContext.getContext().getAttachments();
+        Map<String, String> attachments = RpcContext.getContext().getAttachments();
         Assertions.assertTrue( attachments != null && attachments.size() == 1,"set attachment failed!");
 
         cluster = new AbstractClusterInvoker(dic) {
@@ -158,7 +158,7 @@ public class AbstractClusterInvokerTest {
             protected Result doInvoke(Invocation invocation, List invokers, LoadBalance loadbalance)
                     throws RpcException {
                 // attachment will be bind to invocation
-                String value = (String) invocation.getAttachment(attachKey);
+                String value = invocation.getAttachment(attachKey);
                 Assertions.assertTrue(value != null && value.equals(attachValue),"binding attachment failed!");
                 return null;
             }

--- a/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/support/ForkingClusterInvokerTest.java
+++ b/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/support/ForkingClusterInvokerTest.java
@@ -24,6 +24,7 @@ import org.apache.dubbo.rpc.RpcContext;
 import org.apache.dubbo.rpc.RpcException;
 import org.apache.dubbo.rpc.RpcInvocation;
 import org.apache.dubbo.rpc.cluster.Directory;
+
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -128,7 +129,7 @@ public class ForkingClusterInvokerTest {
 
         RpcContext.getContext().setAttachment(attachKey, attachValue);
 
-        Map<String, Object> attachments = RpcContext.getContext().getAttachments();
+        Map<String, String> attachments = RpcContext.getContext().getAttachments();
         Assertions.assertTrue(attachments != null && attachments.size() == 1, "set attachment failed!");
         try {
             invoker.invoke(invocation);
@@ -137,7 +138,7 @@ public class ForkingClusterInvokerTest {
             Assertions.assertTrue(expected.getMessage().contains("Failed to forking invoke provider"), "Succeeded to forking invoke provider !");
             assertFalse(expected.getCause() instanceof RpcException);
         }
-        Map<String, Object> afterInvoke = RpcContext.getContext().getAttachments();
+        Map<String, String> afterInvoke = RpcContext.getContext().getAttachments();
         Assertions.assertTrue(afterInvoke != null && afterInvoke.size() == 0, "clear attachment failed!");
     }
 

--- a/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/support/MergeableClusterInvokerTest.java
+++ b/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/support/MergeableClusterInvokerTest.java
@@ -105,7 +105,7 @@ public class MergeableClusterInvokerTest {
         given(invocation.getMethodName()).willReturn("getMenu");
         given(invocation.getParameterTypes()).willReturn(new Class<?>[]{});
         given(invocation.getArguments()).willReturn(new Object[]{});
-        given(invocation.getAttachments()).willReturn(new HashMap<String, Object>())
+        given(invocation.getAttachments()).willReturn(new HashMap<String, String>())
                 ;
         given(invocation.getInvoker()).willReturn(firstInvoker);
 
@@ -182,7 +182,7 @@ public class MergeableClusterInvokerTest {
                 new Class<?>[]{String.class, List.class});
         given(invocation.getArguments()).willReturn(new Object[]{menu, menuItems})
                 ;
-        given(invocation.getAttachments()).willReturn(new HashMap<String, Object>())
+        given(invocation.getAttachments()).willReturn(new HashMap<String, String>())
                 ;
         given(invocation.getInvoker()).willReturn(firstInvoker);
 

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/constants/CommonConstants.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/constants/CommonConstants.java
@@ -288,8 +288,6 @@ public interface CommonConstants {
 
     String REGISTER_KEY = "register";
 
-    String DUBBO_INVOCATION_PREFIX = "_DUBBO_IGNORE_ATTACH_";
-
     String INTERFACES = "interfaces";
 
     String SSL_ENABLED_KEY = "ssl-enabled";

--- a/dubbo-compatible/src/main/java/com/alibaba/dubbo/rpc/Invocation.java
+++ b/dubbo-compatible/src/main/java/com/alibaba/dubbo/rpc/Invocation.java
@@ -30,11 +30,11 @@ public interface Invocation extends org.apache.dubbo.rpc.Invocation {
     }
 
     @Override
-    default void setAttachmentIfAbsent(String key, Object value) {
+    default void setAttachmentIfAbsent(String key, String value) {
     }
 
     @Override
-    default void setAttachment(String key, Object value) {
+    default void setAttachment(String key, String value) {
 
     }
 
@@ -49,7 +49,7 @@ public interface Invocation extends org.apache.dubbo.rpc.Invocation {
     }
 
     @Override
-    default Object getAttachment(String key, Object defaultValue) {
+    default String getAttachment(String key, String defaultValue) {
         return null;
     }
 
@@ -97,17 +97,17 @@ public interface Invocation extends org.apache.dubbo.rpc.Invocation {
         }
 
         @Override
-        public Map<String, Object> getAttachments() {
+        public Map<String, String> getAttachments() {
             return delegate.getAttachments();
         }
 
         @Override
-        public Object getAttachment(String key) {
+        public String getAttachment(String key) {
             return delegate.getAttachment(key);
         }
 
         @Override
-        public Object getAttachment(String key, Object defaultValue) {
+        public String getAttachment(String key, String defaultValue) {
             return delegate.getAttachment(key, defaultValue);
         }
 

--- a/dubbo-compatible/src/main/java/com/alibaba/dubbo/rpc/Result.java
+++ b/dubbo-compatible/src/main/java/com/alibaba/dubbo/rpc/Result.java
@@ -108,32 +108,32 @@ public interface Result extends org.apache.dubbo.rpc.Result {
         }
 
         @Override
-        public Map<String, Object> getAttachments() {
+        public Map<String, String> getAttachments() {
             return delegate.getAttachments();
         }
 
         @Override
-        public void addAttachments(Map<String, Object> map) {
+        public void addAttachments(Map<String, String> map) {
             delegate.addAttachments(map);
         }
 
         @Override
-        public void setAttachments(Map<String, Object> map) {
+        public void setAttachments(Map<String, String> map) {
             delegate.setAttachments(map);
         }
 
         @Override
         public String getAttachment(String key) {
-            return (String) delegate.getAttachment(key);
+            return delegate.getAttachment(key);
         }
 
         @Override
-        public String getAttachment(String key, Object defaultValue) {
-            return (String) delegate.getAttachment(key, defaultValue);
+        public String getAttachment(String key, String defaultValue) {
+            return delegate.getAttachment(key, defaultValue);
         }
 
         @Override
-        public void setAttachment(String key, Object value) {
+        public void setAttachment(String key, String value) {
             delegate.setAttachment(key, value);
         }
     }

--- a/dubbo-compatible/src/main/java/com/alibaba/dubbo/rpc/RpcInvocation.java
+++ b/dubbo-compatible/src/main/java/com/alibaba/dubbo/rpc/RpcInvocation.java
@@ -36,7 +36,7 @@ public class RpcInvocation implements Invocation, Serializable {
 
     private Object[] arguments;
 
-    private Map<String, Object> attachments;
+    private Map<String, String> attachments;
 
     private transient Invoker<?> invoker;
 
@@ -45,7 +45,7 @@ public class RpcInvocation implements Invocation, Serializable {
 
     public RpcInvocation(Invocation invocation, Invoker<?> invoker) {
         this(invocation.getMethodName(), invocation.getParameterTypes(),
-                invocation.getArguments(), new HashMap<String, Object>(invocation.getAttachments()),
+                invocation.getArguments(), new HashMap<String, String>(invocation.getAttachments()),
                 invocation.getInvoker());
         if (invoker != null) {
             URL url = invoker.getUrl();
@@ -80,7 +80,7 @@ public class RpcInvocation implements Invocation, Serializable {
         this(method.getName(), method.getParameterTypes(), arguments, null, null);
     }
 
-    public RpcInvocation(Method method, Object[] arguments, Map<String, Object> attachment) {
+    public RpcInvocation(Method method, Object[] arguments, Map<String, String> attachment) {
         this(method.getName(), method.getParameterTypes(), arguments, attachment, null);
     }
 
@@ -88,15 +88,15 @@ public class RpcInvocation implements Invocation, Serializable {
         this(methodName, parameterTypes, arguments, null, null);
     }
 
-    public RpcInvocation(String methodName, Class<?>[] parameterTypes, Object[] arguments, Map<String, Object> attachments) {
+    public RpcInvocation(String methodName, Class<?>[] parameterTypes, Object[] arguments, Map<String, String> attachments) {
         this(methodName, parameterTypes, arguments, attachments, null);
     }
 
-    public RpcInvocation(String methodName, Class<?>[] parameterTypes, Object[] arguments, Map<String, Object> attachments, Invoker<?> invoker) {
+    public RpcInvocation(String methodName, Class<?>[] parameterTypes, Object[] arguments, Map<String, String> attachments, Invoker<?> invoker) {
         this.methodName = methodName;
         this.parameterTypes = parameterTypes == null ? new Class<?>[0] : parameterTypes;
         this.arguments = arguments == null ? new Object[0] : arguments;
-        this.attachments = attachments == null ? new HashMap<String, Object>() : attachments;
+        this.attachments = attachments == null ? new HashMap<String, String>() : attachments;
         this.invoker = invoker;
     }
 
@@ -132,24 +132,24 @@ public class RpcInvocation implements Invocation, Serializable {
         this.arguments = arguments == null ? new Object[0] : arguments;
     }
 
-    public Map<String, Object> getAttachments() {
+    public Map<String, String> getAttachments() {
         return attachments;
     }
 
-    public void setAttachments(Map<String, Object> attachments) {
-        this.attachments = attachments == null ? new HashMap<String, Object>() : attachments;
+    public void setAttachments(Map<String, String> attachments) {
+        this.attachments = attachments == null ? new HashMap<String, String>() : attachments;
     }
 
     public void setAttachment(String key, String value) {
         if (attachments == null) {
-            attachments = new HashMap<String, Object>();
+            attachments = new HashMap<String, String>();
         }
         attachments.put(key, value);
     }
 
     public void setAttachmentIfAbsent(String key, String value) {
         if (attachments == null) {
-            attachments = new HashMap<String, Object>();
+            attachments = new HashMap<String, String>();
         }
         if (!attachments.containsKey(key)) {
             attachments.put(key, value);
@@ -161,7 +161,7 @@ public class RpcInvocation implements Invocation, Serializable {
             return;
         }
         if (this.attachments == null) {
-            this.attachments = new HashMap<String, Object>();
+            this.attachments = new HashMap<String, String>();
         }
         this.attachments.putAll(attachments);
     }

--- a/dubbo-compatible/src/test/java/org/apache/dubbo/cache/CacheTest.java
+++ b/dubbo-compatible/src/test/java/org/apache/dubbo/cache/CacheTest.java
@@ -69,17 +69,17 @@ public class CacheTest {
         }
 
         @Override
-        public Map<String, Object> getAttachments() {
+        public Map<String, String> getAttachments() {
             return null;
         }
 
         @Override
-        public Object getAttachment(String key) {
+        public String getAttachment(String key) {
             return null;
         }
 
         @Override
-        public Object getAttachment(String key, Object defaultValue) {
+        public String getAttachment(String key, String defaultValue) {
             return null;
         }
 

--- a/dubbo-compatible/src/test/java/org/apache/dubbo/filter/LegacyInvocation.java
+++ b/dubbo-compatible/src/test/java/org/apache/dubbo/filter/LegacyInvocation.java
@@ -16,7 +16,6 @@
  */
 package org.apache.dubbo.filter;
 
-
 import com.alibaba.dubbo.rpc.Invocation;
 import com.alibaba.dubbo.rpc.Invoker;
 
@@ -58,8 +57,8 @@ public class LegacyInvocation implements Invocation {
         return new Object[]{arg0};
     }
 
-    public Map<String, Object> getAttachments() {
-        Map<String, Object> attachments = new HashMap<String, Object>();
+    public Map<String, String> getAttachments() {
+        Map<String, String> attachments = new HashMap<String, String>();
         attachments.put(PATH_KEY, "dubbo");
         attachments.put(GROUP_KEY, "dubbo");
         attachments.put(VERSION_KEY, "1.0.0");
@@ -88,11 +87,11 @@ public class LegacyInvocation implements Invocation {
         return null;
     }
 
-    public Object getAttachment(String key) {
+    public String getAttachment(String key) {
         return getAttachments().get(key);
     }
 
-    public Object getAttachment(String key, Object defaultValue) {
+    public String getAttachment(String key, String defaultValue) {
         return getAttachments().get(key);
     }
 

--- a/dubbo-compatible/src/test/java/org/apache/dubbo/service/MockInvocation.java
+++ b/dubbo-compatible/src/test/java/org/apache/dubbo/service/MockInvocation.java
@@ -62,8 +62,8 @@ public class MockInvocation implements Invocation {
         return new Object[]{arg0};
     }
 
-    public Map<String, Object> getAttachments() {
-        Map<String, Object> attachments = new HashMap<String, Object>();
+    public Map<String, String> getAttachments() {
+        Map<String, String> attachments = new HashMap<>();
         attachments.put(PATH_KEY, "dubbo");
         attachments.put(GROUP_KEY, "dubbo");
         attachments.put(VERSION_KEY, "1.0.0");
@@ -74,12 +74,12 @@ public class MockInvocation implements Invocation {
     }
 
     @Override
-    public void setAttachment(String key, Object value) {
+    public void setAttachment(String key, String value) {
 
     }
 
     @Override
-    public void setAttachmentIfAbsent(String key, Object value) {
+    public void setAttachmentIfAbsent(String key, String value) {
 
     }
 
@@ -102,11 +102,11 @@ public class MockInvocation implements Invocation {
         return null;
     }
 
-    public Object getAttachment(String key) {
+    public String getAttachment(String key) {
         return getAttachments().get(key);
     }
 
-    public Object getAttachment(String key, Object defaultValue) {
+    public String getAttachment(String key, String defaultValue) {
         return getAttachments().get(key);
     }
 

--- a/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/cache/CacheTest.java
+++ b/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/cache/CacheTest.java
@@ -131,7 +131,7 @@ public class CacheTest {
         parameters.put("findCache.cache", "threadlocal");
         URL url = new URL("dubbo", "127.0.0.1", 29582, "org.apache.dubbo.config.cache.CacheService", parameters);
 
-        Invocation invocation = new RpcInvocation("findCache", CacheService.class.getName(), new Class[]{String.class}, new String[]{"0"}, null, null);
+        Invocation invocation = new RpcInvocation("findCache", CacheService.class.getName(), new Class[]{String.class}, new String[]{"0"}, null, null, null);
 
         Cache cache = cacheFactory.getCache(url, invocation);
         assertTrue(cache instanceof ThreadLocalCache);

--- a/dubbo-monitor/dubbo-monitor-api/src/main/java/org/apache/dubbo/monitor/support/MonitorFilter.java
+++ b/dubbo-monitor/dubbo-monitor-api/src/main/java/org/apache/dubbo/monitor/support/MonitorFilter.java
@@ -83,7 +83,7 @@ public class MonitorFilter implements Filter, Filter.Listener {
     @Override
     public Result invoke(Invoker<?> invoker, Invocation invocation) throws RpcException {
         if (invoker.getUrl().hasParameter(MONITOR_KEY)) {
-            invocation.setAttachment(MONITOR_FILTER_START_TIME, String.valueOf(System.currentTimeMillis()));
+            invocation.put(MONITOR_FILTER_START_TIME, System.currentTimeMillis());
             getConcurrent(invoker, invocation).incrementAndGet(); // count up
         }
         return invoker.invoke(invocation); // proceed invocation chain
@@ -103,7 +103,7 @@ public class MonitorFilter implements Filter, Filter.Listener {
     @Override
     public void onMessage(Result result, Invoker<?> invoker, Invocation invocation) {
         if (invoker.getUrl().hasParameter(MONITOR_KEY)) {
-            collect(invoker, invocation, result, RpcContext.getContext().getRemoteHost(), Long.valueOf((String) invocation.getAttachment(MONITOR_FILTER_START_TIME)), false);
+            collect(invoker, invocation, result, RpcContext.getContext().getRemoteHost(), (long) invocation.get(MONITOR_FILTER_START_TIME), false);
             getConcurrent(invoker, invocation).decrementAndGet(); // count down
         }
     }
@@ -111,7 +111,7 @@ public class MonitorFilter implements Filter, Filter.Listener {
     @Override
     public void onError(Throwable t, Invoker<?> invoker, Invocation invocation) {
         if (invoker.getUrl().hasParameter(MONITOR_KEY)) {
-            collect(invoker, invocation, null, RpcContext.getContext().getRemoteHost(), Long.valueOf((String) invocation.getAttachment(MONITOR_FILTER_START_TIME)), true);
+            collect(invoker, invocation, null, RpcContext.getContext().getRemoteHost(), (long) invocation.get(MONITOR_FILTER_START_TIME), true);
             getConcurrent(invoker, invocation).decrementAndGet(); // count down
         }
     }
@@ -176,10 +176,10 @@ public class MonitorFilter implements Filter, Filter.Listener {
         }
         String input = "", output = "";
         if (invocation.getAttachment(INPUT_KEY) != null) {
-            input = (String) invocation.getAttachment(INPUT_KEY);
+            input = invocation.getAttachment(INPUT_KEY);
         }
         if (result != null && result.getAttachment(OUTPUT_KEY) != null) {
-            output = (String) result.getAttachment(OUTPUT_KEY);
+            output = result.getAttachment(OUTPUT_KEY);
         }
 
         return new URL(COUNT_PROTOCOL, NetUtils.getLocalHost(), localPort, service + PATH_SEPARATOR + method, MonitorService.APPLICATION, application, MonitorService.INTERFACE, service, MonitorService.METHOD, method, remoteKey, remoteValue, error ? MonitorService.FAILURE : MonitorService.SUCCESS, "1", MonitorService.ELAPSED, String.valueOf(elapsed), MonitorService.CONCURRENT, String.valueOf(concurrent), INPUT_KEY, input, OUTPUT_KEY, output, GROUP_KEY, group, VERSION_KEY, version);

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/AppResponse.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/AppResponse.java
@@ -53,7 +53,7 @@ public class AppResponse implements Result {
 
     private Throwable exception;
 
-    private Map<String, Object> attachments = new HashMap<String, Object>();
+    private Map<String, String> attachments = new HashMap<String, String>();
 
     public AppResponse() {
     }
@@ -117,7 +117,7 @@ public class AppResponse implements Result {
     }
 
     @Override
-    public Map<String, Object> getAttachments() {
+    public Map<String, String> getAttachments() {
         return attachments;
     }
 
@@ -126,35 +126,35 @@ public class AppResponse implements Result {
      *
      * @param map contains all key-value pairs to append
      */
-    public void setAttachments(Map<String, Object> map) {
-        this.attachments = map == null ? new HashMap<String, Object>() : map;
+    public void setAttachments(Map<String, String> map) {
+        this.attachments = map == null ? new HashMap<String, String>() : map;
     }
 
-    public void addAttachments(Map<String, Object> map) {
+    public void addAttachments(Map<String, String> map) {
         if (map == null) {
             return;
         }
         if (this.attachments == null) {
-            this.attachments = new HashMap<String, Object>();
+            this.attachments = new HashMap<String, String>();
         }
         this.attachments.putAll(map);
     }
 
     @Override
-    public Object getAttachment(String key) {
+    public String getAttachment(String key) {
         return attachments.get(key);
     }
 
     @Override
-    public Object getAttachment(String key, Object defaultValue) {
-        Object result = attachments.get(key);
-        if (result == null) {
+    public String getAttachment(String key, String defaultValue) {
+        String result = attachments.get(key);
+        if (result == null || result.length() == 0) {
             result = defaultValue;
         }
         return result;
     }
 
-    public void setAttachment(String key, Object value) {
+    public void setAttachment(String key, String value) {
         attachments.put(key, value);
     }
 

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/AsyncRpcResult.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/AsyncRpcResult.java
@@ -199,32 +199,32 @@ public class AsyncRpcResult implements Result {
     }
 
     @Override
-    public Map<String, Object> getAttachments() {
+    public Map<String, String> getAttachments() {
         return getAppResponse().getAttachments();
     }
 
     @Override
-    public void setAttachments(Map<String, Object> map) {
+    public void setAttachments(Map<String, String> map) {
         getAppResponse().setAttachments(map);
     }
 
     @Override
-    public void addAttachments(Map<String, Object> map) {
+    public void addAttachments(Map<String, String> map) {
         getAppResponse().addAttachments(map);
     }
 
     @Override
-    public Object getAttachment(String key) {
+    public String getAttachment(String key) {
         return getAppResponse().getAttachment(key);
     }
 
     @Override
-    public Object getAttachment(String key, Object defaultValue) {
+    public String getAttachment(String key, String defaultValue) {
         return getAppResponse().getAttachment(key, defaultValue);
     }
 
     @Override
-    public void setAttachment(String key, Object value) {
+    public void setAttachment(String key, String value) {
         getAppResponse().setAttachment(key, value);
     }
 

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/Invocation.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/Invocation.java
@@ -78,11 +78,11 @@ public interface Invocation {
      * @return attachments.
      * @serial
      */
-    Map<String, Object> getAttachments();
+    Map<String, String> getAttachments();
 
-    void setAttachment(String key, Object value);
+    void setAttachment(String key, String value);
 
-    void setAttachmentIfAbsent(String key, Object value);
+    void setAttachmentIfAbsent(String key, String value);
 
     /**
      * get attachment by key.
@@ -90,7 +90,7 @@ public interface Invocation {
      * @return attachment value.
      * @serial
      */
-    Object getAttachment(String key);
+    String getAttachment(String key);
 
     /**
      * get attachment by key with default value.
@@ -98,7 +98,7 @@ public interface Invocation {
      * @return attachment value.
      * @serial
      */
-    Object getAttachment(String key, Object defaultValue);
+    String getAttachment(String key, String defaultValue);
 
     /**
      * get the invoker in current context.

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/Result.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/Result.java
@@ -90,37 +90,37 @@ public interface Result extends Serializable {
      *
      * @return attachments.
      */
-    Map<String, Object> getAttachments();
+    Map<String, String> getAttachments();
 
     /**
      * Add the specified map to existing attachments in this instance.
      *
      * @param map
      */
-    void addAttachments(Map<String, Object> map);
+    void addAttachments(Map<String, String> map);
 
     /**
      * Replace the existing attachments with the specified param.
      *
      * @param map
      */
-    void setAttachments(Map<String, Object> map);
+    void setAttachments(Map<String, String> map);
 
     /**
      * get attachment by key.
      *
      * @return attachment value.
      */
-    Object getAttachment(String key);
+    String getAttachment(String key);
 
     /**
      * get attachment by key with default value.
      *
      * @return attachment value.
      */
-    Object getAttachment(String key, Object defaultValue);
+    String getAttachment(String key, String defaultValue);
 
-    void setAttachment(String key, Object value);
+    void setAttachment(String key, String value);
 
     /**
      * Add a callback which can be triggered when the RPC call finishes.

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/RpcContext.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/RpcContext.java
@@ -73,7 +73,7 @@ public class RpcContext {
         }
     };
 
-    private final Map<String, Object> attachments = new HashMap<String, Object>();
+    private final Map<String, String> attachments = new HashMap<String, String>();
     private final Map<String, Object> values = new HashMap<String, Object>();
 
     private List<URL> urls;
@@ -479,7 +479,7 @@ public class RpcContext {
      * @param key
      * @return attachment
      */
-    public Object getAttachment(String key) {
+    public String getAttachment(String key) {
         return attachments.get(key);
     }
 
@@ -490,7 +490,7 @@ public class RpcContext {
      * @param value
      * @return context
      */
-    public RpcContext setAttachment(String key, Object value) {
+    public RpcContext setAttachment(String key, String value) {
         if (value == null) {
             attachments.remove(key);
         } else {
@@ -515,7 +515,7 @@ public class RpcContext {
      *
      * @return attachments
      */
-    public Map<String, Object> getAttachments() {
+    public Map<String, String> getAttachments() {
         return attachments;
     }
 
@@ -525,7 +525,7 @@ public class RpcContext {
      * @param attachment
      * @return context
      */
-    public RpcContext setAttachments(Map<String, Object> attachment) {
+    public RpcContext setAttachments(Map<String, String> attachment) {
         this.attachments.clear();
         if (attachment != null && attachment.size() > 0) {
             this.attachments.putAll(attachment);

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/RpcInvocation.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/RpcInvocation.java
@@ -61,8 +61,14 @@ public class RpcInvocation implements Invocation, Serializable {
 
     private Object[] arguments;
 
-    private Map<String, Object> attachments;
+    /**
+     * Passed to the remote server during RPC call
+     */
+    private Map<String, String> attachments;
 
+    /**
+     * Only used on the caller side, will not appear on the wire.
+     */
     private Map<Object, Object> attributes = new HashMap<Object, Object>();
 
     private transient Invoker<?> invoker;
@@ -115,7 +121,7 @@ public class RpcInvocation implements Invocation, Serializable {
         this(method, serviceName, arguments, null, null);
     }
 
-    public RpcInvocation(Method method, String serviceName, Object[] arguments, Map<String, Object> attachment, Map<Object, Object> attributes) {
+    public RpcInvocation(Method method, String serviceName, Object[] arguments, Map<String, String> attachment, Map<Object, Object> attributes) {
         this(method.getName(), serviceName, method.getParameterTypes(), arguments, attachment, null);
         this.returnType = method.getReturnType();
         this.attributes = attributes == null ? new HashMap<>() : attributes;
@@ -125,16 +131,16 @@ public class RpcInvocation implements Invocation, Serializable {
         this(methodName, serviceName, parameterTypes, arguments, null, null);
     }
 
-    public RpcInvocation(String methodName, String serviceName, Class<?>[] parameterTypes, Object[] arguments, Map<String, Object> attachments) {
+    public RpcInvocation(String methodName, String serviceName, Class<?>[] parameterTypes, Object[] arguments, Map<String, String> attachments) {
         this(methodName, serviceName, parameterTypes, arguments, attachments, null);
     }
 
-    public RpcInvocation(String methodName, String serviceName, Class<?>[] parameterTypes, Object[] arguments, Map<String, Object> attachments, Invoker<?> invoker) {
+    public RpcInvocation(String methodName, String serviceName, Class<?>[] parameterTypes, Object[] arguments, Map<String, String> attachments, Invoker<?> invoker) {
         this.methodName = methodName;
         this.serviceName = serviceName;
         this.parameterTypes = parameterTypes == null ? new Class<?>[0] : parameterTypes;
         this.arguments = arguments == null ? new Object[0] : arguments;
-        this.attachments = attachments == null ? new HashMap<String, Object>() : attachments;
+        this.attachments = attachments == null ? new HashMap<String, String>() : attachments;
         this.invoker = invoker;
         initParameterDesc();
     }
@@ -246,53 +252,51 @@ public class RpcInvocation implements Invocation, Serializable {
     }
 
     @Override
-    public Map<String, Object> getAttachments() {
+    public Map<String, String> getAttachments() {
         return attachments;
     }
 
-    public void setAttachments(Map<String, Object> attachments) {
-        this.attachments = attachments == null ? new HashMap<String, Object>() : attachments;
+    public void setAttachments(Map<String, String> attachments) {
+        this.attachments = attachments == null ? new HashMap<String, String>() : attachments;
     }
 
-    @Override
-    public void setAttachment(String key, Object value) {
+    public void setAttachment(String key, String value) {
         if (attachments == null) {
-            attachments = new HashMap<String, Object>();
+            attachments = new HashMap<String, String>();
         }
         attachments.put(key, value);
     }
 
-    @Override
-    public void setAttachmentIfAbsent(String key, Object value) {
+    public void setAttachmentIfAbsent(String key, String value) {
         if (attachments == null) {
-            attachments = new HashMap<String, Object>();
+            attachments = new HashMap<String, String>();
         }
         if (!attachments.containsKey(key)) {
             attachments.put(key, value);
         }
     }
 
-    public void addAttachments(Map<String, Object> attachments) {
+    public void addAttachments(Map<String, String> attachments) {
         if (attachments == null) {
             return;
         }
         if (this.attachments == null) {
-            this.attachments = new HashMap<String, Object>();
+            this.attachments = new HashMap<String, String>();
         }
         this.attachments.putAll(attachments);
     }
 
-    public void addAttachmentsIfAbsent(Map<String, Object> attachments) {
+    public void addAttachmentsIfAbsent(Map<String, String> attachments) {
         if (attachments == null) {
             return;
         }
-        for (Map.Entry<String, Object> entry : attachments.entrySet()) {
+        for (Map.Entry<String, String> entry : attachments.entrySet()) {
             setAttachmentIfAbsent(entry.getKey(), entry.getValue());
         }
     }
 
     @Override
-    public Object getAttachment(String key) {
+    public String getAttachment(String key) {
         if (attachments == null) {
             return null;
         }
@@ -300,12 +304,12 @@ public class RpcInvocation implements Invocation, Serializable {
     }
 
     @Override
-    public Object getAttachment(String key, Object defaultValue) {
+    public String getAttachment(String key, String defaultValue) {
         if (attachments == null) {
             return defaultValue;
         }
-        Object value = attachments.get(key);
-        if (null == value) {
+        String value = attachments.get(key);
+        if (StringUtils.isEmpty(value)) {
             return defaultValue;
         }
         return value;

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/RpcInvocation.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/RpcInvocation.java
@@ -85,7 +85,7 @@ public class RpcInvocation implements Invocation, Serializable {
     public RpcInvocation(Invocation invocation, Invoker<?> invoker) {
         this(invocation.getMethodName(), invocation.getServiceName(), invocation.getParameterTypes(),
                 invocation.getArguments(), new HashMap<>(invocation.getAttachments()),
-                invocation.getInvoker());
+                invocation.getInvoker(), invocation.getAttributes());
         if (invoker != null) {
             URL url = invoker.getUrl();
             setAttachment(PATH_KEY, url.getPath());
@@ -113,7 +113,7 @@ public class RpcInvocation implements Invocation, Serializable {
 
     public RpcInvocation(Invocation invocation) {
         this(invocation.getMethodName(), invocation.getServiceName(), invocation.getParameterTypes(),
-                invocation.getArguments(), invocation.getAttachments(), invocation.getInvoker());
+                invocation.getArguments(), invocation.getAttachments(), invocation.getInvoker(), invocation.getAttributes());
         this.targetServiceUniqueName = invocation.getTargetServiceUniqueName();
     }
 
@@ -122,25 +122,26 @@ public class RpcInvocation implements Invocation, Serializable {
     }
 
     public RpcInvocation(Method method, String serviceName, Object[] arguments, Map<String, String> attachment, Map<Object, Object> attributes) {
-        this(method.getName(), serviceName, method.getParameterTypes(), arguments, attachment, null);
+        this(method.getName(), serviceName, method.getParameterTypes(), arguments, attachment, null, attributes);
         this.returnType = method.getReturnType();
-        this.attributes = attributes == null ? new HashMap<>() : attributes;
     }
 
     public RpcInvocation(String methodName, String serviceName, Class<?>[] parameterTypes, Object[] arguments) {
-        this(methodName, serviceName, parameterTypes, arguments, null, null);
+        this(methodName, serviceName, parameterTypes, arguments, null, null, null);
     }
 
     public RpcInvocation(String methodName, String serviceName, Class<?>[] parameterTypes, Object[] arguments, Map<String, String> attachments) {
-        this(methodName, serviceName, parameterTypes, arguments, attachments, null);
+        this(methodName, serviceName, parameterTypes, arguments, attachments, null, null);
     }
 
-    public RpcInvocation(String methodName, String serviceName, Class<?>[] parameterTypes, Object[] arguments, Map<String, String> attachments, Invoker<?> invoker) {
+    public RpcInvocation(String methodName, String serviceName, Class<?>[] parameterTypes, Object[] arguments,
+                         Map<String, String> attachments, Invoker<?> invoker, Map<Object, Object> attributes) {
         this.methodName = methodName;
         this.serviceName = serviceName;
         this.parameterTypes = parameterTypes == null ? new Class<?>[0] : parameterTypes;
         this.arguments = arguments == null ? new Object[0] : arguments;
-        this.attachments = attachments == null ? new HashMap<String, String>() : attachments;
+        this.attachments = attachments == null ? new HashMap<>() : attachments;
+        this.attributes = attributes == null ? new HashMap<>() : attributes;
         this.invoker = invoker;
         initParameterDesc();
     }

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/filter/ContextFilter.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/filter/ContextFilter.java
@@ -54,7 +54,7 @@ public class ContextFilter implements Filter, Filter.Listener {
 
     @Override
     public Result invoke(Invoker<?> invoker, Invocation invocation) throws RpcException {
-        Map<String, Object> attachments = invocation.getAttachments();
+        Map<String, String> attachments = invocation.getAttachments();
         if (attachments != null) {
             attachments = new HashMap<>(attachments);
             attachments.remove(PATH_KEY);

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/filter/GenericFilter.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/filter/GenericFilter.java
@@ -70,10 +70,10 @@ public class GenericFilter implements Filter, Filter.Listener {
                 if (args == null) {
                     args = new Object[params.length];
                 }
-                String generic = (String) inv.getAttachment(GENERIC_KEY);
+                String generic = inv.getAttachment(GENERIC_KEY);
 
                 if (StringUtils.isBlank(generic)) {
-                    generic = (String) RpcContext.getContext().getAttachment(GENERIC_KEY);
+                    generic = RpcContext.getContext().getAttachment(GENERIC_KEY);
                 }
 
                 if (StringUtils.isEmpty(generic)
@@ -156,9 +156,9 @@ public class GenericFilter implements Filter, Filter.Listener {
                 && inv.getArguments().length == 3
                 && !GenericService.class.isAssignableFrom(invoker.getInterface())) {
 
-            String generic = (String) inv.getAttachment(GENERIC_KEY);
+            String generic = inv.getAttachment(GENERIC_KEY);
             if (StringUtils.isBlank(generic)) {
-                generic = (String) RpcContext.getContext().getAttachment(GENERIC_KEY);
+                generic = RpcContext.getContext().getAttachment(GENERIC_KEY);
             }
 
             if (appResponse.hasException() && !(appResponse.getException() instanceof GenericException)) {

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/filter/GenericImplFilter.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/filter/GenericImplFilter.java
@@ -42,7 +42,6 @@ import java.lang.reflect.Type;
 
 import static org.apache.dubbo.common.constants.CommonConstants.$INVOKE;
 import static org.apache.dubbo.common.constants.CommonConstants.$INVOKE_ASYNC;
-import static org.apache.dubbo.common.constants.CommonConstants.DUBBO_INVOCATION_PREFIX;
 import static org.apache.dubbo.rpc.Constants.GENERIC_KEY;
 
 /**
@@ -57,7 +56,7 @@ public class GenericImplFilter implements Filter, Filter.Listener {
 
     private static final String GENERIC_PARAMETER_DESC = "Ljava/lang/String;[Ljava/lang/String;[Ljava/lang/Object;";
 
-    private static final String GENERIC_IMPL_MARKER = DUBBO_INVOCATION_PREFIX + "GENERIC_IMPL";
+    private static final String GENERIC_IMPL_MARKER = "GENERIC_IMPL";
 
     @Override
     public Result invoke(Invoker<?> invoker, Invocation invocation) throws RpcException {
@@ -70,7 +69,7 @@ public class GenericImplFilter implements Filter, Filter.Listener {
              * Mark this invocation as a generic impl call, this value will be removed automatically before passing on the wire.
              * See {@link RpcUtils#sieveUnnecessaryAttachments(Invocation)}
              */
-            invocation2.setAttachment(GENERIC_IMPL_MARKER, true);
+            invocation2.put(GENERIC_IMPL_MARKER, true);
 
             String methodName = invocation2.getMethodName();
             Class<?>[] parameterTypes = invocation2.getParameterTypes();
@@ -135,7 +134,8 @@ public class GenericImplFilter implements Filter, Filter.Listener {
         String generic = invoker.getUrl().getParameter(GENERIC_KEY);
         String methodName = invocation.getMethodName();
         Class<?>[] parameterTypes = invocation.getParameterTypes();
-        if (invocation.getAttachment(GENERIC_IMPL_MARKER) != null) {
+        Object genericImplMarker = invocation.get(GENERIC_IMPL_MARKER);
+        if (genericImplMarker != null && (boolean) invocation.get(GENERIC_IMPL_MARKER)) {
             if (!appResponse.hasException()) {
                 Object value = appResponse.getValue();
                 try {

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/filter/TokenFilter.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/filter/TokenFilter.java
@@ -45,8 +45,8 @@ public class TokenFilter implements Filter {
         String token = invoker.getUrl().getParameter(TOKEN_KEY);
         if (ConfigUtils.isNotEmpty(token)) {
             Class<?> serviceType = invoker.getInterface();
-            Map<String, Object> attachments = inv.getAttachments();
-            String remoteToken = (String) (attachments == null ? null : attachments.get(TOKEN_KEY));
+            Map<String, String> attachments = inv.getAttachments();
+            String remoteToken = (attachments == null ? null : attachments.get(TOKEN_KEY));
             if (!token.equals(remoteToken)) {
                 throw new RpcException("Invalid token! Forbid invoke remote service " + serviceType + " method " + inv.getMethodName() + "() from consumer " + RpcContext.getContext().getRemoteHost() + " to provider " + RpcContext.getContext().getLocalHost());
             }

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/protocol/AbstractInvoker.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/protocol/AbstractInvoker.java
@@ -55,21 +55,21 @@ public abstract class AbstractInvoker<T> implements Invoker<T> {
 
     private final URL url;
 
-    private final Map<String, Object> attachment;
+    private final Map<String, String> attachment;
 
     private volatile boolean available = true;
 
     private AtomicBoolean destroyed = new AtomicBoolean(false);
 
     public AbstractInvoker(Class<T> type, URL url) {
-        this(type, url, (Map<String, Object>) null);
+        this(type, url, (Map<String, String>) null);
     }
 
     public AbstractInvoker(Class<T> type, URL url, String[] keys) {
         this(type, url, convertAttachment(url, keys));
     }
 
-    public AbstractInvoker(Class<T> type, URL url, Map<String, Object> attachment) {
+    public AbstractInvoker(Class<T> type, URL url, Map<String, String> attachment) {
         if (type == null) {
             throw new IllegalArgumentException("service type == null");
         }
@@ -81,11 +81,11 @@ public abstract class AbstractInvoker<T> implements Invoker<T> {
         this.attachment = attachment == null ? null : Collections.unmodifiableMap(attachment);
     }
 
-    private static Map<String, Object> convertAttachment(URL url, String[] keys) {
+    private static Map<String, String> convertAttachment(URL url, String[] keys) {
         if (ArrayUtils.isEmpty(keys)) {
             return null;
         }
-        Map<String, Object> attachment = new HashMap<String, Object>();
+        Map<String, String> attachment = new HashMap<String, String>();
         for (String key : keys) {
             String value = url.getParameter(key);
             if (value != null && value.length() > 0) {
@@ -143,11 +143,11 @@ public abstract class AbstractInvoker<T> implements Invoker<T> {
         if (CollectionUtils.isNotEmptyMap(attachment)) {
             invocation.addAttachmentsIfAbsent(attachment);
         }
-        Map<String, Object> contextAttachments = RpcContext.getContext().getAttachments();
+        Map<String, String> contextAttachments = RpcContext.getContext().getAttachments();
         if (CollectionUtils.isNotEmptyMap(contextAttachments)) {
             /**
              * invocation.addAttachmentsIfAbsent(context){@link RpcInvocation#addAttachmentsIfAbsent(Map)}should not be used here,
-             * because the {@link RpcContext#setAttachment(String, Object)} is passed in the Filter when the call is triggered
+             * because the {@link RpcContext#setAttachment(String, String)} is passed in the Filter when the call is triggered
              * by the built-in retry mechanism of the Dubbo. The attachment to update RpcContext will no longer work, which is
              * a mistake in most cases (for example, through Filter to RpcContext output traceId and spanId and other information).
              */

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/support/RpcUtils.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/support/RpcUtils.java
@@ -28,14 +28,11 @@ import org.apache.dubbo.rpc.service.GenericService;
 
 import java.lang.reflect.Method;
 import java.lang.reflect.Type;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static org.apache.dubbo.common.constants.CommonConstants.$INVOKE;
 import static org.apache.dubbo.common.constants.CommonConstants.$INVOKE_ASYNC;
-import static org.apache.dubbo.common.constants.CommonConstants.DUBBO_INVOCATION_PREFIX;
 import static org.apache.dubbo.rpc.Constants.$ECHO;
 import static org.apache.dubbo.rpc.Constants.ASYNC_KEY;
 import static org.apache.dubbo.rpc.Constants.AUTO_ATTACH_INVOCATIONID_KEY;
@@ -98,7 +95,7 @@ public class RpcUtils {
     }
 
     public static Long getInvocationId(Invocation inv) {
-        String id = (String)inv.getAttachment(ID_KEY);
+        String id = inv.getAttachment(ID_KEY);
         return id == null ? null : new Long(id);
     }
 
@@ -214,16 +211,5 @@ public class RpcUtils {
             isOneway = !url.getMethodParameter(getMethodName(inv), RETURN_KEY, true);
         }
         return isOneway;
-    }
-
-    public static Map<String, Object> sieveUnnecessaryAttachments(Invocation invocation) {
-        Map<String, Object> attachments = invocation.getAttachments();
-        Map<String, Object> attachmentsToPass = new HashMap<>(attachments.size());
-        for (Map.Entry<String, Object> entry : attachments.entrySet()) {
-            if (!entry.getKey().startsWith(DUBBO_INVOCATION_PREFIX)) {
-                attachmentsToPass.put(entry.getKey(), entry.getValue());
-            }
-        }
-        return attachmentsToPass;
     }
 }

--- a/dubbo-rpc/dubbo-rpc-api/src/test/java/org/apache/dubbo/rpc/RpcContextTest.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/test/java/org/apache/dubbo/rpc/RpcContextTest.java
@@ -86,7 +86,7 @@ public class RpcContextTest {
     public void testAttachments() {
 
         RpcContext context = RpcContext.getContext();
-        Map<String, Object> map = new HashMap<String, Object>();
+        Map<String, String> map = new HashMap<String, String>();
         map.put("_11", "1111");
         map.put("_22", "2222");
         map.put(".33", "3333");

--- a/dubbo-rpc/dubbo-rpc-api/src/test/java/org/apache/dubbo/rpc/filter/TokenFilterTest.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/test/java/org/apache/dubbo/rpc/filter/TokenFilterTest.java
@@ -47,7 +47,7 @@ public class TokenFilterTest {
         when(invoker.getUrl()).thenReturn(url);
         when(invoker.invoke(any(Invocation.class))).thenReturn(new AppResponse("result"));
 
-        Map<String, Object> attachments = new HashMap<>();
+        Map<String, String> attachments = new HashMap<>();
         attachments.put(TOKEN_KEY, token);
         Invocation invocation = Mockito.mock(Invocation.class);
         when(invocation.getAttachments()).thenReturn(attachments);
@@ -66,7 +66,7 @@ public class TokenFilterTest {
             when(invoker.getUrl()).thenReturn(url);
             when(invoker.invoke(any(Invocation.class))).thenReturn(new AppResponse("result"));
 
-            Map<String, Object> attachments = new HashMap<>();
+            Map<String, String> attachments = new HashMap<>();
             attachments.put(TOKEN_KEY, "wrongToken");
             Invocation invocation = Mockito.mock(Invocation.class);
             when(invocation.getAttachments()).thenReturn(attachments);

--- a/dubbo-rpc/dubbo-rpc-api/src/test/java/org/apache/dubbo/rpc/support/MockInvocation.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/test/java/org/apache/dubbo/rpc/support/MockInvocation.java
@@ -56,8 +56,8 @@ public class MockInvocation implements Invocation {
         return new Object[]{"aa"};
     }
 
-    public Map<String, Object> getAttachments() {
-        Map<String, Object> attachments = new HashMap<String, Object>();
+    public Map<String, String> getAttachments() {
+        Map<String, String> attachments = new HashMap<>();
         attachments.put(PATH_KEY, "dubbo");
         attachments.put(GROUP_KEY, "dubbo");
         attachments.put(VERSION_KEY, "1.0.0");
@@ -68,12 +68,12 @@ public class MockInvocation implements Invocation {
     }
 
     @Override
-    public void setAttachment(String key, Object value) {
+    public void setAttachment(String key, String value) {
 
     }
 
     @Override
-    public void setAttachmentIfAbsent(String key, Object value) {
+    public void setAttachmentIfAbsent(String key, String value) {
 
     }
 
@@ -96,11 +96,11 @@ public class MockInvocation implements Invocation {
         return null;
     }
 
-    public Object getAttachment(String key) {
+    public String getAttachment(String key) {
         return getAttachments().get(key);
     }
 
-    public Object getAttachment(String key, Object defaultValue) {
+    public String getAttachment(String key, String defaultValue) {
         return getAttachments().get(key);
     }
 

--- a/dubbo-rpc/dubbo-rpc-api/src/test/java/org/apache/dubbo/rpc/support/RpcUtilsTest.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/test/java/org/apache/dubbo/rpc/support/RpcUtilsTest.java
@@ -46,7 +46,7 @@ public class RpcUtilsTest {
     @Test
     public void testAttachInvocationIdIfAsync_normal() {
         URL url = URL.valueOf("dubbo://localhost/?test.async=true");
-        Map<String, Object> attachments = new HashMap<String, Object>();
+        Map<String, String> attachments = new HashMap<String, String>();
         attachments.put("aa", "bb");
         Invocation inv = new RpcInvocation("test", "DemoService", new Class[]{}, new String[]{}, attachments);
         RpcUtils.attachInvocationIdIfAsync(url, inv);

--- a/dubbo-rpc/dubbo-rpc-api/src/test/java/org/apache/dubbo/rpc/support/RpcUtilsTest.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/test/java/org/apache/dubbo/rpc/support/RpcUtilsTest.java
@@ -111,39 +111,39 @@ public class RpcUtilsTest {
         Invoker invoker = mock(Invoker.class);
         String service = "org.apache.dubbo.rpc.support.DemoService";
         given(invoker.getUrl()).willReturn(URL.valueOf("test://127.0.0.1:1/org.apache.dubbo.rpc.support.DemoService?interface=org.apache.dubbo.rpc.support.DemoService"));
-        Invocation inv = new RpcInvocation("testReturnType", service, new Class<?>[]{String.class}, null, null, invoker);
+        Invocation inv = new RpcInvocation("testReturnType", service, new Class<?>[]{String.class}, null, null, invoker, null);
 
         java.lang.reflect.Type[] types = RpcUtils.getReturnTypes(inv);
         Assertions.assertEquals(2, types.length);
         Assertions.assertEquals(String.class, types[0]);
         Assertions.assertEquals(String.class, types[1]);
 
-        Invocation inv1 = new RpcInvocation("testReturnType1", service, new Class<?>[]{String.class}, null, null, invoker);
+        Invocation inv1 = new RpcInvocation("testReturnType1", service, new Class<?>[]{String.class}, null, null, invoker, null);
         java.lang.reflect.Type[] types1 = RpcUtils.getReturnTypes(inv1);
         Assertions.assertEquals(2, types1.length);
         Assertions.assertEquals(List.class, types1[0]);
         Assertions.assertEquals(DemoService.class.getMethod("testReturnType1", new Class<?>[]{String.class}).getGenericReturnType(), types1[1]);
 
-        Invocation inv2 = new RpcInvocation("testReturnType2", service, new Class<?>[]{String.class}, null, null, invoker);
+        Invocation inv2 = new RpcInvocation("testReturnType2", service, new Class<?>[]{String.class}, null, null, invoker, null);
         java.lang.reflect.Type[] types2 = RpcUtils.getReturnTypes(inv2);
         Assertions.assertEquals(2, types2.length);
         Assertions.assertEquals(String.class, types2[0]);
         Assertions.assertEquals(String.class, types2[1]);
 
-        Invocation inv3 = new RpcInvocation("testReturnType3", service, new Class<?>[]{String.class}, null, null, invoker);
+        Invocation inv3 = new RpcInvocation("testReturnType3", service, new Class<?>[]{String.class}, null, null, invoker, null);
         java.lang.reflect.Type[] types3 = RpcUtils.getReturnTypes(inv3);
         Assertions.assertEquals(2, types3.length);
         Assertions.assertEquals(List.class, types3[0]);
         java.lang.reflect.Type genericReturnType3 = DemoService.class.getMethod("testReturnType3", new Class<?>[]{String.class}).getGenericReturnType();
         Assertions.assertEquals(((ParameterizedType) genericReturnType3).getActualTypeArguments()[0], types3[1]);
 
-        Invocation inv4 = new RpcInvocation("testReturnType4", service, new Class<?>[]{String.class}, null, null, invoker);
+        Invocation inv4 = new RpcInvocation("testReturnType4", service, new Class<?>[]{String.class}, null, null, invoker, null);
         java.lang.reflect.Type[] types4 = RpcUtils.getReturnTypes(inv4);
         Assertions.assertEquals(2, types4.length);
         Assertions.assertNull(types4[0]);
         Assertions.assertNull(types4[1]);
 
-        Invocation inv5 = new RpcInvocation("testReturnType5", service, new Class<?>[]{String.class}, null, null, invoker);
+        Invocation inv5 = new RpcInvocation("testReturnType5", service, new Class<?>[]{String.class}, null, null, invoker, null);
         java.lang.reflect.Type[] types5 = RpcUtils.getReturnTypes(inv5);
         Assertions.assertEquals(2, types5.length);
         Assertions.assertEquals(Map.class, types5[0]);

--- a/dubbo-rpc/dubbo-rpc-dubbo/src/main/java/org/apache/dubbo/rpc/protocol/dubbo/CallbackServiceCodec.java
+++ b/dubbo-rpc/dubbo-rpc-dubbo/src/main/java/org/apache/dubbo/rpc/protocol/dubbo/CallbackServiceCodec.java
@@ -288,14 +288,14 @@ class CallbackServiceCodec {
         switch (callbackstatus) {
             case CallbackServiceCodec.CALLBACK_CREATE:
                 try {
-                    return referOrDestroyCallbackService(channel, url, pts[paraIndex], inv, Integer.parseInt((String) inv.getAttachment(INV_ATT_CALLBACK_KEY + paraIndex)), true);
+                    return referOrDestroyCallbackService(channel, url, pts[paraIndex], inv, Integer.parseInt(inv.getAttachment(INV_ATT_CALLBACK_KEY + paraIndex)), true);
                 } catch (Exception e) {
                     logger.error(e.getMessage(), e);
                     throw new IOException(StringUtils.toString(e));
                 }
             case CallbackServiceCodec.CALLBACK_DESTROY:
                 try {
-                    return referOrDestroyCallbackService(channel, url, pts[paraIndex], inv, Integer.parseInt((String) inv.getAttachment(INV_ATT_CALLBACK_KEY + paraIndex)), false);
+                    return referOrDestroyCallbackService(channel, url, pts[paraIndex], inv, Integer.parseInt(inv.getAttachment(INV_ATT_CALLBACK_KEY + paraIndex)), false);
                 } catch (Exception e) {
                     throw new IOException(StringUtils.toString(e));
                 }

--- a/dubbo-rpc/dubbo-rpc-dubbo/src/main/java/org/apache/dubbo/rpc/protocol/dubbo/DecodeableRpcInvocation.java
+++ b/dubbo-rpc/dubbo-rpc-dubbo/src/main/java/org/apache/dubbo/rpc/protocol/dubbo/DecodeableRpcInvocation.java
@@ -146,11 +146,11 @@ public class DecodeableRpcInvocation extends RpcInvocation implements Codec, Dec
             }
             setParameterTypes(pts);
 
-            Map<String, Object> map = in.readAttachments();
+            Map<String, String> map = in.readAttachments();
             if (map != null && map.size() > 0) {
-                Map<String, Object> attachment = getAttachments();
+                Map<String, String> attachment = getAttachments();
                 if (attachment == null) {
-                    attachment = new HashMap<String, Object>();
+                    attachment = new HashMap<String, String>();
                 }
                 attachment.putAll(map);
                 setAttachments(attachment);
@@ -163,8 +163,8 @@ public class DecodeableRpcInvocation extends RpcInvocation implements Codec, Dec
 
             setArguments(args);
             String targetServiceName = buildKey((String) getAttachment(PATH_KEY),
-                    (String) getAttachment(GROUP_KEY),
-                    (String) getAttachment(VERSION_KEY));
+                    getAttachment(GROUP_KEY),
+                    getAttachment(VERSION_KEY));
             setTargetServiceUniqueName(targetServiceName);
         } catch (ClassNotFoundException e) {
             throw new IOException(StringUtils.toString("Read invocation data failed.", e));

--- a/dubbo-rpc/dubbo-rpc-dubbo/src/main/java/org/apache/dubbo/rpc/protocol/dubbo/DubboCodec.java
+++ b/dubbo-rpc/dubbo-rpc-dubbo/src/main/java/org/apache/dubbo/rpc/protocol/dubbo/DubboCodec.java
@@ -42,7 +42,6 @@ import static org.apache.dubbo.common.constants.CommonConstants.VERSION_KEY;
 import static org.apache.dubbo.rpc.protocol.dubbo.CallbackServiceCodec.encodeInvocationArgument;
 import static org.apache.dubbo.rpc.protocol.dubbo.Constants.DECODE_IN_IO_THREAD_KEY;
 import static org.apache.dubbo.rpc.protocol.dubbo.Constants.DEFAULT_DECODE_IN_IO_THREAD;
-import static org.apache.dubbo.rpc.support.RpcUtils.sieveUnnecessaryAttachments;
 
 /**
  * Dubbo codec.
@@ -169,8 +168,8 @@ public class DubboCodec extends ExchangeCodec {
         RpcInvocation inv = (RpcInvocation) data;
 
         out.writeUTF(version);
-        out.writeUTF((String) inv.getAttachment(PATH_KEY));
-        out.writeUTF((String) inv.getAttachment(VERSION_KEY));
+        out.writeUTF(inv.getAttachment(PATH_KEY));
+        out.writeUTF(inv.getAttachment(VERSION_KEY));
 
         out.writeUTF(inv.getMethodName());
         out.writeUTF(inv.getParameterTypesDesc());
@@ -180,7 +179,7 @@ public class DubboCodec extends ExchangeCodec {
                 out.writeObject(encodeInvocationArgument(channel, inv, i));
             }
         }
-        out.writeAttachments(sieveUnnecessaryAttachments(inv));
+        out.writeAttachments(inv.getAttachments());
     }
 
     @Override

--- a/dubbo-rpc/dubbo-rpc-dubbo/src/main/java/org/apache/dubbo/rpc/protocol/dubbo/DubboProtocol.java
+++ b/dubbo-rpc/dubbo-rpc-dubbo/src/main/java/org/apache/dubbo/rpc/protocol/dubbo/DubboProtocol.java
@@ -242,7 +242,7 @@ public class DubboProtocol extends AbstractProtocol {
         boolean isCallBackServiceInvoke = false;
         boolean isStubServiceInvoke = false;
         int port = channel.getLocalAddress().getPort();
-        String path = (String) inv.getAttachments().get(PATH_KEY);
+        String path = inv.getAttachments().get(PATH_KEY);
 
         // if it's callback service on client side
         isStubServiceInvoke = Boolean.TRUE.toString().equals(inv.getAttachments().get(STUB_EVENT_KEY));
@@ -257,7 +257,7 @@ public class DubboProtocol extends AbstractProtocol {
             inv.getAttachments().put(IS_CALLBACK_SERVICE_INVOKE, Boolean.TRUE.toString());
         }
 
-        String serviceKey = serviceKey(port, path, (String) inv.getAttachments().get(VERSION_KEY), (String) inv.getAttachments().get(GROUP_KEY));
+        String serviceKey = serviceKey(port, path, inv.getAttachments().get(VERSION_KEY), inv.getAttachments().get(GROUP_KEY));
         DubboExporter<?> exporter = (DubboExporter<?>) exporterMap.get(serviceKey);
 
         if (exporter == null) {

--- a/dubbo-rpc/dubbo-rpc-grpc/src/main/java/org/apache/dubbo/rpc/protocol/grpc/interceptors/RpcContextInterceptor.java
+++ b/dubbo-rpc/dubbo-rpc-grpc/src/main/java/org/apache/dubbo/rpc/protocol/grpc/interceptors/RpcContextInterceptor.java
@@ -44,9 +44,9 @@ public class RpcContextInterceptor implements ClientInterceptor, ServerIntercept
     @Override
     public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(MethodDescriptor<ReqT, RespT> method, CallOptions callOptions, Channel next) {
         RpcContext rpcContext = RpcContext.getContext();
-        Map<String, Object> attachments = rpcContext.getAttachments();
+        Map<String, String> attachments = rpcContext.getAttachments();
         if (attachments != null) {
-            for (Map.Entry<String, Object> entry : attachments.entrySet()) {
+            for (Map.Entry<String, String> entry : attachments.entrySet()) {
                 callOptions = callOptions.withOption(CallOptions.Key.create(DUBBO + entry.getKey()), entry.getValue());
             }
         }

--- a/dubbo-rpc/dubbo-rpc-hessian/src/main/java/org/apache/dubbo/rpc/protocol/hessian/DubboHessianURLConnectionFactory.java
+++ b/dubbo-rpc/dubbo-rpc-hessian/src/main/java/org/apache/dubbo/rpc/protocol/hessian/DubboHessianURLConnectionFactory.java
@@ -33,7 +33,7 @@ public class DubboHessianURLConnectionFactory extends HessianURLConnectionFactor
         HessianConnection connection = super.open(url);
         RpcContext context = RpcContext.getContext();
         for (String key : context.getAttachments().keySet()) {
-            connection.addHeader(Constants.DEFAULT_EXCHANGER + key, (String) context.getAttachment(key));
+            connection.addHeader(Constants.DEFAULT_EXCHANGER + key, context.getAttachment(key));
         }
 
         return connection;

--- a/dubbo-rpc/dubbo-rpc-hessian/src/main/java/org/apache/dubbo/rpc/protocol/hessian/HttpClientConnectionFactory.java
+++ b/dubbo-rpc/dubbo-rpc-hessian/src/main/java/org/apache/dubbo/rpc/protocol/hessian/HttpClientConnectionFactory.java
@@ -51,7 +51,7 @@ public class HttpClientConnectionFactory implements HessianConnectionFactory {
         HttpClientConnection httpClientConnection = new HttpClientConnection(httpClient, url);
         RpcContext context = RpcContext.getContext();
         for (String key : context.getAttachments().keySet()) {
-            httpClientConnection.addHeader(DEFAULT_EXCHANGER + key, (String) context.getAttachment(key));
+            httpClientConnection.addHeader(DEFAULT_EXCHANGER + key, context.getAttachment(key));
         }
         return httpClientConnection;
     }

--- a/dubbo-rpc/dubbo-rpc-rest/src/main/java/org/apache/dubbo/rpc/protocol/rest/RpcContextFilter.java
+++ b/dubbo-rpc/dubbo-rpc-rest/src/main/java/org/apache/dubbo/rpc/protocol/rest/RpcContextFilter.java
@@ -70,9 +70,9 @@ public class RpcContextFilter implements ContainerRequestFilter, ClientRequestFi
     @Override
     public void filter(ClientRequestContext requestContext) throws IOException {
         int size = 0;
-        for (Map.Entry<String, Object> entry : RpcContext.getContext().getAttachments().entrySet()) {
+        for (Map.Entry<String, String> entry : RpcContext.getContext().getAttachments().entrySet()) {
             String key = entry.getKey();
-            String value = (String) entry.getValue();
+            String value = entry.getValue();
             if (illegalHttpHeaderKey(key) || illegalHttpHeaderValue(value)) {
                 throw new IllegalArgumentException("The attachments of " + RpcContext.class.getSimpleName() + " must not contain ',' or '=' when using rest protocol");
             }

--- a/dubbo-rpc/dubbo-rpc-rest/src/test/java/org/apache/dubbo/rpc/protocol/rest/DemoServiceImpl.java
+++ b/dubbo-rpc/dubbo-rpc-rest/src/test/java/org/apache/dubbo/rpc/protocol/rest/DemoServiceImpl.java
@@ -22,7 +22,7 @@ import org.apache.dubbo.rpc.RpcContext;
 import java.util.Map;
 
 public class DemoServiceImpl implements DemoService {
-    private static Map<String, Object> context;
+    private static Map<String, String> context;
     private boolean called;
 
     public String sayHello(String name) {
@@ -46,7 +46,7 @@ public class DemoServiceImpl implements DemoService {
         throw new RuntimeException();
     }
 
-    public static Map<String, Object> getAttachments() {
+    public static Map<String, String> getAttachments() {
         return context;
     }
 

--- a/dubbo-rpc/dubbo-rpc-rest/src/test/java/org/apache/dubbo/rpc/protocol/rest/RestProtocolTest.java
+++ b/dubbo-rpc/dubbo-rpc-rest/src/test/java/org/apache/dubbo/rpc/protocol/rest/RestProtocolTest.java
@@ -224,7 +224,7 @@ public class RestProtocolTest {
 
         assertThat(result, is(3));
 
-        Map<String, Object> attachment = DemoServiceImpl.getAttachments();
+        Map<String, String> attachment = DemoServiceImpl.getAttachments();
         assertThat(attachment.get("key1"), nullValue());
         assertThat(attachment.get("key2"), equalTo("value"));
         assertThat(attachment.get("key3"), equalTo("=value"));

--- a/dubbo-rpc/dubbo-rpc-rmi/src/main/java/org/apache/dubbo/rpc/protocol/rmi/RmiRemoteInvocation.java
+++ b/dubbo-rpc/dubbo-rpc-rmi/src/main/java/org/apache/dubbo/rpc/protocol/rmi/RmiRemoteInvocation.java
@@ -50,7 +50,7 @@ public class RmiRemoteInvocation extends RemoteInvocation {
     public Object invoke(Object targetObject) throws NoSuchMethodException, IllegalAccessException,
             InvocationTargetException {
         RpcContext context = RpcContext.getContext();
-        context.setAttachments((Map<String, Object>) getAttribute(DUBBO_ATTACHMENTS_ATTR_NAME));
+        context.setAttachments((Map<String, String>) getAttribute(DUBBO_ATTACHMENTS_ATTR_NAME));
         String generic = (String) getAttribute(GENERIC_KEY);
         if (StringUtils.isNotEmpty(generic)) {
             context.setAttachment(GENERIC_KEY, generic);

--- a/dubbo-rpc/dubbo-rpc-thrift/src/main/java/org/apache/dubbo/rpc/protocol/thrift/ThriftCodec.java
+++ b/dubbo-rpc/dubbo-rpc-thrift/src/main/java/org/apache/dubbo/rpc/protocol/thrift/ThriftCodec.java
@@ -397,7 +397,7 @@ public class ThriftCodec implements Codec2 {
 
         int seqId = nextSeqId();
 
-        String serviceName = (String) inv.getAttachment(INTERFACE_KEY);
+        String serviceName = inv.getAttachment(INTERFACE_KEY);
 
         if (StringUtils.isEmpty(serviceName)) {
             throw new IllegalArgumentException("Could not find service name in attachment with key "
@@ -491,7 +491,7 @@ public class ThriftCodec implements Codec2 {
             // service name
             protocol.writeString(serviceName);
             // path
-            protocol.writeString((String) inv.getAttachment(PATH_KEY));
+            protocol.writeString(inv.getAttachment(PATH_KEY));
             // dubbo request id
             protocol.writeI64(request.getId());
             protocol.getTransport().flush();

--- a/dubbo-rpc/dubbo-rpc-thrift/src/main/java/org/apache/dubbo/rpc/protocol/thrift/ThriftProtocol.java
+++ b/dubbo-rpc/dubbo-rpc-thrift/src/main/java/org/apache/dubbo/rpc/protocol/thrift/ThriftProtocol.java
@@ -70,7 +70,7 @@ public class ThriftProtocol extends AbstractProtocol {
 
             if (msg instanceof Invocation) {
                 Invocation inv = (Invocation) msg;
-                String path = (String) inv.getAttachments().get(PATH_KEY);
+                String path = inv.getAttachments().get(PATH_KEY);
                 String serviceKey = serviceKey(channel.getLocalAddress().getPort(),
                         path, null, null);
                 DubboExporter<?> exporter = (DubboExporter<?>) exporterMap.get(serviceKey);

--- a/dubbo-rpc/dubbo-rpc-thrift/src/test/java/org/apache/dubbo/rpc/protocol/thrift/ThriftCodecTest.java
+++ b/dubbo-rpc/dubbo-rpc-thrift/src/test/java/org/apache/dubbo/rpc/protocol/thrift/ThriftCodecTest.java
@@ -402,10 +402,10 @@ public class ThriftCodecTest {
         protocol.writeI16(Short.MAX_VALUE);
         protocol.writeByte(ThriftCodec.VERSION);
         protocol.writeString(
-                (String) ((RpcInvocation) request.getData())
+                ((RpcInvocation) request.getData())
                         .getAttachment(INTERFACE_KEY));
         protocol.writeString(
-                (String) ((RpcInvocation) request.getData())
+                ((RpcInvocation) request.getData())
                         .getAttachment(PATH_KEY));
         protocol.writeI64(request.getId());
         protocol.getTransport().flush();

--- a/dubbo-serialization/dubbo-serialization-api/src/main/java/org/apache/dubbo/common/serialize/ObjectInput.java
+++ b/dubbo-serialization/dubbo-serialization-api/src/main/java/org/apache/dubbo/common/serialize/ObjectInput.java
@@ -83,7 +83,7 @@ public interface ObjectInput extends DataInput {
         return readObject();
     }
 
-    default Map<String, Object> readAttachments() throws IOException, ClassNotFoundException {
+    default Map<String, String> readAttachments() throws IOException, ClassNotFoundException {
         return readObject(Map.class);
     }
 }

--- a/dubbo-serialization/dubbo-serialization-api/src/main/java/org/apache/dubbo/common/serialize/ObjectOutput.java
+++ b/dubbo-serialization/dubbo-serialization-api/src/main/java/org/apache/dubbo/common/serialize/ObjectOutput.java
@@ -53,7 +53,7 @@ public interface ObjectOutput extends DataOutput {
         writeObject(data);
     }
 
-    default void writeAttachments(Map<String, Object> attachments) throws IOException {
+    default void writeAttachments(Map<String, String> attachments) throws IOException {
         writeObject(attachments);
     }
 

--- a/dubbo-serialization/dubbo-serialization-protobuf/src/main/java/org/apache/dubbo/common/serialize/protobuf/support/GenericProtobufJsonObjectInput.java
+++ b/dubbo-serialization/dubbo-serialization-protobuf/src/main/java/org/apache/dubbo/common/serialize/protobuf/support/GenericProtobufJsonObjectInput.java
@@ -34,7 +34,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.lang.reflect.Type;
-import java.util.HashMap;
 import java.util.Map;
 
 import static org.apache.dubbo.common.constants.CommonConstants.HEARTBEAT_EVENT;
@@ -135,22 +134,10 @@ public class GenericProtobufJsonObjectInput implements ObjectInput {
         return ProtobufUtils.convertToException(throwableProto);
     }
 
-    /**
-     * FIXME, only supports transmission of String values.
-     *
-     * @return
-     * @throws IOException
-     * @throws ClassNotFoundException
-     */
     @Override
-    public Map<String, Object> readAttachments() throws IOException, ClassNotFoundException {
+    public Map<String, String> readAttachments() throws IOException, ClassNotFoundException {
         String json = readLine();
-        Map<String, String> attachments = ProtobufUtils.deserializeJson(json, MapValue.Map.class).getAttachmentsMap();
-        Map<String, Object> genericAttachments = new HashMap<>();
-        attachments.forEach((k, v) -> {
-            genericAttachments.put(k, v);
-        });
-        return genericAttachments;
+        return ProtobufUtils.deserializeJson(json, MapValue.Map.class).getAttachmentsMap();
     }
 
     @Override

--- a/dubbo-serialization/dubbo-serialization-protobuf/src/main/java/org/apache/dubbo/common/serialize/protobuf/support/GenericProtobufJsonObjectOutput.java
+++ b/dubbo-serialization/dubbo-serialization-protobuf/src/main/java/org/apache/dubbo/common/serialize/protobuf/support/GenericProtobufJsonObjectOutput.java
@@ -32,7 +32,6 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
-import java.util.HashMap;
 import java.util.Map;
 
 import static org.apache.dubbo.common.constants.CommonConstants.HEARTBEAT_EVENT;
@@ -133,21 +132,13 @@ public class GenericProtobufJsonObjectOutput implements ObjectOutput {
         writeUTF((String) data);
     }
 
-    /**
-     * FIXME, only supports transmission of String values.
-     *
-     * @param attachments
-     * @throws IOException
-     */
     @Override
-    public void writeAttachments(Map<String, Object> attachments) throws IOException {
+    public void writeAttachments(Map<String, String> attachments) throws IOException {
         if (attachments == null) {
             return;
         }
 
-        Map<String, String> stringAttachments = new HashMap<>();
-        attachments.forEach((k, v) -> stringAttachments.put(k, (String) v));
-        MapValue.Map proto = MapValue.Map.newBuilder().putAllAttachments(stringAttachments).build();
+        MapValue.Map proto = MapValue.Map.newBuilder().putAllAttachments(attachments).build();
         writer.write(ProtobufUtils.serializeJson(proto));
         writer.println();
         writer.flush();

--- a/dubbo-serialization/dubbo-serialization-protobuf/src/main/java/org/apache/dubbo/common/serialize/protobuf/support/GenericProtobufObjectInput.java
+++ b/dubbo-serialization/dubbo-serialization-protobuf/src/main/java/org/apache/dubbo/common/serialize/protobuf/support/GenericProtobufObjectInput.java
@@ -31,7 +31,6 @@ import com.google.protobuf.StringValue;
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.Type;
-import java.util.HashMap;
 import java.util.Map;
 
 import static org.apache.dubbo.common.constants.CommonConstants.HEARTBEAT_EVENT;
@@ -134,13 +133,7 @@ public class GenericProtobufObjectInput implements ObjectInput {
     }
 
     @Override
-    public Map<String, Object> readAttachments() throws IOException {
-        Map<String, String> stringAttachments = ProtobufUtils.deserialize(is, MapValue.Map.class).getAttachmentsMap();
-        Map<String, Object> attachments = new HashMap<>();
-
-        if (stringAttachments != null) {
-            stringAttachments.forEach((k, v) -> attachments.put(k, v));
-        }
-        return attachments;
+    public Map<String, String> readAttachments() throws IOException {
+        return ProtobufUtils.deserialize(is, MapValue.Map.class).getAttachmentsMap();
     }
 }

--- a/dubbo-serialization/dubbo-serialization-protobuf/src/main/java/org/apache/dubbo/common/serialize/protobuf/support/GenericProtobufObjectOutput.java
+++ b/dubbo-serialization/dubbo-serialization-protobuf/src/main/java/org/apache/dubbo/common/serialize/protobuf/support/GenericProtobufObjectOutput.java
@@ -31,7 +31,6 @@ import com.google.protobuf.StringValue;
 
 import java.io.IOException;
 import java.io.OutputStream;
-import java.util.HashMap;
 import java.util.Map;
 
 import static org.apache.dubbo.common.constants.CommonConstants.HEARTBEAT_EVENT;
@@ -137,15 +136,12 @@ public class GenericProtobufObjectOutput implements ObjectOutput {
     }
 
     @Override
-    public void writeAttachments(Map<String, Object> attachments) throws IOException {
+    public void writeAttachments(Map<String, String> attachments) throws IOException {
         if (attachments == null) {
             return;
         }
 
-        Map<String, String> stringAttachments = new HashMap<>();
-        attachments.forEach((k, v) -> stringAttachments.put(k, (String) v));
-
-        ProtobufUtils.serialize(MapValue.Map.newBuilder().putAllAttachments(stringAttachments).build(), os);
+        ProtobufUtils.serialize(MapValue.Map.newBuilder().putAllAttachments(attachments).build(), os);
         os.flush();
     }
 

--- a/dubbo-serialization/dubbo-serialization-test/src/test/java/org/apache/dubbo/common/serialize/protobuf/support/AbstractProtobufSerializationTest.java
+++ b/dubbo-serialization/dubbo-serialization-test/src/test/java/org/apache/dubbo/common/serialize/protobuf/support/AbstractProtobufSerializationTest.java
@@ -345,7 +345,7 @@ public class AbstractProtobufSerializationTest {
      */
     @Test
     public void testPbMap() throws Exception {
-        Map<String, Object> attachments = new HashMap<>();
+        Map<String, String> attachments = new HashMap<>();
         attachments.put("key", "value");
         ObjectOutput objectOutput = serialization.serialize(url, byteArrayOutputStream);
         objectOutput.writeAttachments(attachments);
@@ -355,7 +355,7 @@ public class AbstractProtobufSerializationTest {
                 byteArrayOutputStream.toByteArray());
         ObjectInput objectInput = serialization.deserialize(url, byteArrayInputStream);
 
-        Map<String, Object> derializedAttachments = objectInput.readAttachments();
+        Map<String, String> derializedAttachments = objectInput.readAttachments();
         assertEquals(attachments, derializedAttachments);
     }
 

--- a/dubbo-serialization/dubbo-serialization-test/src/test/java/org/apache/dubbo/common/serialize/protobuf/support/GenericProtobufJsonObjectOutputTest.java
+++ b/dubbo-serialization/dubbo-serialization-test/src/test/java/org/apache/dubbo/common/serialize/protobuf/support/GenericProtobufJsonObjectOutputTest.java
@@ -167,7 +167,7 @@ public class GenericProtobufJsonObjectOutputTest {
 
     @Test
     public void testWriteMap() throws IOException, ClassNotFoundException {
-        Map<String, Object> map = new HashMap<>();
+        Map<String, String> map = new HashMap<>();
         map.put("key", "hello");
         map.put("value", "dubbo");
         this.genericProtobufObjectOutput.writeAttachments(map);
@@ -180,7 +180,7 @@ public class GenericProtobufJsonObjectOutputTest {
     void testWriteMultiType() throws IOException, ClassNotFoundException {
         long random = new Random().nextLong();
         this.genericProtobufObjectOutput.writeLong(random);
-        Map<String, Object> map = new HashMap<>();
+        Map<String, String> map = new HashMap<>();
         map.put("key", "hello");
         map.put("value", "world");
         this.genericProtobufObjectOutput.writeAttachments(map);


### PR DESCRIPTION
This reverts commit 333cc2f733bdecf0fca95c68004a65b4a3b0e32b.

The change was introduced from 3.x, it breaks the API compatibility and is not acceptable in 2.7.x version.