### PR TITLE
[Dubbo-5790] Fix  NullPointerException when set dubbo.provider.version

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/config/ServiceConfigBase.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/config/ServiceConfigBase.java
@@ -244,6 +244,14 @@ public abstract class ServiceConfigBase<T> extends AbstractServiceConfig {
 
     public void checkDefault() {
         createProviderIfAbsent();
+        if (provider != null) {
+            if (version == null) {
+                setVersion(provider.getVersion());
+            }
+            if (group == null) {
+                setGroup(provider.getGroup());
+            }
+        }
     }
 
     private void createProviderIfAbsent() {


### PR DESCRIPTION
## What is the purpose of the change

fix #5790

## Brief changelog

set `version` when the `provider` exist and `version` is `null`

## Verifying this change

start success when set dubbo.provider.version
