### PR TITLE
upgrade fastjson to 1.2.68

### DIFF
--- a/dependencies-bom/pom.xml
+++ b/dependencies-bom/pom.xml
@@ -94,7 +94,7 @@
         <mina_version>1.1.7</mina_version>
         <grizzly_version>2.1.4</grizzly_version>
         <httpclient_version>4.5.3</httpclient_version>
-        <fastjson_version>1.2.60</fastjson_version>
+        <fastjson_version>1.2.68</fastjson_version>
         <zookeeper_version>3.4.9</zookeeper_version>
         <zkclient_version>0.2</zkclient_version>
         <curator_version>2.12.0</curator_version>


### PR DESCRIPTION
https://github.com/alibaba/fastjson/releases/tag/1.2.68
在1.2.68中引入一个safeMode的配置，配置safeMode后，无论白名单和黑名单，都不支持autoType。

