### PR TITLE
lazy init ReferenceBean util actually use

### DIFF
--- a/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/util/ConfigCommonUtils.java
+++ b/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/util/ConfigCommonUtils.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.config.spring.util;
+
+import org.apache.dubbo.config.spring.ReferenceBean;
+
+import org.springframework.aop.TargetSource;
+import org.springframework.aop.framework.ProxyFactory;
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Supplier;
+
+public class ConfigCommonUtils {
+    public static Object getSpringProxy(final Class targetClass, final ClassLoader classLoader, final Supplier supplier) {
+        TargetSource ts = new TargetSource() {
+            @Override
+            public Class<?> getTargetClass() {
+                return targetClass;
+            }
+
+            @Override
+            public boolean isStatic() {
+                return false;
+            }
+
+            @Override
+            public Object getTarget() {
+                Object target = supplier.get();
+                if (target == null) {
+                    Class<?> type = getTargetClass();
+                    if (Map.class == type) {
+                        return Collections.emptyMap();
+                    }
+                    else if (List.class == type) {
+                        return Collections.emptyList();
+                    }
+                    else if (Set.class == type || Collection.class == type) {
+                        return Collections.emptySet();
+                    }
+                    throw new NoSuchBeanDefinitionException(ReferenceBean.class,
+                        "Optional dependency not present for lazy injection point");
+                }
+                return target;
+            }
+
+            @Override
+            public void releaseTarget(Object target) {
+            }
+        };
+        ProxyFactory pf = new ProxyFactory();
+        pf.setTargetSource(ts);
+        if (targetClass.isInterface()) {
+            pf.addInterface(targetClass);
+        }
+
+        return pf.getProxy(classLoader);
+    }
+}

--- a/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/util/DubboConfigSpringConstants.java
+++ b/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/util/DubboConfigSpringConstants.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.config.spring.util;
+
+public interface DubboConfigSpringConstants {
+    /**
+     * It's the same meaning as init when it's true,
+     * but it's true lazy-init when it's false,
+     * that is to say: Dubbo <i>does not</i> init reference
+     * even if developer use @Autowired util the spring actually use the reference bean.
+     */
+    String TRUE_INIT_KEY = "dubbo.consumer.trueinit";
+}

