### PR TITLE
Rename ServiceDescriptor to BaseServiceMetadata

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/BaseServiceMetadata.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/BaseServiceMetadata.java
@@ -21,7 +21,7 @@ import org.apache.dubbo.common.utils.StringUtils;
 /**
  * 2019-10-10
  */
-public class ServiceDescriptor {
+public class BaseServiceMetadata {
     public static final char COLON_SEPERATOR = ':';
 
     protected String serviceKey;
@@ -58,12 +58,12 @@ public class ServiceDescriptor {
      * @param displayKey
      * @return
      */
-    public static ServiceDescriptor revertDisplayServiceKey(String displayKey) {
+    public static BaseServiceMetadata revertDisplayServiceKey(String displayKey) {
         String[] eles = StringUtils.split(displayKey, COLON_SEPERATOR);
         if (eles == null || eles.length < 1 || eles.length > 2) {
-            return new ServiceDescriptor();
+            return new BaseServiceMetadata();
         }
-        ServiceDescriptor serviceDescriptor = new ServiceDescriptor();
+        BaseServiceMetadata serviceDescriptor = new BaseServiceMetadata();
         serviceDescriptor.setServiceInterfaceName(eles[0]);
         if (eles.length == 2) {
             serviceDescriptor.setVersion(eles[1]);

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/URL.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/URL.java
@@ -1424,7 +1424,7 @@ class URL implements Serializable {
     }
 
     public static String buildKey(String path, String group, String version) {
-        return ServiceDescriptor.buildServiceKey(path, group, version);
+        return BaseServiceMetadata.buildServiceKey(path, group, version);
     }
 
     public String toServiceStringWithoutResolving() {

--- a/dubbo-common/src/main/java/org/apache/dubbo/rpc/model/ServiceMetadata.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/rpc/model/ServiceMetadata.java
@@ -16,7 +16,7 @@
  */
 package org.apache.dubbo.rpc.model;
 
-import org.apache.dubbo.common.ServiceDescriptor;
+import org.apache.dubbo.common.BaseServiceMetadata;
 import org.apache.dubbo.common.URL;
 
 import java.util.Map;
@@ -28,7 +28,7 @@ import java.util.concurrent.ConcurrentHashMap;
  * data related to service level such as name, version, classloader of business service,
  * security info, etc. Also with a AttributeMap for extension.
  */
-public class ServiceMetadata extends ServiceDescriptor {
+public class ServiceMetadata extends BaseServiceMetadata {
 
     private String defaultGroup;
     private Class<?> serviceType;


### PR DESCRIPTION
Rename ServiceDescriptor to BaseServiceMetadata to avoid name confusion.