### PR TITLE
Fix consul, getproperty return null if key does not match a value.

### DIFF
--- a/dubbo-configcenter/dubbo-configcenter-consul/src/main/java/org/apache/dubbo/configcenter/consul/ConsulDynamicConfiguration.java
+++ b/dubbo-configcenter/dubbo-configcenter-consul/src/main/java/org/apache/dubbo/configcenter/consul/ConsulDynamicConfiguration.java
@@ -151,7 +151,7 @@ public class ConsulDynamicConfiguration implements DynamicConfiguration {
     @Override
     public Object getInternalProperty(String key) {
         logger.info("getting config from: " + key);
-        return kvClient.getValueAsString(key, Charsets.UTF_8).orElseThrow(() -> new IllegalArgumentException(key + " does not exit."));
+        return kvClient.getValueAsString(key, Charsets.UTF_8).orElse(null);
     }
 
     @Override

--- a/dubbo-configcenter/dubbo-configcenter-consul/src/test/java/org/apache/dubbo/configcenter/consul/ConsulDynamicConfigurationTest.java
+++ b/dubbo-configcenter/dubbo-configcenter-consul/src/test/java/org/apache/dubbo/configcenter/consul/ConsulDynamicConfigurationTest.java
@@ -71,7 +71,7 @@ public class ConsulDynamicConfigurationTest {
         assertEquals("bar", configuration.getConfig("foo", "dubbo"));
         // test does not block
         assertEquals("bar", configuration.getConfig("foo", "dubbo"));
-        Assertions.assertThrows(IllegalArgumentException.class, () -> configuration.getConfig("not-exist", "dubbo"));
+        Assertions.assertNull(configuration.getConfig("not-exist", "dubbo"));
     }
 
     @Test


### PR DESCRIPTION
instead of throw exception.