### PR TITLE
EchoService.class will lose if the 'types' not null

### DIFF
--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/com/alibaba/dubbo/rpc/proxy/AbstractProxyFactory.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/com/alibaba/dubbo/rpc/proxy/AbstractProxyFactory.java
@@ -45,7 +45,7 @@ public abstract class AbstractProxyFactory implements ProxyFactory {
                 interfaces[0] = invoker.getInterface();
                 interfaces[1] = EchoService.class;
                 for (int i = 0; i < types.length; i++) {
-                    interfaces[i + 1] = ReflectUtils.forName(types[i]);
+                    interfaces[i + 2] = ReflectUtils.forName(types[i]);
                 }
             }
         }


### PR DESCRIPTION
## What is the purpose of the change

修正 2.6.x 版本中， AbstractProxyFactory 类的 getProxy(Invoker<T> invoker, boolean generic) 函数的一个小问题

## Brief changelog

按照既定的逻辑，interfaces 数组的前两个位置应该放的是接口类和 EchoService 类，也就是说 type 应该从第三个位置即 interfaces[2] 开始放，但是此处是从 interfaces[1] 开始放的。如果 types 不为 null，EchoService.class 将会被意外覆盖。

## Verifying this change

XXXXX

Follow this checklist to help us incorporate your contribution quickly and easily:

- [ ] Make sure there is a [GITHUB_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Run `mvn clean install -DskipTests=false` & `mvn clean test-compile failsafe:integration-test` to make sure unit-test and integration-test pass.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
