### PR TITLE
[Dubbo-Optimization] fix ReferenceBean cannot be autowired in some situation.

### DIFF
--- a/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/beans/factory/annotation/ReferenceBeanFactoryPostProcessor.java
+++ b/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/beans/factory/annotation/ReferenceBeanFactoryPostProcessor.java
@@ -1,0 +1,212 @@
+package org.apache.dubbo.config.spring.beans.factory.annotation;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.dubbo.config.annotation.Reference;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.BeanFactory;
+import org.springframework.beans.factory.BeanFactoryAware;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.config.BeanFactoryPostProcessor;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.beans.factory.support.MergedBeanDefinitionPostProcessor;
+import org.springframework.beans.factory.support.RootBeanDefinition;
+import org.springframework.core.BridgeMethodResolver;
+import org.springframework.core.annotation.AnnotatedElementUtils;
+import org.springframework.core.annotation.AnnotationAttributes;
+import org.springframework.util.ClassUtils;
+import org.springframework.util.ReflectionUtils;
+
+import javax.annotation.Resource;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.AccessibleObject;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Used for autowired {@link org.apache.dubbo.config.spring.ReferenceBean}
+ * 1. Store all BeanDefinition contains {@link org.apache.dubbo.config.annotation.Reference} field or method.
+ * 2. When one class has {@link Autowired} or {@link Resource} or {@link javax.inject.Inject} a reference field,
+ * call getBean method store in the previous step first.
+ * @see org.springframework.beans.factory.BeanFactory#getBean
+ * @author anLA7856
+ */
+public class ReferenceBeanFactoryPostProcessor implements BeanFactoryPostProcessor, MergedBeanDefinitionPostProcessor, BeanFactoryAware {
+
+    /**
+     * The bean name of {@link ReferenceBeanFactoryPostProcessor}
+     */
+    public static final String BEAN_NAME = "referenceBeanFactoryPostProcessor";
+
+    protected final Log logger = LogFactory.getLog(getClass());
+
+    private final Set<Class<? extends Annotation>> referenceAnnotationTypes = new LinkedHashSet<>(4);
+    private final Set<Class<? extends Annotation>> autowiredAnnotationTypes = new LinkedHashSet<>(4);
+
+    private Map<String, Set<String>> referenceIdToBeanNames = new ConcurrentHashMap<>(256);
+    private Map<String, Boolean> referenceHasInit = new ConcurrentHashMap<>(256);
+
+    private BeanFactory beanFactory;
+
+    public ReferenceBeanFactoryPostProcessor() {
+        this.referenceAnnotationTypes.add(Reference.class);
+        this.autowiredAnnotationTypes.add(Autowired.class);
+        this.autowiredAnnotationTypes.add(Resource.class);
+        try {
+            this.autowiredAnnotationTypes.add((Class<? extends Annotation>)
+                    ClassUtils.forName("javax.inject.Inject", ReferenceBeanFactoryPostProcessor.class.getClassLoader()));
+            logger.trace("JSR-330 'javax.inject.Inject' annotation found and supported for autowiring");
+        }
+        catch (ClassNotFoundException ex) {
+            // JSR-330 API not available - simply skip.
+        }
+    }
+
+    private void buildReferenceMetadata(final Class<?> clazz, String beanName) {
+        findOrInjectAnnotation(clazz, (FindCallback) this::cacheRef, beanName, referenceAnnotationTypes, Reference.class.getName());
+    }
+
+    private void findOrInjectAnnotation(Class<?> targetClass, CallBack callBack, String beanName, Set<Class<? extends Annotation>> annotationTypes, String type) {
+        do {
+            ReflectionUtils.doWithLocalFields(targetClass, field -> {
+                AnnotationAttributes ann = findAnnotation(field, annotationTypes);
+                if (ann != null) {
+                    if (Modifier.isStatic(field.getModifiers())) {
+                        if (logger.isInfoEnabled()) {
+                            logger.info(type + " is not supported on static fields: " + field);
+                        }
+                        return;
+                    }
+                    String name = field.getType().getName();
+                    callBack.callback(name, beanName);
+                }
+            });
+
+            Class<?> finalTargetClass = targetClass;
+            ReflectionUtils.doWithLocalMethods(targetClass, method -> {
+                Method bridgedMethod = BridgeMethodResolver.findBridgedMethod(method);
+                if (!BridgeMethodResolver.isVisibilityBridgeMethodPair(method, bridgedMethod)) {
+                    return;
+                }
+                AnnotationAttributes ann = findAnnotation(bridgedMethod, annotationTypes);
+                if (ann != null && method.equals(ClassUtils.getMostSpecificMethod(method, finalTargetClass))) {
+                    if (Modifier.isStatic(method.getModifiers())) {
+                        if (logger.isInfoEnabled()) {
+                            logger.info(type + " annotation is not supported on static methods: " + method);
+                        }
+                        return;
+                    }
+                    if (method.getParameterCount() == 0) {
+                        if (logger.isInfoEnabled()) {
+                            logger.info(type + " annotation should only be used on methods with parameters: " +
+                                    method);
+                        }
+                    }
+                    if (callBack instanceof FindCallback){
+                        String name = method.getReturnType().getName();
+                        callBack.callback(name, beanName);
+                    }else {
+                        Class<?>[] parameterTypes = method.getParameterTypes();
+                        for (Class<?> clazz : parameterTypes){
+                            String name = clazz.getName();
+                            callBack.callback(name, beanName);
+                        }
+                    }
+
+                }
+            });
+
+            targetClass = targetClass.getSuperclass();
+        }
+        while (targetClass != null && targetClass != Object.class);
+    }
+
+    private void cacheRef(String name, String beanName) {
+        Set<String> beanNames = referenceIdToBeanNames.get(name);
+        if (beanNames == null){
+            beanNames = new HashSet<>();
+            referenceHasInit.put(name, Boolean.FALSE);
+        }
+        beanNames.add(beanName);
+        referenceIdToBeanNames.put(name, beanNames);
+    }
+
+    private AnnotationAttributes findAnnotation(AccessibleObject ao, Set<Class<? extends Annotation>> autowiredAnnotationTypes) {
+        if (ao.getAnnotations().length > 0) {
+            for (Class<? extends Annotation> type : autowiredAnnotationTypes) {
+                // same effects with AnnotatedElementUtils.getMergedAnnotation
+                AnnotationAttributes attributes = AnnotatedElementUtils.getMergedAnnotationAttributes(ao, type);
+                if (attributes != null) {
+                    return attributes;
+                }
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public void postProcessBeanFactory(ConfigurableListableBeanFactory beanFactory) throws BeansException {
+        String[] beanNames = beanFactory.getBeanDefinitionNames();
+        for(String beanName : beanNames){
+            Class<?> clazz = beanFactory.getType(beanName);
+            if (clazz != null){
+                buildReferenceMetadata(clazz, beanName);
+            }else {
+                logger.debug(beanName + " class not found");
+            }
+        }
+    }
+
+
+    @Override
+    public void postProcessMergedBeanDefinition(RootBeanDefinition beanDefinition, Class<?> beanType, String beanName) {
+        initReference(beanType, beanName);
+    }
+
+    private void initReference(Class<?> beanType, String beanName) {
+        findOrInjectAnnotation(beanType, (InjectCallback) this::doInitReference, beanName, this.autowiredAnnotationTypes, Autowired.class.getName());
+    }
+
+    private void doInitReference(String name, String beanName) {
+        if (this.referenceIdToBeanNames.containsKey(name) && !referenceHasInit.get(name)){
+            Set<String> beanNames = referenceIdToBeanNames.get(name);
+            beanNames.forEach(t->beanFactory.getBean(t));
+            referenceHasInit.put(name, Boolean.TRUE);
+        }
+    }
+
+    @Override
+    public void setBeanFactory(BeanFactory beanFactory) throws BeansException {
+        if (!(beanFactory instanceof ConfigurableListableBeanFactory)) {
+            throw new IllegalArgumentException(
+                    "ReferenceBeanFactoryPostProcessor requires a ConfigurableListableBeanFactory: " + beanFactory);
+        }
+        this.beanFactory = beanFactory;
+    }
+
+    @Override
+    public Object postProcessBeforeInitialization(Object bean, String beanName) throws BeansException {
+        return bean;
+    }
+
+    @Override
+    public Object postProcessAfterInitialization(Object bean, String beanName) throws BeansException {
+        return bean;
+    }
+
+    interface CallBack{
+        void callback(String name, String beanName);
+    }
+
+    interface FindCallback extends CallBack{
+
+    }
+    interface InjectCallback extends CallBack{
+
+    }
+}

--- a/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/util/DubboBeanUtils.java
+++ b/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/util/DubboBeanUtils.java
@@ -18,6 +18,7 @@ package org.apache.dubbo.config.spring.util;
 
 import org.apache.dubbo.config.spring.beans.factory.annotation.DubboConfigAliasPostProcessor;
 import org.apache.dubbo.config.spring.beans.factory.annotation.ReferenceAnnotationBeanPostProcessor;
+import org.apache.dubbo.config.spring.beans.factory.annotation.ReferenceBeanFactoryPostProcessor;
 import org.apache.dubbo.config.spring.beans.factory.config.DubboConfigDefaultPropertyValueBeanPostProcessor;
 import org.apache.dubbo.config.spring.context.DubboBootstrapApplicationListener;
 import org.apache.dubbo.config.spring.context.DubboLifecycleComponentApplicationListener;
@@ -64,5 +65,9 @@ public interface DubboBeanUtils {
         // Since 2.7.6 Register DubboConfigDefaultPropertyValueBeanPostProcessor as an infrastructure Bean
         registerInfrastructureBean(registry, DubboConfigDefaultPropertyValueBeanPostProcessor.BEAN_NAME,
                 DubboConfigDefaultPropertyValueBeanPostProcessor.class);
+
+        // add ReferenceBeanFactoryPostProcessor
+        registerInfrastructureBean(registry, ReferenceBeanFactoryPostProcessor.BEAN_NAME,
+                ReferenceBeanFactoryPostProcessor.class);
     }
 }

--- a/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/beans/factory/annotation/ReferenceBeanFactoryPostProcessorTest.java
+++ b/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/beans/factory/annotation/ReferenceBeanFactoryPostProcessorTest.java
@@ -1,0 +1,161 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.config.spring.beans.factory.annotation;
+
+import org.apache.dubbo.config.ApplicationConfig;
+import org.apache.dubbo.config.ProtocolConfig;
+import org.apache.dubbo.config.RegistryConfig;
+import org.apache.dubbo.config.annotation.Reference;
+import org.apache.dubbo.config.spring.api.DemoService;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.config.ConstructorArgumentValues;
+import org.springframework.beans.factory.support.GenericBeanDefinition;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.core.env.MapPropertySource;
+import org.springframework.core.env.MutablePropertySources;
+
+import javax.annotation.Resource;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * {@link ReferenceBeanFactoryPostProcessor} Test
+ *
+ * @author anLA7856
+ */
+public class ReferenceBeanFactoryPostProcessorTest {
+
+    private AnnotationConfigApplicationContext context;
+
+    @Before
+    public void setUp() {
+        context = new AnnotationConfigApplicationContext();
+        registerApplicationConfig();
+        registerRegistryConfig();
+        registerProtocolConfig();
+        setProperty();
+    }
+
+    private void setProperty() {
+        MutablePropertySources propertySources = context.getEnvironment().getPropertySources();
+        Map<String, Object> map = new HashMap<>();
+        map.put("demo.service.version","2.5.7");
+        map.put("demo.service.application", "dubbo-demo-application");
+        map.put("demo.service.protocol", "dubbo");
+        map.put("demo.service.registry", "my-registry");
+        propertySources
+                .addFirst(new MapPropertySource("newmap", map));
+    }
+
+    @After
+    public void tearDown() {
+        context.close();
+    }
+
+    @Test
+    public void testAutowired() {
+        context.register(ReferenceAnnotationBeanPostProcessor.class,
+                ReferenceBeanFactoryPostProcessor.class,
+                TestAutowiredConfig.class,
+                TestReferenceConfig.class);
+        context.refresh();
+        context.start();
+        TestAutowiredConfig testAutowiredConfig = context.getBean(TestAutowiredConfig.class);
+        Assert.assertNotNull(testAutowiredConfig);
+        Assert.assertNotNull(testAutowiredConfig.getDemoService());
+    }
+
+    @Test
+    public void testResource() {
+        context.register(ReferenceAnnotationBeanPostProcessor.class,
+                ReferenceBeanFactoryPostProcessor.class,
+                TestResourceConfig.class,
+                TestReferenceConfig.class);
+        context.refresh();
+        context.start();
+        TestResourceConfig testResourceConfig = context.getBean(TestResourceConfig.class);
+        Assert.assertNotNull(testResourceConfig);
+        Assert.assertNotNull(testResourceConfig.getDemoService());
+    }
+
+    @Test
+    public void testWithoutReferenceBeanFactoryPostProcessor() {
+        context.register(ReferenceAnnotationBeanPostProcessor.class,
+                TestAutowiredConfig.class,
+                TestReferenceConfig.class);
+        // UnsatisfiedDependencyException or NoSuchBeanDefinitionException
+        Exception exception = assertThrows(Exception.class, () -> {
+            context.refresh();
+        });
+        String expectedMessage = "Exception";
+        String actualMessage = exception.getMessage();
+        assertTrue(actualMessage.contains(expectedMessage));
+    }
+    
+    static class TestReferenceConfig{
+        @Reference(version = "2.5.7", url = "dubbo://127.0.0.1:12345?version=2.5.7", check = false)
+        DemoService demoService;
+    }
+
+    static class TestAutowiredConfig{
+        @Autowired
+        DemoService demoService;
+
+        public DemoService getDemoService() {
+            return demoService;
+        }
+    }
+
+    static class TestResourceConfig{
+        @Resource
+        DemoService demoService;
+
+        public DemoService getDemoService() {
+            return demoService;
+        }
+    }
+
+
+    public void registerApplicationConfig() {
+        GenericBeanDefinition definition = new GenericBeanDefinition();
+        definition.setBeanClass(ApplicationConfig.class);
+        definition.getPropertyValues().add("name",  "dubbo-demo-application");
+        context.registerBeanDefinition("dubbo-demo-application", definition);
+    }
+
+    public void registerRegistryConfig() {
+        GenericBeanDefinition definition = new GenericBeanDefinition();
+        definition.setBeanClass(RegistryConfig.class);
+        definition.getPropertyValues().add("address",  "N/A");
+        context.registerBeanDefinition("my-registry", definition);
+    }
+
+    public void registerProtocolConfig() {
+        GenericBeanDefinition definition = new GenericBeanDefinition();
+        definition.setBeanClass(ProtocolConfig.class);
+        definition.getPropertyValues().add("name",  "dubbo").add("port","12345");
+        context.registerBeanDefinition("dubbo", definition);
+    }
+
+}


### PR DESCRIPTION
I write a class named `ReferenceBeanFactoryPostProcessor.class` to solve this problem #6000.
It  go through all beans in SpringContext will store them.
when `postProcessMergedBeanDefinition` in `MergedBeanDefinitionPostProcessor` calls, it will find some beans to call `getBean`.

## What is the purpose of the change

fix `ReferenceBean` cannot be autowired in some situation.

## Brief changelog

1. fix `ReferenceBean` cannot be autowired in some situation.

## Verifying this change

XXXXX

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a [GITHUB_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [x] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Run `mvn clean install -DskipTests=false` & `mvn clean test-compile failsafe:integration-test` to make sure unit-test and integration-test pass.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