--- a/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/context/annotation/consumer/ConsumerConfigTrueinitTest.java
+++ b/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/context/annotation/consumer/ConsumerConfigTrueinitTest.java
@@ -1,0 +1,232 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.dubbo.config.spring.context.annotation.consumer;
+
+import org.apache.dubbo.config.spring.api.DemoService;
+import org.apache.dubbo.config.spring.context.annotation.consumer.test.component.TestDemoServiceComponentAnnotationWithTrueinitFalse;
+import org.apache.dubbo.config.spring.context.annotation.consumer.test.component.TestDemoServiceComponentAnnotationWithTrueinitTrue;
+import org.apache.dubbo.config.spring.context.annotation.consumer.test.component.TestDemoServiceComponentAnnotationWithoutTrueinit;
+import org.apache.dubbo.config.spring.context.annotation.consumer.test.component.TestDemoServiceComponentXmlWithTrueinitFalse;
+import org.apache.dubbo.config.spring.context.annotation.provider.ProviderConfiguration;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.aop.support.AopUtils;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+
+import java.util.Map;
+
+public class ConsumerConfigTrueinitTest {
+    /**
+     * 'dubbo.consumer.trueinit=true'
+     *
+     * Test true lazy: init util actually use, not when injected.
+     * This could cut down the startup time in develop or test env.
+     */
+    @Test
+    public void testConsumerConfigTrueinitFalse() {
+        AnnotationConfigApplicationContext providerContext = null;
+        AnnotationConfigApplicationContext consumerContext = null;
+        try {
+            providerContext = new AnnotationConfigApplicationContext();
+            providerContext.register(ProviderConfiguration.class);
+            providerContext.refresh();
+
+            consumerContext = new AnnotationConfigApplicationContext();
+            consumerContext.register(TestDemoServiceComponentAnnotationWithTrueinitFalse.class);
+            consumerContext.refresh();
+
+            TestDemoServiceComponentAnnotationWithTrueinitFalse testDemoServiceComponentAnnotationWithTrueinitFalse = consumerContext.getBean(TestDemoServiceComponentAnnotationWithTrueinitFalse.class);
+            Map<String, DemoService> beansBefore = consumerContext.getBeansOfType(DemoService.class);
+            Assertions.assertTrue(beansBefore.isEmpty());
+
+            long begin = System.currentTimeMillis();
+            String value = testDemoServiceComponentAnnotationWithTrueinitFalse.sayHello("Zhai");
+            Assertions.assertEquals("Hello,Zhai", value);
+            System.out.println("######## testConsumerConfigTrueinitFalse - sayHello() cost: " + (System.currentTimeMillis() - begin)
+                + " ms, because initializing ReferenceBean");
+
+            Map<String, DemoService> beansAfter = consumerContext.getBeansOfType(DemoService.class);
+            Assertions.assertEquals(1, beansAfter.size());
+
+            long beginAgain = System.currentTimeMillis();
+            String valueAgain = testDemoServiceComponentAnnotationWithTrueinitFalse.sayHello("Zhai");
+            Assertions.assertEquals("Hello,Zhai", valueAgain);
+            System.out.println("######## testConsumerConfigTrueinitFalse - sayHello() again cost: " + (System.currentTimeMillis() - beginAgain)
+                + " ms, because ReferenceBean has already init");
+        }
+        finally {
+            if (providerContext != null) {
+                providerContext.close();
+            }
+            if (consumerContext != null) {
+                consumerContext.close();
+            }
+        }
+    }
+
+    /**
+     * without 'dubbo.consumer.trueinit'
+     */
+    @Test
+    public void testConsumerConfigTrueinitWithout() {
+        AnnotationConfigApplicationContext providerContext = null;
+        AnnotationConfigApplicationContext consumerContext = null;
+        try {
+            providerContext = new AnnotationConfigApplicationContext();
+            providerContext.register(ProviderConfiguration.class);
+            providerContext.refresh();
+
+            consumerContext = new AnnotationConfigApplicationContext();
+            consumerContext.register(TestDemoServiceComponentAnnotationWithoutTrueinit.class);
+            consumerContext.refresh();
+
+            TestDemoServiceComponentAnnotationWithoutTrueinit testDemoServiceComponentAnnotationWithoutTrueinit = consumerContext.getBean(TestDemoServiceComponentAnnotationWithoutTrueinit.class);
+            Map<String, DemoService> beansBefore = consumerContext.getBeansOfType(DemoService.class);
+            Assertions.assertEquals(1, beansBefore.size());
+
+            long begin = System.currentTimeMillis();
+            String value = testDemoServiceComponentAnnotationWithoutTrueinit.sayHello("Zhai");
+            Assertions.assertEquals("Hello,Zhai", value);
+            System.out.println("######## testConsumerConfigTrueinitWithout - sayHello() cost: " + (System.currentTimeMillis() - begin)
+                + " ms, because ReferenceBean has already init");
+
+            Map<String, DemoService> beansAfter = consumerContext.getBeansOfType(DemoService.class);
+            Assertions.assertEquals(1, beansAfter.size());
+
+            long beginAgain = System.currentTimeMillis();
+            String valueAgain = testDemoServiceComponentAnnotationWithoutTrueinit.sayHello("Zhai");
+            Assertions.assertEquals("Hello,Zhai", valueAgain);
+            System.out.println("######## testConsumerConfigTrueinitWithout - sayHello() again cost: " + (System.currentTimeMillis() - beginAgain)
+                + " ms, because ReferenceBean has already init");
+        }
+        finally {
+            if (providerContext != null) {
+                providerContext.close();
+            }
+            if (consumerContext != null) {
+                consumerContext.close();
+            }
+        }
+    }
+
+    /**
+     * 'dubbo.consumer.trueinit=true'
+     */
+    @Test
+    public void testConsumerConfigTrueinitTrue() {
+        AnnotationConfigApplicationContext providerContext = null;
+        AnnotationConfigApplicationContext consumerContext = null;
+        try {
+            providerContext = new AnnotationConfigApplicationContext();
+            providerContext.register(ProviderConfiguration.class);
+            providerContext.refresh();
+
+            consumerContext = new AnnotationConfigApplicationContext();
+            consumerContext.register(TestDemoServiceComponentAnnotationWithTrueinitTrue.class);
+            consumerContext.refresh();
+
+            TestDemoServiceComponentAnnotationWithTrueinitTrue testDemoServiceComponentAnnotationWithTrueinitTrue = consumerContext.getBean(TestDemoServiceComponentAnnotationWithTrueinitTrue.class);
+            Map<String, DemoService> beansBefore = consumerContext.getBeansOfType(DemoService.class);
+            Assertions.assertEquals(1, beansBefore.size());
+
+            long begin = System.currentTimeMillis();
+            String value = testDemoServiceComponentAnnotationWithTrueinitTrue.sayHello("Zhai");
+            Assertions.assertEquals("Hello,Zhai", value);
+            System.out.println("######## testConsumerConfigTrueinitTrue - sayHello() cost: " + (System.currentTimeMillis() - begin)
+                + " ms, because ReferenceBean has already init");
+
+            Map<String, DemoService> beansAfter = consumerContext.getBeansOfType(DemoService.class);
+            Assertions.assertEquals(1, beansAfter.size());
+
+            long beginAgain = System.currentTimeMillis();
+            String valueAgain = testDemoServiceComponentAnnotationWithTrueinitTrue.sayHello("Zhai");
+            Assertions.assertEquals("Hello,Zhai", valueAgain);
+            System.out.println("######## testConsumerConfigTrueinitTrue - sayHello() again cost: " + (System.currentTimeMillis() - beginAgain)
+                + " ms, because ReferenceBean has already init");
+        }
+        finally {
+            if (providerContext != null) {
+                providerContext.close();
+            }
+            if (consumerContext != null) {
+                consumerContext.close();
+            }
+        }
+    }
+
+    @Test
+    public void testConsumerConfigXmlTrueinitFalse() {
+        AnnotationConfigApplicationContext providerContext = null;
+        AnnotationConfigApplicationContext consumerContext = null;
+        try {
+            providerContext = new AnnotationConfigApplicationContext();
+            providerContext.register(ProviderConfiguration.class);
+            providerContext.refresh();
+
+            consumerContext = new AnnotationConfigApplicationContext();
+            consumerContext.register(TestDemoServiceComponentXmlWithTrueinitFalse.class);
+            consumerContext.refresh();
+
+            // test demoService inject
+            TestDemoServiceComponentXmlWithTrueinitFalse testDemoServiceComponentXmlWithTrueinitFalse = consumerContext.getBean(TestDemoServiceComponentXmlWithTrueinitFalse.class);
+            Map<String, DemoService> beansBefore = consumerContext.getBeansOfType(DemoService.class);
+            Assertions.assertTrue(beansBefore.isEmpty());
+
+            long begin = System.currentTimeMillis();
+            String value = testDemoServiceComponentXmlWithTrueinitFalse.sayName("Zhai");
+            Assertions.assertEquals("Hello,Zhai", value);
+            System.out.println("######## testConsumerConfigXmlTrueinitFalse - sayName() cost: " + (System.currentTimeMillis() - begin)
+                + " ms, because initializing ReferenceBean");
+
+            Map<String, DemoService> beansAfter = consumerContext.getBeansOfType(DemoService.class);
+            Assertions.assertEquals(1, beansAfter.size());
+
+            long beginAgain = System.currentTimeMillis();
+            String valueAgain = testDemoServiceComponentXmlWithTrueinitFalse.sayName("Zhai");
+            Assertions.assertEquals("Hello,Zhai", valueAgain);
+            System.out.println("######## testConsumerConfigXmlTrueinitFalse - sayName() again cost: " + (System.currentTimeMillis() - beginAgain)
+                + " ms, because ReferenceBean has already init");
+
+            // test helloService inject
+            Assertions.assertTrue(AopUtils.isAopProxy(testDemoServiceComponentXmlWithTrueinitFalse.getHelloService2()));
+
+            long beginHello = System.currentTimeMillis();
+            String valueHello = testDemoServiceComponentXmlWithTrueinitFalse.sayHello("Zhai");
+            Assertions.assertEquals("Greeting, Zhai", valueHello);
+            System.out.println("######## testConsumerConfigXmlTrueinitFalse - sayHello() cost: " + (System.currentTimeMillis() - beginHello)
+                + " ms, because initializing ReferenceBean");
+
+            long beginHelloAgain = System.currentTimeMillis();
+            String valueHelloAgain = testDemoServiceComponentXmlWithTrueinitFalse.sayHello("Zhai");
+            Assertions.assertEquals("Greeting, Zhai", valueHelloAgain);
+            System.out.println("######## testConsumerConfigXmlTrueinitFalse - sayHello() again cost: " + (System.currentTimeMillis() - beginHelloAgain)
+                + " ms, because ReferenceBean has already init");
+        }
+        finally {
+            if (providerContext != null) {
+                providerContext.close();
+            }
+            if (consumerContext != null) {
+                consumerContext.close();
+            }
+        }
+    }
+}

