### PR TITLE
fix: override getUrl in RegistryDirectory

### DIFF
--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/integration/RegistryDirectory.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/integration/RegistryDirectory.java
@@ -630,6 +630,11 @@ public class RegistryDirectory<T> extends AbstractDirectory<T> implements Notify
         return this.overrideDirectoryUrl;
     }
 
+    @Override
+    public URL getUrl () {
+        return this.overrideDirectoryUrl;
+    }
+
     public URL getRegisteredConsumerUrl() {
         return registeredConsumerUrl;
     }


### PR DESCRIPTION
## What is the purpose of the change

In `RegistryDirectory`, the `getUrl` method haven't been overrided, which may cause adaptive extension unable to fetch the consumer's url correctly. ( Parameter `cluster` will become invalid )

## Brief changelog

Add override method `getUrl` with `overrideDirectoryUrl`

Linked Issue #5966 
