### PR TITLE
backward compatible with ListenableFilter

### DIFF
--- a/dubbo-monitor/dubbo-monitor-api/src/main/java/org/apache/dubbo/monitor/support/MonitorFilter.java
+++ b/dubbo-monitor/dubbo-monitor-api/src/main/java/org/apache/dubbo/monitor/support/MonitorFilter.java
@@ -52,7 +52,7 @@ import static org.apache.dubbo.rpc.Constants.OUTPUT_KEY;
  * MonitorFilter. (SPI, Singleton, ThreadSafe)
  */
 @Activate(group = {PROVIDER, CONSUMER})
-public class MonitorFilter implements Filter, Filter.Listener {
+public class MonitorFilter implements Filter, Filter.Listener2 {
 
     private static final Logger logger = LoggerFactory.getLogger(MonitorFilter.class);
     private static final String MONITOR_FILTER_START_TIME = "monitor_filter_start_time";

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/Filter.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/Filter.java
@@ -48,7 +48,7 @@ public interface Filter {
     Result invoke(Invoker<?> invoker, Invocation invocation) throws RpcException;
 
     /**
-     * Please use {@link Listener#onMessage(Result, Invoker, Invocation)} instead.
+     * Please use {@link Listener2#onMessage(Result, Invoker, Invocation)} instead.
      * This method is kept only for compatibility and may get removed at any version in the future.
      *
      * @param appResponse
@@ -60,11 +60,19 @@ public interface Filter {
         return appResponse;
     }
 
+    @Deprecated
     interface Listener {
+
+        void onResponse(Result appResponse, Invoker<?> invoker, Invocation invocation);
+
+        void onError(Throwable t, Invoker<?> invoker, Invocation invocation);
+    }
+    interface Listener2 {
 
         void onMessage(Result appResponse, Invoker<?> invoker, Invocation invocation);
 
         void onError(Throwable t, Invoker<?> invoker, Invocation invocation);
     }
+
 
 }

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/ListenableFilter.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/ListenableFilter.java
@@ -18,7 +18,7 @@ package org.apache.dubbo.rpc;
 
 /**
  * This abstract will be removed soon from one future release.
- * Please implementing Filter.Listener directly for callback registration,
+ * Please implementing Filter.Listener2 directly for callback registration,
  * check the default implementation, see {@link org.apache.dubbo.rpc.filter.ExceptionFilter}, for example.
  */
 @Deprecated

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/filter/ActiveLimitFilter.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/filter/ActiveLimitFilter.java
@@ -42,7 +42,7 @@ import static org.apache.dubbo.rpc.Constants.ACTIVES_KEY;
  * @see Filter
  */
 @Activate(group = CONSUMER, value = ACTIVES_KEY)
-public class ActiveLimitFilter implements Filter, Filter.Listener {
+public class ActiveLimitFilter implements Filter, Filter.Listener2 {
 
     private static final String ACTIVELIMIT_FILTER_START_TIME = "activelimit_filter_start_time";
 

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/filter/CompatibleFilter.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/filter/CompatibleFilter.java
@@ -45,7 +45,7 @@ import static org.apache.dubbo.remoting.Constants.SERIALIZATION_KEY;
  * @see Filter
  *
  */
-public class CompatibleFilter implements Filter, Filter.Listener {
+public class CompatibleFilter implements Filter, Filter.Listener2 {
 
     private static Logger logger = LoggerFactory.getLogger(CompatibleFilter.class);
 

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/filter/ContextFilter.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/filter/ContextFilter.java
@@ -49,7 +49,7 @@ import static org.apache.dubbo.rpc.Constants.TOKEN_KEY;
  * @see RpcContext
  */
 @Activate(group = PROVIDER, order = -10000)
-public class ContextFilter implements Filter, Filter.Listener {
+public class ContextFilter implements Filter, Filter.Listener2 {
     private static final String TAG_KEY = "dubbo.tag";
 
     @Override

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/filter/ExceptionFilter.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/filter/ExceptionFilter.java
@@ -44,7 +44,7 @@ import java.lang.reflect.Method;
  * </ol>
  */
 @Activate(group = CommonConstants.PROVIDER)
-public class ExceptionFilter implements Filter, Filter.Listener {
+public class ExceptionFilter implements Filter, Filter.Listener2 {
     private Logger logger = LoggerFactory.getLogger(ExceptionFilter.class);
 
     @Override

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/filter/ExecuteLimitFilter.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/filter/ExecuteLimitFilter.java
@@ -37,7 +37,7 @@ import static org.apache.dubbo.rpc.Constants.EXECUTES_KEY;
  *
  */
 @Activate(group = CommonConstants.PROVIDER, value = EXECUTES_KEY)
-public class ExecuteLimitFilter implements Filter, Filter.Listener {
+public class ExecuteLimitFilter implements Filter, Filter.Listener2 {
 
     private static final String EXECUTELIMIT_FILTER_START_TIME = "execugtelimit_filter_start_time";
 

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/filter/GenericFilter.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/filter/GenericFilter.java
@@ -53,7 +53,7 @@ import static org.apache.dubbo.rpc.Constants.GENERIC_KEY;
  * GenericInvokerFilter.
  */
 @Activate(group = CommonConstants.PROVIDER, order = -20000)
-public class GenericFilter implements Filter, Filter.Listener {
+public class GenericFilter implements Filter, Filter.Listener2 {
 
     @Override
     public Result invoke(Invoker<?> invoker, Invocation inv) throws RpcException {

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/filter/GenericImplFilter.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/filter/GenericImplFilter.java
@@ -49,7 +49,7 @@ import static org.apache.dubbo.rpc.Constants.GENERIC_KEY;
  * GenericImplInvokerFilter
  */
 @Activate(group = CommonConstants.CONSUMER, value = GENERIC_KEY, order = 20000)
-public class GenericImplFilter implements Filter, Filter.Listener {
+public class GenericImplFilter implements Filter, Filter.Listener2 {
 
     private static final Logger logger = LoggerFactory.getLogger(GenericImplFilter.class);
 

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/filter/TimeoutFilter.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/filter/TimeoutFilter.java
@@ -32,7 +32,7 @@ import java.util.Arrays;
  * Log any invocation timeout, but don't stop server from running
  */
 @Activate(group = CommonConstants.PROVIDER)
-public class TimeoutFilter implements Filter, Filter.Listener {
+public class TimeoutFilter implements Filter, Filter.Listener2 {
 
     private static final Logger logger = LoggerFactory.getLogger(TimeoutFilter.class);
 

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/protocol/ProtocolFilterWrapper.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/protocol/ProtocolFilterWrapper.java
@@ -85,8 +85,8 @@ public class ProtocolFilterWrapper implements Protocol {
                                 if (listener != null) {
                                     listener.onError(e, invoker, invocation);
                                 }
-                            } else if (filter instanceof Filter.Listener) {
-                                Filter.Listener listener = (Filter.Listener) filter;
+                            } else if (filter instanceof Filter.Listener2) {
+                                Filter.Listener2 listener = (Filter.Listener2) filter;
                                 listener.onError(e, invoker, invocation);
                             }
                             throw e;
@@ -98,13 +98,13 @@ public class ProtocolFilterWrapper implements Protocol {
                                 Filter.Listener listener = ((ListenableFilter) filter).listener();
                                 if (listener != null) {
                                     if (t == null) {
-                                        listener.onMessage(r, invoker, invocation);
+                                        listener.onResponse(r, invoker, invocation);
                                     } else {
                                         listener.onError(t, invoker, invocation);
                                     }
                                 }
-                            } else if (filter instanceof Filter.Listener) {
-                                Filter.Listener listener = (Filter.Listener) filter;
+                            } else if (filter instanceof Filter.Listener2) {
+                                Filter.Listener2 listener = (Filter.Listener2) filter;
                                 if (t == null) {
                                     listener.onMessage(r, invoker, invocation);
                                 } else {

--- a/dubbo-rpc/dubbo-rpc-api/src/test/java/org/apache/dubbo/rpc/filter/ActiveLimitFilterTest.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/test/java/org/apache/dubbo/rpc/filter/ActiveLimitFilterTest.java
@@ -126,7 +126,7 @@ public class ActiveLimitFilterTest {
                             activeLimitFilter.onMessage(result, invoker, invocation);
                         } catch (RpcException expected) {
                             count.incrementAndGet();
-//                            activeLimitFilter.listener().onError(expected, invoker, invocation);
+//                            activeLimitFilter.Listener2().onError(expected, invoker, invocation);
                         } catch (Exception e) {
                             fail();
                         }

--- a/dubbo-rpc/dubbo-rpc-dubbo/src/main/java/org/apache/dubbo/rpc/protocol/dubbo/filter/FutureFilter.java
+++ b/dubbo-rpc/dubbo-rpc-dubbo/src/main/java/org/apache/dubbo/rpc/protocol/dubbo/filter/FutureFilter.java
@@ -38,7 +38,7 @@ import static org.apache.dubbo.common.constants.CommonConstants.$INVOKE;
  * EventFilter
  */
 @Activate(group = CommonConstants.CONSUMER)
-public class FutureFilter implements Filter, Filter.Listener {
+public class FutureFilter implements Filter, Filter.Listener2 {
 
     protected static final Logger logger = LoggerFactory.getLogger(FutureFilter.class);
 


### PR DESCRIPTION
fix #5619 
This pr is to fix the bug that is not compatible with the previous listenable filter in version 2.7.5, but if this pr is used, it will not be compatible with the filter created by the  listener declared in 2.7.5. I think this should be regarded as an urgent bug-fix.
@chickenlj What do you think?  Is there any other way to solve this problem perfectly?