--- a/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/context/annotation/consumer/test/component/TestDemoServiceComponentAnnotationWithTrueinitFalse.java
+++ b/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/context/annotation/consumer/test/component/TestDemoServiceComponentAnnotationWithTrueinitFalse.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.dubbo.config.spring.context.annotation.consumer.test.component;
+
+import org.apache.dubbo.config.annotation.Reference;
+import org.apache.dubbo.config.spring.api.DemoService;
+import org.apache.dubbo.config.spring.context.annotation.EnableDubbo;
+
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.stereotype.Component;
+
+@EnableDubbo
+@PropertySource("classpath:dubbo-consumer-trueinit-false.properties")
+@Component
+public class TestDemoServiceComponentAnnotationWithTrueinitFalse {
+    private static final String remoteURL = "dubbo://127.0.0.1:12345?version=2.5.7";
+
+    @Reference(version = "2.5.7", url = remoteURL)
+    private DemoService demoService;
+
+    public String sayHello(String name) {
+        return demoService.sayName(name);
+    }
+}

--- a/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/context/annotation/consumer/test/component/TestDemoServiceComponentAnnotationWithTrueinitTrue.java
+++ b/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/context/annotation/consumer/test/component/TestDemoServiceComponentAnnotationWithTrueinitTrue.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.dubbo.config.spring.context.annotation.consumer.test.component;
+
+import org.apache.dubbo.config.annotation.Reference;
+import org.apache.dubbo.config.spring.api.DemoService;
+import org.apache.dubbo.config.spring.context.annotation.EnableDubbo;
+
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.stereotype.Component;
+
+@EnableDubbo
+@PropertySource("classpath:dubbo-consumer-trueinit-true.properties")
+@Component
+public class TestDemoServiceComponentAnnotationWithTrueinitTrue {
+    private static final String remoteURL = "dubbo://127.0.0.1:12345?version=2.5.7";
+
+    @Reference(version = "2.5.7", url = remoteURL)
+    private DemoService demoService;
+
+    public String sayHello(String name) {
+        return demoService.sayName(name);
+    }
+}

