### PR TITLE
Invoker deactivation should be destroyed in ReferenceConfig

### DIFF
--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/ReferenceConfig.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/ReferenceConfig.java
@@ -337,6 +337,7 @@ public class ReferenceConfig<T> extends ReferenceConfigBase<T> {
         }
 
         if (shouldCheck() && !invoker.isAvailable()) {
+            invoker.destroy();
             throw new IllegalStateException("Failed to check the status of the service "
                     + interfaceName
                     + ". No provider available for the service "


### PR DESCRIPTION
My program as a `consumer` gets the Invoker by dynamically calling the `ReferenceConfig.get` method. If the `provider` restarts frequently in a short period of time, my program memory will continue to grow.
The problem occurs when the `ReferenceConfig.createProxy` method is abnormal and the `invoker.destroy` method is not executed to destroy resources and cause a memory leak.