### PR TITLE
Fix: Cluster get wrong extension name

### DIFF
--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/support/AdaptiveCluster.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/support/AdaptiveCluster.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.rpc.cluster.support;
+
+import org.apache.dubbo.common.URL;
+import org.apache.dubbo.common.constants.CommonConstants;
+import org.apache.dubbo.common.extension.Adaptive;
+import org.apache.dubbo.common.extension.ExtensionLoader;
+import org.apache.dubbo.rpc.Invoker;
+import org.apache.dubbo.rpc.RpcException;
+import org.apache.dubbo.rpc.cluster.Cluster;
+import org.apache.dubbo.rpc.cluster.Directory;
+
+@Adaptive
+public class AdaptiveCluster implements Cluster {
+
+    @Override
+    public <T> Invoker<T> join(Directory<T> directory) throws RpcException {
+        if (directory == null) {
+            throw new RpcException("Cluster join fail. Cause: directory is null !");
+        }
+
+        // use ConsumerUrl first
+        URL url = directory.getConsumerUrl();
+        url = url != null ? url : directory.getUrl();
+        String extensionName = url != null ? url.getParameter(CommonConstants.CLUSTER_KEY) : null;
+        if (extensionName != null) {
+            return ExtensionLoader.getExtensionLoader(Cluster.class).getExtension(extensionName).join(directory);
+        } else {
+            return ExtensionLoader.getExtensionLoader(Cluster.class).getDefaultExtension().join(directory);
+        }
+    }
+}

--- a/dubbo-cluster/src/main/resources/META-INF/dubbo/internal/org.apache.dubbo.rpc.cluster.Cluster
+++ b/dubbo-cluster/src/main/resources/META-INF/dubbo/internal/org.apache.dubbo.rpc.cluster.Cluster
@@ -8,3 +8,4 @@ available=org.apache.dubbo.rpc.cluster.support.AvailableCluster
 mergeable=org.apache.dubbo.rpc.cluster.support.MergeableCluster
 broadcast=org.apache.dubbo.rpc.cluster.support.BroadcastCluster
 zone-aware=org.apache.dubbo.rpc.cluster.support.registry.ZoneAwareCluster
+adaptive=org.apache.dubbo.rpc.cluster.support.AdaptiveCluster

--- a/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/support/AdaptiveClusterTest.java
+++ b/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/support/AdaptiveClusterTest.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.rpc.cluster.support;
+
+
+import org.apache.dubbo.common.URL;
+import org.apache.dubbo.common.extension.ExtensionLoader;
+import org.apache.dubbo.rpc.RpcException;
+import org.apache.dubbo.rpc.cluster.Cluster;
+import org.apache.dubbo.rpc.cluster.Directory;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+public class AdaptiveClusterTest {
+
+    Directory<?> directory1 = mock(Directory.class);
+    Directory<?> directory2 = mock(Directory.class);
+    Directory<?> directory3 = mock(Directory.class);
+
+    URL url = URL.valueOf("test://test:11/test?cluster=AdaptiveClusterTest");
+
+    @BeforeAll
+    public static void setUpExtension() {
+        ExtensionLoader<Cluster> extensionLoader = ExtensionLoader.getExtensionLoader(Cluster.class);
+        extensionLoader.addExtension("AdaptiveClusterTest", MockCluster.class);
+    }
+
+    @Test
+    public void testNullDic() {
+        AdaptiveCluster adaptiveCluster = new AdaptiveCluster();
+        Assertions.assertThrows(RpcException.class, () -> adaptiveCluster.join(null));
+    }
+
+    @Test
+    public void testJoin() {
+        given(directory1.getUrl()).willReturn(url);
+        given(directory1.getConsumerUrl()).willReturn(null);
+
+        given(directory2.getUrl()).willReturn(null);
+        given(directory2.getConsumerUrl()).willReturn(url);
+
+        given(directory3.getUrl()).willReturn(url);
+        given(directory3.getConsumerUrl()).willReturn(url);
+
+        AdaptiveCluster adaptiveCluster = new AdaptiveCluster();
+        adaptiveCluster.join(directory1);
+        adaptiveCluster.join(directory2);
+        adaptiveCluster.join(directory3);
+    }
+}

--- a/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/support/MockCluster.java
+++ b/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/support/MockCluster.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.rpc.cluster.support;
+
+import org.apache.dubbo.rpc.Invoker;
+import org.apache.dubbo.rpc.RpcException;
+import org.apache.dubbo.rpc.cluster.Cluster;
+import org.apache.dubbo.rpc.cluster.Directory;
+
+public class MockCluster implements Cluster {
+    @Override
+    public <T> Invoker<T> join(Directory<T> directory) throws RpcException {
+        return null;
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

After the pr of distinguish usage of getUrl and getConsumerUrl (#5686), the adaptive extension of `Cluster` still use `getUrl` to get consumer's url which will cause properties of `Reference` lose when refer cluster. (#5966)

## Brief changelog

Add custom `AdaptiveCluster` of `Cluster` which will use `getConsumerUrl` prefer when 
get consumer's url.
