### PR TITLE
correct the number of selected invoker

### DIFF
--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/support/ForkingClusterInvoker.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/support/ForkingClusterInvoker.java
@@ -70,8 +70,8 @@ public class ForkingClusterInvoker<T> extends AbstractClusterInvoker<T> {
             if (forks <= 0 || forks >= invokers.size()) {
                 selected = invokers;
             } else {
-                selected = new ArrayList<>();
-                for (int i = 0; i < forks; i++) {
+                selected = new ArrayList<>(forks);
+                while (selected.size() < forks) {
                     Invoker<T> invoker = select(loadbalance, invocation, invokers, selected);
                     if (!selected.contains(invoker)) {
                         //Avoid add the same invoker several times.


### PR DESCRIPTION
## What is the purpose of the change

To make sure the number of selected invoker is as specified in the parameter of "forks".

## Brief changelog

In the previous version, there was no guarantee that enough invokers were selected because of the “if” statement. It can only ensure that the loop is executed “forks” times.

## Verifying this change

XXXXX
