### PR TITLE
[Dubbo-5531] fix lazy connection not share in some circumstance.

### DIFF
--- a/dubbo-rpc/dubbo-rpc-dubbo/src/main/java/org/apache/dubbo/rpc/protocol/dubbo/LazyConnectExchangeClient.java
+++ b/dubbo-rpc/dubbo-rpc-dubbo/src/main/java/org/apache/dubbo/rpc/protocol/dubbo/LazyConnectExchangeClient.java
@@ -187,7 +187,7 @@ final class LazyConnectExchangeClient implements ExchangeClient {
         if (client != null) {
             return client.isClosed();
         } else {
-            return true;
+            return false;
         }
     }
 

--- a/dubbo-rpc/dubbo-rpc-dubbo/src/test/java/org/apache/dubbo/rpc/protocol/dubbo/DubboInvokerAvilableTest.java
+++ b/dubbo-rpc/dubbo-rpc-dubbo/src/test/java/org/apache/dubbo/rpc/protocol/dubbo/DubboInvokerAvilableTest.java
@@ -43,7 +43,7 @@ import static org.junit.jupiter.api.Assertions.fail;
  * Check available status for dubboInvoker
  */
 public class DubboInvokerAvilableTest {
-    private static DubboProtocol protocol = DubboProtocol.getDubboProtocol();
+    private static DubboProtocol protocol;
     private static ProxyFactory proxy = ExtensionLoader.getExtensionLoader(ProxyFactory.class).getAdaptiveExtension();
 
     @BeforeAll
@@ -52,6 +52,7 @@ public class DubboInvokerAvilableTest {
 
     @BeforeEach
     public void setUp() throws Exception {
+        protocol = new DubboProtocol();
     }
 
     @AfterAll
@@ -97,10 +98,10 @@ public class DubboInvokerAvilableTest {
 
         long start = System.currentTimeMillis();
 
-        try{
+        try {
             System.setProperty(SHUTDOWN_WAIT_KEY, "2000");
             protocol.destroy();
-        }finally {
+        } finally {
             System.getProperties().remove(SHUTDOWN_WAIT_KEY);
         }
 
@@ -130,8 +131,11 @@ public class DubboInvokerAvilableTest {
 
         AsyncToSyncInvoker<?> invoker = (AsyncToSyncInvoker) protocol.refer(IDemoService.class, url);
         Assertions.assertTrue(invoker.isAvailable());
+
+        ExchangeClient exchangeClient = getClients((DubboInvoker<?>) invoker.getInvoker())[0];
+        Assertions.assertFalse(exchangeClient.isClosed());
         try {
-            getClients((DubboInvoker<?>) invoker.getInvoker())[0].setAttribute(Constants.CHANNEL_ATTRIBUTE_READONLY_KEY, Boolean.TRUE);
+            exchangeClient.setAttribute(Constants.CHANNEL_ATTRIBUTE_READONLY_KEY, Boolean.TRUE);
             fail();
         } catch (IllegalStateException e) {
 
@@ -141,7 +145,7 @@ public class DubboInvokerAvilableTest {
         Assertions.assertEquals("ok", service.get());
 
         Assertions.assertTrue(invoker.isAvailable());
-        getClients((DubboInvoker<?>) invoker.getInvoker())[0].setAttribute(Constants.CHANNEL_ATTRIBUTE_READONLY_KEY, Boolean.TRUE);
+        exchangeClient.setAttribute(Constants.CHANNEL_ATTRIBUTE_READONLY_KEY, Boolean.TRUE);
         Assertions.assertFalse(invoker.isAvailable());
     }
 


### PR DESCRIPTION
For PR: #5531 

## Verifying this change
Connection is able to share for lazy connection.

  TCP    0.0.0.0:20880          0.0.0.0:0              LISTENING       16660
  TCP    10.xx.xx.151:20880     10.xx.xx.151:53785     ESTABLISHED     16660
  TCP    10.xx.xx:53785     10.xx.xx.151:20880     ESTABLISHED     19704
  TCP    [::]:20880             [::]:0                 LISTENING       16660

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a [GITHUB_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Run `mvn clean install -DskipTests=false` & `mvn clean test-compile failsafe:integration-test` to make sure unit-test and integration-test pass.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
