### PR TITLE
[Dubbo] refactoring to remove feature envy

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/rpc/model/ProviderModel.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/rpc/model/ProviderModel.java
@@ -18,6 +18,8 @@ package org.apache.dubbo.rpc.model;
 
 import org.apache.dubbo.common.URL;
 import org.apache.dubbo.config.ServiceConfigBase;
+import org.apache.dubbo.registry.Registry;
+import org.apache.dubbo.registry.RegistryFactory;
 
 import java.lang.reflect.Method;
 import java.util.ArrayList;
@@ -120,6 +122,26 @@ public class ProviderModel {
 
         public void setRegistryUrl(URL registryUrl) {
             this.registryUrl = registryUrl;
+        }
+        
+        public static void registerList(List<RegisterStatedURL> urls, RegistryFactory registryFactory) {
+            for (ProviderModel.RegisterStatedURL statedURL : urls) {
+                if (!statedURL.isRegistered()) {
+                    Registry registry = registryFactory.getRegistry(statedURL.getRegistryUrl());
+                    registry.register(statedURL.getProviderUrl());
+                    statedURL.setRegistered(true);
+                }
+            }
+        }
+        
+        public static void unregisterList(List<RegisterStatedURL> urls, RegistryFactory registryFactory) {
+            for (ProviderModel.RegisterStatedURL statedURL : urls) {
+                if (statedURL.isRegistered()) {
+                    Registry registry = registryFactory.getRegistry(statedURL.getRegistryUrl());
+                    registry.unregister(statedURL.getProviderUrl());
+                    statedURL.setRegistered(false);
+                }
+            }
         }
     }
 

--- a/dubbo-plugin/dubbo-qos/src/main/java/org/apache/dubbo/qos/command/impl/Offline.java
+++ b/dubbo-plugin/dubbo-qos/src/main/java/org/apache/dubbo/qos/command/impl/Offline.java
@@ -64,14 +64,7 @@ public class Offline implements BaseCommand {
         for (ProviderModel providerModel : providerModelList) {
             if (providerModel.getServiceMetadata().getDisplayServiceKey().matches(servicePattern)) {
                 hasService = true;
-                List<ProviderModel.RegisterStatedURL> statedUrls = providerModel.getStatedUrl();
-                for (ProviderModel.RegisterStatedURL statedURL : statedUrls) {
-                    if (statedURL.isRegistered()) {
-                        Registry registry = registryFactory.getRegistry(statedURL.getRegistryUrl());
-                        registry.unregister(statedURL.getProviderUrl());
-                        statedURL.setRegistered(false);
-                    }
-                }
+                ProviderModel.RegisterStatedURL.unregisterList(providerModel.getStatedUrl(), registryFactory);
             }
         }
 

--- a/dubbo-plugin/dubbo-qos/src/main/java/org/apache/dubbo/qos/command/impl/Online.java
+++ b/dubbo-plugin/dubbo-qos/src/main/java/org/apache/dubbo/qos/command/impl/Online.java
@@ -64,14 +64,7 @@ public class Online implements BaseCommand {
         for (ProviderModel providerModel : providerModelList) {
             if (providerModel.getServiceMetadata().getDisplayServiceKey().matches(servicePattern)) {
                 hasService = true;
-                List<ProviderModel.RegisterStatedURL> statedUrls = providerModel.getStatedUrl();
-                for (ProviderModel.RegisterStatedURL statedURL : statedUrls) {
-                    if (!statedURL.isRegistered()) {
-                        Registry registry = registryFactory.getRegistry(statedURL.getRegistryUrl());
-                        registry.register(statedURL.getProviderUrl());
-                        statedURL.setRegistered(true);
-                    }
-                }
+                ProviderModel.RegisterStatedURL.registerList(providerModel.getStatedUrl(), registryFactory);
             }
         }
 


### PR DESCRIPTION
I found a refactoring opportunity on Dubbo project.
I believe the online method of the Online class can be improved. This method calls 8 other methods from other classes.

Besides that, the online method calls many times ProviderModel.RegisterStatedURL inner class. In my view, a part of the online method should be extracted to a new method, and this new method should be moved to RegisterStatedURL. What do you think?

The same logic is applied to the offline method.

The advantages of theses changes are:
Remove a feature envy (this method has 4 calls to the ProviderModel.RegisterStatedURL).

Regards