### PR TITLE
Fixed a bug where the provider did not correctly inject the token

### DIFF
--- a/dubbo-all/pom.xml
+++ b/dubbo-all/pom.xml
@@ -95,6 +95,13 @@
         </dependency>
         <dependency>
             <groupId>org.apache.dubbo</groupId>
+            <artifactId>dubbo-remoting-etcd3</artifactId>
+            <version>${project.version}</version>
+            <scope>compile</scope>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.dubbo</groupId>
             <artifactId>dubbo-remoting-mina</artifactId>
             <version>${project.version}</version>
             <scope>compile</scope>
@@ -277,6 +284,13 @@
                     <artifactId>grpc-netty</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.dubbo</groupId>
+            <artifactId>dubbo-registry-eureka</artifactId>
+            <version>${project.version}</version>
+            <scope>compile</scope>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.apache.dubbo</groupId>
@@ -602,6 +616,7 @@
                                     <include>org.apache.dubbo:dubbo-remoting-api</include>
                                     <include>org.apache.dubbo:dubbo-remoting-netty</include>
                                     <include>org.apache.dubbo:dubbo-remoting-netty4</include>
+                                    <include>org.apache.dubbo:dubbo-remoting-etcd3</include>
                                     <include>org.apache.dubbo:dubbo-remoting-mina</include>
                                     <include>org.apache.dubbo:dubbo-remoting-grizzly</include>
                                     <include>org.apache.dubbo:dubbo-remoting-p2p</include>
@@ -615,6 +630,7 @@
                                     <include>org.apache.dubbo:dubbo-rpc-hessian</include>
                                     <include>org.apache.dubbo:dubbo-rpc-webservice</include>
                                     <include>org.apache.dubbo:dubbo-rpc-thrift</include>
+                                    <include>org.apache.dubbo:dubbo-rpc-native-thrift</include>
                                     <include>org.apache.dubbo:dubbo-rpc-memcached</include>
                                     <include>org.apache.dubbo:dubbo-rpc-redis</include>
                                     <include>org.apache.dubbo:dubbo-rpc-rest</include>
@@ -630,6 +646,7 @@
                                     <include>org.apache.dubbo:dubbo-registry-redis</include>
                                     <include>org.apache.dubbo:dubbo-registry-consul</include>
                                     <include>org.apache.dubbo:dubbo-registry-etcd3</include>
+                                    <include>org.apache.dubbo:dubbo-registry-eureka</include>
                                     <include>org.apache.dubbo:dubbo-registry-nacos</include>
                                     <include>org.apache.dubbo:dubbo-registry-sofa</include>
                                     <include>org.apache.dubbo:dubbo-registry-multiple</include>
@@ -664,7 +681,6 @@
                                     <include>org.apache.dubbo:dubbo-metadata-report-etcd</include>
                                     <include>org.apache.dubbo:dubbo-metadata-report-nacos</include>
                                     <include>org.apache.dubbo:dubbo-serialization-native-hession</include>
-                                    <include>org.apache.dubbo:dubbo-rpc-native-thrift</include>
                                 </includes>
                             </artifactSet>
                             <transformers>

--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/ServiceConfig.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/ServiceConfig.java
@@ -412,6 +412,14 @@ public class ServiceConfig<T> extends ServiceConfigBase<T> {
                 map.put(METHODS_KEY, StringUtils.join(new HashSet<String>(Arrays.asList(methods)), ","));
             }
         }
