### PR TITLE
add new thread pool strategy for Consumer, allow all service calls to share the same thread pool.

### DIFF
--- a/dubbo-common/src/main/java/com/alibaba/dubbo/common/Constants.java
+++ b/dubbo-common/src/main/java/com/alibaba/dubbo/common/Constants.java
@@ -599,6 +599,10 @@ public class Constants {
 
     public static final String EXECUTOR_SERVICE_COMPONENT_KEY = ExecutorService.class.getName();
 
+    public static final String SHARE_EXECUTOR_KEY = "share.threadpool";
+
+    public static final String SHARED_CONSUMER_EXECUTOR_PORT = "consumer.executor.port";
+
     public static final String GENERIC_SERIALIZATION_NATIVE_JAVA = "nativejava";
 
     public static final String GENERIC_SERIALIZATION_DEFAULT = "true";

--- a/dubbo-common/src/main/java/com/alibaba/dubbo/common/store/support/SimpleDataStore.java
+++ b/dubbo-common/src/main/java/com/alibaba/dubbo/common/store/support/SimpleDataStore.java
@@ -48,12 +48,12 @@ public class SimpleDataStore implements DataStore {
 
     @Override
     public void put(String componentName, String key, Object value) {
-        Map<String, Object> componentData = data.get(componentName);
+        ConcurrentMap<String, Object> componentData = data.get(componentName);
         if (null == componentData) {
             data.putIfAbsent(componentName, new ConcurrentHashMap<String, Object>());
             componentData = data.get(componentName);
         }
-        componentData.put(key, value);
+        componentData.putIfAbsent(key, value);
     }
 
     @Override

--- a/dubbo-remoting/dubbo-remoting-api/src/test/java/com/alibaba/dubbo/remoting/handler/WrappedChannelHandlerTest.java
+++ b/dubbo-remoting/dubbo-remoting-api/src/test/java/com/alibaba/dubbo/remoting/handler/WrappedChannelHandlerTest.java
@@ -21,12 +21,12 @@ import com.alibaba.dubbo.common.URL;
 import com.alibaba.dubbo.remoting.Channel;
 import com.alibaba.dubbo.remoting.RemotingException;
 import com.alibaba.dubbo.remoting.transport.dispatcher.WrappedChannelHandler;
-
 import junit.framework.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.lang.reflect.Field;
+import java.util.concurrent.ThreadPoolExecutor;
 
 import static org.junit.Assert.fail;
 
@@ -103,6 +103,30 @@ public class WrappedChannelHandlerTest {
         } catch (Exception e) {
             Assert.assertEquals(BizException.class, e.getCause().getClass());
         }
+    }
+
+    @Test
+    public void testShareConsumerExecutor() {
+        URL url1 = URL.valueOf("dubbo://10.20.30.40:1234/DemoService?side=consumer&share-executor=true&threadpool=fixed");
+        WrappedChannelHandler handler1 = new WrappedChannelHandler(new BizChannelHander(true), url1);
+        WrappedChannelHandler handler2 = new WrappedChannelHandler(new BizChannelHander(true), url1);
+        Assert.assertEquals(200, ((ThreadPoolExecutor) (handler1.getExecutor())).getMaximumPoolSize());
+        Assert.assertSame(handler1.getExecutor(), handler2.getExecutor());
+
+        URL url2 = URL.valueOf("dubbo://10.20.30.40:1234/DemoService?side=consumer&share-executor=false");
+        WrappedChannelHandler handler3 = new WrappedChannelHandler(new BizChannelHander(true), url2);
+        WrappedChannelHandler handler4 = new WrappedChannelHandler(new BizChannelHander(true), url2);
+        Assert.assertNotSame(handler3.getExecutor(), handler4.getExecutor());
+        Assert.assertNotSame(handler3.getExecutor(), handler1.getExecutor());
+    }
+
+    @Test
+    public void testProviderExecutor() {
+        URL url1 = URL.valueOf("dubbo://10.20.30.40:1234/DemoService?side=provider");
+        URL url2 = URL.valueOf("dubbo://10.20.30.40:6789/DemoService?side=provider");
+        WrappedChannelHandler handler1 = new WrappedChannelHandler(new BizChannelHander(true), url1);
+        WrappedChannelHandler handler2 = new WrappedChannelHandler(new BizChannelHander(true), url2);
+        Assert.assertNotSame(handler1.getExecutor(), handler2.getExecutor());
     }
 
     class BizChannelHander extends MockedChannelHandler {

--- a/dubbo-remoting/dubbo-remoting-api/src/test/java/com/alibaba/dubbo/remoting/handler/WrappedChannelHandlerTest.java
+++ b/dubbo-remoting/dubbo-remoting-api/src/test/java/com/alibaba/dubbo/remoting/handler/WrappedChannelHandlerTest.java
@@ -107,13 +107,13 @@ public class WrappedChannelHandlerTest {
 
     @Test
     public void testShareConsumerExecutor() {
-        URL url1 = URL.valueOf("dubbo://10.20.30.40:1234/DemoService?side=consumer&share-executor=true&threadpool=fixed");
+        URL url1 = URL.valueOf("dubbo://10.20.30.40:1234/DemoService?side=consumer&share.threadpool=true&threadpool=fixed");
         WrappedChannelHandler handler1 = new WrappedChannelHandler(new BizChannelHander(true), url1);
         WrappedChannelHandler handler2 = new WrappedChannelHandler(new BizChannelHander(true), url1);
         Assert.assertEquals(200, ((ThreadPoolExecutor) (handler1.getExecutor())).getMaximumPoolSize());
         Assert.assertSame(handler1.getExecutor(), handler2.getExecutor());
 
-        URL url2 = URL.valueOf("dubbo://10.20.30.40:1234/DemoService?side=consumer&share-executor=false");
+        URL url2 = URL.valueOf("dubbo://10.20.30.40:1234/DemoService?side=consumer&share.threadpool=false");
         WrappedChannelHandler handler3 = new WrappedChannelHandler(new BizChannelHander(true), url2);
         WrappedChannelHandler handler4 = new WrappedChannelHandler(new BizChannelHander(true), url2);
         Assert.assertNotSame(handler3.getExecutor(), handler4.getExecutor());


### PR DESCRIPTION
If you want to share one single thread pool for all services and requests, configure like this:
```xml
<dubbo:consumer threadpool="fixed" threads="700">
        <dubbo:parameter key="share-threadpool" value="true"/>
</dubbo:consumer>
```

There's no strict rules for which strategy is the best, every strategy has its pros and cons, just pick the one that is suitable for your case. Sharing the same fixed-size thread pool can be very helpful for Consumers working as a proxy.