### PR TITLE
[Dubbo-Refactor]: remove NetUtils.getHostAddress() and relace it with NetUtil…

### DIFF
--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/interceptor/ConsumerContextClusterInterceptor.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/interceptor/ConsumerContextClusterInterceptor.java
@@ -31,7 +31,7 @@ public class ConsumerContextClusterInterceptor implements ClusterInterceptor, Cl
     public void before(AbstractClusterInvoker<?> invoker, Invocation invocation) {
         RpcContext.getContext()
                 .setInvocation(invocation)
-                .setLocalAddress(NetUtils.getHostAddress(), 0);
+                .setLocalAddress(NetUtils.getLocalHost(), 0);
         if (invocation instanceof RpcInvocation) {
             ((RpcInvocation) invocation).setInvoker(invoker);
         }

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/utils/NetUtils.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/utils/NetUtils.java
@@ -139,12 +139,12 @@ public class NetUtils {
         if (address == null || address.isLoopbackAddress()) {
             return false;
         }
+
         String name = address.getHostAddress();
-        boolean result = (name != null
+        return (name != null
                 && IP_PATTERN.matcher(name).matches()
                 && !ANYHOST_VALUE.equals(name)
                 && !LOCALHOST_VALUE.equals(name));
-        return result;
     }
 
     /**
@@ -186,18 +186,16 @@ public class NetUtils {
 
     private static volatile String HOST_ADDRESS;
 
-    public static String getHostAddress () {
+    public static String getLocalHost() {
         if (HOST_ADDRESS != null) {
             return HOST_ADDRESS;
         }
 
-        HOST_ADDRESS = getLocalHost();
-        return HOST_ADDRESS;
-    }
-
-    public static String getLocalHost() {
         InetAddress address = getLocalAddress();
-        return address == null ? LOCALHOST_VALUE : address.getHostAddress();
+        if (address != null) {
+            return HOST_ADDRESS = address.getHostAddress();
+        }
+        return LOCALHOST_VALUE;
     }
 
     public static String filterLocalHost(String host) {
@@ -287,7 +285,7 @@ public class NetUtils {
                             Optional<InetAddress> addressOp = toValidAddress(addresses.nextElement());
                             if (addressOp.isPresent()) {
                                 try {
-                                    if(addressOp.get().isReachable(100)){
+                                    if (addressOp.get().isReachable(100)) {
                                         return addressOp.get();
                                     }
                                 } catch (IOException e) {
@@ -387,7 +385,7 @@ public class NetUtils {
                 InetAddress address = (InetAddress) addresses.nextElement();
                 if (preferIpv6 && address instanceof Inet6Address) {
                     try {
-                        if(address.isReachable(100)){
+                        if (address.isReachable(100)) {
                             multicastSocket.setInterface(address);
                             interfaceSet = true;
                             break;
@@ -397,7 +395,7 @@ public class NetUtils {
                     }
                 } else if (!preferIpv6 && address instanceof Inet4Address) {
                     try {
-                        if(address.isReachable(100)){
+                        if (address.isReachable(100)) {
                             multicastSocket.setInterface(address);
                             interfaceSet = true;
                             break;

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/utils/NetUtilsTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/utils/NetUtilsTest.java
@@ -300,4 +300,11 @@ public class NetUtilsTest {
         assertFalse(NetUtils.matchIpRange("192.168.1.1-61:90", "192.168.1.62", 90));
         assertFalse(NetUtils.matchIpRange("192.168.1.62:90", "192.168.1.63", 90));
     }
+
+    @Test
+    public void testLocalHost() {
+        assertEquals(NetUtils.getLocalHost(), NetUtils.getLocalAddress().getHostAddress());
+        assertTrue(NetUtils.isValidLocalHost(NetUtils.getLocalHost()));
+        assertFalse(NetUtils.isInvalidLocalHost(NetUtils.getLocalHost()));
+    }
 }


### PR DESCRIPTION
…s.getLocalHost()

## What is the purpose of the change

Remove duplicate method `NetUtils.getHostAddress()`.

## Brief changelog

NetUtils

## Verifying this change

XXXXX

Follow this checklist to help us incorporate your contribution quickly and easily:

- [ ] Make sure there is a [GITHUB_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [x] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Run `mvn clean install -DskipTests=false` & `mvn clean test-compile failsafe:integration-test` to make sure unit-test and integration-test pass.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
