### PR TITLE
[Dubbo-5563] fix useless null check in RmiProtocol

### DIFF
--- a/dubbo-rpc/dubbo-rpc-rmi/src/main/java/org/apache/dubbo/rpc/protocol/rmi/RmiProtocol.java
+++ b/dubbo-rpc/dubbo-rpc-rmi/src/main/java/org/apache/dubbo/rpc/protocol/rmi/RmiProtocol.java
@@ -86,17 +86,17 @@ public class RmiProtocol extends AbstractProxyProtocol {
           3. if the provider version is lower than v2.6.3, does not use customized RemoteInvocation.
          */
         if (isRelease270OrHigher(url.getParameter(RELEASE_KEY))) {
-            rmiProxyFactoryBean.setRemoteInvocationFactory((methodInvocation) -> {
+            rmiProxyFactoryBean.setRemoteInvocationFactory(methodInvocation -> {
                 RemoteInvocation invocation = new RmiRemoteInvocation(methodInvocation);
-                if (invocation != null && isGeneric) {
+                if (isGeneric) {
                     invocation.addAttribute(GENERIC_KEY, generic);
                 }
                 return invocation;
             });
         } else if (isRelease263OrHigher(url.getParameter(DUBBO_VERSION_KEY))) {
-            rmiProxyFactoryBean.setRemoteInvocationFactory((methodInvocation) -> {
+            rmiProxyFactoryBean.setRemoteInvocationFactory(methodInvocation -> {
                 RemoteInvocation invocation = new com.alibaba.dubbo.rpc.protocol.rmi.RmiRemoteInvocation(methodInvocation);
-                if (invocation != null && isGeneric) {
+                if (isGeneric) {
                     invocation.addAttribute(GENERIC_KEY, generic);
                 }
                 return invocation;


### PR DESCRIPTION
## What is the purpose of the change

fixes #5563 

## Brief changelog

1.dubbo-rpc/dubbo-rpc-rmi/src/main/java/org/apache/dubbo/rpc/protocol/rmi/RmiProtocol.java

## Verifying this change

Passed unit tests

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a [GITHUB_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Run `mvn clean install -DskipTests=false` & `mvn clean test-compile failsafe:integration-test` to make sure unit-test and integration-test pass.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
