### PR TITLE
[feature] publish ThreadPoolExhaustedEvent when thread pool exhausted

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/threadpool/event/ThreadPoolExhaustedEvent.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/threadpool/event/ThreadPoolExhaustedEvent.java
@@ -1,0 +1,22 @@
+package org.apache.dubbo.common.threadpool.event;
+
+import org.apache.dubbo.event.Event;
+
+/**
+ * An {@link Event Dubbo event} when the Dubbo thread pool is exhausted.
+ *
+ * @see Event
+ */
+public class ThreadPoolExhaustedEvent extends Event {
+
+    final String msg;
+
+    public ThreadPoolExhaustedEvent(Object source, String msg) {
+        super(source);
+        this.msg = msg;
+    }
+
+    public String getMsg() {
+        return msg;
+    }
+}

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/threadpool/event/ThreadPoolExhaustedEvent.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/threadpool/event/ThreadPoolExhaustedEvent.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.dubbo.common.threadpool.event;
 
 import org.apache.dubbo.event.Event;

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/threadpool/support/AbortPolicyWithReport.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/threadpool/support/AbortPolicyWithReport.java
@@ -29,7 +29,9 @@ import java.util.concurrent.ThreadPoolExecutor;
 import org.apache.dubbo.common.URL;
 import org.apache.dubbo.common.logger.Logger;
 import org.apache.dubbo.common.logger.LoggerFactory;
+import org.apache.dubbo.common.threadpool.event.ThreadPoolExhaustedEvent;
 import org.apache.dubbo.common.utils.JVMUtil;
+import org.apache.dubbo.event.EventDispatcher;
 
 import static org.apache.dubbo.common.constants.CommonConstants.DUMP_DIRECTORY;
 
@@ -76,7 +78,16 @@ public class AbortPolicyWithReport extends ThreadPoolExecutor.AbortPolicy {
             url.getProtocol(), url.getIp(), url.getPort());
         logger.warn(msg);
         dumpJStack();
+        dispatchThreadPoolExhaustedEvent(msg);
         throw new RejectedExecutionException(msg);
+    }
+
+    /**
+     * dispatch ThreadPoolExhaustedEvent
+     * @param msg
+     */
+    public void dispatchThreadPoolExhaustedEvent(String msg) {
+        EventDispatcher.getDefaultExtension().dispatch(new ThreadPoolExhaustedEvent(this, msg));
     }
 
     private void dumpJStack() {

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/threadpool/event/ThreadPoolExhaustedEventListenerTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/threadpool/event/ThreadPoolExhaustedEventListenerTest.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.dubbo.common.threadpool.event;
 
 import org.apache.dubbo.event.*;

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/threadpool/event/ThreadPoolExhaustedEventListenerTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/threadpool/event/ThreadPoolExhaustedEventListenerTest.java
@@ -1,0 +1,53 @@
+package org.apache.dubbo.common.threadpool.event;
+
+import org.apache.dubbo.event.*;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * {@link ThreadPoolExhaustedEvent} Test
+ */
+public class ThreadPoolExhaustedEventListenerTest {
+
+    private EventDispatcher eventDispatcher;
+
+    private ThreadPoolExhaustedEventListenerTest.MyGenericEventListener listener;
+
+    @BeforeEach
+    public void init() {
+        this.listener = new ThreadPoolExhaustedEventListenerTest.MyGenericEventListener();
+        this.eventDispatcher = EventDispatcher.getDefaultExtension();
+        this.eventDispatcher.addEventListener(listener);
+    }
+
+    @AfterEach
+    public void destroy() {
+        this.eventDispatcher.removeAllEventListeners();
+    }
+
+    @Test
+    public void testOnEvent() {
+        String msg = "Thread pool is EXHAUSTED! Thread Name: DubboServerHandler-127.0.0.1:12345, Pool Size: 1 (active: 0, core: 1, max: 1, largest: 1), Task: 6 (completed: 6), Executor status:(isShutdown:false, isTerminated:false, isTerminating:false), in dubbo://127.0.0.1:12345!, dubbo version: 2.7.3, current host: 127.0.0.1";
+        ThreadPoolExhaustedEvent exhaustedEvent = new ThreadPoolExhaustedEvent(this, msg);
+        eventDispatcher.dispatch(exhaustedEvent);
+        assertEquals(exhaustedEvent, listener.getThreadPoolExhaustedEvent());
+        assertEquals(this, listener.getThreadPoolExhaustedEvent().getSource());
+    }
+
+    class MyGenericEventListener implements EventListener<ThreadPoolExhaustedEvent> {
+
+        private ThreadPoolExhaustedEvent threadPoolExhaustedEvent;
+
+        @Override
+        public void onEvent(ThreadPoolExhaustedEvent event) {
+            this.threadPoolExhaustedEvent = event;
+        }
+
+        public ThreadPoolExhaustedEvent getThreadPoolExhaustedEvent() {
+            return threadPoolExhaustedEvent;
+        }
+    }
+}

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/threadpool/event/ThreadPoolExhaustedEventTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/threadpool/event/ThreadPoolExhaustedEventTest.java
@@ -1,0 +1,23 @@
+package org.apache.dubbo.common.threadpool.event;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ *  {@link ThreadPoolExhaustedEvent} Test
+ */
+public class ThreadPoolExhaustedEventTest {
+
+    @Test
+    public void test() {
+        long timestamp = System.currentTimeMillis();
+        String msg = "Thread pool is EXHAUSTED! Thread Name: DubboServerHandler-127.0.0.1:12345, Pool Size: 1 (active: 0, core: 1, max: 1, largest: 1), Task: 6 (completed: 6), Executor status:(isShutdown:false, isTerminated:false, isTerminating:false), in dubbo://127.0.0.1:12345!, dubbo version: 2.7.3, current host: 127.0.0.1";
+        ThreadPoolExhaustedEvent event = new ThreadPoolExhaustedEvent(this, msg);
+
+        assertEquals(this, event.getSource());
+        assertEquals(msg, event.getMsg());
+        assertTrue(event.getTimestamp() >= timestamp);
+    }
+}

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/threadpool/event/ThreadPoolExhaustedEventTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/threadpool/event/ThreadPoolExhaustedEventTest.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.dubbo.common.threadpool.event;
 
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
## What is the purpose of the change

publish ThreadPoolExhaustedEvent when thread pool is exhausted

fix https://github.com/apache/dubbo/issues/5957

## Brief changelog

add ThreadPoolExhaustedEvent and publish it in AbortPolicyWithReport.rejectedExecution method

## Verifying this change

run ThreadPoolExhaustedEventTest、ThreadPoolExhaustedEventListenerTest

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a [GITHUB_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [x] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Run `mvn clean install -DskipTests=false` & `mvn clean test-compile failsafe:integration-test` to make sure unit-test and integration-test pass.
- [x] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
