### PR TITLE
[Dubbo-StringUtils] Fix StringUtils.split(String, char) not correct for input "d,1,2,4",…

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/utils/StringUtils.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/utils/StringUtils.java
@@ -627,23 +627,38 @@ public final class StringUtils {
      * @return string array.
      */
     public static String[] split(String str, char ch) {
-        List<String> list = null;
-        char c;
+        if (isEmpty(str)) {
+            return EMPTY_STRING_ARRAY;
+        }
+        return splitToList0(str, ch).toArray(EMPTY_STRING_ARRAY);
+    }
+
+    private static List<String> splitToList0(String str, char ch) {
+        List<String> result = new ArrayList<>();
         int ix = 0, len = str.length();
         for (int i = 0; i < len; i++) {
-            c = str.charAt(i);
-            if (c == ch) {
-                if (list == null) {
-                    list = new ArrayList<String>();
-                }
-                list.add(str.substring(ix, i));
+            if (str.charAt(i) == ch) {
+                result.add(str.substring(ix, i));
                 ix = i + 1;
             }
         }
-        if (ix > 0) {
-            list.add(str.substring(ix));
+
+        if (ix >= 0) {
+            result.add(str.substring(ix));
         }
-        return list == null ? EMPTY_STRING_ARRAY : (String[]) list.toArray(EMPTY_STRING_ARRAY);
+        return result;
+    }
+
+    /**
+     * Splits String around matches of the given character.
+     * <p>
+     * Note: Compare with {@link StringUtils#split(String, char)}, this method reduce memory copy.
+     */
+    public static List<String> splitToList(String str, char ch) {
+        if (isEmpty(str)) {
+            return Collections.emptyList();
+        }
+        return splitToList0(str, ch);
     }
 
     /**

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/utils/StringUtilsTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/utils/StringUtilsTest.java
@@ -18,11 +18,7 @@ package org.apache.dubbo.common.utils;
 
 import org.junit.jupiter.api.Test;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import static org.apache.dubbo.common.constants.CommonConstants.GROUP_KEY;
 import static org.apache.dubbo.common.constants.CommonConstants.INTERFACE_KEY;
@@ -33,9 +29,8 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.isEmptyOrNullString;
 import static org.hamcrest.Matchers.nullValue;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
 public class StringUtilsTest {
     @Test
@@ -220,8 +215,33 @@ public class StringUtilsTest {
 
     @Test
     public void testSplit() throws Exception {
-        String s = "d,1,2,4";
-        assertEquals(StringUtils.split(s, ',').length, 4);
+        String str = "d,1,2,4";
+
+        assertEquals(4, StringUtils.split(str, ',').length);
+        assertArrayEquals(str.split(","), StringUtils.split(str, ','));
+
+        assertEquals(1, StringUtils.split(str, 'a').length);
+        assertArrayEquals(str.split("a"), StringUtils.split(str, 'a'));
+
+        assertEquals(0, StringUtils.split("", 'a').length);
+        assertEquals(0, StringUtils.split(null, 'a').length);
+
+        System.out.println(Arrays.toString(StringUtils.split("boo:and:foo", ':')));
+        System.out.println(Arrays.toString(StringUtils.split("boo:and:foo", 'o')));
+    }
+
+    @Test
+    public void testSplitToList() throws Exception {
+        String str = "d,1,2,4";
+
+        assertEquals(4, StringUtils.splitToList(str, ',').size());
+        assertEquals(Arrays.asList(str.split(",")), StringUtils.splitToList(str, ','));
+
+        assertEquals(1, StringUtils.splitToList(str, 'a').size());
+        assertEquals(Arrays.asList(str.split("a")), StringUtils.splitToList(str, 'a'));
+
+        assertEquals(0, StringUtils.splitToList("", 'a').size());
+        assertEquals(0, StringUtils.splitToList(null, 'a').size());
     }
 
     @Test


### PR DESCRIPTION
… 'a'

## What is the purpose of the change

fix ISSUE: https://github.com/apache/dubbo/issues/5458


Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a [GITHUB_issue](https://github.com/apache/dubbo/issues/5458) field for the change (usually before you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [x] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Run `mvn clean install -DskipTests=false` & `mvn clean test-compile failsafe:integration-test` to make sure unit-test and integration-test pass.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
