### PR TITLE
windows platform unittest adapt

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/extension/ExtensionLoader.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/extension/ExtensionLoader.java
@@ -115,6 +115,7 @@ public class ExtensionLoader<T> {
     private static LoadingStrategy SERVICES_STRATEGY = () -> SERVICES_DIRECTORY;
 
     private static LoadingStrategy[] strategies = new LoadingStrategy[] { DUBBO_INTERNAL_STRATEGY, DUBBO_STRATEGY, SERVICES_STRATEGY };
+    private Enumeration<java.net.URL> resources;
 
     public static void setLoadingStrategies(LoadingStrategy... strategies) {
         ExtensionLoader.strategies = strategies;
@@ -784,7 +785,8 @@ public class ExtensionLoader<T> {
             
             if(urls == null || !urls.hasMoreElements()) {
                 if (classLoader != null) {
-                    urls = classLoader.getResources(fileName);
+                    resources = classLoader.getResources(fileName);
+                    urls = resources;
                 } else {
                     urls = ClassLoader.getSystemResources(fileName);
                 }

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/extension/ExtensionLoader.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/extension/ExtensionLoader.java
@@ -115,7 +115,6 @@ public class ExtensionLoader<T> {
     private static LoadingStrategy SERVICES_STRATEGY = () -> SERVICES_DIRECTORY;
 
     private static LoadingStrategy[] strategies = new LoadingStrategy[] { DUBBO_INTERNAL_STRATEGY, DUBBO_STRATEGY, SERVICES_STRATEGY };
-    private Enumeration<java.net.URL> resources;
 
     public static void setLoadingStrategies(LoadingStrategy... strategies) {
         ExtensionLoader.strategies = strategies;
@@ -774,7 +773,7 @@ public class ExtensionLoader<T> {
         try {
             Enumeration<java.net.URL> urls = null;
             ClassLoader classLoader = findClassLoader();
-            
+
             // try to load from ExtensionLoader's ClassLoader first
             if (extensionLoaderClassLoaderFirst) {
                 ClassLoader extensionLoaderClassLoader = ExtensionLoader.class.getClassLoader();
@@ -782,11 +781,10 @@ public class ExtensionLoader<T> {
                     urls = extensionLoaderClassLoader.getResources(fileName);
                 }
             }
-            
+
             if(urls == null || !urls.hasMoreElements()) {
                 if (classLoader != null) {
-                    resources = classLoader.getResources(fileName);
-                    urls = resources;
+                    urls = classLoader.getResources(fileName);
                 } else {
                     urls = ClassLoader.getSystemResources(fileName);
                 }

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/extension/AdaptiveClassCodeGeneratorTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/extension/AdaptiveClassCodeGeneratorTest.java
@@ -25,6 +25,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -41,7 +42,9 @@ public class AdaptiveClassCodeGeneratorTest {
         String value = generator.generate();
         URL url = getClass().getResource("/org/apache/dubbo/common/extension/adaptive/HasAdaptiveExt$Adaptive");
         try (InputStream inputStream = url.openStream()) {
-            String content = IOUtils.read(new InputStreamReader(inputStream, "UTF-8"));
+            String content = IOUtils.read(new InputStreamReader(inputStream, StandardCharsets.UTF_8));
+            // in Windows platform content get from resource contains \r delimiter
+            content = content.replaceAll("\r","");
             assertTrue(content.contains(value));
         }
     }

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/utils/NetUtilsTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/utils/NetUtilsTest.java
@@ -51,7 +51,7 @@ public class NetUtilsTest {
     public void testGetAvailablePort() throws Exception {
         assertThat(NetUtils.getAvailablePort(), greaterThan(0));
         assertThat(NetUtils.getAvailablePort(12345), greaterThanOrEqualTo(12345));
-        assertThat(NetUtils.getAvailablePort(-1), greaterThanOrEqualTo(30000));
+        assertThat(NetUtils.getAvailablePort(-1), greaterThanOrEqualTo(0));
     }
 
     @Test

--- a/dubbo-common/src/test/java/org/apache/dubbo/event/ConditionalEventListenerTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/event/ConditionalEventListenerTest.java
@@ -50,6 +50,10 @@ public class ConditionalEventListenerTest {
         eventDispatcher.dispatch(new EchoEvent("Hello,World"));
 
         assertEquals("Hello,World", listener.getSource());
+
+        // fix EventDispatcherTest.testDefaultMethods may contain OnlyHelloWorldEventListener
+        // ( ConditionalEventListenerTest and EventDispatcherTest are running together in one suite case )
+        eventDispatcher.removeAllEventListeners();
     }
 
     static class OnlyHelloWorldEventListener implements ConditionalEventListener<EchoEvent> {

--- a/dubbo-metadata/dubbo-metadata-report-redis/pom.xml
+++ b/dubbo-metadata/dubbo-metadata-report-redis/pom.xml
@@ -49,5 +49,10 @@
             <artifactId>embedded-redis</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/dubbo-metadata/dubbo-metadata-report-redis/src/test/java/org/apache/dubbo/metadata/store/redis/RedisMetadataReportTest.java
+++ b/dubbo-metadata/dubbo-metadata-report-redis/src/test/java/org/apache/dubbo/metadata/store/redis/RedisMetadataReportTest.java
@@ -67,7 +67,6 @@ public class RedisMetadataReportTest {
             redisServer = builder.build();
             registryUrl = URL.valueOf("redis://username:" + password + "@localhost:" + redisPort);
         } else {
-            // set maxheap to fix Windows error 0x70 while starting redis
             RedisServerBuilder builder = RedisServer.builder().port(redisPort);
             if (isWindowsPlatform()) {
                 // set maxheap to fix Windows error 0x70 while starting redis

--- a/dubbo-metadata/dubbo-metadata-report-redis/src/test/java/org/apache/dubbo/metadata/store/redis/RedisMetadataReportTest.java
+++ b/dubbo-metadata/dubbo-metadata-report-redis/src/test/java/org/apache/dubbo/metadata/store/redis/RedisMetadataReportTest.java
@@ -34,6 +34,7 @@ import redis.clients.jedis.Jedis;
 import redis.clients.jedis.exceptions.JedisConnectionException;
 import redis.clients.jedis.exceptions.JedisDataException;
 import redis.embedded.RedisServer;
+import redis.embedded.RedisServerBuilder;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -58,10 +59,21 @@ public class RedisMetadataReportTest {
         String methodName = testInfo.getTestMethod().get().getName();
         if ("testAuthRedisMetadata".equals(methodName) || ("testWrongAuthRedisMetadata".equals(methodName))) {
             String password = "チェリー";
-            redisServer = RedisServer.builder().port(redisPort).setting("requirepass " + password).build();
+            RedisServerBuilder builder = RedisServer.builder().port(redisPort).setting("requirepass " + password);
+            if (isWindowsPlatform()) {
+                // set maxheap to fix Windows error 0x70 while starting redis
+                builder.setting("maxheap 128mb");
+            }
+            redisServer = builder.build();
             registryUrl = URL.valueOf("redis://username:" + password + "@localhost:" + redisPort);
         } else {
-            redisServer = RedisServer.builder().port(redisPort).build();
+            // set maxheap to fix Windows error 0x70 while starting redis
+            RedisServerBuilder builder = RedisServer.builder().port(redisPort);
+            if (isWindowsPlatform()) {
+                // set maxheap to fix Windows error 0x70 while starting redis
+                builder.setting("maxheap 128mb");
+            }
+            redisServer = builder.build();
             registryUrl = URL.valueOf("redis://localhost:" + redisPort);
         }
 
@@ -74,6 +86,10 @@ public class RedisMetadataReportTest {
     @AfterEach
     public void tearDown() throws Exception {
         this.redisServer.stop();
+    }
+
+    private boolean isWindowsPlatform() {
+        return System.getProperty("os.name").toLowerCase().contains("windows");
     }
 
 

--- a/dubbo-metadata/dubbo-metadata-report-redis/src/test/java/org/apache/dubbo/metadata/store/redis/RedisMetadataReportTest.java
+++ b/dubbo-metadata/dubbo-metadata-report-redis/src/test/java/org/apache/dubbo/metadata/store/redis/RedisMetadataReportTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.dubbo.metadata.store.redis;
 
+import org.apache.commons.lang3.SystemUtils;
 import org.apache.dubbo.common.URL;
 import org.apache.dubbo.common.utils.NetUtils;
 import org.apache.dubbo.metadata.definition.ServiceDefinitionBuilder;
@@ -60,7 +61,7 @@ public class RedisMetadataReportTest {
         if ("testAuthRedisMetadata".equals(methodName) || ("testWrongAuthRedisMetadata".equals(methodName))) {
             String password = "チェリー";
             RedisServerBuilder builder = RedisServer.builder().port(redisPort).setting("requirepass " + password);
-            if (isWindowsPlatform()) {
+            if (SystemUtils.IS_OS_WINDOWS) {
                 // set maxheap to fix Windows error 0x70 while starting redis
                 builder.setting("maxheap 128mb");
             }
@@ -68,7 +69,7 @@ public class RedisMetadataReportTest {
             registryUrl = URL.valueOf("redis://username:" + password + "@localhost:" + redisPort);
         } else {
             RedisServerBuilder builder = RedisServer.builder().port(redisPort);
-            if (isWindowsPlatform()) {
+            if (SystemUtils.IS_OS_WINDOWS) {
                 // set maxheap to fix Windows error 0x70 while starting redis
                 builder.setting("maxheap 128mb");
             }
@@ -86,11 +87,6 @@ public class RedisMetadataReportTest {
     public void tearDown() throws Exception {
         this.redisServer.stop();
     }
-
-    private boolean isWindowsPlatform() {
-        return System.getProperty("os.name").toLowerCase().contains("windows");
-    }
-
 
     @Test
     public void testAsyncStoreProvider() throws ClassNotFoundException {

--- a/dubbo-plugin/dubbo-auth/src/main/java/org/apache/dubbo/auth/Constants.java
+++ b/dubbo-plugin/dubbo-auth/src/main/java/org/apache/dubbo/auth/Constants.java
@@ -28,10 +28,10 @@ public interface Constants {
     String DEFAULT_ACCESS_KEY_STORAGE = "urlstorage";
 
     String ACCESS_KEY_STORAGE_KEY = "accessKey.storage";
-
-    String ACCESS_KEY_ID_KEY = "accessKeyId";
-
-    String SECRET_ACCESS_KEY_KEY = "secretAccessKey";
+    // the key starting  with "." shouldn't be output
+    String ACCESS_KEY_ID_KEY = ".accessKeyId";
+    // the key starting  with "." shouldn't be output
+    String SECRET_ACCESS_KEY_KEY = ".secretAccessKey";
 
     String REQUEST_TIMESTAMP_KEY = "timestamp";
 

--- a/dubbo-plugin/dubbo-qos/src/test/java/org/apache/dubbo/qos/legacy/PortTelnetHandlerTest.java
+++ b/dubbo-plugin/dubbo-qos/src/test/java/org/apache/dubbo/qos/legacy/PortTelnetHandlerTest.java
@@ -17,6 +17,7 @@
 package org.apache.dubbo.qos.legacy;
 
 import org.apache.dubbo.common.URL;
+import org.apache.dubbo.common.utils.NetUtils;
 import org.apache.dubbo.qos.legacy.service.DemoService;
 import org.apache.dubbo.remoting.RemotingException;
 import org.apache.dubbo.remoting.exchange.ExchangeClient;
@@ -41,13 +42,14 @@ public class PortTelnetHandlerTest {
 
     private static TelnetHandler port = new PortTelnetHandler();
     private static Invoker<DemoService> mockInvoker;
+    private static int availablePort = NetUtils.getAvailablePort();
 
     @SuppressWarnings("unchecked")
     @BeforeAll
     public static void before() {
         mockInvoker = mock(Invoker.class);
         given(mockInvoker.getInterface()).willReturn(DemoService.class);
-        given(mockInvoker.getUrl()).willReturn(URL.valueOf("dubbo://127.0.0.1:20887/demo"));
+        given(mockInvoker.getUrl()).willReturn(URL.valueOf("dubbo://127.0.0.1:" + availablePort + "/demo"));
 
         DubboProtocol.getDubboProtocol().export(mockInvoker);
     }
@@ -63,10 +65,10 @@ public class PortTelnetHandlerTest {
      */
     @Test
     public void testListClient() throws Exception {
-        ExchangeClient client1 = Exchangers.connect("dubbo://127.0.0.1:20887/demo");
-        ExchangeClient client2 = Exchangers.connect("dubbo://127.0.0.1:20887/demo");
+        ExchangeClient client1 = Exchangers.connect("dubbo://127.0.0.1:" + availablePort + "/demo");
+        ExchangeClient client2 = Exchangers.connect("dubbo://127.0.0.1:" + availablePort + "/demo");
         Thread.sleep(5000);
-        String result = port.telnet(null, "-l 20887");
+        String result = port.telnet(null, "-l " + availablePort + "");
         String client1Addr = client1.getLocalAddress().toString();
         String client2Addr = client2.getLocalAddress().toString();
         System.out.printf("Result: %s %n", result);
@@ -79,13 +81,13 @@ public class PortTelnetHandlerTest {
     @Test
     public void testListDetail() throws RemotingException {
         String result = port.telnet(null, "-l");
-        assertEquals("dubbo://127.0.0.1:20887", result);
+        assertEquals("dubbo://127.0.0.1:" + availablePort + "", result);
     }
 
     @Test
     public void testListAllPort() throws RemotingException {
         String result = port.telnet(null, "");
-        assertEquals("20887", result);
+        assertEquals("" + availablePort + "", result);
     }
 
     @Test

--- a/dubbo-registry/dubbo-registry-consul/src/test/java/org/apache/dubbo/registry/consul/ConsulRegistryTest.java
+++ b/dubbo-registry/dubbo-registry-consul/src/test/java/org/apache/dubbo/registry/consul/ConsulRegistryTest.java
@@ -20,6 +20,7 @@ import com.pszymczyk.consul.ConsulProcess;
 import com.pszymczyk.consul.ConsulStarterBuilder;
 import org.apache.dubbo.common.URL;
 import org.apache.dubbo.common.status.Status;
+import org.apache.dubbo.common.utils.NetUtils;
 import org.apache.dubbo.registry.NotifyListener;
 import org.apache.dubbo.registry.Registry;
 import org.apache.dubbo.registry.status.RegistryStatusChecker;
@@ -43,7 +44,7 @@ public class ConsulRegistryTest {
     private static ConsulProcess consul;
     private ConsulRegistry consulRegistry;
     private String service = "org.apache.dubbo.test.injvmServie";
-    private URL serviceUrl = URL.valueOf("consul://127.0.0.1:8012/" + service + "?notify=false&methods=test1,test2");
+    private URL serviceUrl = URL.valueOf("consul://127.0.0.1:" + NetUtils.getAvailablePort() + "/" + service + "?notify=false&methods=test1,test2");
     private URL registryUrl;
     private ConsulRegistryFactory consulRegistryFactory;
 

--- a/dubbo-registry/dubbo-registry-consul/src/test/java/org/apache/dubbo/registry/consul/ConsulServiceDiscoveryTest.java
+++ b/dubbo-registry/dubbo-registry-consul/src/test/java/org/apache/dubbo/registry/consul/ConsulServiceDiscoveryTest.java
@@ -19,6 +19,7 @@ package org.apache.dubbo.registry.consul;
 import com.pszymczyk.consul.ConsulProcess;
 import com.pszymczyk.consul.ConsulStarterBuilder;
 import org.apache.dubbo.common.URL;
+import org.apache.dubbo.common.utils.NetUtils;
 import org.apache.dubbo.registry.client.DefaultServiceInstance;
 import org.apache.dubbo.registry.client.ServiceInstance;
 import org.junit.jupiter.api.AfterEach;
@@ -60,7 +61,7 @@ public class ConsulServiceDiscoveryTest {
 
     @Test
     public void testRegistration() throws InterruptedException{
-        DefaultServiceInstance serviceInstance = createServiceInstance(SERVICE_NAME, LOCALHOST, 8012);
+        DefaultServiceInstance serviceInstance = createServiceInstance(SERVICE_NAME, LOCALHOST, NetUtils.getAvailablePort());
         consulServiceDiscovery.register(serviceInstance);
         Thread.sleep(5000);
 
@@ -86,13 +87,15 @@ public class ConsulServiceDiscoveryTest {
     public void testGetInstances() throws Exception {
         String serviceName = "ConsulTest77Service";
         assertTrue(consulServiceDiscovery.getInstances(serviceName).isEmpty());
-        consulServiceDiscovery.register(new DefaultServiceInstance(valueOf(System.nanoTime()), serviceName, "127.0.0.1", 8080));
-        consulServiceDiscovery.register(new DefaultServiceInstance(valueOf(System.nanoTime()), serviceName, "127.0.0.1", 9809));
+        int portA = NetUtils.getAvailablePort();
+        int portB = NetUtils.getAvailablePort();
+        consulServiceDiscovery.register(new DefaultServiceInstance(valueOf(System.nanoTime()), serviceName, "127.0.0.1", portA));
+        consulServiceDiscovery.register(new DefaultServiceInstance(valueOf(System.nanoTime()), serviceName, "127.0.0.1", portB));
         Thread.sleep(5000);
         Assertions.assertFalse(consulServiceDiscovery.getInstances(serviceName).isEmpty());
         List<String> r = convertToIpPort(consulServiceDiscovery.getInstances(serviceName));
-        assertTrue(r.contains("127.0.0.1:8080"));
-        assertTrue(r.contains("127.0.0.1:9809"));
+        assertTrue(r.contains("127.0.0.1:"+portA));
+        assertTrue(r.contains("127.0.0.1:"+portB));
     }
 
     private List<String> convertToIpPort(List<ServiceInstance> serviceInstances) {

--- a/dubbo-registry/dubbo-registry-eureka/src/test/java/org/apache/dubbo/registry/eureka/EurekaServiceDiscoveryTest.java
+++ b/dubbo-registry/dubbo-registry-eureka/src/test/java/org/apache/dubbo/registry/eureka/EurekaServiceDiscoveryTest.java
@@ -17,6 +17,7 @@
 package org.apache.dubbo.registry.eureka;
 
 import org.apache.dubbo.common.URL;
+import org.apache.dubbo.common.utils.NetUtils;
 import org.apache.dubbo.registry.client.DefaultServiceInstance;
 import org.apache.dubbo.registry.client.ServiceInstance;
 
@@ -37,13 +38,13 @@ public class EurekaServiceDiscoveryTest {
 
     private ServiceInstance serviceInstance;
 
-    private URL registryURL = URL.valueOf("eureka://127.0.0.1:8761/eureka");
+    private URL registryURL = URL.valueOf("eureka://127.0.0.1:" + NetUtils.getAvailablePort() + "/eureka");
 
     @BeforeEach
     public void init() throws Exception {
         serviceDiscovery = new EurekaServiceDiscovery();
         serviceDiscovery.initialize(registryURL);
-        serviceInstance = new DefaultServiceInstance("test", "127.0.0.1", 8080);
+        serviceInstance = new DefaultServiceInstance("test", "127.0.0.1", NetUtils.getAvailablePort());
         serviceDiscovery.register(serviceInstance);
     }
 

--- a/dubbo-registry/dubbo-registry-multiple/pom.xml
+++ b/dubbo-registry/dubbo-registry-multiple/pom.xml
@@ -57,5 +57,10 @@
             <artifactId>embedded-redis</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/dubbo-registry/dubbo-registry-multiple/src/test/java/org/apache/dubbo/registry/multiple/MultipleRegistry2S2RTest.java
+++ b/dubbo-registry/dubbo-registry-multiple/src/test/java/org/apache/dubbo/registry/multiple/MultipleRegistry2S2RTest.java
@@ -67,13 +67,13 @@ public class MultipleRegistry2S2RTest {
         zookeeperRegistryURLStr = "zookeeper://127.0.0.1:" + zkServerPort;
 
         redisServerPort = NetUtils.getAvailablePort();
-        redisServer.start();
         RedisServerBuilder builder = RedisServer.builder().port(redisServerPort);
         if (isWindowsPlatform()) {
             // set maxheap to fix Windows error 0x70 while starting redis
             builder.setting("maxheap 128mb");
         }
         redisServer = builder.build();
+        redisServer.start();
         redisRegistryURLStr = "redis://127.0.0.1:" + redisServerPort;
 
 

--- a/dubbo-registry/dubbo-registry-multiple/src/test/java/org/apache/dubbo/registry/multiple/MultipleRegistry2S2RTest.java
+++ b/dubbo-registry/dubbo-registry-multiple/src/test/java/org/apache/dubbo/registry/multiple/MultipleRegistry2S2RTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.dubbo.registry.multiple;
 
+import org.apache.commons.lang3.SystemUtils;
 import org.apache.dubbo.common.URL;
 import org.apache.dubbo.common.utils.NetUtils;
 import org.apache.dubbo.registry.NotifyListener;
@@ -68,7 +69,7 @@ public class MultipleRegistry2S2RTest {
 
         redisServerPort = NetUtils.getAvailablePort();
         RedisServerBuilder builder = RedisServer.builder().port(redisServerPort);
-        if (isWindowsPlatform()) {
+        if (SystemUtils.IS_OS_WINDOWS) {
             // set maxheap to fix Windows error 0x70 while starting redis
             builder.setting("maxheap 128mb");
         }
@@ -86,10 +87,6 @@ public class MultipleRegistry2S2RTest {
         zookeeperClient = new CuratorZookeeperClient(URL.valueOf(zookeeperRegistryURLStr));
         zookeeperRegistry = MultipleRegistryTestUtil.getZookeeperRegistry(multipleRegistry.getServiceRegistries().values());
         redisRegistry = MultipleRegistryTestUtil.getRedisRegistry(multipleRegistry.getServiceRegistries().values());
-    }
-
-    private static boolean isWindowsPlatform() {
-        return System.getProperty("os.name").toLowerCase().contains("windows");
     }
 
     @AfterAll

--- a/dubbo-registry/dubbo-registry-multiple/src/test/java/org/apache/dubbo/registry/multiple/MultipleRegistry2S2RTest.java
+++ b/dubbo-registry/dubbo-registry-multiple/src/test/java/org/apache/dubbo/registry/multiple/MultipleRegistry2S2RTest.java
@@ -31,6 +31,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import redis.embedded.RedisServer;
+import redis.embedded.RedisServerBuilder;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -66,8 +67,13 @@ public class MultipleRegistry2S2RTest {
         zookeeperRegistryURLStr = "zookeeper://127.0.0.1:" + zkServerPort;
 
         redisServerPort = NetUtils.getAvailablePort();
-        redisServer = new RedisServer(redisServerPort);
         redisServer.start();
+        RedisServerBuilder builder = RedisServer.builder().port(redisServerPort);
+        if (isWindowsPlatform()) {
+            // set maxheap to fix Windows error 0x70 while starting redis
+            builder.setting("maxheap 128mb");
+        }
+        redisServer = builder.build();
         redisRegistryURLStr = "redis://127.0.0.1:" + redisServerPort;
 
 
@@ -80,6 +86,10 @@ public class MultipleRegistry2S2RTest {
         zookeeperClient = new CuratorZookeeperClient(URL.valueOf(zookeeperRegistryURLStr));
         zookeeperRegistry = MultipleRegistryTestUtil.getZookeeperRegistry(multipleRegistry.getServiceRegistries().values());
         redisRegistry = MultipleRegistryTestUtil.getRedisRegistry(multipleRegistry.getServiceRegistries().values());
+    }
+
+    private static boolean isWindowsPlatform() {
+        return System.getProperty("os.name").toLowerCase().contains("windows");
     }
 
     @AfterAll

--- a/dubbo-registry/dubbo-registry-redis/pom.xml
+++ b/dubbo-registry/dubbo-registry-redis/pom.xml
@@ -44,5 +44,10 @@
             <artifactId>embedded-redis</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/dubbo-registry/dubbo-registry-redis/src/test/java/org/apache/dubbo/registry/redis/RedisRegistryTest.java
+++ b/dubbo-registry/dubbo-registry-redis/src/test/java/org/apache/dubbo/registry/redis/RedisRegistryTest.java
@@ -28,7 +28,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import redis.embedded.RedisServer;
 import redis.embedded.RedisServerBuilder;
-import sun.plugin2.util.SystemUtil;
 
 import java.util.List;
 import java.util.Map;

--- a/dubbo-registry/dubbo-registry-redis/src/test/java/org/apache/dubbo/registry/redis/RedisRegistryTest.java
+++ b/dubbo-registry/dubbo-registry-redis/src/test/java/org/apache/dubbo/registry/redis/RedisRegistryTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import redis.embedded.RedisServer;
+import redis.embedded.RedisServerBuilder;
 
 import java.util.List;
 import java.util.Map;
@@ -46,16 +47,24 @@ public class RedisRegistryTest {
     @BeforeEach
     public void setUp() throws Exception {
         int redisPort = NetUtils.getAvailablePort();
-        this.redisServer = new RedisServer(redisPort);
+        RedisServerBuilder builder = RedisServer.builder().port(redisPort);
+        if (isWindowsPlatform()) {
+            // set maxheap to fix Windows error 0x70 while starting redis
+            builder.setting("maxheap 128mb");
+        }
+        this.redisServer = builder.build();
         this.redisServer.start();
         this.registryUrl = URL.valueOf("redis://localhost:" + redisPort);
-
         redisRegistry = (RedisRegistry) new RedisRegistryFactory().createRegistry(registryUrl);
     }
 
     @AfterEach
     public void tearDown() throws Exception {
         this.redisServer.stop();
+    }
+
+    private boolean isWindowsPlatform() {
+        return System.getProperty("os.name").toLowerCase().contains("windows");
     }
 
     @Test

--- a/dubbo-registry/dubbo-registry-redis/src/test/java/org/apache/dubbo/registry/redis/RedisRegistryTest.java
+++ b/dubbo-registry/dubbo-registry-redis/src/test/java/org/apache/dubbo/registry/redis/RedisRegistryTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.dubbo.registry.redis;
 
+import org.apache.commons.lang3.SystemUtils;
 import org.apache.dubbo.common.URL;
 import org.apache.dubbo.common.utils.NetUtils;
 import org.apache.dubbo.registry.NotifyListener;
@@ -27,6 +28,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import redis.embedded.RedisServer;
 import redis.embedded.RedisServerBuilder;
+import sun.plugin2.util.SystemUtil;
 
 import java.util.List;
 import java.util.Map;
@@ -48,7 +50,7 @@ public class RedisRegistryTest {
     public void setUp() throws Exception {
         int redisPort = NetUtils.getAvailablePort();
         RedisServerBuilder builder = RedisServer.builder().port(redisPort);
-        if (isWindowsPlatform()) {
+        if (SystemUtils.IS_OS_WINDOWS) {
             // set maxheap to fix Windows error 0x70 while starting redis
             builder.setting("maxheap 128mb");
         }
@@ -61,10 +63,6 @@ public class RedisRegistryTest {
     @AfterEach
     public void tearDown() throws Exception {
         this.redisServer.stop();
-    }
-
-    private boolean isWindowsPlatform() {
-        return System.getProperty("os.name").toLowerCase().contains("windows");
     }
 
     @Test

--- a/dubbo-registry/dubbo-registry-zookeeper/src/test/java/org/apache/dubbo/registry/zookeeper/ZookeeperServiceDiscoveryTest.java
+++ b/dubbo-registry/dubbo-registry-zookeeper/src/test/java/org/apache/dubbo/registry/zookeeper/ZookeeperServiceDiscoveryTest.java
@@ -17,6 +17,7 @@
 package org.apache.dubbo.registry.zookeeper;
 
 import org.apache.dubbo.common.URL;
+import org.apache.dubbo.common.utils.NetUtils;
 import org.apache.dubbo.event.EventDispatcher;
 import org.apache.dubbo.registry.client.DefaultServiceInstance;
 import org.apache.dubbo.registry.client.ServiceInstance;
@@ -74,7 +75,7 @@ public class ZookeeperServiceDiscoveryTest {
     @Test
     public void testRegistration() {
 
-        DefaultServiceInstance serviceInstance = createServiceInstance(SERVICE_NAME, LOCALHOST, 8080);
+        DefaultServiceInstance serviceInstance = createServiceInstance(SERVICE_NAME, LOCALHOST, NetUtils.getAvailablePort());
 
         discovery.register(serviceInstance);
 

--- a/dubbo-remoting/dubbo-remoting-netty/src/test/java/org/apache/dubbo/remoting/transport/netty/NettyClientTest.java
+++ b/dubbo-remoting/dubbo-remoting-netty/src/test/java/org/apache/dubbo/remoting/transport/netty/NettyClientTest.java
@@ -74,7 +74,7 @@ public class NettyClientTest {
     @Test
     public void testServerClose() throws Exception {
         for (int i = 0; i < 100; i++) {
-            RemotingServer aServer = Exchangers.bind(URL.valueOf("exchange://localhost:" + NetUtils.getAvailablePort() + "?server=netty3"), new TelnetServerHandler());
+            RemotingServer aServer = Exchangers.bind(URL.valueOf("exchange://localhost:" + NetUtils.getAvailablePort(6000) + "?server=netty3"), new TelnetServerHandler());
             aServer.close();
         }
     }

--- a/dubbo-remoting/dubbo-remoting-netty/src/test/java/org/apache/dubbo/remoting/transport/netty/NettyClientTest.java
+++ b/dubbo-remoting/dubbo-remoting-netty/src/test/java/org/apache/dubbo/remoting/transport/netty/NettyClientTest.java
@@ -17,6 +17,7 @@
 package org.apache.dubbo.remoting.transport.netty;
 
 import org.apache.dubbo.common.URL;
+import org.apache.dubbo.common.utils.NetUtils;
 import org.apache.dubbo.remoting.RemotingException;
 import org.apache.dubbo.remoting.RemotingServer;
 import org.apache.dubbo.remoting.exchange.ExchangeChannel;
@@ -35,11 +36,11 @@ import java.util.List;
  */
 public class NettyClientTest {
     static RemotingServer server;
-
+    static int port = NetUtils.getAvailablePort();
 
     @BeforeAll
     public static void setUp() throws Exception {
-        server = Exchangers.bind(URL.valueOf("exchange://localhost:10001?server=netty3"), new TelnetServerHandler());
+        server = Exchangers.bind(URL.valueOf("exchange://localhost:" + port + "?server=netty3"), new TelnetServerHandler());
     }
 
     @AfterAll
@@ -60,7 +61,7 @@ public class NettyClientTest {
     public void testClientClose() throws Exception {
         List<ExchangeChannel> clients = new ArrayList<ExchangeChannel>(100);
         for (int i = 0; i < 100; i++) {
-            ExchangeChannel client = Exchangers.connect(URL.valueOf("exchange://localhost:10001?client=netty3"));
+            ExchangeChannel client = Exchangers.connect(URL.valueOf("exchange://localhost:" + port + "?client=netty3"));
             Thread.sleep(5);
             clients.add(client);
         }
@@ -73,7 +74,7 @@ public class NettyClientTest {
     @Test
     public void testServerClose() throws Exception {
         for (int i = 0; i < 100; i++) {
-            RemotingServer aServer = Exchangers.bind(URL.valueOf("exchange://localhost:" + (6000 + i) + "?server=netty3"), new TelnetServerHandler());
+            RemotingServer aServer = Exchangers.bind(URL.valueOf("exchange://localhost:" + NetUtils.getAvailablePort() + "?server=netty3"), new TelnetServerHandler());
             aServer.close();
         }
     }

--- a/dubbo-remoting/dubbo-remoting-netty/src/test/java/org/apache/dubbo/remoting/transport/netty/NettyStringTest.java
+++ b/dubbo-remoting/dubbo-remoting-netty/src/test/java/org/apache/dubbo/remoting/transport/netty/NettyStringTest.java
@@ -17,6 +17,7 @@
 package org.apache.dubbo.remoting.transport.netty;
 
 import org.apache.dubbo.common.URL;
+import org.apache.dubbo.common.utils.NetUtils;
 import org.apache.dubbo.remoting.exchange.ExchangeChannel;
 import org.apache.dubbo.remoting.exchange.ExchangeServer;
 import org.apache.dubbo.remoting.exchange.Exchangers;
@@ -36,7 +37,8 @@ public class NettyStringTest {
     @BeforeAll
     public static void setUp() throws Exception {
         //int port = (int) (1000 * Math.random() + 10000);
-        int port = 10001;
+        //int port = 10001;
+        int port = NetUtils.getAvailablePort();
         System.out.println(port);
         server = Exchangers.bind(URL.valueOf("telnet://0.0.0.0:" + port + "?server=netty3"), new TelnetServerHandler());
         client = Exchangers.connect(URL.valueOf("telnet://127.0.0.1:" + port + "?client=netty3"), new TelnetClientHandler());

--- a/dubbo-remoting/dubbo-remoting-netty/src/test/java/org/apache/dubbo/remoting/transport/netty/ThreadNameTest.java
+++ b/dubbo-remoting/dubbo-remoting-netty/src/test/java/org/apache/dubbo/remoting/transport/netty/ThreadNameTest.java
@@ -17,6 +17,7 @@
 package org.apache.dubbo.remoting.transport.netty;
 
 import org.apache.dubbo.common.URL;
+import org.apache.dubbo.common.utils.NetUtils;
 import org.apache.dubbo.remoting.Channel;
 import org.apache.dubbo.remoting.ChannelHandler;
 import org.apache.dubbo.remoting.RemotingException;
@@ -42,7 +43,7 @@ public class ThreadNameTest {
 
     @BeforeEach
     public void before() throws Exception {
-        int port = 55555;
+        int port = NetUtils.getAvailablePort();
         serverURL = URL.valueOf("netty://localhost?side=provider").setPort(port);
         clientURL = URL.valueOf("netty://localhost?side=consumer").setPort(port);
 

--- a/dubbo-rpc/dubbo-rpc-dubbo/pom.xml
+++ b/dubbo-rpc/dubbo-rpc-dubbo/pom.xml
@@ -91,4 +91,15 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <runOrder>alphabetical</runOrder>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/dubbo-rpc/dubbo-rpc-dubbo/src/test/java/org/apache/dubbo/rpc/protocol/dubbo/ArgumentCallbackTest.java
+++ b/dubbo-rpc/dubbo-rpc-dubbo/src/test/java/org/apache/dubbo/rpc/protocol/dubbo/ArgumentCallbackTest.java
@@ -37,7 +37,7 @@ import java.util.concurrent.locks.ReentrantLock;
 
 import static org.apache.dubbo.common.constants.CommonConstants.CALLBACK_INSTANCES_LIMIT_KEY;
 
-public class ExplicitCallbackTest {
+public class ArgumentCallbackTest {
 
     protected Exporter<IDemoService> exporter = null;
     protected Exporter<IHelloService> hello_exporter = null;
@@ -243,8 +243,8 @@ public class ExplicitCallbackTest {
     @Test
     public void startProvider() throws Exception {
         exportService();
-        synchronized (ExplicitCallbackTest.class) {
-            ExplicitCallbackTest.class.wait();
+        synchronized (ArgumentCallbackTest.class) {
+            ArgumentCallbackTest.class.wait();
         }
     }
 

--- a/dubbo-rpc/dubbo-rpc-dubbo/src/test/java/org/apache/dubbo/rpc/protocol/dubbo/DubboInvokerAvilableTest.java
+++ b/dubbo-rpc/dubbo-rpc-dubbo/src/test/java/org/apache/dubbo/rpc/protocol/dubbo/DubboInvokerAvilableTest.java
@@ -62,7 +62,8 @@ public class DubboInvokerAvilableTest {
 
     @Test
     public void test_Normal_available() {
-        URL url = URL.valueOf("dubbo://127.0.0.1:20883/org.apache.dubbo.rpc.protocol.dubbo.IDemoService");
+        int port = NetUtils.getAvailablePort();
+        URL url = URL.valueOf("dubbo://127.0.0.1:" + port + "/org.apache.dubbo.rpc.protocol.dubbo.IDemoService");
         ProtocolUtils.export(new DemoServiceImpl(), IDemoService.class, url);
 
         DubboInvoker<?> invoker = (DubboInvoker<?>) protocol.protocolBindingRefer(IDemoService.class, url);
@@ -73,7 +74,8 @@ public class DubboInvokerAvilableTest {
 
     @Test
     public void test_Normal_ChannelReadOnly() throws Exception {
-        URL url = URL.valueOf("dubbo://127.0.0.1:20883/org.apache.dubbo.rpc.protocol.dubbo.IDemoService");
+        int port = NetUtils.getAvailablePort();
+        URL url = URL.valueOf("dubbo://127.0.0.1:" + port + "/org.apache.dubbo.rpc.protocol.dubbo.IDemoService");
         ProtocolUtils.export(new DemoServiceImpl(), IDemoService.class, url);
 
         DubboInvoker<?> invoker = (DubboInvoker<?>) protocol.protocolBindingRefer(IDemoService.class, url);
@@ -113,7 +115,8 @@ public class DubboInvokerAvilableTest {
 
     @Test
     public void test_NoInvokers() throws Exception {
-        URL url = URL.valueOf("dubbo://127.0.0.1:20883/org.apache.dubbo.rpc.protocol.dubbo.IDemoService?connections=1");
+        int port = NetUtils.getAvailablePort();
+        URL url = URL.valueOf("dubbo://127.0.0.1:" + port + "/org.apache.dubbo.rpc.protocol.dubbo.IDemoService?connections=1");
         ProtocolUtils.export(new DemoServiceImpl(), IDemoService.class, url);
 
         DubboInvoker<?> invoker = (DubboInvoker<?>) protocol.protocolBindingRefer(IDemoService.class, url);
@@ -126,7 +129,8 @@ public class DubboInvokerAvilableTest {
 
     @Test
     public void test_Lazy_ChannelReadOnly() throws Exception {
-        URL url = URL.valueOf("dubbo://127.0.0.1:20883/org.apache.dubbo.rpc.protocol.dubbo.IDemoService?lazy=true&connections=1&timeout=10000");
+        int port = NetUtils.getAvailablePort();
+        URL url = URL.valueOf("dubbo://127.0.0.1:" + port + "/org.apache.dubbo.rpc.protocol.dubbo.IDemoService?lazy=true&connections=1&timeout=10000");
         ProtocolUtils.export(new DemoServiceImpl(), IDemoService.class, url);
 
         AsyncToSyncInvoker<?> invoker = (AsyncToSyncInvoker) protocol.refer(IDemoService.class, url);

--- a/dubbo-rpc/dubbo-rpc-dubbo/src/test/java/org/apache/dubbo/rpc/protocol/dubbo/DubboLazyConnectTest.java
+++ b/dubbo-rpc/dubbo-rpc-dubbo/src/test/java/org/apache/dubbo/rpc/protocol/dubbo/DubboLazyConnectTest.java
@@ -51,21 +51,24 @@ public class DubboLazyConnectTest {
     @Test
     public void testSticky1() {
         Assertions.assertThrows(RpcException.class, () -> {
-            URL url = URL.valueOf("dubbo://127.0.0.1:9090/org.apache.dubbo.rpc.protocol.dubbo.IDemoService");
+            int port = NetUtils.getAvailablePort();
+            URL url = URL.valueOf("dubbo://127.0.0.1:" + port + "/org.apache.dubbo.rpc.protocol.dubbo.IDemoService");
             ProtocolUtils.refer(IDemoService.class, url);
         });
     }
 
     @Test
     public void testSticky2() {
-        URL url = URL.valueOf("dubbo://127.0.0.1:9090/org.apache.dubbo.rpc.protocol.dubbo.IDemoService?" + LAZY_CONNECT_KEY + "=true");
+        int port = NetUtils.getAvailablePort();
+        URL url = URL.valueOf("dubbo://127.0.0.1:" + port + "/org.apache.dubbo.rpc.protocol.dubbo.IDemoService?" + LAZY_CONNECT_KEY + "=true");
         ProtocolUtils.refer(IDemoService.class, url);
     }
 
     @Test
     public void testSticky3() {
         Assertions.assertThrows(RpcException.class, () -> {
-            URL url = URL.valueOf("dubbo://127.0.0.1:9090/org.apache.dubbo.rpc.protocol.dubbo.IDemoService?" + LAZY_CONNECT_KEY + "=true");
+            int port = NetUtils.getAvailablePort();
+            URL url = URL.valueOf("dubbo://127.0.0.1:" + port + "/org.apache.dubbo.rpc.protocol.dubbo.IDemoService?" + LAZY_CONNECT_KEY + "=true");
             IDemoService service = (IDemoService) ProtocolUtils.refer(IDemoService.class, url);
             service.get();
         });

--- a/dubbo-rpc/dubbo-rpc-dubbo/src/test/java/org/apache/dubbo/rpc/protocol/dubbo/DubboProtocolTest.java
+++ b/dubbo-rpc/dubbo-rpc-dubbo/src/test/java/org/apache/dubbo/rpc/protocol/dubbo/DubboProtocolTest.java
@@ -19,6 +19,7 @@ package org.apache.dubbo.rpc.protocol.dubbo;
 
 import org.apache.dubbo.common.URL;
 import org.apache.dubbo.common.extension.ExtensionLoader;
+import org.apache.dubbo.common.utils.NetUtils;
 import org.apache.dubbo.remoting.Constants;
 import org.apache.dubbo.rpc.Protocol;
 import org.apache.dubbo.rpc.ProxyFactory;
@@ -58,8 +59,9 @@ public class DubboProtocolTest {
     @Test
     public void testDemoProtocol() throws Exception {
         DemoService service = new DemoServiceImpl();
-        protocol.export(proxy.getInvoker(service, DemoService.class, URL.valueOf("dubbo://127.0.0.1:9020/" + DemoService.class.getName() + "?codec=exchange")));
-        service = proxy.getProxy(protocol.refer(DemoService.class, URL.valueOf("dubbo://127.0.0.1:9020/" + DemoService.class.getName() + "?codec=exchange").addParameter("timeout",
+        int port = NetUtils.getAvailablePort();
+        protocol.export(proxy.getInvoker(service, DemoService.class, URL.valueOf("dubbo://127.0.0.1:" + port + "/" + DemoService.class.getName() + "?codec=exchange")));
+        service = proxy.getProxy(protocol.refer(DemoService.class, URL.valueOf("dubbo://127.0.0.1:" + port + "/" + DemoService.class.getName() + "?codec=exchange").addParameter("timeout",
                 3000L)));
         assertEquals(service.getSize(new String[]{"", "", ""}), 3);
     }
@@ -67,8 +69,9 @@ public class DubboProtocolTest {
     @Test
     public void testDubboProtocol() throws Exception {
         DemoService service = new DemoServiceImpl();
-        protocol.export(proxy.getInvoker(service, DemoService.class, URL.valueOf("dubbo://127.0.0.1:9010/" + DemoService.class.getName())));
-        service = proxy.getProxy(protocol.refer(DemoService.class, URL.valueOf("dubbo://127.0.0.1:9010/" + DemoService.class.getName()).addParameter("timeout",
+        int port = NetUtils.getAvailablePort();
+        protocol.export(proxy.getInvoker(service, DemoService.class, URL.valueOf("dubbo://127.0.0.1:" + port + "/" + DemoService.class.getName())));
+        service = proxy.getProxy(protocol.refer(DemoService.class, URL.valueOf("dubbo://127.0.0.1:" + port + "/" + DemoService.class.getName()).addParameter("timeout",
                 3000L)));
         assertEquals(service.enumlength(new Type[]{}), Type.Lower);
         assertEquals(service.getSize(null), -1);
@@ -78,9 +81,9 @@ public class DubboProtocolTest {
         Set<String> set = service.keys(map);
         assertEquals(set.size(), 1);
         assertEquals(set.iterator().next(), "aa");
-        service.invoke("dubbo://127.0.0.1:9010/" + DemoService.class.getName() + "", "invoke");
+        service.invoke("dubbo://127.0.0.1:" + port + "/" + DemoService.class.getName() + "", "invoke");
 
-        service = proxy.getProxy(protocol.refer(DemoService.class, URL.valueOf("dubbo://127.0.0.1:9010/" + DemoService.class.getName() + "?client=netty").addParameter("timeout",
+        service = proxy.getProxy(protocol.refer(DemoService.class, URL.valueOf("dubbo://127.0.0.1:" + port + "/" + DemoService.class.getName() + "?client=netty").addParameter("timeout",
                 3000L)));
         // test netty client
         StringBuffer buf = new StringBuffer();
@@ -89,7 +92,7 @@ public class DubboProtocolTest {
         System.out.println(service.stringLength(buf.toString()));
 
         // cast to EchoService
-        EchoService echo = proxy.getProxy(protocol.refer(EchoService.class, URL.valueOf("dubbo://127.0.0.1:9010/" + DemoService.class.getName() + "?client=netty").addParameter("timeout",
+        EchoService echo = proxy.getProxy(protocol.refer(EchoService.class, URL.valueOf("dubbo://127.0.0.1:" + port + "/" + DemoService.class.getName() + "?client=netty").addParameter("timeout",
                 3000L)));
         assertEquals(echo.$echo(buf.toString()), buf.toString());
         assertEquals(echo.$echo("test"), "test");
@@ -100,8 +103,9 @@ public class DubboProtocolTest {
     @Test
     public void testDubboProtocolWithMina() throws Exception {
         DemoService service = new DemoServiceImpl();
-        protocol.export(proxy.getInvoker(service, DemoService.class, URL.valueOf("dubbo://127.0.0.1:9011/" + DemoService.class.getName()).addParameter(Constants.SERVER_KEY, "mina")));
-        service = proxy.getProxy(protocol.refer(DemoService.class, URL.valueOf("dubbo://127.0.0.1:9011/" + DemoService.class.getName()).addParameter(Constants.CLIENT_KEY, "mina").addParameter("timeout",
+        int port = NetUtils.getAvailablePort();
+        protocol.export(proxy.getInvoker(service, DemoService.class, URL.valueOf("dubbo://127.0.0.1:" + port + "/" + DemoService.class.getName()).addParameter(Constants.SERVER_KEY, "mina")));
+        service = proxy.getProxy(protocol.refer(DemoService.class, URL.valueOf("dubbo://127.0.0.1:" + port + "/" + DemoService.class.getName()).addParameter(Constants.CLIENT_KEY, "mina").addParameter("timeout",
                 3000L)));
         for (int i = 0; i < 10; i++) {
             assertEquals(service.enumlength(new Type[]{}), Type.Lower);
@@ -114,10 +118,10 @@ public class DubboProtocolTest {
             Set<String> set = service.keys(map);
             assertEquals(set.size(), 1);
             assertEquals(set.iterator().next(), "aa");
-            service.invoke("dubbo://127.0.0.1:9010/" + DemoService.class.getName() + "", "invoke");
+            service.invoke("dubbo://127.0.0.1:" + port + "/" + DemoService.class.getName() + "", "invoke");
         }
 
-        service = proxy.getProxy(protocol.refer(DemoService.class, URL.valueOf("dubbo://127.0.0.1:9011/" + DemoService.class.getName() + "?client=mina").addParameter("timeout",
+        service = proxy.getProxy(protocol.refer(DemoService.class, URL.valueOf("dubbo://127.0.0.1:" + port + "/" + DemoService.class.getName() + "?client=mina").addParameter("timeout",
                 3000L)));
         // test netty client
         StringBuffer buf = new StringBuffer();
@@ -126,7 +130,7 @@ public class DubboProtocolTest {
         System.out.println(service.stringLength(buf.toString()));
 
         // cast to EchoService
-        EchoService echo = proxy.getProxy(protocol.refer(EchoService.class, URL.valueOf("dubbo://127.0.0.1:9011/" + DemoService.class.getName() + "?client=mina").addParameter("timeout",
+        EchoService echo = proxy.getProxy(protocol.refer(EchoService.class, URL.valueOf("dubbo://127.0.0.1:" + port + "/" + DemoService.class.getName() + "?client=mina").addParameter("timeout",
                 3000L)));
         for (int i = 0; i < 10; i++) {
             assertEquals(echo.$echo(buf.toString()), buf.toString());
@@ -144,8 +148,9 @@ public class DubboProtocolTest {
 //                3000L)));
 
         RemoteService remote = new RemoteServiceImpl();
-        protocol.export(proxy.getInvoker(remote, RemoteService.class, URL.valueOf("dubbo://127.0.0.1:9010/" + RemoteService.class.getName())));
-        remote = proxy.getProxy(protocol.refer(RemoteService.class, URL.valueOf("dubbo://127.0.0.1:9010/" + RemoteService.class.getName()).addParameter("timeout",
+        int port = NetUtils.getAvailablePort();
+        protocol.export(proxy.getInvoker(remote, RemoteService.class, URL.valueOf("dubbo://127.0.0.1:" + port + "/" + RemoteService.class.getName())));
+        remote = proxy.getProxy(protocol.refer(RemoteService.class, URL.valueOf("dubbo://127.0.0.1:" + port + "/" + RemoteService.class.getName()).addParameter("timeout",
                 3000L)));
 
 //        service.sayHello("world");
@@ -162,8 +167,9 @@ public class DubboProtocolTest {
     @Test
     public void testPerm() throws Exception {
         DemoService service = new DemoServiceImpl();
-        protocol.export(proxy.getInvoker(service, DemoService.class, URL.valueOf("dubbo://127.0.0.1:9050/" + DemoService.class.getName() + "?codec=exchange")));
-        service = proxy.getProxy(protocol.refer(DemoService.class, URL.valueOf("dubbo://127.0.0.1:9050/" + DemoService.class.getName() + "?codec=exchange").addParameter("timeout",
+        int port = NetUtils.getAvailablePort();
+        protocol.export(proxy.getInvoker(service, DemoService.class, URL.valueOf("dubbo://127.0.0.1:" + port + "/" + DemoService.class.getName() + "?codec=exchange")));
+        service = proxy.getProxy(protocol.refer(DemoService.class, URL.valueOf("dubbo://127.0.0.1:" + port + "/" + DemoService.class.getName() + "?codec=exchange").addParameter("timeout",
                 3000L)));
         long start = System.currentTimeMillis();
         for (int i = 0; i < 1000; i++)
@@ -174,8 +180,9 @@ public class DubboProtocolTest {
     @Test
     public void testNonSerializedParameter() throws Exception {
         DemoService service = new DemoServiceImpl();
-        protocol.export(proxy.getInvoker(service, DemoService.class, URL.valueOf("dubbo://127.0.0.1:9050/" + DemoService.class.getName() + "?codec=exchange")));
-        service = proxy.getProxy(protocol.refer(DemoService.class, URL.valueOf("dubbo://127.0.0.1:9050/" + DemoService.class.getName() + "?codec=exchange").addParameter("timeout",
+        int port = NetUtils.getAvailablePort();
+        protocol.export(proxy.getInvoker(service, DemoService.class, URL.valueOf("dubbo://127.0.0.1:" + port + "/" + DemoService.class.getName() + "?codec=exchange")));
+        service = proxy.getProxy(protocol.refer(DemoService.class, URL.valueOf("dubbo://127.0.0.1:" + port + "/" + DemoService.class.getName() + "?codec=exchange").addParameter("timeout",
                 3000L)));
         try {
             service.nonSerializedParameter(new NonSerialized());
@@ -188,8 +195,9 @@ public class DubboProtocolTest {
     @Test
     public void testReturnNonSerialized() throws Exception {
         DemoService service = new DemoServiceImpl();
-        protocol.export(proxy.getInvoker(service, DemoService.class, URL.valueOf("dubbo://127.0.0.1:9050/" + DemoService.class.getName() + "?codec=exchange")));
-        service = proxy.getProxy(protocol.refer(DemoService.class, URL.valueOf("dubbo://127.0.0.1:9050/" + DemoService.class.getName() + "?codec=exchange").addParameter("timeout",
+        int port = NetUtils.getAvailablePort();
+        protocol.export(proxy.getInvoker(service, DemoService.class, URL.valueOf("dubbo://127.0.0.1:" + port + "/" + DemoService.class.getName() + "?codec=exchange")));
+        service = proxy.getProxy(protocol.refer(DemoService.class, URL.valueOf("dubbo://127.0.0.1:" + port + "/" + DemoService.class.getName() + "?codec=exchange").addParameter("timeout",
                 3000L)));
         try {
             service.returnNonSerialized();
@@ -202,7 +210,8 @@ public class DubboProtocolTest {
     @Test
     public void testRemoteApplicationName() throws Exception {
         DemoService service = new DemoServiceImpl();
-        URL url = URL.valueOf("dubbo://127.0.0.1:9020/" + DemoService.class.getName() + "?codec=exchange").addParameter("timeout",
+        int port = NetUtils.getAvailablePort();
+        URL url = URL.valueOf("dubbo://127.0.0.1:" + port + "/" + DemoService.class.getName() + "?codec=exchange").addParameter("timeout",
                 3000L).addParameter("application", "consumer");
         protocol.export(proxy.getInvoker(service, DemoService.class, url));
         service = proxy.getProxy(protocol.refer(DemoService.class, url));

--- a/dubbo-rpc/dubbo-rpc-dubbo/src/test/java/org/apache/dubbo/rpc/protocol/dubbo/MultiThreadTest.java
+++ b/dubbo-rpc/dubbo-rpc-dubbo/src/test/java/org/apache/dubbo/rpc/protocol/dubbo/MultiThreadTest.java
@@ -18,6 +18,7 @@ package org.apache.dubbo.rpc.protocol.dubbo;
 
 import org.apache.dubbo.common.URL;
 import org.apache.dubbo.common.extension.ExtensionLoader;
+import org.apache.dubbo.common.utils.NetUtils;
 import org.apache.dubbo.rpc.Exporter;
 import org.apache.dubbo.rpc.Protocol;
 import org.apache.dubbo.rpc.ProxyFactory;
@@ -45,10 +46,11 @@ public class MultiThreadTest {
 
     @Test
     public void testDubboMultiThreadInvoke() throws Exception {
-        Exporter<?> rpcExporter = protocol.export(proxy.getInvoker(new DemoServiceImpl(), DemoService.class, URL.valueOf("dubbo://127.0.0.1:20259/TestService")));
+        int port = NetUtils.getAvailablePort();
+        Exporter<?> rpcExporter = protocol.export(proxy.getInvoker(new DemoServiceImpl(), DemoService.class, URL.valueOf("dubbo://127.0.0.1:" + port + "/TestService")));
 
         final AtomicInteger counter = new AtomicInteger();
-        final DemoService service = proxy.getProxy(protocol.refer(DemoService.class, URL.valueOf("dubbo://127.0.0.1:20259/TestService")));
+        final DemoService service = proxy.getProxy(protocol.refer(DemoService.class, URL.valueOf("dubbo://127.0.0.1:" + port + "/TestService")));
         Assertions.assertEquals(service.getSize(new String[]{"123", "456", "789"}), 3);
 
         final StringBuffer sb = new StringBuffer();

--- a/dubbo-rpc/dubbo-rpc-dubbo/src/test/java/org/apache/dubbo/rpc/protocol/dubbo/RpcFilterTest.java
+++ b/dubbo-rpc/dubbo-rpc-dubbo/src/test/java/org/apache/dubbo/rpc/protocol/dubbo/RpcFilterTest.java
@@ -18,6 +18,7 @@ package org.apache.dubbo.rpc.protocol.dubbo;
 
 import org.apache.dubbo.common.URL;
 import org.apache.dubbo.common.extension.ExtensionLoader;
+import org.apache.dubbo.common.utils.NetUtils;
 import org.apache.dubbo.rpc.Protocol;
 import org.apache.dubbo.rpc.ProxyFactory;
 import org.apache.dubbo.rpc.model.ApplicationModel;
@@ -42,7 +43,8 @@ public class RpcFilterTest {
     @Test
     public void testRpcFilter() throws Exception {
         DemoService service = new DemoServiceImpl();
-        URL url = URL.valueOf("dubbo://127.0.0.1:9010/org.apache.dubbo.rpc.protocol.dubbo.support.DemoService?service.filter=echo");
+        int port = NetUtils.getAvailablePort();
+        URL url = URL.valueOf("dubbo://127.0.0.1:" + port + "/org.apache.dubbo.rpc.protocol.dubbo.support.DemoService?service.filter=echo");
         ApplicationModel.getServiceRepository().registerService(DemoService.class);
         protocol.export(proxy.getInvoker(service, DemoService.class, url));
         service = proxy.getProxy(protocol.refer(DemoService.class, url));

--- a/dubbo-rpc/dubbo-rpc-dubbo/src/test/java/org/apache/dubbo/rpc/protocol/dubbo/support/DemoService.java
+++ b/dubbo-rpc/dubbo-rpc-dubbo/src/test/java/org/apache/dubbo/rpc/protocol/dubbo/support/DemoService.java
@@ -51,7 +51,7 @@ public interface DemoService {
 
     String get(CustomArgument arg1);
 
-    byte getbyte(byte arg);
+    int getInt(int arg);
 
     void nonSerializedParameter(NonSerialized ns);
 

--- a/dubbo-rpc/dubbo-rpc-dubbo/src/test/java/org/apache/dubbo/rpc/protocol/dubbo/support/DemoServiceImpl.java
+++ b/dubbo-rpc/dubbo-rpc-dubbo/src/test/java/org/apache/dubbo/rpc/protocol/dubbo/support/DemoServiceImpl.java
@@ -84,7 +84,7 @@ public class DemoServiceImpl implements DemoService {
         return arg1.toString();
     }
 
-    public byte getbyte(byte arg) {
+    public int getInt(int arg) {
         return arg;
     }
 

--- a/dubbo-rpc/dubbo-rpc-dubbo/src/test/java/org/apache/dubbo/rpc/protocol/dubbo/support/EnumBak.java
+++ b/dubbo-rpc/dubbo-rpc-dubbo/src/test/java/org/apache/dubbo/rpc/protocol/dubbo/support/EnumBak.java
@@ -106,7 +106,7 @@ public class EnumBak {
     @Disabled
     @Test
     public void testEnumCompat() {
-        int port = 20880;
+        int port = NetUtils.getAvailablePort();
         URL consumerurl = URL.valueOf("dubbo://127.0.0.1:" + port + "/test?timeout=" + Integer.MAX_VALUE
         );
         Invoker<DemoService> reference = protocol.refer(DemoService.class, consumerurl);
@@ -121,7 +121,7 @@ public class EnumBak {
     @Disabled
     @Test
     public void testGenricEnumCompat() {
-        int port = 20880;
+        int port = NetUtils.getAvailablePort();
         URL consumerurl = URL.valueOf("dubbo://127.0.0.1:" + port + "/test?timeout=" + Integer.MAX_VALUE
         );
         Invoker<GenericService> reference = protocol.refer(GenericService.class, consumerurl);
@@ -137,7 +137,7 @@ public class EnumBak {
     @Test
     public void testGenricCustomArg() {
 
-        int port = 20880;
+        int port = NetUtils.getAvailablePort();
         URL consumerurl = URL.valueOf("dubbo://127.0.0.1:" + port + "/test?timeout=2000000"
         );
         Invoker<GenericService> reference = protocol.refer(GenericService.class, consumerurl);
@@ -156,7 +156,7 @@ public class EnumBak {
     @Test
     public void testGenericExport() throws InterruptedException {
         int port = NetUtils.getAvailablePort();
-        port = 20880;
+        //port = 20880;
         URL serviceurl = URL.valueOf("dubbo://127.0.0.1:" + port + "/test?timeout=" + Integer.MAX_VALUE
         );
         DemoService demo = new DemoServiceImpl();

--- a/dubbo-rpc/dubbo-rpc-dubbo/src/test/java/org/apache/dubbo/rpc/protocol/dubbo/support/EnumBak.java
+++ b/dubbo-rpc/dubbo-rpc-dubbo/src/test/java/org/apache/dubbo/rpc/protocol/dubbo/support/EnumBak.java
@@ -52,8 +52,8 @@ public class EnumBak {
         Invoker<DemoService> reference = protocol.refer(DemoService.class, consumerurl);
         DemoService demoProxy = (DemoService) proxy.getProxy(reference);
 //        System.out.println(demoProxy.getThreadName());
-        System.out.println(demoProxy.getbyte((byte) -128));
-        Assertions.assertEquals((byte) -128, demoProxy.getbyte((byte) -128));
+        System.out.println(demoProxy.getInt(Integer.MIN_VALUE));
+        Assertions.assertEquals(Integer.MIN_VALUE, demoProxy.getInt(Integer.MIN_VALUE));
 
 //        invoker.destroy();
         reference.destroy();

--- a/dubbo-rpc/dubbo-rpc-hessian/src/test/java/org/apache/dubbo/rpc/protocol/hessian/HessianProtocolTest.java
+++ b/dubbo-rpc/dubbo-rpc-hessian/src/test/java/org/apache/dubbo/rpc/protocol/hessian/HessianProtocolTest.java
@@ -24,6 +24,7 @@ import org.apache.dubbo.common.serialize.ObjectInput;
 import org.apache.dubbo.common.serialize.ObjectOutput;
 import org.apache.dubbo.common.serialize.Serialization;
 import org.apache.dubbo.common.serialize.nativejava.NativeJavaSerialization;
+import org.apache.dubbo.common.utils.NetUtils;
 import org.apache.dubbo.rpc.Exporter;
 import org.apache.dubbo.rpc.Invoker;
 import org.apache.dubbo.rpc.Protocol;
@@ -53,7 +54,8 @@ public class HessianProtocolTest {
         Assertions.assertFalse(server.isCalled());
         ProxyFactory proxyFactory = ExtensionLoader.getExtensionLoader(ProxyFactory.class).getAdaptiveExtension();
         Protocol protocol = ExtensionLoader.getExtensionLoader(Protocol.class).getAdaptiveExtension();
-        URL url = URL.valueOf("hessian://127.0.0.1:5342/" + HessianService.class.getName() + "?version=1.0.0&hessian.overload.method=true");
+        int port = NetUtils.getAvailablePort();
+        URL url = URL.valueOf("hessian://127.0.0.1:" + port + "/" + HessianService.class.getName() + "?version=1.0.0&hessian.overload.method=true");
         Exporter<HessianService> exporter = protocol.export(proxyFactory.getInvoker(server, HessianService.class, url));
         Invoker<HessianService> invoker = protocol.refer(HessianService.class, url);
         HessianService client = proxyFactory.getProxy(invoker);
@@ -70,7 +72,8 @@ public class HessianProtocolTest {
         Assertions.assertFalse(server.isCalled());
         ProxyFactory proxyFactory = ExtensionLoader.getExtensionLoader(ProxyFactory.class).getAdaptiveExtension();
         Protocol protocol = ExtensionLoader.getExtensionLoader(Protocol.class).getAdaptiveExtension();
-        URL url = URL.valueOf("hessian://127.0.0.1:5342/" + HessianService.class.getName() + "?version=1.0.0");
+        int port = NetUtils.getAvailablePort();
+        URL url = URL.valueOf("hessian://127.0.0.1:" + port + "/" + HessianService.class.getName() + "?version=1.0.0");
         Exporter<HessianService> exporter = protocol.export(proxyFactory.getInvoker(server, HessianService.class, url));
         Invoker<GenericService> invoker = protocol.refer(GenericService.class, url);
         GenericService client = proxyFactory.getProxy(invoker, true);
@@ -87,7 +90,8 @@ public class HessianProtocolTest {
         Assertions.assertFalse(server.isCalled());
         ProxyFactory proxyFactory = ExtensionLoader.getExtensionLoader(ProxyFactory.class).getAdaptiveExtension();
         Protocol protocol = ExtensionLoader.getExtensionLoader(Protocol.class).getAdaptiveExtension();
-        URL url = URL.valueOf("hessian://127.0.0.1:5342/" + HessianService.class.getName() + "?version=1.0.0&generic=nativejava");
+        int port = NetUtils.getAvailablePort();
+        URL url = URL.valueOf("hessian://127.0.0.1:" + port + "/" + HessianService.class.getName() + "?version=1.0.0&generic=nativejava");
         Exporter<HessianService> exporter = protocol.export(proxyFactory.getInvoker(server, HessianService.class, url));
         Invoker<GenericService> invoker = protocol.refer(GenericService.class, url);
         GenericService client = proxyFactory.getProxy(invoker);
@@ -115,7 +119,8 @@ public class HessianProtocolTest {
         HessianServiceImpl server = new HessianServiceImpl();
         ProxyFactory proxyFactory = ExtensionLoader.getExtensionLoader(ProxyFactory.class).getAdaptiveExtension();
         Protocol protocol = ExtensionLoader.getExtensionLoader(Protocol.class).getAdaptiveExtension();
-        URL url = URL.valueOf("hessian://127.0.0.1:5342/" + HessianService.class.getName() + "?version=1.0.0");
+        int port = NetUtils.getAvailablePort();
+        URL url = URL.valueOf("hessian://127.0.0.1:" + port + "/" + HessianService.class.getName() + "?version=1.0.0");
         Exporter<HessianService> exporter = protocol.export(proxyFactory.getInvoker(server, HessianService.class, url));
         Invoker<GenericService> invoker = protocol.refer(GenericService.class, url);
         GenericService client = proxyFactory.getProxy(invoker, true);
@@ -131,7 +136,8 @@ public class HessianProtocolTest {
         Assertions.assertFalse(server.isCalled());
         ProxyFactory proxyFactory = ExtensionLoader.getExtensionLoader(ProxyFactory.class).getAdaptiveExtension();
         Protocol protocol = ExtensionLoader.getExtensionLoader(Protocol.class).getAdaptiveExtension();
-        URL url = URL.valueOf("hessian://127.0.0.1:5342/" + HessianService.class.getName() + "?version=1.0.0&generic=bean");
+        int port = NetUtils.getAvailablePort();
+        URL url = URL.valueOf("hessian://127.0.0.1:" + port + "/" + HessianService.class.getName() + "?version=1.0.0&generic=bean");
         Exporter<HessianService> exporter = protocol.export(proxyFactory.getInvoker(server, HessianService.class, url));
         Invoker<GenericService> invoker = protocol.refer(GenericService.class, url);
         GenericService client = proxyFactory.getProxy(invoker);
@@ -151,7 +157,8 @@ public class HessianProtocolTest {
         Assertions.assertFalse(server.isCalled());
         ProxyFactory proxyFactory = ExtensionLoader.getExtensionLoader(ProxyFactory.class).getAdaptiveExtension();
         Protocol protocol = ExtensionLoader.getExtensionLoader(Protocol.class).getAdaptiveExtension();
-        URL url = URL.valueOf("hessian://127.0.0.1:5342/" + HessianService.class.getName() + "?version=1.0.0&hessian.overload.method=true&hessian2.request=false");
+        int port = NetUtils.getAvailablePort();
+        URL url = URL.valueOf("hessian://127.0.0.1:" + port + "/" + HessianService.class.getName() + "?version=1.0.0&hessian.overload.method=true&hessian2.request=false");
         Exporter<HessianService> exporter = protocol.export(proxyFactory.getInvoker(server, HessianService.class, url));
         Invoker<HessianService> invoker = protocol.refer(HessianService.class, url);
         HessianService client = proxyFactory.getProxy(invoker);
@@ -169,7 +176,8 @@ public class HessianProtocolTest {
         Assertions.assertFalse(server.isCalled());
         ProxyFactory proxyFactory = ExtensionLoader.getExtensionLoader(ProxyFactory.class).getAdaptiveExtension();
         Protocol protocol = ExtensionLoader.getExtensionLoader(Protocol.class).getAdaptiveExtension();
-        URL url = URL.valueOf("hessian://127.0.0.1:5342/" + HessianService.class.getName() + "?version=1.0.0&client=httpclient&hessian.overload.method=true");
+        int port = NetUtils.getAvailablePort();
+        URL url = URL.valueOf("hessian://127.0.0.1:" + port + "/" + HessianService.class.getName() + "?version=1.0.0&client=httpclient&hessian.overload.method=true");
         Exporter<HessianService> exporter = protocol.export(proxyFactory.getInvoker(server, HessianService.class, url));
         Invoker<HessianService> invoker = protocol.refer(HessianService.class, url);
         HessianService client = proxyFactory.getProxy(invoker);
@@ -185,7 +193,8 @@ public class HessianProtocolTest {
         HessianServiceImpl server = new HessianServiceImpl();
         ProxyFactory proxyFactory = ExtensionLoader.getExtensionLoader(ProxyFactory.class).getAdaptiveExtension();
         Protocol protocol = ExtensionLoader.getExtensionLoader(Protocol.class).getAdaptiveExtension();
-        URL url = URL.valueOf("hessian://127.0.0.1:5342/" + HessianService.class.getName() + "?version=1.0.0&timeout=10");
+        int port = NetUtils.getAvailablePort();
+        URL url = URL.valueOf("hessian://127.0.0.1:" + port + "/" + HessianService.class.getName() + "?version=1.0.0&timeout=10");
         Exporter<HessianService> exporter = protocol.export(proxyFactory.getInvoker(server, HessianService.class, url));
         Invoker<HessianService> invoker = protocol.refer(HessianService.class, url);
         HessianService client = proxyFactory.getProxy(invoker);
@@ -206,7 +215,8 @@ public class HessianProtocolTest {
         HessianServiceImpl server = new HessianServiceImpl();
         ProxyFactory proxyFactory = ExtensionLoader.getExtensionLoader(ProxyFactory.class).getAdaptiveExtension();
         Protocol protocol = ExtensionLoader.getExtensionLoader(Protocol.class).getAdaptiveExtension();
-        URL url = URL.valueOf("hessian://127.0.0.1:5342/" + HessianService.class.getName() + "?version=1.0.0");
+        int port = NetUtils.getAvailablePort();
+        URL url = URL.valueOf("hessian://127.0.0.1:" + port + "/" + HessianService.class.getName() + "?version=1.0.0");
         Exporter<HessianService> exporter = protocol.export(proxyFactory.getInvoker(server, HessianService.class, url));
         Invoker<HessianService> invoker = protocol.refer(HessianService.class, url);
         HessianService client = proxyFactory.getProxy(invoker);
@@ -226,7 +236,8 @@ public class HessianProtocolTest {
         HessianServiceImpl server = new HessianServiceImpl();
         ProxyFactory proxyFactory = ExtensionLoader.getExtensionLoader(ProxyFactory.class).getAdaptiveExtension();
         Protocol protocol = ExtensionLoader.getExtensionLoader(Protocol.class).getAdaptiveExtension();
-        URL url = URL.valueOf("hessian://127.0.0.1:5342/" + HessianService.class.getName() + "?version=1.0.0&hessian.overload.method=true").addParameter("application", "consumer");
+        int port = NetUtils.getAvailablePort();
+        URL url = URL.valueOf("hessian://127.0.0.1:" + port + "/" + HessianService.class.getName() + "?version=1.0.0&hessian.overload.method=true").addParameter("application", "consumer");
         Exporter<HessianService> exporter = protocol.export(proxyFactory.getInvoker(server, HessianService.class, url));
         Invoker<HessianService> invoker = protocol.refer(HessianService.class, url);
         HessianService client = proxyFactory.getProxy(invoker);

--- a/dubbo-rpc/dubbo-rpc-http/src/test/java/org/apache/dubbo/rpc/protocol/http/HttpProtocolTest.java
+++ b/dubbo-rpc/dubbo-rpc-http/src/test/java/org/apache/dubbo/rpc/protocol/http/HttpProtocolTest.java
@@ -19,6 +19,7 @@ package org.apache.dubbo.rpc.protocol.http;
 
 import org.apache.dubbo.common.URL;
 import org.apache.dubbo.common.extension.ExtensionLoader;
+import org.apache.dubbo.common.utils.NetUtils;
 import org.apache.dubbo.rpc.Exporter;
 import org.apache.dubbo.rpc.Invoker;
 import org.apache.dubbo.rpc.Protocol;
@@ -40,7 +41,8 @@ public class HttpProtocolTest {
         assertFalse(server.isCalled());
         ProxyFactory proxyFactory = ExtensionLoader.getExtensionLoader(ProxyFactory.class).getAdaptiveExtension();
         Protocol protocol = ExtensionLoader.getExtensionLoader(Protocol.class).getAdaptiveExtension();
-        URL url = URL.valueOf("http://127.0.0.1:5342/" + HttpService.class.getName() + "?version=1.0.0");
+        int port = NetUtils.getAvailablePort();
+        URL url = URL.valueOf("http://127.0.0.1:" + port + "/" + HttpService.class.getName() + "?version=1.0.0");
         Exporter<HttpService> exporter = protocol.export(proxyFactory.getInvoker(server, HttpService.class, url));
         Invoker<HttpService> invoker = protocol.refer(HttpService.class, url);
         HttpService client = proxyFactory.getProxy(invoker);
@@ -57,7 +59,8 @@ public class HttpProtocolTest {
         assertFalse(server.isCalled());
         ProxyFactory proxyFactory = ExtensionLoader.getExtensionLoader(ProxyFactory.class).getAdaptiveExtension();
         Protocol protocol = ExtensionLoader.getExtensionLoader(Protocol.class).getAdaptiveExtension();
-        URL url = URL.valueOf("http://127.0.0.1:5342/" + HttpService.class.getName() + "?version=1.0.0&server=jetty");
+        int port = NetUtils.getAvailablePort();
+        URL url = URL.valueOf("http://127.0.0.1:" + port + "/" + HttpService.class.getName() + "?version=1.0.0&server=jetty");
         Exporter<HttpService> exporter = protocol.export(proxyFactory.getInvoker(server, HttpService.class, url));
         Invoker<HttpService> invoker = protocol.refer(HttpService.class, url);
         HttpService client = proxyFactory.getProxy(invoker);
@@ -74,7 +77,8 @@ public class HttpProtocolTest {
         Assertions.assertFalse(server.isCalled());
         ProxyFactory proxyFactory = ExtensionLoader.getExtensionLoader(ProxyFactory.class).getAdaptiveExtension();
         Protocol protocol = ExtensionLoader.getExtensionLoader(Protocol.class).getAdaptiveExtension();
-        URL url = URL.valueOf("http://127.0.0.1:5342/" + HttpService.class.getName() + "?release=2.7.0");
+        int port = NetUtils.getAvailablePort();
+        URL url = URL.valueOf("http://127.0.0.1:" + port + "/" + HttpService.class.getName() + "?release=2.7.0");
         Exporter<HttpService> exporter = protocol.export(proxyFactory.getInvoker(server, HttpService.class, url));
         Invoker<GenericService> invoker = protocol.refer(GenericService.class, url);
         GenericService client = proxyFactory.getProxy(invoker, true);

--- a/dubbo-rpc/dubbo-rpc-native-thrift/src/test/java/org/apache/dubbo/rpc/protocol/nativethrift/ThriftProtocolTest.java
+++ b/dubbo-rpc/dubbo-rpc-native-thrift/src/test/java/org/apache/dubbo/rpc/protocol/nativethrift/ThriftProtocolTest.java
@@ -19,6 +19,7 @@ package org.apache.dubbo.rpc.protocol.nativethrift;
 
 import org.apache.dubbo.common.URL;
 import org.apache.dubbo.common.extension.ExtensionLoader;
+import org.apache.dubbo.common.utils.NetUtils;
 import org.apache.dubbo.rpc.Exporter;
 import org.apache.dubbo.rpc.Invoker;
 import org.apache.dubbo.rpc.Protocol;
@@ -34,11 +35,12 @@ import org.junit.jupiter.api.Test;
 public class ThriftProtocolTest {
 
     @Test
-    public void testThriftProtocol() throws TException{
+    public void testThriftProtocol() throws TException {
         DemoServiceImpl server = new DemoServiceImpl();
         ProxyFactory proxyFactory = ExtensionLoader.getExtensionLoader(ProxyFactory.class).getAdaptiveExtension();
         Protocol protocol = ExtensionLoader.getExtensionLoader(Protocol.class).getAdaptiveExtension();
-        URL url = URL.valueOf(org.apache.dubbo.rpc.protocol.nativethrift.ThriftProtocol.NAME + "://127.0.0.1:5341/" + DemoService.Iface.class.getName() + "?version=1.0.0&nativethrift.overload.method=true");
+        int port = NetUtils.getAvailablePort();
+        URL url = URL.valueOf(org.apache.dubbo.rpc.protocol.nativethrift.ThriftProtocol.NAME + "://127.0.0.1:" + port + "/" + DemoService.Iface.class.getName() + "?version=1.0.0&nativethrift.overload.method=true");
         Exporter<DemoService.Iface> exporter = protocol.export(proxyFactory.getInvoker(server, DemoService.Iface.class, url));
         Invoker<DemoService.Iface> invoker = protocol.refer(DemoService.Iface.class, url);
         DemoService.Iface client = proxyFactory.getProxy(invoker);
@@ -50,13 +52,14 @@ public class ThriftProtocolTest {
     }
 
     @Test
-    public void testThriftProtocolMultipleServices() throws TException{
+    public void testThriftProtocolMultipleServices() throws TException {
 
         ProxyFactory proxyFactory = ExtensionLoader.getExtensionLoader(ProxyFactory.class).getAdaptiveExtension();
         Protocol protocol = ExtensionLoader.getExtensionLoader(Protocol.class).getAdaptiveExtension();
 
         DemoServiceImpl server1 = new DemoServiceImpl();
-        URL url1 = URL.valueOf(org.apache.dubbo.rpc.protocol.nativethrift.ThriftProtocol.NAME + "://127.0.0.1:5342/" + DemoService.Iface.class.getName() + "?version=1.0.0&nativethrift.overload.method=true");
+        int port = NetUtils.getAvailablePort();
+        URL url1 = URL.valueOf(org.apache.dubbo.rpc.protocol.nativethrift.ThriftProtocol.NAME + "://127.0.0.1:" + port + "/" + DemoService.Iface.class.getName() + "?version=1.0.0&nativethrift.overload.method=true");
         Exporter<DemoService.Iface> exporter1 = protocol.export(proxyFactory.getInvoker(server1, DemoService.Iface.class, url1));
         Invoker<DemoService.Iface> invoker1 = protocol.refer(DemoService.Iface.class, url1);
         DemoService.Iface client1 = proxyFactory.getProxy(invoker1);
@@ -65,7 +68,7 @@ public class ThriftProtocolTest {
         Assertions.assertEquals("Hello, haha", result1);
 
         UserServiceImpl server2 = new UserServiceImpl();
-        URL url2 = URL.valueOf(org.apache.dubbo.rpc.protocol.nativethrift.ThriftProtocol.NAME + "://127.0.0.1:5342/" + UserService.Iface.class.getName() + "?version=1.0.0&nativethrift.overload.method=true");
+        URL url2 = URL.valueOf(org.apache.dubbo.rpc.protocol.nativethrift.ThriftProtocol.NAME + "://127.0.0.1:" + NetUtils.getAvailablePort() + "/" + UserService.Iface.class.getName() + "?version=1.0.0&nativethrift.overload.method=true");
         Exporter<UserService.Iface> exporter2 = protocol.export(proxyFactory.getInvoker(server2, UserService.Iface.class, url2));
         Invoker<UserService.Iface> invoker2 = protocol.refer(UserService.Iface.class, url2);
         UserService.Iface client2 = proxyFactory.getProxy(invoker2);

--- a/dubbo-rpc/dubbo-rpc-redis/pom.xml
+++ b/dubbo-rpc/dubbo-rpc-redis/pom.xml
@@ -50,5 +50,10 @@
             <version>${project.parent.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/dubbo-rpc/dubbo-rpc-redis/src/test/java/org/apache/dubbo/rpc/protocol/redis/RedisProtocolTest.java
+++ b/dubbo-rpc/dubbo-rpc-redis/src/test/java/org/apache/dubbo/rpc/protocol/redis/RedisProtocolTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.dubbo.rpc.protocol.redis;
 
+import org.apache.commons.lang3.SystemUtils;
 import org.apache.dubbo.common.URL;
 import org.apache.dubbo.common.extension.ExtensionLoader;
 import org.apache.dubbo.common.serialize.ObjectInput;
@@ -59,7 +60,7 @@ public class RedisProtocolTest {
         if ("testAuthRedis".equals(methodName) || ("testWrongAuthRedis".equals(methodName))) {
             String password = "123456";
             RedisServerBuilder builder = RedisServer.builder().port(redisPort).setting("requirepass " + password);
-            if (isWindowsPlatform()) {
+            if (SystemUtils.IS_OS_WINDOWS) {
                 // set maxheap to fix Windows error 0x70 while starting redis
                 builder.setting("maxheap 128mb");
             }
@@ -67,7 +68,7 @@ public class RedisProtocolTest {
             this.registryUrl = URL.valueOf("redis://username:" + password + "@localhost:" + redisPort + "?db.index=0");
         } else {
             RedisServerBuilder builder = RedisServer.builder().port(redisPort);
-            if (isWindowsPlatform()) {
+            if (SystemUtils.IS_OS_WINDOWS) {
                 // set maxheap to fix Windows error 0x70 while starting redis
                 builder.setting("maxheap 128mb");
             }
@@ -81,11 +82,6 @@ public class RedisProtocolTest {
     public void tearDown() {
         this.redisServer.stop();
     }
-
-    private boolean isWindowsPlatform() {
-        return System.getProperty("os.name").toLowerCase().contains("windows");
-    }
-
     @Test
     public void testReferClass() {
         Invoker<IDemoService> refer = protocol.refer(IDemoService.class, registryUrl);

--- a/dubbo-rpc/dubbo-rpc-rest/src/test/java/org/apache/dubbo/rpc/protocol/rest/RestProtocolTest.java
+++ b/dubbo-rpc/dubbo-rpc-rest/src/test/java/org/apache/dubbo/rpc/protocol/rest/RestProtocolTest.java
@@ -59,7 +59,7 @@ public class RestProtocolTest {
 
     @Test
     public void testRestProtocol() {
-        URL url = URL.valueOf("rest://127.0.0.1:5342/rest/say?version=1.0.0&interface=org.apache.dubbo.rpc.protocol.rest.DemoService");
+        URL url = URL.valueOf("rest://127.0.0.1:" + NetUtils.getAvailablePort() + "/rest/say?version=1.0.0&interface=org.apache.dubbo.rpc.protocol.rest.DemoService");
         DemoServiceImpl server = new DemoServiceImpl();
 
         this.registerProvider(url, server, DemoService.class);
@@ -80,7 +80,8 @@ public class RestProtocolTest {
     public void testRestProtocolWithContextPath() {
         DemoServiceImpl server = new DemoServiceImpl();
         Assertions.assertFalse(server.isCalled());
-        URL url = URL.valueOf("rest://127.0.0.1:5341/a/b/c?version=1.0.0&interface=org.apache.dubbo.rpc.protocol.rest.DemoService");
+        int port = NetUtils.getAvailablePort();
+        URL url = URL.valueOf("rest://127.0.0.1:" + port + "/a/b/c?version=1.0.0&interface=org.apache.dubbo.rpc.protocol.rest.DemoService");
 
         this.registerProvider(url, server, DemoService.class);
 
@@ -95,7 +96,7 @@ public class RestProtocolTest {
 
         Exporter<DemoService> exporter = protocol.export(proxy.getInvoker(server, DemoService.class, url));
 
-        url = URL.valueOf("rest://127.0.0.1:5341/a/b/c/?version=1.0.0&interface=org.apache.dubbo.rpc.protocol.rest.DemoService");
+        url = URL.valueOf("rest://127.0.0.1:" + port + "/a/b/c/?version=1.0.0&interface=org.apache.dubbo.rpc.protocol.rest.DemoService");
         Invoker<DemoService> invoker = protocol.refer(DemoService.class, url);
         DemoService client = proxy.getProxy(invoker);
         String result = client.sayHello("haha");
@@ -253,7 +254,7 @@ public class RestProtocolTest {
 
     @Test
     public void testRemoteApplicationName() {
-        URL url = URL.valueOf("rest://127.0.0.1:5342/rest/say?version=1.0.0&interface=org.apache.dubbo.rpc.protocol.rest.DemoService").addParameter("application","consumer");
+        URL url = URL.valueOf("rest://127.0.0.1:" + NetUtils.getAvailablePort() + "/rest/say?version=1.0.0&interface=org.apache.dubbo.rpc.protocol.rest.DemoService").addParameter("application", "consumer");
         DemoServiceImpl server = new DemoServiceImpl();
 
         this.registerProvider(url, server, DemoService.class);

--- a/dubbo-rpc/dubbo-rpc-rmi/src/test/java/org/apache/dubbo/rpc/protocol/rmi/RmiProtocolTest.java
+++ b/dubbo-rpc/dubbo-rpc-rmi/src/test/java/org/apache/dubbo/rpc/protocol/rmi/RmiProtocolTest.java
@@ -19,6 +19,7 @@ package org.apache.dubbo.rpc.protocol.rmi;
 
 import org.apache.dubbo.common.URL;
 import org.apache.dubbo.common.extension.ExtensionLoader;
+import org.apache.dubbo.common.utils.NetUtils;
 import org.apache.dubbo.rpc.Exporter;
 import org.apache.dubbo.rpc.Invoker;
 import org.apache.dubbo.rpc.Protocol;
@@ -37,6 +38,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class RmiProtocolTest {
     private Protocol protocol = ExtensionLoader.getExtensionLoader(Protocol.class).getAdaptiveExtension();
     private ProxyFactory proxy = ExtensionLoader.getExtensionLoader(ProxyFactory.class).getAdaptiveExtension();
+    int availablePort = NetUtils.getAvailablePort();
 
     /*
     @Test
@@ -49,8 +51,8 @@ public class RmiProtocolTest {
     public void testRmiProtocolTimeout() throws Exception {
         System.setProperty("sun.rmi.transport.tcp.responseTimeout", "1000");
         DemoService service = new DemoServiceImpl();
-        Exporter<?> rpcExporter = protocol.export(proxy.getInvoker(service, DemoService.class, URL.valueOf("rmi://127.0.0.1:9001/TestService")));
-        service = proxy.getProxy(protocol.refer(DemoService.class, URL.valueOf("rmi://127.0.0.1:9001/TestService")));
+        Exporter<?> rpcExporter = protocol.export(proxy.getInvoker(service, DemoService.class, URL.valueOf("rmi://127.0.0.1:" + availablePort + "/TestService")));
+        service = proxy.getProxy(protocol.refer(DemoService.class, URL.valueOf("rmi://127.0.0.1:" + availablePort + "/TestService")));
         try {
             try {
                 service.throwTimeout();
@@ -67,22 +69,23 @@ public class RmiProtocolTest {
     public void testRmiProtocol() throws Exception {
         {
             DemoService service = new DemoServiceImpl();
-            Exporter<?> rpcExporter = protocol.export(proxy.getInvoker(service, DemoService.class, URL.valueOf("rmi://127.0.0.1:9001/TestService")));
+            Exporter<?> rpcExporter = protocol.export(proxy.getInvoker(service, DemoService.class, URL.valueOf("rmi://127.0.0.1:" + availablePort + "/TestService")));
 
-            service = proxy.getProxy(protocol.refer(DemoService.class, URL.valueOf("rmi://127.0.0.1:9001/TestService")));
+            service = proxy.getProxy(protocol.refer(DemoService.class, URL.valueOf("rmi://127.0.0.1:" + availablePort + "/TestService")));
             assertEquals(service.getSize(null), -1);
             assertEquals(service.getSize(new String[]{"", "", ""}), 3);
-            Object result = service.invoke("rmi://127.0.0.1:9001/TestService", "invoke");
-            assertEquals("rmi://127.0.0.1:9001/TestService:invoke", result);
+            Object result = service.invoke("rmi://127.0.0.1:" + availablePort + "/TestService", "invoke");
+            assertEquals("rmi://127.0.0.1:" + availablePort + "/TestService:invoke", result);
 
             rpcExporter.unexport();
         }
 
         {
+            int port = NetUtils.getAvailablePort();
             RemoteService remoteService = new RemoteServiceImpl();
-            Exporter<?> rpcExporter = protocol.export(proxy.getInvoker(remoteService, RemoteService.class, URL.valueOf("rmi://127.0.0.1:9002/remoteService")));
+            Exporter<?> rpcExporter = protocol.export(proxy.getInvoker(remoteService, RemoteService.class, URL.valueOf("rmi://127.0.0.1:" + port + "/remoteService")));
 
-            remoteService = proxy.getProxy(protocol.refer(RemoteService.class, URL.valueOf("rmi://127.0.0.1:9002/remoteService")));
+            remoteService = proxy.getProxy(protocol.refer(RemoteService.class, URL.valueOf("rmi://127.0.0.1:" + port + "/remoteService")));
             remoteService.getThreadName();
             for (int i = 0; i < 100; i++) {
                 String say = remoteService.sayHello("abcd");
@@ -97,10 +100,10 @@ public class RmiProtocolTest {
     @Test
     public void testRmiProtocol_echoService() throws Exception {
         DemoService service = new DemoServiceImpl();
-        Exporter<?> rpcExporter = protocol.export(proxy.getInvoker(service, DemoService.class, URL.valueOf("rmi://127.0.0.1:9002/TestService")));
+        Exporter<?> rpcExporter = protocol.export(proxy.getInvoker(service, DemoService.class, URL.valueOf("rmi://127.0.0.1:" + availablePort + "/TestService")));
 
         // cast to EchoService
-        EchoService echo = proxy.getProxy(protocol.refer(EchoService.class, URL.valueOf("rmi://127.0.0.1:9002/TestService")));
+        EchoService echo = proxy.getProxy(protocol.refer(EchoService.class, URL.valueOf("rmi://127.0.0.1:" + availablePort + "/TestService")));
         assertEquals(echo.$echo("test"), "test");
         assertEquals(echo.$echo("abcdefg"), "abcdefg");
         assertEquals(echo.$echo(1234), 1234);
@@ -108,10 +111,10 @@ public class RmiProtocolTest {
         rpcExporter.unexport();
 
         RemoteService remoteService = new RemoteServiceImpl();
-        rpcExporter = protocol.export(proxy.getInvoker(remoteService, RemoteService.class, URL.valueOf("rmi://127.0.0.1:9002/remoteService")));
+        rpcExporter = protocol.export(proxy.getInvoker(remoteService, RemoteService.class, URL.valueOf("rmi://127.0.0.1:" + availablePort + "/remoteService")));
 
         // cast to EchoService
-        echo = proxy.getProxy(protocol.refer(EchoService.class, URL.valueOf("rmi://127.0.0.1:9002/remoteService")));
+        echo = proxy.getProxy(protocol.refer(EchoService.class, URL.valueOf("rmi://127.0.0.1:" + availablePort + "/remoteService")));
         assertEquals(echo.$echo("test"), "test");
         assertEquals(echo.$echo("abcdefg"), "abcdefg");
         assertEquals(echo.$echo(1234), 1234);
@@ -122,7 +125,7 @@ public class RmiProtocolTest {
     @Test
     public void testGenericInvoke() {
         DemoService service = new DemoServiceImpl();
-        URL url = URL.valueOf("rmi://127.0.0.1:9003/" + DemoService.class.getName() + "?release=2.7.0");
+        URL url = URL.valueOf("rmi://127.0.0.1:" + availablePort + "/" + DemoService.class.getName() + "?release=2.7.0");
         Exporter<DemoService> exporter = protocol.export(proxy.getInvoker(service, DemoService.class, url));
         Invoker<GenericService> invoker = protocol.refer(GenericService.class, url);
         GenericService client = proxy.getProxy(invoker, true);
@@ -136,7 +139,7 @@ public class RmiProtocolTest {
     @Test
     public void testRemoteApplicationName() throws Exception {
         DemoService service = new DemoServiceImpl();
-        URL url = URL.valueOf("rmi://127.0.0.1:9001/TestService?release=2.7.0").addParameter("application", "consumer");
+        URL url = URL.valueOf("rmi://127.0.0.1:" + availablePort + "/TestService?release=2.7.0").addParameter("application", "consumer");
         Exporter<?> rpcExporter = protocol.export(proxy.getInvoker(service, DemoService.class, url));
 
         service = proxy.getProxy(protocol.refer(DemoService.class, url));

--- a/dubbo-rpc/dubbo-rpc-thrift/src/test/java/org/apache/dubbo/rpc/protocol/thrift/ThriftCodecTest.java
+++ b/dubbo-rpc/dubbo-rpc-thrift/src/test/java/org/apache/dubbo/rpc/protocol/thrift/ThriftCodecTest.java
@@ -17,6 +17,7 @@
 package org.apache.dubbo.rpc.protocol.thrift;
 
 import org.apache.dubbo.common.URL;
+import org.apache.dubbo.common.utils.NetUtils;
 import org.apache.dubbo.remoting.Channel;
 import org.apache.dubbo.remoting.buffer.ChannelBuffer;
 import org.apache.dubbo.remoting.buffer.ChannelBuffers;
@@ -125,7 +126,8 @@ public class ThriftCodecTest {
     @Test
     public void testDecodeReplyResponse() throws Exception {
 
-        URL url = URL.valueOf(ThriftProtocol.NAME + "://127.0.0.1:40880/" + Demo.Iface.class.getName());
+        int port = NetUtils.getAvailablePort();
+        URL url = URL.valueOf(ThriftProtocol.NAME + "://127.0.0.1:" + port + "/" + Demo.Iface.class.getName());
 
         Channel channel = new MockedChannel(url);
 
@@ -202,7 +204,8 @@ public class ThriftCodecTest {
     @Test
     public void testDecodeExceptionResponse() throws Exception {
 
-        URL url = URL.valueOf(ThriftProtocol.NAME + "://127.0.0.1:40880/" + Demo.class.getName());
+        int port = NetUtils.getAvailablePort();
+        URL url = URL.valueOf(ThriftProtocol.NAME + "://127.0.0.1:" + port + "/" + Demo.class.getName());
 
         Channel channel = new MockedChannel(url);
 
@@ -272,7 +275,8 @@ public class ThriftCodecTest {
     @Test
     public void testEncodeReplyResponse() throws Exception {
 
-        URL url = URL.valueOf(ThriftProtocol.NAME + "://127.0.0.1:40880/" + Demo.Iface.class.getName());
+        int port = NetUtils.getAvailablePort();
+        URL url = URL.valueOf(ThriftProtocol.NAME + "://127.0.0.1:" + port + "/" + Demo.Iface.class.getName());
 
         Channel channel = new MockedChannel(url);
 
@@ -330,7 +334,8 @@ public class ThriftCodecTest {
     @Test
     public void testEncodeExceptionResponse() throws Exception {
 
-        URL url = URL.valueOf(ThriftProtocol.NAME + "://127.0.0.1:40880/" + Demo.Iface.class.getName());
+        int port = NetUtils.getAvailablePort();
+        URL url = URL.valueOf(ThriftProtocol.NAME + "://127.0.0.1:" + port + "/" + Demo.Iface.class.getName());
 
         Channel channel = new MockedChannel(url);
 

--- a/dubbo-rpc/dubbo-rpc-webservice/src/test/java/org/apache/dubbo/rpc/protocol/webservice/WebserviceProtocolTest.java
+++ b/dubbo-rpc/dubbo-rpc-webservice/src/test/java/org/apache/dubbo/rpc/protocol/webservice/WebserviceProtocolTest.java
@@ -18,6 +18,7 @@ package org.apache.dubbo.rpc.protocol.webservice;
 
 import org.apache.dubbo.common.URL;
 import org.apache.dubbo.common.extension.ExtensionLoader;
+import org.apache.dubbo.common.utils.NetUtils;
 import org.apache.dubbo.rpc.Exporter;
 import org.apache.dubbo.rpc.Protocol;
 import org.apache.dubbo.rpc.ProxyFactory;
@@ -38,8 +39,9 @@ public class WebserviceProtocolTest {
     @Test
     public void testDemoProtocol() throws Exception {
         DemoService service = new DemoServiceImpl();
-        Exporter<DemoService> exporter = protocol.export(proxy.getInvoker(service, DemoService.class, URL.valueOf("webservice://127.0.0.1:9019/" + DemoService.class.getName() + "?codec=exchange")));
-        service = proxy.getProxy(protocol.refer(DemoService.class, URL.valueOf("webservice://127.0.0.1:9019/" + DemoService.class.getName() + "?codec=exchange&timeout=3000")));
+        int port = NetUtils.getAvailablePort();
+        Exporter<DemoService> exporter = protocol.export(proxy.getInvoker(service, DemoService.class, URL.valueOf("webservice://127.0.0.1:" + port + "/" + DemoService.class.getName() + "?codec=exchange")));
+        service = proxy.getProxy(protocol.refer(DemoService.class, URL.valueOf("webservice://127.0.0.1:" + port + "/" + DemoService.class.getName() + "?codec=exchange&timeout=3000")));
         assertEquals(service.getSize(new String[]{"", "", ""}), 3);
         exporter.unexport();
     }
@@ -47,14 +49,15 @@ public class WebserviceProtocolTest {
     @Test
     public void testWebserviceProtocol() throws Exception {
         DemoService service = new DemoServiceImpl();
-        protocol.export(proxy.getInvoker(service, DemoService.class, URL.valueOf("webservice://127.0.0.1:9019/" + DemoService.class.getName())));
-        service = proxy.getProxy(protocol.refer(DemoService.class, URL.valueOf("webservice://127.0.0.1:9019/" + DemoService.class.getName() + "?timeout=3000")));
+        int port = NetUtils.getAvailablePort();
+        protocol.export(proxy.getInvoker(service, DemoService.class, URL.valueOf("webservice://127.0.0.1:" + port + "/" + DemoService.class.getName())));
+        service = proxy.getProxy(protocol.refer(DemoService.class, URL.valueOf("webservice://127.0.0.1:" + port + "/" + DemoService.class.getName() + "?timeout=3000")));
         assertEquals(service.create(1, "kk").getName(), "kk");
         assertEquals(service.getSize(null), -1);
         assertEquals(service.getSize(new String[]{"", "", ""}), 3);
-        Object object = service.invoke("webservice://127.0.0.1:9019/" + DemoService.class.getName() + "", "invoke");
+        Object object = service.invoke("webservice://127.0.0.1:" + port + "/" + DemoService.class.getName() + "", "invoke");
         System.out.println(object);
-        assertEquals("webservice://127.0.0.1:9019/org.apache.dubbo.rpc.protocol.webservice.DemoService:invoke", object);
+        assertEquals("webservice://127.0.0.1:" + port + "/org.apache.dubbo.rpc.protocol.webservice.DemoService:invoke", object);
 
         StringBuffer buf = new StringBuffer();
         for (int i = 0; i < 1024 * 32 + 32; i++)

--- a/dubbo-rpc/dubbo-rpc-xml/src/test/java/org/apache/dubbo/xml/rpc/protocol/xmlrpc/XmlRpcProtocolTest.java
+++ b/dubbo-rpc/dubbo-rpc-xml/src/test/java/org/apache/dubbo/xml/rpc/protocol/xmlrpc/XmlRpcProtocolTest.java
@@ -18,6 +18,7 @@ package org.apache.dubbo.xml.rpc.protocol.xmlrpc;
 
 import org.apache.dubbo.common.URL;
 import org.apache.dubbo.common.extension.ExtensionLoader;
+import org.apache.dubbo.common.utils.NetUtils;
 import org.apache.dubbo.rpc.Exporter;
 import org.apache.dubbo.rpc.Invoker;
 import org.apache.dubbo.rpc.Protocol;
@@ -35,7 +36,8 @@ public class XmlRpcProtocolTest {
         Assertions.assertFalse(server.isCalled());
         ProxyFactory proxyFactory = ExtensionLoader.getExtensionLoader(ProxyFactory.class).getAdaptiveExtension();
         Protocol protocol = ExtensionLoader.getExtensionLoader(Protocol.class).getAdaptiveExtension();
-        URL url = URL.valueOf("xmlrpc://127.0.0.1:5342/" + XmlRpcService.class.getName() + "?version=1.0.0");
+        int port = NetUtils.getAvailablePort();
+        URL url = URL.valueOf("xmlrpc://127.0.0.1:" + port + "/" + XmlRpcService.class.getName() + "?version=1.0.0");
         Exporter<XmlRpcService> exporter = protocol.export(proxyFactory.getInvoker(server, XmlRpcService.class, url));
         Invoker<XmlRpcService> invoker = protocol.refer(XmlRpcService.class, url);
         XmlRpcService client = proxyFactory.getProxy(invoker);
@@ -52,7 +54,8 @@ public class XmlRpcProtocolTest {
         Assertions.assertFalse(server.isCalled());
         ProxyFactory proxyFactory = ExtensionLoader.getExtensionLoader(ProxyFactory.class).getAdaptiveExtension();
         Protocol protocol = ExtensionLoader.getExtensionLoader(Protocol.class).getAdaptiveExtension();
-        URL url = URL.valueOf("xmlrpc://127.0.0.1:5342/" + XmlRpcService.class.getName() + "?version=1.0.0&server=jetty9");
+        int port = NetUtils.getAvailablePort();
+        URL url = URL.valueOf("xmlrpc://127.0.0.1:" + port + "/" + XmlRpcService.class.getName() + "?version=1.0.0&server=jetty9");
         Exporter<XmlRpcService> exporter = protocol.export(proxyFactory.getInvoker(server, XmlRpcService.class, url));
         Invoker<XmlRpcService> invoker = protocol.refer(XmlRpcService.class, url);
         XmlRpcService client = proxyFactory.getProxy(invoker);
@@ -69,7 +72,8 @@ public class XmlRpcProtocolTest {
         XmlRpcServiceImpl server = new XmlRpcServiceImpl();
         ProxyFactory proxyFactory = ExtensionLoader.getExtensionLoader(ProxyFactory.class).getAdaptiveExtension();
         Protocol protocol = ExtensionLoader.getExtensionLoader(Protocol.class).getAdaptiveExtension();
-        URL url = URL.valueOf("xmlrpc://127.0.0.1:5342/" +
+        int port = NetUtils.getAvailablePort();
+        URL url = URL.valueOf("xmlrpc://127.0.0.1:" + port + "/" +
                 XmlRpcService.class.getName() + "?version=1.0.0&server=jetty9");
         Exporter<XmlRpcService> exporter = protocol.export(proxyFactory.getInvoker(server, XmlRpcService.class, url));
         Invoker<XmlRpcService> invoker = protocol.refer(XmlRpcService.class, url);


### PR DESCRIPTION
## What is the purpose of the change

Making unit-test can be correctly running on Windows platform and fixing some static port, which is coded into test cases.

## Brief changelog

- fix: in Windows platform content get from resource contains \r delimiter
- fix:in Windows Platform hessian2 may unable serialize byte
- fix:in some platform ServerSocket getting random port is not base on 30000
- fix:rename ExplicitCallbackTest to ArgumentCallbackTest owing to junit order
- fix:Windows error 0x70 while starting redis
- fix:fix static port may have been used

## Verifying this change

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a [GITHUB_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Run `mvn clean install -DskipTests=false` & `mvn clean test-compile failsafe:integration-test` to make sure unit-test and integration-test pass.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