--- a/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/context/annotation/consumer/test/component/TestDemoServiceComponentAnnotationWithoutTrueinit.java
+++ b/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/context/annotation/consumer/test/component/TestDemoServiceComponentAnnotationWithoutTrueinit.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.dubbo.config.spring.context.annotation.consumer.test.component;
+
+import org.apache.dubbo.config.annotation.Reference;
+import org.apache.dubbo.config.spring.api.DemoService;
+import org.apache.dubbo.config.spring.context.annotation.EnableDubbo;
+
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.stereotype.Component;
+
+@EnableDubbo
+@PropertySource("classpath:dubbo-consumer-trueinit.properties")
+@Component
+public class TestDemoServiceComponentAnnotationWithoutTrueinit {
+    private static final String remoteURL = "dubbo://127.0.0.1:12345?version=2.5.7";
+
+    @Reference(version = "2.5.7", url = remoteURL)
+    private DemoService demoService;
+
+    public String sayHello(String name) {
+        return demoService.sayName(name);
+    }
+}

--- a/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/context/annotation/consumer/test/component/TestDemoServiceComponentXmlWithTrueinitFalse.java
+++ b/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/context/annotation/consumer/test/component/TestDemoServiceComponentXmlWithTrueinitFalse.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.dubbo.config.spring.context.annotation.consumer.test.component;
+
+import org.apache.dubbo.config.annotation.Reference;
+import org.apache.dubbo.config.spring.api.DemoService;
+import org.apache.dubbo.config.spring.api.HelloService;
+import org.apache.dubbo.config.spring.context.annotation.EnableDubbo;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.ImportResource;
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.stereotype.Component;
+
+@EnableDubbo
+@PropertySource("classpath:dubbo-consumer-trueinit-false.properties")
+@Component
+@ImportResource("classpath:/org/apache/dubbo/config/spring/consumer-config-trueinit-false.xml")
+public class TestDemoServiceComponentXmlWithTrueinitFalse {
+    private static final String remoteURL = "dubbo://127.0.0.1:12345?version=2.5.7";
+
+    @Reference(version = "2.5.7", url = remoteURL)
+    private DemoService demoService;
+
+    @Autowired
+    private HelloService helloService2;
+
+    public HelloService getHelloService2() {
+        return helloService2;
+    }
+
+    public String sayName(String name) {
+        return demoService.sayName(name);
+    }
+
+    public String sayHello(String name) {
+        return helloService2.sayHello(name);
+    }
+}

