### PR TITLE
fix:eureka InstanceInfo.InstanceStatus should be OUT_OF_SERVICE when unregister

### DIFF
--- a/dubbo-registry/dubbo-registry-eureka/src/main/java/org/apache/dubbo/registry/eureka/EurekaServiceDiscovery.java
+++ b/dubbo-registry/dubbo-registry-eureka/src/main/java/org/apache/dubbo/registry/eureka/EurekaServiceDiscovery.java
@@ -223,7 +223,7 @@ public class EurekaServiceDiscovery implements ServiceDiscovery {
 
     @Override
     public void unregister(ServiceInstance serviceInstance) throws RuntimeException {
-        setInstanceStatus(InstanceInfo.InstanceStatus.UP);
+        setInstanceStatus(InstanceInfo.InstanceStatus.OUT_OF_SERVICE);
     }
 
     @Override


### PR DESCRIPTION
## What is the purpose of the change

fix, eureka InstanceInfo.InstanceStatus should be OUT_OF_SERVICE when unregister

## Brief changelog

change InstanceInfo.InstanceStatus from UP to OUT_OF_SERVICE when unregister