+
+        /**
+         * Here the token value configured by the provider is used to assign the value to ServiceConfig#token
+         */
+        if(ConfigUtils.isEmpty(token) && provider != null) {
+            token = provider.getToken();
+        }
+
         if (!ConfigUtils.isEmpty(token)) {
             if (ConfigUtils.isDefault(token)) {
                 map.put(TOKEN_KEY, UUID.randomUUID().toString());


### PR DESCRIPTION
我发现一个可能一直存在的问题，就是我们的token机制没有被正确使用，我之前使用的dubbo-2.5.3版本就有这个问题，最近我在使用dubbo-2.7.5版本时发现这个问题仍然存在。
I found a problem that may have existed all the time, that is, our token mechanism has not been used correctly. This problem existed in dubbo-2.5.3, which I used before. Recently, when I used dubbo-2.7.5, I found that this problem still exists.

现象：
当token设置成true时，provider没有将token的UUID正确注入到注册中心的bug，例如：
Phenomenon:
When the token is set to true, the provider does not correctly inject the UUID of the token into the bug in the registry, for example:
`<dubbo:provider token="true" filter="SystemParamProviderFilter,DLProviderFilter,MetricsProviderFilter"/>`

我在provider端暴露了一个dubbo协议的接口：com.manzhizhen.dubbo.api.Dubbo1Service，结果我在注册中心上（zookeeper）看到的结果如下：
I exposed an interface of Dubbo protocol on the provider side: com.manzhen.dubbo.api.dubbo1service. As a result, the results I saw on the zookeeper are as follows:
```
[zk: localhost:2181(CONNECTED) 12] ls /dubbo/com.manzhizhen.dubbo.api.Dubbo1Service/providers
[dubbo://192.168.1.6:4445/com.manzhizhen.dubbo.api.Dubbo1Service?anyhost=true&application=mzz-dubbo1&deprecated=false&dubbo=2.0.2&dynamic=true&generic=false&interface=com.manzhizhen.dubbo.api.Dubbo1Service&methods=study&pid=5808&release=2.7.5&revision=1.0.0&service.filter=SystemParamProviderFilter,DLProviderFilter,MetricsProviderFilter&side=provider&threads=10&timestamp=1580090144366&token=true&version=1.0.0]
```

注意，其中token=true，但其实应该是token=某个UUID，而不是true。
Note that token = true, but it should be token = a UUID instead of true.

下面是我修改代码后的效果：
Here is the effect after I modify the code:
```
[zk: localhost:2181(CONNECTED) 14] ls /dubbo/com.manzhizhen.dubbo.api.Dubbo1Service/providers
[dubbo%3A%2F%2F192.168.1.6%3A4445%2Fcom.manzhizhen.dubbo.api.Dubbo1Service%3Fanyhost%3Dtrue%26application%3Dmzz-dubbo1%26deprecated%3Dfalse%26dubbo%3D2.0.2%26dynamic%3Dtrue%26generic%3Dfalse%26interface%3Dcom.manzhizhen.dubbo.api.Dubbo1Service%26methods%3Dstudy%26pid%3D13360%26release%3D2.7.5-didi-yzq-2-SNAPSHOT%26revision%3D1.0.0%26service.filter%3DSystemParamProviderFilter%2CDLProviderFilter%2CMetricsProviderFilter%26side%3Dprovider%26threads%3D10%26timestamp%3D1580096635841%26token%3D89b5748a-8016-454d-940c-89d53d78f104%26version%3D1.0.0]
```
这里显示了正确的效果，token=89b5748a-8016-454d-940c-89d53d78f104，一个UUID的值。
The correct effect is shown here, token = 89b5748a-8016-454d-940c-89d53d78f104, a UUID value.

这符合之前org.apache.dubbo.config.ServiceConfig中的代码逻辑：
This is in line with the previous code logic in org.apache.dubbo.config.Serviceconfig:

```
        if (!ConfigUtils.isEmpty(token)) {
            if (ConfigUtils.isDefault(token)) {
                map.put(TOKEN_KEY, UUID.randomUUID().toString());
            } else {
                map.put(TOKEN_KEY, token);
            }
        }
```

此次PR还修复了dubbo-all中缺失的两个模块依赖问题，所以我们在dubbo-all/pom.xml中添加了遗漏的dubbo-remoting-etcd3和dubbo-registry-eureka模块。
This PR also fixed two missing module dependencies in Dubbo all, so we added the missing Dubbo remoting etcd3 and Dubbo registry Eureka modules in Dubbo all / pom.xml.

