### PR TITLE
[Dubbo-fix]  fix typo `CHARECTER` -> `CHARACTER`

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/utils/NetUtils.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/utils/NetUtils.java
@@ -71,8 +71,8 @@ public class NetUtils {
     private static final Map<String, String> HOST_NAME_CACHE = new LRUCache<>(1000);
     private static volatile InetAddress LOCAL_ADDRESS = null;
 
-    private static final String SPLIT_IPV4_CHARECTER = "\\.";
-    private static final String SPLIT_IPV6_CHARECTER = ":";
+    private static final String SPLIT_IPV4_CHARACTER = "\\.";
+    private static final String SPLIT_IPV6_CHARACTER = ":";
 
     public static int getRandomPort() {
         return RND_PORT_START + ThreadLocalRandom.current().nextInt(RND_PORT_RANGE);
@@ -448,9 +448,9 @@ public class NetUtils {
         }
         pattern = hostAndPort[0];
 
-        String splitCharacter = SPLIT_IPV4_CHARECTER;
+        String splitCharacter = SPLIT_IPV4_CHARACTER;
         if (!isIpv4) {
-            splitCharacter = SPLIT_IPV6_CHARECTER;
+            splitCharacter = SPLIT_IPV6_CHARACTER;
         }
         String[] mask = pattern.split(splitCharacter);
         //check format of pattern


### PR DESCRIPTION
## What is the purpose of the change

Fix typo `CHARECTER` -> `CHARACTER`.
I have searched in opened PR.
Fell free to close it if it has be included in other PRs or It is not expected to change.

## Brief changelog

Only rename `SPLIT_IPV4_CHARECTER `&`SPLIT_IPV6_CHARECTER `
to `SPLIT_IPV4_CHARACTER `&`SPLIT_IPV6_CHARACTER `.


## Verifying this change

These two private variables do not affect the other methods or classes except `getRandomPort `.
The current test case 'NetUtilsTest' is enough.

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a [GITHUB_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [x] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Run `mvn clean install -DskipTests=false` & `mvn clean test-compile failsafe:integration-test` to make sure unit-test and integration-test pass.
- [x] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
