### PR TITLE
Remove unnecessary logical judgments

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/extension/ExtensionLoader.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/extension/ExtensionLoader.java
@@ -747,14 +747,15 @@ public class ExtensionLoader<T> {
 
         String value = defaultAnnotation.value();
         if ((value = value.trim()).length() > 0) {
-            String[] names = NAME_SEPARATOR.split(value);
+            cachedDefaultName = value;
+           /* String[] names = NAME_SEPARATOR.split(value);
             if (names.length > 1) {
                 throw new IllegalStateException("More than 1 default extension name on extension " + type.getName()
                         + ": " + Arrays.toString(names));
             }
             if (names.length == 1) {
                 cachedDefaultName = names[0];
-            }
+            }*/
         }
     }
 

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/extension/ExtensionLoader.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/extension/ExtensionLoader.java
@@ -748,14 +748,6 @@ public class ExtensionLoader<T> {
         String value = defaultAnnotation.value();
         if ((value = value.trim()).length() > 0) {
             cachedDefaultName = value;
-           /* String[] names = NAME_SEPARATOR.split(value);
-            if (names.length > 1) {
-                throw new IllegalStateException("More than 1 default extension name on extension " + type.getName()
-                        + ": " + Arrays.toString(names));
-            }
-            if (names.length == 1) {
-                cachedDefaultName = names[0];
-            }*/
         }
     }
 


### PR DESCRIPTION
## What is the purpose of the change

org.apache.dubbo.common.extension.ExtensionLoader#cacheDefaultExtensionName
Remove unnecessary logical judgments,i think there is a default extension name on extension ,it should't split with pattern.

## Verifying this change
```java
 private void cacheDefaultExtensionName() {
         final SPI defaultAnnotation = type.getAnnotation(SPI.class);
         if (defaultAnnotation == null) {
             return;
         }

         String value = defaultAnnotation.value();
         if ((value = value.trim()).length() > 0) {
             cachedDefaultName = value;
            /* String[] names = NAME_SEPARATOR.split(value);
             if (names.length > 1) {
                 throw new IllegalStateException("More than 1 default extension name on extension " + type.getName()
                         + ": " + Arrays.toString(names));
             }
             if (names.length == 1) {
                 cachedDefaultName = names[0];
             }*/
         }
     }
```