### PR TITLE
 solve the bug:if config the service configurators(protocol of overri…

### DIFF
--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/support/FailbackRegistry.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/support/FailbackRegistry.java
@@ -232,12 +232,12 @@ public abstract class FailbackRegistry extends AbstractRegistry {
             logger.info("URL " + url + " will not be registered to Registry. Registry " + url + " does not accept service of this protocol type.");
             return;
         }
-        super.register(url);
-        removeFailedRegistered(url);
-        removeFailedUnregistered(url);
         try {
             // Sending a registration request to the server side
             doRegister(url);
+            super.register(url);
+            removeFailedRegistered(url);
+            removeFailedUnregistered(url);
         } catch (Exception e) {
             Throwable t = e;
 
@@ -262,12 +262,12 @@ public abstract class FailbackRegistry extends AbstractRegistry {
 
     @Override
     public void unregister(URL url) {
-        super.unregister(url);
-        removeFailedRegistered(url);
-        removeFailedUnregistered(url);
         try {
             // Sending a cancellation request to the server side
             doUnregister(url);
+            super.unregister(url);
+            removeFailedRegistered(url);
+            removeFailedUnregistered(url);
         } catch (Exception e) {
             Throwable t = e;
 


### PR DESCRIPTION
solve the bug:if config the service configurators(protocol of override),as long as dubbo application lost connection with zookeeper.the OverrideListener will trigger.but the notifyUrl's protocol is empty,so the service  will reExport.in the process,will delete the old registedUrl in AbstractRegistry firstly,then delete
 zookeeper node,but zookeeper connection has lost,it will throw exception,the new providerUrl will not register to AbstractRegistry.then the notify will put in failed notify task,the second notify will not reExport,becase the exported url already change just now.So when the connection with zookeeper reconnected,the recover process will lost this provider url,lead to the consumer throw no provider exception.So that,delete zookeeper node first,then delete memory cache.

