### PR TITLE
Make THREAD_NAME_KEY work

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/config/ProtocolConfig.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/config/ProtocolConfig.java
@@ -60,6 +60,11 @@ public class ProtocolConfig extends AbstractConfig {
     private String threadpool;
 
     /**
+     * Thread pool name
+     */
+    private String threadname;
+
+    /**
      * Thread pool core thread size
      */
     private Integer corethreads;
@@ -261,6 +266,14 @@ public class ProtocolConfig extends AbstractConfig {
 
     public void setThreadpool(String threadpool) {
         this.threadpool = threadpool;
+    }
+
+    public String getThreadname() {
+        return threadname;
+    }
+
+    public void setThreadname(String threadname) {
+        this.threadname = threadname;
     }
 
     public Integer getCorethreads() {

--- a/dubbo-common/src/main/java/org/apache/dubbo/config/ProviderConfig.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/config/ProviderConfig.java
@@ -55,6 +55,11 @@ public class ProviderConfig extends AbstractServiceConfig {
     private String threadpool;
 
     /**
+     * Thread pool name
+     */
+    private String threadname;
+
+    /**
      * Thread pool size (fixed size)
      */
     private Integer threads;
@@ -209,6 +214,14 @@ public class ProviderConfig extends AbstractServiceConfig {
 
     public void setThreadpool(String threadpool) {
         this.threadpool = threadpool;
+    }
+
+    public String getThreadname() {
+        return threadname;
+    }
+
+    public void setThreadname(String threadname) {
+        this.threadname = threadname;
     }
 
     public Integer getThreads() {

--- a/dubbo-config/dubbo-config-spring/src/main/resources/META-INF/compat/dubbo.xsd
+++ b/dubbo-config/dubbo-config-spring/src/main/resources/META-INF/compat/dubbo.xsd
@@ -1040,6 +1040,11 @@
                 <xsd:documentation><![CDATA[ The thread pool type. ]]></xsd:documentation>
             </xsd:annotation>
         </xsd:attribute>
+        <xsd:attribute name="threadname" type="xsd:string">
+            <xsd:annotation>
+                <xsd:documentation><![CDATA[ The thread pool name. ]]></xsd:documentation>
+            </xsd:annotation>
+        </xsd:attribute>
         <xsd:attribute name="threads" type="xsd:string">
             <xsd:annotation>
                 <xsd:documentation><![CDATA[ The thread pool size. ]]></xsd:documentation>
@@ -1214,6 +1219,11 @@
                 <xsd:attribute name="threadpool" type="xsd:string">
                     <xsd:annotation>
                         <xsd:documentation><![CDATA[ The thread pool type. ]]></xsd:documentation>
+                    </xsd:annotation>
+                </xsd:attribute>
+                <xsd:attribute name="threadname" type="xsd:string">
+                    <xsd:annotation>
+                        <xsd:documentation><![CDATA[ The thread pool name. ]]></xsd:documentation>
                     </xsd:annotation>
                 </xsd:attribute>
                 <xsd:attribute name="threads" type="xsd:string">

--- a/dubbo-config/dubbo-config-spring/src/main/resources/META-INF/dubbo.xsd
+++ b/dubbo-config/dubbo-config-spring/src/main/resources/META-INF/dubbo.xsd
@@ -1040,6 +1040,11 @@
                 <xsd:documentation><![CDATA[ The thread pool type. ]]></xsd:documentation>
             </xsd:annotation>
         </xsd:attribute>
+        <xsd:attribute name="threadname" type="xsd:string">
+            <xsd:annotation>
+                <xsd:documentation><![CDATA[ The thread pool name. ]]></xsd:documentation>
+            </xsd:annotation>
+        </xsd:attribute>
         <xsd:attribute name="threads" type="xsd:string">
             <xsd:annotation>
                 <xsd:documentation><![CDATA[ The thread pool size. ]]></xsd:documentation>
@@ -1214,6 +1219,11 @@
                 <xsd:attribute name="threadpool" type="xsd:string">
                     <xsd:annotation>
                         <xsd:documentation><![CDATA[ The thread pool type. ]]></xsd:documentation>
+                    </xsd:annotation>
+                </xsd:attribute>
+                <xsd:attribute name="threadname" type="xsd:string">
+                    <xsd:annotation>
+                        <xsd:documentation><![CDATA[ The thread pool name. ]]></xsd:documentation>
                     </xsd:annotation>
                 </xsd:attribute>
                 <xsd:attribute name="threads" type="xsd:string">


### PR DESCRIPTION
我们知道可以给Provider的业务处理线程池设置类型和size（见ThreadPool扩展点），在org.apache.dubbo.common.constants.CommonConstants中我们定义了THREADPOOL_KEY、THREAD_NAME_KEY、THREADS_KEY等，但唯独THREAD_NAME_KEY的值threadname在dubbo.xsd中没有设定，我想应该是漏了，导致我们无法给线程池设置想要的名字。所以此PR是为了解决这个问题。

We know that you can set the type and size of the Provider's business processing thread pool (see the ThreadPool extension point). In org.apache.dubbo.common.constants.CommonConstants we define THREADPOOL_KEY, THREAD_NAME_KEY, THREADS_KEY, etc., but only the value of THREAD_NAME_KEY The threadname is not set in dubbo.xsd, I think it should be missed, which prevents us from setting the desired name for the thread pool. So this PR is to solve this problem.

