### PR TITLE
Fine grained control select registry URL

### DIFF
--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/support/registry/ZoneAwareClusterInvoker.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/support/registry/ZoneAwareClusterInvoker.java
@@ -56,14 +56,8 @@ public class ZoneAwareClusterInvoker<T> extends AbstractClusterInvoker<T> {
     @Override
     @SuppressWarnings({"unchecked", "rawtypes"})
     public Result doInvoke(Invocation invocation, final List<Invoker<T>> invokers, LoadBalance loadbalance) throws RpcException {
-        // First, pick the invoker (XXXClusterInvoker) that comes from the local registry, distinguish by a 'preferred' key.
-        for (Invoker<T> invoker : invokers) {
-            if (invoker.isAvailable() && invoker.getUrl().getParameter(REGISTRY_KEY + "." + PREFERRED_KEY, false)) {
-                return invoker.invoke(invocation);
-            }
-        }
 
-        // providers in the registry with the same
+        //First: providers in the registry with the same
         String zone = (String) invocation.getAttachment(REGISTRY_ZONE);
         if (StringUtils.isNotEmpty(zone)) {
             for (Invoker<T> invoker : invokers) {
@@ -79,6 +73,12 @@ public class ZoneAwareClusterInvoker<T> extends AbstractClusterInvoker<T> {
             }
         }
 
+        // Second: pick the invoker (XXXClusterInvoker) that comes from the local registry, distinguish by a 'preferred' key.
+        for (Invoker<T> invoker : invokers) {
+            if (invoker.isAvailable() && invoker.getUrl().getParameter(REGISTRY_KEY + "." + PREFERRED_KEY, false)) {
+                return invoker.invoke(invocation);
+            }
+        }
 
         // load balance among all registries, with registry weight count in.
         Invoker<T> balancedInvoker = select(loadbalance, invocation, invokers, null);


### PR DESCRIPTION
调整preferred 和zone的优先级, zone的优先级应该高于preferred ,

可以更加细粒度的控制注册中心的选址,

解决在通过preferred设置默认注册中心的情况下,将无法通过zone来控制注册中心选择.

preferred相当于应用粒度的控制,而zone可以实现服务接口粒度的控制. 

例如可以通过dubbo-admin动态设置单个服务注册中心选址.