### PR TITLE
fix reuse ID

### DIFF
--- a/dubbo-serialization/dubbo-serialization-api/src/main/java/org/apache/dubbo/common/serialize/Constants.java
+++ b/dubbo-serialization/dubbo-serialization-api/src/main/java/org/apache/dubbo/common/serialize/Constants.java
@@ -30,4 +30,7 @@ public interface Constants {
     byte AVRO_SERIALIZATION_ID = 11;
     byte GSON_SERIALIZATION_ID = 16;
     byte PROTOBUF_JSON_SERIALIZATION_ID = 21;
+
+    byte PROTOBUF_SERIALIZATION_ID = 22;
+    byte KRYO_SERIALIZATION2_ID = 25;
 }

--- a/dubbo-serialization/dubbo-serialization-kryo/src/main/java/org/apache/dubbo/common/serialize/kryo/optimized/KryoSerialization2.java
+++ b/dubbo-serialization/dubbo-serialization-kryo/src/main/java/org/apache/dubbo/common/serialize/kryo/optimized/KryoSerialization2.java
@@ -17,6 +17,7 @@
 package org.apache.dubbo.common.serialize.kryo.optimized;
 
 import org.apache.dubbo.common.URL;
+import org.apache.dubbo.common.serialize.Constants;
 import org.apache.dubbo.common.serialize.ObjectInput;
 import org.apache.dubbo.common.serialize.ObjectOutput;
 import org.apache.dubbo.common.serialize.Serialization;
@@ -24,8 +25,6 @@ import org.apache.dubbo.common.serialize.Serialization;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-
-import static org.apache.dubbo.common.serialize.Constants.KRYO_SERIALIZATION_ID;
 
 /**
  * TODO for now kryo serialization doesn't deny classes that don't implement the serializable interface
@@ -38,7 +37,7 @@ public class KryoSerialization2 implements Serialization {
 
     @Override
     public byte getContentTypeId() {
-        return KRYO_SERIALIZATION_ID;
+        return Constants.KRYO_SERIALIZATION2_ID;
     }
 
     @Override

--- a/dubbo-serialization/dubbo-serialization-protobuf/src/main/java/org/apache/dubbo/common/serialize/protobuf/support/GenericProtobufSerialization.java
+++ b/dubbo-serialization/dubbo-serialization-protobuf/src/main/java/org/apache/dubbo/common/serialize/protobuf/support/GenericProtobufSerialization.java
@@ -17,14 +17,13 @@
 package org.apache.dubbo.common.serialize.protobuf.support;
 
 import org.apache.dubbo.common.URL;
+import org.apache.dubbo.common.serialize.Constants;
 import org.apache.dubbo.common.serialize.ObjectInput;
 import org.apache.dubbo.common.serialize.ObjectOutput;
 import org.apache.dubbo.common.serialize.Serialization;
 
 import java.io.InputStream;
 import java.io.OutputStream;
-
-import static org.apache.dubbo.common.serialize.Constants.PROTOBUF_JSON_SERIALIZATION_ID;
 
 /**
  * <p>
@@ -44,7 +43,7 @@ public class GenericProtobufSerialization implements Serialization {
 
     @Override
     public byte getContentTypeId() {
-        return PROTOBUF_JSON_SERIALIZATION_ID;
+        return Constants.PROTOBUF_SERIALIZATION_ID;
     }
 
     @Override


### PR DESCRIPTION
fix bug

2020-01-07 16:03:12.180 ERROR 14400 --- [erverWorker-3-2] o.a.d.remoting.transport.CodecSupport    :  [DUBBO] Serialization extension org.apache.dubbo.common.serialize.kryo.optimized.KryoSerialization2 has duplicate id to Serialization extension org.apache.dubbo.common.serialize.kryo.KryoSerialization, ignore this Serialization extension, dubbo version: 2.7.5, current host: 127.0.0.1
2020-01-07 16:03:12.181 ERROR 14400 --- [erverWorker-3-2] o.a.d.remoting.transport.CodecSupport    :  [DUBBO] Serialization extension org.apache.dubbo.common.serialize.protobuf.support.GenericProtobufJsonSerialization has duplicate id to Serialization extension org.apache.dubbo.common.serialize.protobuf.support.GenericProtobufSerialization, ignore this Serialization extension, dubbo version: 2.7.5, current host: 127.0.0.1
