### PR TITLE
[Dubbo-Optimization]: remove unnecessary step `collect` before call `forEach` in stream

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/utils/ClassUtils.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/utils/ClassUtils.java
@@ -34,7 +34,6 @@ import java.util.function.Predicate;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptySet;
 import static java.util.Collections.unmodifiableSet;
-import static java.util.stream.Collectors.toList;
 import static org.apache.dubbo.common.function.Streams.filterAll;
 import static org.apache.dubbo.common.utils.ArrayUtils.isNotEmpty;
 import static org.apache.dubbo.common.utils.CollectionUtils.ofSet;
@@ -401,7 +400,6 @@ public class ClassUtils {
         allInterfaces.stream()
                 .map(ClassUtils::getAllInterfaces)
                 .flatMap(Collection::stream)
-                .collect(toList())
                 .forEach(allInterfaces::add);
 
         return filterAll(allInterfaces, interfaceFilters);


### PR DESCRIPTION
## What is the purpose of the change

It's not necessary to collect stream before call forEach.

## Brief changelog

Remove unnecessary step `collect` before call `forEach` in stream.

## Verifying this change

Run test case `org.apache.dubbo.common.utils.ClassUtilsTest`


Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a [GITHUB_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [x] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Run `mvn clean install -DskipTests=false` & `mvn clean test-compile failsafe:integration-test` to make sure unit-test and integration-test pass.
- [x] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
