### PR TITLE
upgrade fastjson to 1.2.68

### DIFF
--- a/dubbo-dependencies-bom/pom.xml
+++ b/dubbo-dependencies-bom/pom.xml
@@ -97,7 +97,7 @@
         <grizzly_version>2.1.4</grizzly_version>
         <httpclient_version>4.5.3</httpclient_version>
         <httpcore_version>4.4.6</httpcore_version>
-        <fastjson_version>1.2.67</fastjson_version>
+        <fastjson_version>1.2.68</fastjson_version>
         <zookeeper_version>3.4.13</zookeeper_version>
         <curator_version>4.0.1</curator_version>
         <curator_test_version>2.12.0</curator_test_version>


### PR DESCRIPTION
https://github.com/alibaba/fastjson/releases/tag/1.2.68
在1.2.68中引入一个safeMode的配置，配置safeMode后，无论白名单和黑名单，都不支持autoType。
