### PR TITLE
[Dubbo] Refactoring to remove feature envy

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/config/AbstractInterfaceConfig.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/config/AbstractInterfaceConfig.java
@@ -243,16 +243,16 @@ public abstract class AbstractInterfaceConfig extends AbstractMethodConfig {
      *                       side, it is the {@link Class} of the remote service interface
      */
     public void checkStubAndLocal(Class<?> interfaceClass) {
-        if (ConfigUtils.isNotEmpty(local)) {
-            Class<?> localClass = ConfigUtils.isDefault(local) ?
-                    ReflectUtils.forName(interfaceClass.getName() + "Local") : ReflectUtils.forName(local);
-            verify(interfaceClass, localClass);
-        }
-        if (ConfigUtils.isNotEmpty(stub)) {
-            Class<?> localClass = ConfigUtils.isDefault(stub) ?
-                    ReflectUtils.forName(interfaceClass.getName() + "Stub") : ReflectUtils.forName(stub);
-            verify(interfaceClass, localClass);
-        }
+        verifyStubAndLocal(local, "Local", interfaceClass);
+        verifyStubAndLocal(stub, "Stub", interfaceClass);
+    }
+    
+    public void verifyStubAndLocal(String className, String label, Class<?> interfaceClass){
+    	if (ConfigUtils.isNotEmpty(className)) {
+                Class<?> localClass = ConfigUtils.isDefault(className) ?
+                        ReflectUtils.forName(interfaceClass.getName() + label) : 			ReflectUtils.forName(className);
+                        verify(interfaceClass, localClass);
+            }
     }
 
     private void verify(Class<?> interfaceClass, Class<?> localClass) {


### PR DESCRIPTION
I found a refactoring opportunity on Dubbo project.
I believe the checkStubAndLocal method can be improved. This method calls ReflectUtils.forName() method 4 times and ConfigUtils class 4 times.
I am proposing a reduction in the amount of calls.

Regards