### PR TITLE
[Dubbo-5610] Fix A bean with that name has already been defined and overriding is disabled

### DIFF
--- a/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/beans/factory/annotation/ServiceAnnotationBeanPostProcessor.java
+++ b/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/beans/factory/annotation/ServiceAnnotationBeanPostProcessor.java
@@ -65,6 +65,7 @@ import java.util.Map;
 import java.util.Set;
 
 import static com.alibaba.spring.util.AnnotatedBeanDefinitionRegistryUtils.registerBeans;
+import static com.alibaba.spring.util.AnnotatedBeanDefinitionRegistryUtils.isPresentBean;
 import static com.alibaba.spring.util.ObjectUtils.of;
 import static org.apache.dubbo.config.spring.beans.factory.annotation.ServiceBeanNameBuilder.create;
 import static org.apache.dubbo.config.spring.util.DubboAnnotationUtils.resolveServiceInterfaceClass;
@@ -108,9 +109,11 @@ public class ServiceAnnotationBeanPostProcessor implements BeanDefinitionRegistr
 
     @Override
     public void postProcessBeanDefinitionRegistry(BeanDefinitionRegistry registry) throws BeansException {
-
-        // @since 2.7.5
-        registerBeans(registry, DubboBootstrapApplicationListener.class);
+        //when bean dubboBootstrapApplicationListener.class is not register , do registerBeans
+        if (!isPresentBean(registry, DubboBootstrapApplicationListener.class)) {
+            // @since 2.7.5
+            registerBeans(registry, DubboBootstrapApplicationListener.class);
+        }
 
         Set<String> resolvedPackagesToScan = resolvePackagesToScan(packagesToScan);
 

--- a/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/beans/factory/annotation/ServiceAnnotationBeanPostProcessor.java
+++ b/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/beans/factory/annotation/ServiceAnnotationBeanPostProcessor.java
@@ -109,7 +109,7 @@ public class ServiceAnnotationBeanPostProcessor implements BeanDefinitionRegistr
 
     @Override
     public void postProcessBeanDefinitionRegistry(BeanDefinitionRegistry registry) throws BeansException {
-        //when bean dubboBootstrapApplicationListener.class is not register , do registerBeans
+        //when bean dubboBootstrapApplicationListener.class is not registered , do registerBeans
         if (!isPresentBean(registry, DubboBootstrapApplicationListener.class)) {
             // @since 2.7.5
             registerBeans(registry, DubboBootstrapApplicationListener.class);


### PR DESCRIPTION
## What is the purpose of the change

fixed: [issue 5610](https://github.com/apache/dubbo/issues/5610)

## Brief changelog

when `registerBeans(registry, DubboBootstrapApplicationListener.class);`   check  bean `dubboBootstrapApplicationListener` whether already in spring context or not 

## Verifying this change

XXXXX

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a [GITHUB_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Run `mvn clean install -DskipTests=false` & `mvn clean test-compile failsafe:integration-test` to make sure unit-test and integration-test pass.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