--- a/dubbo-config/dubbo-config-spring/src/test/resources/dubbo-consumer-trueinit-false.properties
+++ b/dubbo-config/dubbo-config-spring/src/test/resources/dubbo-consumer-trueinit-false.properties
@@ -1,0 +1,22 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+dubbo.application.name=dubbo-test-consumer-trueinit-false
+dubbo.registry.address=N/A
+dubbo.consumer.trueinit=false

--- a/dubbo-config/dubbo-config-spring/src/test/resources/dubbo-consumer-trueinit-true.properties
+++ b/dubbo-config/dubbo-config-spring/src/test/resources/dubbo-consumer-trueinit-true.properties
@@ -1,0 +1,22 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+dubbo.application.name=dubbo-test-consumer-trueinit-false
+dubbo.registry.address=N/A
+dubbo.consumer.trueinit=true

--- a/dubbo-config/dubbo-config-spring/src/test/resources/dubbo-consumer-trueinit.properties
+++ b/dubbo-config/dubbo-config-spring/src/test/resources/dubbo-consumer-trueinit.properties
@@ -1,0 +1,21 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+dubbo.application.name=dubbo-test-consumer-trueinit
+dubbo.registry.address=N/A

--- a/dubbo-config/dubbo-config-spring/src/test/resources/org/apache/dubbo/config/spring/consumer-config-trueinit-false.xml
+++ b/dubbo-config/dubbo-config-spring/src/test/resources/org/apache/dubbo/config/spring/consumer-config-trueinit-false.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -17,16 +16,15 @@
   -->
 <beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:dubbo="http://dubbo.apache.org/schema/dubbo"
-       xmlns="http://www.springframework.org/schema/beans" xmlns:context="http://www.springframework.org/schema/context"
+       xmlns="http://www.springframework.org/schema/beans"
        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.3.xsd
-       http://dubbo.apache.org/schema/dubbo http://dubbo.apache.org/schema/dubbo/dubbo.xsd http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
+    http://dubbo.apache.org/schema/dubbo http://dubbo.apache.org/schema/dubbo/dubbo.xsd
+    ">
 
-    <dubbo:application name="demo-consumer"/>
+    <!-- current application configuration -->
+<!--    <dubbo:application name="test-consumer-config-trueinit-false"/>-->
 
-    <dubbo:registry address="zookeeper://127.0.0.1:2181"/>
-
-    <dubbo:reference id="demoService" check="false" interface="org.apache.dubbo.demo.DemoService"/>
-
-    <context:component-scan base-package="org.apache.dubbo.demo.consumer.service"/>
+    <!-- service reference configuration -->
+    <dubbo:reference id="helloService5" interface="org.apache.dubbo.config.spring.api.HelloService"/>
 
 </beans>

--- a/dubbo-demo/dubbo-demo-xml/dubbo-demo-xml-consumer/src/main/java/org/apache/dubbo/demo/consumer/service/DemoServiceComponent.java
+++ b/dubbo-demo/dubbo-demo-xml/dubbo-demo-xml-consumer/src/main/java/org/apache/dubbo/demo/consumer/service/DemoServiceComponent.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.demo.consumer.service;
+
+import org.apache.dubbo.demo.DemoService;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.stereotype.Component;
+
+@Component("demoServiceComponent")
+@PropertySource("classpath:dubbo.properties")
+public class DemoServiceComponent implements DemoService {
+    @Autowired
+    private DemoService demoService;
+
+    @Override
+    public String sayHello(String name) {
+        return demoService.sayHello(name);
+    }
+}

--- a/dubbo-demo/dubbo-demo-xml/dubbo-demo-xml-consumer/src/main/resources/dubbo.properties
+++ b/dubbo-demo/dubbo-demo-xml/dubbo-demo-xml-consumer/src/main/resources/dubbo.properties
@@ -1,1 +1,2 @@
 dubbo.application.qos.port=33333
+dubbo.consumer.trueinit=false


### PR DESCRIPTION
## What is the purpose of the change

We use `@Autowired` or `@Reference` to inject ReferenceBean<T>, and the ReferenceBean will init while the project is starting. The startup processor may process too long time. And In the local development environment, we may just modify few logics, but we must wait maybe a long time to restart, dubbo should provide `lazy init ReferenceBean util actually use not just in injection`.

Thus, if we set `dubbo.consumer.trueinit=false`, it will cost more time in the first use of one ReferenceBean, but I think it's ok in the development enviroment.

## Brief changelog

XXXXX

## Verifying this change

XXXXX

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a [GITHUB_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Run `mvn clean install -DskipTests=false` & `mvn clean test-compile failsafe:integration-test` to make sure unit-test and integration-test pass.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
