### PR TITLE
set target type property for reference bean definition

### DIFF
--- a/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/schema/DubboBeanDefinitionParser.java
+++ b/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/schema/DubboBeanDefinitionParser.java
@@ -129,7 +129,13 @@ public class DubboBeanDefinitionParser implements BeanDefinitionParser {
                 parseProperties(element.getChildNodes(), classDefinition);
                 beanDefinition.getPropertyValues().addPropertyValue("ref", new BeanDefinitionHolder(classDefinition, id + "Impl"));
             }
-        } else if (ProviderConfig.class.equals(beanClass)) {
+        }  else if(ReferenceBean.class.equals(beanClass)){
+            String interfaceClassName = element.getAttribute("interface");
+            if(StringUtils.isNotEmpty(interfaceClassName)){
+                Class<?> interfaceClass = ReflectUtils.forName(interfaceClassName);
+                beanDefinition.setTargetType(interfaceClass);
+            }
+        }else if (ProviderConfig.class.equals(beanClass)) {
             parseNested(element, parserContext, ServiceBean.class, true, "service", "provider", id, beanDefinition);
         } else if (ConsumerConfig.class.equals(beanClass)) {
             parseNested(element, parserContext, ReferenceBean.class, false, "reference", "consumer", id, beanDefinition);


### PR DESCRIPTION
## What is the purpose of the change

Set  target type property of reference bean definition can avoid reference bean early initialization 
 when define reference bean in xml.
 The reason is spring will  try to create factory bean instance to look what factory bean create if spring can't get target type from bean definition.

## Brief changelog

set target type property for  reference bean definition when parse dubbo bean definition.
