### PR TITLE
add auto-generated Regsitry and Protocol to ConfigManager

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/config/AbstractInterfaceConfig.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/config/AbstractInterfaceConfig.java
@@ -270,7 +270,6 @@ public abstract class AbstractInterfaceConfig extends AbstractMethodConfig {
                 if (registryConfigs.isEmpty()) {
                     registryConfigs = new ArrayList<>();
                     RegistryConfig registryConfig = new RegistryConfig();
-                    registryConfig.setDefault(true);
                     registryConfig.refresh();
                     registryConfigs.add(registryConfig);
                 }

--- a/dubbo-common/src/main/java/org/apache/dubbo/config/AbstractInterfaceConfig.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/config/AbstractInterfaceConfig.java
@@ -270,8 +270,10 @@ public abstract class AbstractInterfaceConfig extends AbstractMethodConfig {
                 if (registryConfigs.isEmpty()) {
                     registryConfigs = new ArrayList<>();
                     RegistryConfig registryConfig = new RegistryConfig();
+                    registryConfig.setDefault(true);
                     registryConfig.refresh();
                     registryConfigs.add(registryConfig);
+                    ApplicationModel.getConfigManager().addRegistry(registryConfig);
                 }
                 setRegistries(registryConfigs);
             }

--- a/dubbo-common/src/main/java/org/apache/dubbo/config/AbstractInterfaceConfig.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/config/AbstractInterfaceConfig.java
@@ -273,7 +273,6 @@ public abstract class AbstractInterfaceConfig extends AbstractMethodConfig {
                     registryConfig.setDefault(true);
                     registryConfig.refresh();
                     registryConfigs.add(registryConfig);
-                    ApplicationModel.getConfigManager().addRegistry(registryConfig);
                 }
                 setRegistries(registryConfigs);
             }

--- a/dubbo-common/src/main/java/org/apache/dubbo/config/ServiceConfigBase.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/config/ServiceConfigBase.java
@@ -276,8 +276,10 @@ public abstract class ServiceConfigBase<T> extends AbstractServiceConfig {
                 if (protocolConfigs.isEmpty()) {
                     protocolConfigs = new ArrayList<>(1);
                     ProtocolConfig protocolConfig = new ProtocolConfig();
+                    protocolConfig.setDefault(true);
                     protocolConfig.refresh();
                     protocolConfigs.add(protocolConfig);
+                    ApplicationModel.getConfigManager().addProtocol(protocolConfig);
                 }
                 setProtocols(protocolConfigs);
             }


### PR DESCRIPTION
When user does not specify any ProtocolConfig or RegistryConfig, the auto-generated Regsitry and Protocol should be added to ConfigManager