### PR TITLE
optimize getSharedExecutorService

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/threadpool/manager/ExecutorRepository.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/threadpool/manager/ExecutorRepository.java
@@ -31,12 +31,20 @@ public interface ExecutorRepository {
     /**
      * Called by both Client and Server. TODO, consider separate these two parts.
      * When the Client or Server starts for the first time, generate a new threadpool according to the parameters specified.
+     * If executor has been shut down, create a new one.
      *
      * @param url
      * @return
      */
     ExecutorService createExecutorIfAbsent(URL url);
 
+    /**
+     * Return executorService , return null if not exist.
+     * If executor has been shut down, create a new one.
+     *
+     * @param url
+     * @return executorService
+     */
     ExecutorService getExecutor(URL url);
 
     /**

--- a/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/transport/dispatcher/WrappedChannelHandler.java
+++ b/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/transport/dispatcher/WrappedChannelHandler.java
@@ -133,11 +133,7 @@ public class WrappedChannelHandler implements ChannelHandlerDelegate {
     public ExecutorService getSharedExecutorService() {
         ExecutorRepository executorRepository =
                 ExtensionLoader.getExtensionLoader(ExecutorRepository.class).getDefaultExtension();
-        ExecutorService executor = executorRepository.getExecutor(url);
-        if (executor == null) {
-            executor = executorRepository.createExecutorIfAbsent(url);
-        }
-        return executor;
+        return executorRepository.createExecutorIfAbsent(url);
     }
 
     @Deprecated


### PR DESCRIPTION
## Verifying this change

1.There is no need to call method `getExecutor` before calling method `getSharedExecutorService`
2.optimize doc

