### PR TITLE
[Dubbo-Optimization]: polish ClassUtils

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/utils/ClassUtils.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/utils/ClassUtils.java
@@ -21,20 +21,19 @@ import java.lang.reflect.Array;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
+import java.util.LinkedList;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Queue;
 import java.util.Set;
 import java.util.function.Predicate;
 
-import static java.util.Arrays.asList;
 import static java.util.Collections.emptySet;
 import static java.util.Collections.unmodifiableSet;
-import static java.util.stream.Collectors.toList;
 import static org.apache.dubbo.common.function.Streams.filterAll;
 import static org.apache.dubbo.common.utils.ArrayUtils.isNotEmpty;
 import static org.apache.dubbo.common.utils.CollectionUtils.ofSet;
@@ -360,12 +359,10 @@ public class ClassUtils {
         Set<Class<?>> allSuperClasses = new LinkedHashSet<>();
 
         Class<?> superClass = type.getSuperclass();
-
-        if (superClass != null) {
+        while (superClass != null) {
             // add current super class
             allSuperClasses.add(superClass);
-            // add ancestor classes
-            allSuperClasses.addAll(getAllSuperClasses(superClass));
+            superClass = superClass.getSuperclass();
         }
 
         return unmodifiableSet(filterAll(allSuperClasses, classFilters));
@@ -380,29 +377,38 @@ public class ClassUtils {
      * @since 2.7.6
      */
     public static Set<Class<?>> getAllInterfaces(Class<?> type, Predicate<Class<?>>... interfaceFilters) {
-
         if (type == null || type.isPrimitive()) {
             return emptySet();
         }
 
         Set<Class<?>> allInterfaces = new LinkedHashSet<>();
+        Set<Class<?>> resolved = new LinkedHashSet<>();
+        Queue<Class<?>> waitResolve = new LinkedList<>();
 
-        Class<?>[] interfaces = type.getInterfaces();
+        resolved.add(type);
+        Class<?> clazz = type;
+        while (clazz != null) {
 
-        if (isNotEmpty(interfaces)) {
-            // add current interfaces
-            allInterfaces.addAll(asList(interfaces));
+            Class<?>[] interfaces = clazz.getInterfaces();
+
+            if (isNotEmpty(interfaces)) {
+                // add current interfaces
+                Arrays.stream(interfaces)
+                        .filter(resolved::add)
+                        .forEach(cls -> {
+                            allInterfaces.add(cls);
+                            waitResolve.add(cls);
+                        });
+            }
+
+            // add all super classes to waitResolve
+            getAllSuperClasses(clazz)
+                    .stream()
+                    .filter(resolved::add)
+                    .forEach(waitResolve::add);
+
+            clazz = waitResolve.poll();
         }
-
-        // add all super interfaces
-        getAllSuperClasses(type).forEach(superType -> allInterfaces.addAll(getAllInterfaces(superType)));
-
-        // add all super interfaces from all interfaces
-        allInterfaces.stream()
-                .map(ClassUtils::getAllInterfaces)
-                .flatMap(Collection::stream)
-                .collect(toList())
-                .forEach(allInterfaces::add);
 
         return filterAll(allInterfaces, interfaceFilters);
     }


### PR DESCRIPTION
## What is the purpose of the change

- Polish ClassUtils.
- I try add a log to https://github.com/apache/dubbo/blob/317e62f73fd0a9bac4b34eb8b2c31bbae591ef91/dubbo-common/src/main/java/org/apache/dubbo/common/utils/ClassUtils.java#L382-L387
like this:
```java
 public static Set<Class<?>> getAllInterfaces(Class<?> type, Predicate<Class<?>>... interfaceFilters) {

        System.out.println("getAllInterfaces of " + (type == null ? "null" : type.getName()));
        if (type == null || type.isPrimitive()) {
            return emptySet();
        }
       ...
    }
```
Run  test case https://github.com/apache/dubbo/blob/master/dubbo-common/src/test/java/org/apache/dubbo/convert/multiple/StringToBlockingDequeConverterTest.java

Output:
```
getAllInterfaces of org.apache.dubbo.common.convert.multiple.StringToBlockingDequeConverter
getAllInterfaces of org.apache.dubbo.common.convert.multiple.StringToIterableConverter
getAllInterfaces of java.lang.Object
getAllInterfaces of org.apache.dubbo.common.convert.multiple.StringToMultiValueConverter
getAllInterfaces of org.apache.dubbo.common.convert.multiple.MultiValueConverter
getAllInterfaces of org.apache.dubbo.common.lang.Prioritized
getAllInterfaces of java.lang.Comparable
getAllInterfaces of java.lang.Object
getAllInterfaces of org.apache.dubbo.common.convert.multiple.StringToMultiValueConverter
getAllInterfaces of org.apache.dubbo.common.convert.multiple.MultiValueConverter
getAllInterfaces of org.apache.dubbo.common.lang.Prioritized
getAllInterfaces of java.lang.Comparable
getAllInterfaces of org.apache.dubbo.common.convert.multiple.MultiValueConverter
getAllInterfaces of org.apache.dubbo.common.lang.Prioritized
getAllInterfaces of java.lang.Comparable
getAllInterfaces of org.apache.dubbo.common.lang.Prioritized
getAllInterfaces of java.lang.Comparable
getAllInterfaces of java.lang.Comparable
getAllInterfaces of java.lang.Object
getAllInterfaces of java.util.concurrent.BlockingDeque
getAllInterfaces of java.util.concurrent.BlockingQueue
getAllInterfaces of java.util.Queue
getAllInterfaces of java.util.Collection
getAllInterfaces of java.lang.Iterable
getAllInterfaces of java.util.Deque
getAllInterfaces of java.util.Queue
getAllInterfaces of java.util.Collection
getAllInterfaces of java.lang.Iterable
getAllInterfaces of org.apache.dubbo.common.convert.multiple.StringToBlockingDequeConverter
getAllInterfaces of org.apache.dubbo.common.convert.multiple.StringToIterableConverter
getAllInterfaces of java.lang.Object
getAllInterfaces of org.apache.dubbo.common.convert.multiple.StringToMultiValueConverter
getAllInterfaces of org.apache.dubbo.common.convert.multiple.MultiValueConverter
getAllInterfaces of org.apache.dubbo.common.lang.Prioritized
getAllInterfaces of java.lang.Comparable
getAllInterfaces of java.lang.Object
getAllInterfaces of org.apache.dubbo.common.convert.multiple.StringToMultiValueConverter
getAllInterfaces of org.apache.dubbo.common.convert.multiple.MultiValueConverter
getAllInterfaces of org.apache.dubbo.common.lang.Prioritized
getAllInterfaces of java.lang.Comparable
getAllInterfaces of org.apache.dubbo.common.convert.multiple.MultiValueConverter
getAllInterfaces of org.apache.dubbo.common.lang.Prioritized
getAllInterfaces of java.lang.Comparable
getAllInterfaces of org.apache.dubbo.common.lang.Prioritized
getAllInterfaces of java.lang.Comparable
getAllInterfaces of java.lang.Comparable
getAllInterfaces of java.lang.Object
getAllInterfaces of org.apache.dubbo.common.convert.StringToIntegerConverter
getAllInterfaces of java.lang.Object
getAllInterfaces of org.apache.dubbo.common.convert.StringConverter
getAllInterfaces of org.apache.dubbo.common.convert.Converter
getAllInterfaces of org.apache.dubbo.common.lang.Prioritized
getAllInterfaces of java.lang.Comparable
getAllInterfaces of org.apache.dubbo.common.convert.StringToIntegerConverter
getAllInterfaces of java.lang.Object
getAllInterfaces of org.apache.dubbo.common.convert.StringConverter
getAllInterfaces of org.apache.dubbo.common.convert.Converter
getAllInterfaces of org.apache.dubbo.common.lang.Prioritized
getAllInterfaces of java.lang.Comparable
getAllInterfaces of org.apache.dubbo.common.convert.StringToIntegerConverter
getAllInterfaces of java.lang.Object
getAllInterfaces of org.apache.dubbo.common.convert.StringConverter
getAllInterfaces of org.apache.dubbo.common.convert.Converter
getAllInterfaces of org.apache.dubbo.common.lang.Prioritized
getAllInterfaces of java.lang.Comparable
getAllInterfaces of org.apache.dubbo.common.convert.StringToIntegerConverter
getAllInterfaces of java.lang.Object
getAllInterfaces of org.apache.dubbo.common.convert.StringConverter
getAllInterfaces of org.apache.dubbo.common.convert.Converter
getAllInterfaces of org.apache.dubbo.common.lang.Prioritized
getAllInterfaces of java.lang.Comparable
getAllInterfaces of org.apache.dubbo.common.convert.multiple.StringToBlockingDequeConverter
getAllInterfaces of org.apache.dubbo.common.convert.multiple.StringToIterableConverter
getAllInterfaces of java.lang.Object
getAllInterfaces of org.apache.dubbo.common.convert.multiple.StringToMultiValueConverter
getAllInterfaces of org.apache.dubbo.common.convert.multiple.MultiValueConverter
getAllInterfaces of org.apache.dubbo.common.lang.Prioritized
getAllInterfaces of java.lang.Comparable
getAllInterfaces of java.lang.Object
getAllInterfaces of org.apache.dubbo.common.convert.multiple.StringToMultiValueConverter
getAllInterfaces of org.apache.dubbo.common.convert.multiple.MultiValueConverter
getAllInterfaces of org.apache.dubbo.common.lang.Prioritized
getAllInterfaces of java.lang.Comparable
getAllInterfaces of org.apache.dubbo.common.convert.multiple.MultiValueConverter
getAllInterfaces of org.apache.dubbo.common.lang.Prioritized
getAllInterfaces of java.lang.Comparable
getAllInterfaces of org.apache.dubbo.common.lang.Prioritized
getAllInterfaces of java.lang.Comparable
getAllInterfaces of java.lang.Comparable
getAllInterfaces of java.lang.Object
getAllInterfaces of org.apache.dubbo.common.convert.multiple.StringToBlockingDequeConverter
getAllInterfaces of org.apache.dubbo.common.convert.multiple.StringToIterableConverter
getAllInterfaces of java.lang.Object
getAllInterfaces of org.apache.dubbo.common.convert.multiple.StringToMultiValueConverter
getAllInterfaces of org.apache.dubbo.common.convert.multiple.MultiValueConverter
getAllInterfaces of org.apache.dubbo.common.lang.Prioritized
getAllInterfaces of java.lang.Comparable
getAllInterfaces of java.lang.Object
getAllInterfaces of org.apache.dubbo.common.convert.multiple.StringToMultiValueConverter
getAllInterfaces of org.apache.dubbo.common.convert.multiple.MultiValueConverter
getAllInterfaces of org.apache.dubbo.common.lang.Prioritized
getAllInterfaces of java.lang.Comparable
getAllInterfaces of org.apache.dubbo.common.convert.multiple.MultiValueConverter
getAllInterfaces of org.apache.dubbo.common.lang.Prioritized
getAllInterfaces of java.lang.Comparable
getAllInterfaces of org.apache.dubbo.common.lang.Prioritized
getAllInterfaces of java.lang.Comparable
getAllInterfaces of java.lang.Comparable
getAllInterfaces of java.lang.Object
getAllInterfaces of org.apache.dubbo.common.convert.multiple.StringToBlockingDequeConverter
getAllInterfaces of org.apache.dubbo.common.convert.multiple.StringToIterableConverter
getAllInterfaces of java.lang.Object
getAllInterfaces of org.apache.dubbo.common.convert.multiple.StringToMultiValueConverter
getAllInterfaces of org.apache.dubbo.common.convert.multiple.MultiValueConverter
getAllInterfaces of org.apache.dubbo.common.lang.Prioritized
getAllInterfaces of java.lang.Comparable
getAllInterfaces of java.lang.Object
getAllInterfaces of org.apache.dubbo.common.convert.multiple.StringToMultiValueConverter
getAllInterfaces of org.apache.dubbo.common.convert.multiple.MultiValueConverter
getAllInterfaces of org.apache.dubbo.common.lang.Prioritized
getAllInterfaces of java.lang.Comparable
getAllInterfaces of org.apache.dubbo.common.convert.multiple.MultiValueConverter
getAllInterfaces of org.apache.dubbo.common.lang.Prioritized
getAllInterfaces of java.lang.Comparable
getAllInterfaces of org.apache.dubbo.common.lang.Prioritized
getAllInterfaces of java.lang.Comparable
getAllInterfaces of java.lang.Comparable
getAllInterfaces of java.lang.Object
getAllInterfaces of org.apache.dubbo.common.convert.multiple.StringToBlockingDequeConverter
getAllInterfaces of org.apache.dubbo.common.convert.multiple.StringToIterableConverter
getAllInterfaces of java.lang.Object
getAllInterfaces of org.apache.dubbo.common.convert.multiple.StringToMultiValueConverter
getAllInterfaces of org.apache.dubbo.common.convert.multiple.MultiValueConverter
getAllInterfaces of org.apache.dubbo.common.lang.Prioritized
getAllInterfaces of java.lang.Comparable
getAllInterfaces of java.lang.Object
getAllInterfaces of org.apache.dubbo.common.convert.multiple.StringToMultiValueConverter
getAllInterfaces of org.apache.dubbo.common.convert.multiple.MultiValueConverter
getAllInterfaces of org.apache.dubbo.common.lang.Prioritized
getAllInterfaces of java.lang.Comparable
getAllInterfaces of org.apache.dubbo.common.convert.multiple.MultiValueConverter
getAllInterfaces of org.apache.dubbo.common.lang.Prioritized
getAllInterfaces of java.lang.Comparable
getAllInterfaces of org.apache.dubbo.common.lang.Prioritized
getAllInterfaces of java.lang.Comparable
getAllInterfaces of java.lang.Comparable
getAllInterfaces of java.lang.Object
getAllInterfaces of org.apache.dubbo.common.convert.multiple.StringToBlockingDequeConverter
getAllInterfaces of org.apache.dubbo.common.convert.multiple.StringToIterableConverter
getAllInterfaces of java.lang.Object
getAllInterfaces of org.apache.dubbo.common.convert.multiple.StringToMultiValueConverter
getAllInterfaces of org.apache.dubbo.common.convert.multiple.MultiValueConverter
getAllInterfaces of org.apache.dubbo.common.lang.Prioritized
getAllInterfaces of java.lang.Comparable
getAllInterfaces of java.lang.Object
getAllInterfaces of org.apache.dubbo.common.convert.multiple.StringToMultiValueConverter
getAllInterfaces of org.apache.dubbo.common.convert.multiple.MultiValueConverter
getAllInterfaces of org.apache.dubbo.common.lang.Prioritized
getAllInterfaces of java.lang.Comparable
getAllInterfaces of org.apache.dubbo.common.convert.multiple.MultiValueConverter
getAllInterfaces of org.apache.dubbo.common.lang.Prioritized
getAllInterfaces of java.lang.Comparable
getAllInterfaces of org.apache.dubbo.common.lang.Prioritized
getAllInterfaces of java.lang.Comparable
getAllInterfaces of java.lang.Comparable
getAllInterfaces of java.lang.Object
getAllInterfaces of org.apache.dubbo.common.convert.multiple.StringToBlockingDequeConverter
getAllInterfaces of org.apache.dubbo.common.convert.multiple.StringToIterableConverter
getAllInterfaces of java.lang.Object
getAllInterfaces of org.apache.dubbo.common.convert.multiple.StringToMultiValueConverter
getAllInterfaces of org.apache.dubbo.common.convert.multiple.MultiValueConverter
getAllInterfaces of org.apache.dubbo.common.lang.Prioritized
getAllInterfaces of java.lang.Comparable
getAllInterfaces of java.lang.Object
getAllInterfaces of org.apache.dubbo.common.convert.multiple.StringToMultiValueConverter
getAllInterfaces of org.apache.dubbo.common.convert.multiple.MultiValueConverter
getAllInterfaces of org.apache.dubbo.common.lang.Prioritized
getAllInterfaces of java.lang.Comparable
getAllInterfaces of org.apache.dubbo.common.convert.multiple.MultiValueConverter
getAllInterfaces of org.apache.dubbo.common.lang.Prioritized
getAllInterfaces of java.lang.Comparable
getAllInterfaces of org.apache.dubbo.common.lang.Prioritized
getAllInterfaces of java.lang.Comparable
getAllInterfaces of java.lang.Comparable
getAllInterfaces of java.lang.Object
getAllInterfaces of org.apache.dubbo.common.convert.multiple.StringToBlockingDequeConverter
getAllInterfaces of org.apache.dubbo.common.convert.multiple.StringToIterableConverter
getAllInterfaces of java.lang.Object
getAllInterfaces of org.apache.dubbo.common.convert.multiple.StringToMultiValueConverter
getAllInterfaces of org.apache.dubbo.common.convert.multiple.MultiValueConverter
getAllInterfaces of org.apache.dubbo.common.lang.Prioritized
getAllInterfaces of java.lang.Comparable
getAllInterfaces of java.lang.Object
getAllInterfaces of org.apache.dubbo.common.convert.multiple.StringToMultiValueConverter
getAllInterfaces of org.apache.dubbo.common.convert.multiple.MultiValueConverter
getAllInterfaces of org.apache.dubbo.common.lang.Prioritized
getAllInterfaces of java.lang.Comparable
getAllInterfaces of org.apache.dubbo.common.convert.multiple.MultiValueConverter
getAllInterfaces of org.apache.dubbo.common.lang.Prioritized
getAllInterfaces of java.lang.Comparable
getAllInterfaces of org.apache.dubbo.common.lang.Prioritized
getAllInterfaces of java.lang.Comparable
getAllInterfaces of java.lang.Comparable
getAllInterfaces of java.lang.Object
getAllInterfaces of org.apache.dubbo.common.convert.multiple.StringToBlockingDequeConverter
getAllInterfaces of org.apache.dubbo.common.convert.multiple.StringToIterableConverter
getAllInterfaces of java.lang.Object
getAllInterfaces of org.apache.dubbo.common.convert.multiple.StringToMultiValueConverter
getAllInterfaces of org.apache.dubbo.common.convert.multiple.MultiValueConverter
getAllInterfaces of org.apache.dubbo.common.lang.Prioritized
getAllInterfaces of java.lang.Comparable
getAllInterfaces of java.lang.Object
getAllInterfaces of org.apache.dubbo.common.convert.multiple.StringToMultiValueConverter
getAllInterfaces of org.apache.dubbo.common.convert.multiple.MultiValueConverter
getAllInterfaces of org.apache.dubbo.common.lang.Prioritized
getAllInterfaces of java.lang.Comparable
getAllInterfaces of org.apache.dubbo.common.convert.multiple.MultiValueConverter
getAllInterfaces of org.apache.dubbo.common.lang.Prioritized
getAllInterfaces of java.lang.Comparable
getAllInterfaces of org.apache.dubbo.common.lang.Prioritized
getAllInterfaces of java.lang.Comparable
getAllInterfaces of java.lang.Comparable
getAllInterfaces of java.lang.Object
getAllInterfaces of org.apache.dubbo.common.convert.multiple.StringToBlockingDequeConverter
getAllInterfaces of org.apache.dubbo.common.convert.multiple.StringToIterableConverter
getAllInterfaces of java.lang.Object
getAllInterfaces of org.apache.dubbo.common.convert.multiple.StringToMultiValueConverter
getAllInterfaces of org.apache.dubbo.common.convert.multiple.MultiValueConverter
getAllInterfaces of org.apache.dubbo.common.lang.Prioritized
getAllInterfaces of java.lang.Comparable
getAllInterfaces of java.lang.Object
getAllInterfaces of org.apache.dubbo.common.convert.multiple.StringToMultiValueConverter
getAllInterfaces of org.apache.dubbo.common.convert.multiple.MultiValueConverter
getAllInterfaces of org.apache.dubbo.common.lang.Prioritized
getAllInterfaces of java.lang.Comparable
getAllInterfaces of org.apache.dubbo.common.convert.multiple.MultiValueConverter
getAllInterfaces of org.apache.dubbo.common.lang.Prioritized
getAllInterfaces of java.lang.Comparable
getAllInterfaces of org.apache.dubbo.common.lang.Prioritized
getAllInterfaces of java.lang.Comparable
getAllInterfaces of java.lang.Comparable
getAllInterfaces of java.lang.Object
getAllInterfaces of org.apache.dubbo.common.convert.multiple.StringToBlockingDequeConverter
getAllInterfaces of org.apache.dubbo.common.convert.multiple.StringToIterableConverter
getAllInterfaces of java.lang.Object
getAllInterfaces of org.apache.dubbo.common.convert.multiple.StringToMultiValueConverter
getAllInterfaces of org.apache.dubbo.common.convert.multiple.MultiValueConverter
getAllInterfaces of org.apache.dubbo.common.lang.Prioritized
getAllInterfaces of java.lang.Comparable
getAllInterfaces of java.lang.Object
getAllInterfaces of org.apache.dubbo.common.convert.multiple.StringToMultiValueConverter
getAllInterfaces of org.apache.dubbo.common.convert.multiple.MultiValueConverter
getAllInterfaces of org.apache.dubbo.common.lang.Prioritized
getAllInterfaces of java.lang.Comparable
getAllInterfaces of org.apache.dubbo.common.convert.multiple.MultiValueConverter
getAllInterfaces of org.apache.dubbo.common.lang.Prioritized
getAllInterfaces of java.lang.Comparable
getAllInterfaces of org.apache.dubbo.common.lang.Prioritized
getAllInterfaces of java.lang.Comparable
getAllInterfaces of java.lang.Comparable
getAllInterfaces of java.lang.Object
getAllInterfaces of org.apache.dubbo.common.convert.multiple.StringToBlockingDequeConverter
getAllInterfaces of org.apache.dubbo.common.convert.multiple.StringToIterableConverter
getAllInterfaces of java.lang.Object
getAllInterfaces of org.apache.dubbo.common.convert.multiple.StringToMultiValueConverter
getAllInterfaces of org.apache.dubbo.common.convert.multiple.MultiValueConverter
getAllInterfaces of org.apache.dubbo.common.lang.Prioritized
getAllInterfaces of java.lang.Comparable
getAllInterfaces of java.lang.Object
getAllInterfaces of org.apache.dubbo.common.convert.multiple.StringToMultiValueConverter
getAllInterfaces of org.apache.dubbo.common.convert.multiple.MultiValueConverter
getAllInterfaces of org.apache.dubbo.common.lang.Prioritized
getAllInterfaces of java.lang.Comparable
getAllInterfaces of org.apache.dubbo.common.convert.multiple.MultiValueConverter
getAllInterfaces of org.apache.dubbo.common.lang.Prioritized
getAllInterfaces of java.lang.Comparable
getAllInterfaces of org.apache.dubbo.common.lang.Prioritized
getAllInterfaces of java.lang.Comparable
getAllInterfaces of java.lang.Comparable
getAllInterfaces of java.lang.Object
getAllInterfaces of org.apache.dubbo.common.convert.multiple.StringToBlockingDequeConverter
getAllInterfaces of org.apache.dubbo.common.convert.multiple.StringToIterableConverter
getAllInterfaces of java.lang.Object
getAllInterfaces of org.apache.dubbo.common.convert.multiple.StringToMultiValueConverter
getAllInterfaces of org.apache.dubbo.common.convert.multiple.MultiValueConverter
getAllInterfaces of org.apache.dubbo.common.lang.Prioritized
getAllInterfaces of java.lang.Comparable
getAllInterfaces of java.lang.Object
getAllInterfaces of org.apache.dubbo.common.convert.multiple.StringToMultiValueConverter
getAllInterfaces of org.apache.dubbo.common.convert.multiple.MultiValueConverter
getAllInterfaces of org.apache.dubbo.common.lang.Prioritized
getAllInterfaces of java.lang.Comparable
getAllInterfaces of org.apache.dubbo.common.convert.multiple.MultiValueConverter
getAllInterfaces of org.apache.dubbo.common.lang.Prioritized
getAllInterfaces of java.lang.Comparable
getAllInterfaces of org.apache.dubbo.common.lang.Prioritized
getAllInterfaces of java.lang.Comparable
getAllInterfaces of java.lang.Comparable
getAllInterfaces of java.lang.Object
getAllInterfaces of org.apache.dubbo.common.convert.multiple.StringToBlockingDequeConverter
getAllInterfaces of org.apache.dubbo.common.convert.multiple.StringToIterableConverter
getAllInterfaces of java.lang.Object
getAllInterfaces of org.apache.dubbo.common.convert.multiple.StringToMultiValueConverter
getAllInterfaces of org.apache.dubbo.common.convert.multiple.MultiValueConverter
getAllInterfaces of org.apache.dubbo.common.lang.Prioritized
getAllInterfaces of java.lang.Comparable
getAllInterfaces of java.lang.Object
getAllInterfaces of org.apache.dubbo.common.convert.multiple.StringToMultiValueConverter
getAllInterfaces of org.apache.dubbo.common.convert.multiple.MultiValueConverter
getAllInterfaces of org.apache.dubbo.common.lang.Prioritized
getAllInterfaces of java.lang.Comparable
getAllInterfaces of org.apache.dubbo.common.convert.multiple.MultiValueConverter
getAllInterfaces of org.apache.dubbo.common.lang.Prioritized
getAllInterfaces of java.lang.Comparable
getAllInterfaces of org.apache.dubbo.common.lang.Prioritized
getAllInterfaces of java.lang.Comparable
getAllInterfaces of java.lang.Comparable
getAllInterfaces of java.lang.Object
getAllInterfaces of org.apache.dubbo.common.convert.multiple.StringToBlockingDequeConverter
getAllInterfaces of org.apache.dubbo.common.convert.multiple.StringToIterableConverter
getAllInterfaces of java.lang.Object
getAllInterfaces of org.apache.dubbo.common.convert.multiple.StringToMultiValueConverter
getAllInterfaces of org.apache.dubbo.common.convert.multiple.MultiValueConverter
getAllInterfaces of org.apache.dubbo.common.lang.Prioritized
getAllInterfaces of java.lang.Comparable
getAllInterfaces of java.lang.Object
getAllInterfaces of org.apache.dubbo.common.convert.multiple.StringToMultiValueConverter
getAllInterfaces of org.apache.dubbo.common.convert.multiple.MultiValueConverter
getAllInterfaces of org.apache.dubbo.common.lang.Prioritized
getAllInterfaces of java.lang.Comparable
getAllInterfaces of org.apache.dubbo.common.convert.multiple.MultiValueConverter
getAllInterfaces of org.apache.dubbo.common.lang.Prioritized
getAllInterfaces of java.lang.Comparable
getAllInterfaces of org.apache.dubbo.common.lang.Prioritized
getAllInterfaces of java.lang.Comparable
getAllInterfaces of java.lang.Comparable
getAllInterfaces of java.lang.Object
getAllInterfaces of org.apache.dubbo.common.convert.multiple.StringToBlockingDequeConverter
getAllInterfaces of org.apache.dubbo.common.convert.multiple.StringToIterableConverter
getAllInterfaces of java.lang.Object
getAllInterfaces of org.apache.dubbo.common.convert.multiple.StringToMultiValueConverter
getAllInterfaces of org.apache.dubbo.common.convert.multiple.MultiValueConverter
getAllInterfaces of org.apache.dubbo.common.lang.Prioritized
getAllInterfaces of java.lang.Comparable
getAllInterfaces of java.lang.Object
getAllInterfaces of org.apache.dubbo.common.convert.multiple.StringToMultiValueConverter
getAllInterfaces of org.apache.dubbo.common.convert.multiple.MultiValueConverter
getAllInterfaces of org.apache.dubbo.common.lang.Prioritized
getAllInterfaces of java.lang.Comparable
getAllInterfaces of org.apache.dubbo.common.convert.multiple.MultiValueConverter
getAllInterfaces of org.apache.dubbo.common.lang.Prioritized
getAllInterfaces of java.lang.Comparable
getAllInterfaces of org.apache.dubbo.common.lang.Prioritized
getAllInterfaces of java.lang.Comparable
getAllInterfaces of java.lang.Comparable
getAllInterfaces of java.lang.Object
getAllInterfaces of org.apache.dubbo.common.convert.multiple.StringToBlockingDequeConverter
getAllInterfaces of org.apache.dubbo.common.convert.multiple.StringToIterableConverter
getAllInterfaces of java.lang.Object
getAllInterfaces of org.apache.dubbo.common.convert.multiple.StringToMultiValueConverter
getAllInterfaces of org.apache.dubbo.common.convert.multiple.MultiValueConverter
getAllInterfaces of org.apache.dubbo.common.lang.Prioritized
getAllInterfaces of java.lang.Comparable
getAllInterfaces of java.lang.Object
getAllInterfaces of org.apache.dubbo.common.convert.multiple.StringToMultiValueConverter
getAllInterfaces of org.apache.dubbo.common.convert.multiple.MultiValueConverter
getAllInterfaces of org.apache.dubbo.common.lang.Prioritized
getAllInterfaces of java.lang.Comparable
getAllInterfaces of org.apache.dubbo.common.convert.multiple.MultiValueConverter
getAllInterfaces of org.apache.dubbo.common.lang.Prioritized
getAllInterfaces of java.lang.Comparable
getAllInterfaces of org.apache.dubbo.common.lang.Prioritized
getAllInterfaces of java.lang.Comparable
getAllInterfaces of java.lang.Comparable
getAllInterfaces of java.lang.Object
getAllInterfaces of org.apache.dubbo.common.convert.multiple.StringToBlockingDequeConverter
getAllInterfaces of org.apache.dubbo.common.convert.multiple.StringToIterableConverter
getAllInterfaces of java.lang.Object
getAllInterfaces of org.apache.dubbo.common.convert.multiple.StringToMultiValueConverter
getAllInterfaces of org.apache.dubbo.common.convert.multiple.MultiValueConverter
getAllInterfaces of org.apache.dubbo.common.lang.Prioritized
getAllInterfaces of java.lang.Comparable
getAllInterfaces of java.lang.Object
getAllInterfaces of org.apache.dubbo.common.convert.multiple.StringToMultiValueConverter
getAllInterfaces of org.apache.dubbo.common.convert.multiple.MultiValueConverter
getAllInterfaces of org.apache.dubbo.common.lang.Prioritized
getAllInterfaces of java.lang.Comparable
getAllInterfaces of org.apache.dubbo.common.convert.multiple.MultiValueConverter
getAllInterfaces of org.apache.dubbo.common.lang.Prioritized
getAllInterfaces of java.lang.Comparable
getAllInterfaces of org.apache.dubbo.common.lang.Prioritized
getAllInterfaces of java.lang.Comparable
getAllInterfaces of java.lang.Comparable
getAllInterfaces of java.lang.Object
getAllInterfaces of org.apache.dubbo.common.convert.multiple.StringToBlockingDequeConverter
getAllInterfaces of org.apache.dubbo.common.convert.multiple.StringToIterableConverter
getAllInterfaces of java.lang.Object
getAllInterfaces of org.apache.dubbo.common.convert.multiple.StringToMultiValueConverter
getAllInterfaces of org.apache.dubbo.common.convert.multiple.MultiValueConverter
getAllInterfaces of org.apache.dubbo.common.lang.Prioritized
getAllInterfaces of java.lang.Comparable
getAllInterfaces of java.lang.Object
getAllInterfaces of org.apache.dubbo.common.convert.multiple.StringToMultiValueConverter
getAllInterfaces of org.apache.dubbo.common.convert.multiple.MultiValueConverter
getAllInterfaces of org.apache.dubbo.common.lang.Prioritized
getAllInterfaces of java.lang.Comparable
getAllInterfaces of org.apache.dubbo.common.convert.multiple.MultiValueConverter
getAllInterfaces of org.apache.dubbo.common.lang.Prioritized
getAllInterfaces of java.lang.Comparable
getAllInterfaces of org.apache.dubbo.common.lang.Prioritized
getAllInterfaces of java.lang.Comparable
getAllInterfaces of java.lang.Comparable
getAllInterfaces of java.lang.Object
getAllInterfaces of org.apache.dubbo.common.convert.multiple.StringToBlockingDequeConverter
getAllInterfaces of org.apache.dubbo.common.convert.multiple.StringToIterableConverter
getAllInterfaces of java.lang.Object
getAllInterfaces of org.apache.dubbo.common.convert.multiple.StringToMultiValueConverter
getAllInterfaces of org.apache.dubbo.common.convert.multiple.MultiValueConverter
getAllInterfaces of org.apache.dubbo.common.lang.Prioritized
getAllInterfaces of java.lang.Comparable
getAllInterfaces of java.lang.Object
getAllInterfaces of org.apache.dubbo.common.convert.multiple.StringToMultiValueConverter
getAllInterfaces of org.apache.dubbo.common.convert.multiple.MultiValueConverter
getAllInterfaces of org.apache.dubbo.common.lang.Prioritized
getAllInterfaces of java.lang.Comparable
getAllInterfaces of org.apache.dubbo.common.convert.multiple.MultiValueConverter
getAllInterfaces of org.apache.dubbo.common.lang.Prioritized
getAllInterfaces of java.lang.Comparable
getAllInterfaces of org.apache.dubbo.common.lang.Prioritized
getAllInterfaces of java.lang.Comparable
getAllInterfaces of java.lang.Comparable
getAllInterfaces of java.lang.Object
```

- Add the log in PR branch like this:

```java
    public static Set<Class<?>> getAllInterfaces(Class<?> type, Predicate<Class<?>>... interfaceFilters) {
        ...

        while (clazz != null) {

            System.out.println("getAllInterfaces of " + clazz.getName());
            ...
        }
        ...
```
Output:
```
getAllInterfaces of org.apache.dubbo.common.convert.multiple.StringToBlockingDequeConverter
getAllInterfaces of org.apache.dubbo.common.convert.multiple.StringToIterableConverter
getAllInterfaces of java.lang.Object
getAllInterfaces of org.apache.dubbo.common.convert.multiple.StringToMultiValueConverter
getAllInterfaces of org.apache.dubbo.common.convert.multiple.MultiValueConverter
getAllInterfaces of org.apache.dubbo.common.lang.Prioritized
getAllInterfaces of java.lang.Comparable
getAllInterfaces of java.lang.Object
getAllInterfaces of java.util.concurrent.BlockingDeque
getAllInterfaces of java.util.concurrent.BlockingQueue
getAllInterfaces of java.util.Deque
getAllInterfaces of java.util.Queue
getAllInterfaces of java.util.Collection
getAllInterfaces of java.lang.Iterable
getAllInterfaces of org.apache.dubbo.common.convert.multiple.StringToBlockingDequeConverter
getAllInterfaces of org.apache.dubbo.common.convert.multiple.StringToIterableConverter
getAllInterfaces of java.lang.Object
getAllInterfaces of org.apache.dubbo.common.convert.multiple.StringToMultiValueConverter
getAllInterfaces of org.apache.dubbo.common.convert.multiple.MultiValueConverter
getAllInterfaces of org.apache.dubbo.common.lang.Prioritized
getAllInterfaces of java.lang.Comparable
getAllInterfaces of java.lang.Object
getAllInterfaces of org.apache.dubbo.common.convert.StringToIntegerConverter
getAllInterfaces of org.apache.dubbo.common.convert.StringConverter
getAllInterfaces of java.lang.Object
getAllInterfaces of org.apache.dubbo.common.convert.Converter
getAllInterfaces of org.apache.dubbo.common.lang.Prioritized
getAllInterfaces of java.lang.Comparable
getAllInterfaces of org.apache.dubbo.common.convert.StringToIntegerConverter
getAllInterfaces of org.apache.dubbo.common.convert.StringConverter
getAllInterfaces of java.lang.Object
getAllInterfaces of org.apache.dubbo.common.convert.Converter
getAllInterfaces of org.apache.dubbo.common.lang.Prioritized
getAllInterfaces of java.lang.Comparable
getAllInterfaces of org.apache.dubbo.common.convert.StringToIntegerConverter
getAllInterfaces of org.apache.dubbo.common.convert.StringConverter
getAllInterfaces of java.lang.Object
getAllInterfaces of org.apache.dubbo.common.convert.Converter
getAllInterfaces of org.apache.dubbo.common.lang.Prioritized
getAllInterfaces of java.lang.Comparable
getAllInterfaces of org.apache.dubbo.common.convert.StringToIntegerConverter
getAllInterfaces of org.apache.dubbo.common.convert.StringConverter
getAllInterfaces of java.lang.Object
getAllInterfaces of org.apache.dubbo.common.convert.Converter
getAllInterfaces of org.apache.dubbo.common.lang.Prioritized
getAllInterfaces of java.lang.Comparable
getAllInterfaces of org.apache.dubbo.common.convert.multiple.StringToBlockingDequeConverter
getAllInterfaces of org.apache.dubbo.common.convert.multiple.StringToIterableConverter
getAllInterfaces of java.lang.Object
getAllInterfaces of org.apache.dubbo.common.convert.multiple.StringToMultiValueConverter
getAllInterfaces of org.apache.dubbo.common.convert.multiple.MultiValueConverter
getAllInterfaces of org.apache.dubbo.common.lang.Prioritized
getAllInterfaces of java.lang.Comparable
getAllInterfaces of java.lang.Object
getAllInterfaces of org.apache.dubbo.common.convert.multiple.StringToBlockingDequeConverter
getAllInterfaces of org.apache.dubbo.common.convert.multiple.StringToIterableConverter
getAllInterfaces of java.lang.Object
getAllInterfaces of org.apache.dubbo.common.convert.multiple.StringToMultiValueConverter
getAllInterfaces of org.apache.dubbo.common.convert.multiple.MultiValueConverter
getAllInterfaces of org.apache.dubbo.common.lang.Prioritized
getAllInterfaces of java.lang.Comparable
getAllInterfaces of java.lang.Object
getAllInterfaces of org.apache.dubbo.common.convert.multiple.StringToBlockingDequeConverter
getAllInterfaces of org.apache.dubbo.common.convert.multiple.StringToIterableConverter
getAllInterfaces of java.lang.Object
getAllInterfaces of org.apache.dubbo.common.convert.multiple.StringToMultiValueConverter
getAllInterfaces of org.apache.dubbo.common.convert.multiple.MultiValueConverter
getAllInterfaces of org.apache.dubbo.common.lang.Prioritized
getAllInterfaces of java.lang.Comparable
getAllInterfaces of java.lang.Object
getAllInterfaces of org.apache.dubbo.common.convert.multiple.StringToBlockingDequeConverter
getAllInterfaces of org.apache.dubbo.common.convert.multiple.StringToIterableConverter
getAllInterfaces of java.lang.Object
getAllInterfaces of org.apache.dubbo.common.convert.multiple.StringToMultiValueConverter
getAllInterfaces of org.apache.dubbo.common.convert.multiple.MultiValueConverter
getAllInterfaces of org.apache.dubbo.common.lang.Prioritized
getAllInterfaces of java.lang.Comparable
getAllInterfaces of java.lang.Object
getAllInterfaces of org.apache.dubbo.common.convert.multiple.StringToBlockingDequeConverter
getAllInterfaces of org.apache.dubbo.common.convert.multiple.StringToIterableConverter
getAllInterfaces of java.lang.Object
getAllInterfaces of org.apache.dubbo.common.convert.multiple.StringToMultiValueConverter
getAllInterfaces of org.apache.dubbo.common.convert.multiple.MultiValueConverter
getAllInterfaces of org.apache.dubbo.common.lang.Prioritized
getAllInterfaces of java.lang.Comparable
getAllInterfaces of java.lang.Object
getAllInterfaces of org.apache.dubbo.common.convert.multiple.StringToBlockingDequeConverter
getAllInterfaces of org.apache.dubbo.common.convert.multiple.StringToIterableConverter
getAllInterfaces of java.lang.Object
getAllInterfaces of org.apache.dubbo.common.convert.multiple.StringToMultiValueConverter
getAllInterfaces of org.apache.dubbo.common.convert.multiple.MultiValueConverter
getAllInterfaces of org.apache.dubbo.common.lang.Prioritized
getAllInterfaces of java.lang.Comparable
getAllInterfaces of java.lang.Object
getAllInterfaces of org.apache.dubbo.common.convert.multiple.StringToBlockingDequeConverter
getAllInterfaces of org.apache.dubbo.common.convert.multiple.StringToIterableConverter
getAllInterfaces of java.lang.Object
getAllInterfaces of org.apache.dubbo.common.convert.multiple.StringToMultiValueConverter
getAllInterfaces of org.apache.dubbo.common.convert.multiple.MultiValueConverter
getAllInterfaces of org.apache.dubbo.common.lang.Prioritized
getAllInterfaces of java.lang.Comparable
getAllInterfaces of java.lang.Object
getAllInterfaces of org.apache.dubbo.common.convert.multiple.StringToBlockingDequeConverter
getAllInterfaces of org.apache.dubbo.common.convert.multiple.StringToIterableConverter
getAllInterfaces of java.lang.Object
getAllInterfaces of org.apache.dubbo.common.convert.multiple.StringToMultiValueConverter
getAllInterfaces of org.apache.dubbo.common.convert.multiple.MultiValueConverter
getAllInterfaces of org.apache.dubbo.common.lang.Prioritized
getAllInterfaces of java.lang.Comparable
getAllInterfaces of java.lang.Object
getAllInterfaces of org.apache.dubbo.common.convert.multiple.StringToBlockingDequeConverter
getAllInterfaces of org.apache.dubbo.common.convert.multiple.StringToIterableConverter
getAllInterfaces of java.lang.Object
getAllInterfaces of org.apache.dubbo.common.convert.multiple.StringToMultiValueConverter
getAllInterfaces of org.apache.dubbo.common.convert.multiple.MultiValueConverter
getAllInterfaces of org.apache.dubbo.common.lang.Prioritized
getAllInterfaces of java.lang.Comparable
getAllInterfaces of java.lang.Object
getAllInterfaces of org.apache.dubbo.common.convert.multiple.StringToBlockingDequeConverter
getAllInterfaces of org.apache.dubbo.common.convert.multiple.StringToIterableConverter
getAllInterfaces of java.lang.Object
getAllInterfaces of org.apache.dubbo.common.convert.multiple.StringToMultiValueConverter
getAllInterfaces of org.apache.dubbo.common.convert.multiple.MultiValueConverter
getAllInterfaces of org.apache.dubbo.common.lang.Prioritized
getAllInterfaces of java.lang.Comparable
getAllInterfaces of java.lang.Object
getAllInterfaces of org.apache.dubbo.common.convert.multiple.StringToBlockingDequeConverter
getAllInterfaces of org.apache.dubbo.common.convert.multiple.StringToIterableConverter
getAllInterfaces of java.lang.Object
getAllInterfaces of org.apache.dubbo.common.convert.multiple.StringToMultiValueConverter
getAllInterfaces of org.apache.dubbo.common.convert.multiple.MultiValueConverter
getAllInterfaces of org.apache.dubbo.common.lang.Prioritized
getAllInterfaces of java.lang.Comparable
getAllInterfaces of java.lang.Object
getAllInterfaces of org.apache.dubbo.common.convert.multiple.StringToBlockingDequeConverter
getAllInterfaces of org.apache.dubbo.common.convert.multiple.StringToIterableConverter
getAllInterfaces of java.lang.Object
getAllInterfaces of org.apache.dubbo.common.convert.multiple.StringToMultiValueConverter
getAllInterfaces of org.apache.dubbo.common.convert.multiple.MultiValueConverter
getAllInterfaces of org.apache.dubbo.common.lang.Prioritized
getAllInterfaces of java.lang.Comparable
getAllInterfaces of java.lang.Object
getAllInterfaces of org.apache.dubbo.common.convert.multiple.StringToBlockingDequeConverter
getAllInterfaces of org.apache.dubbo.common.convert.multiple.StringToIterableConverter
getAllInterfaces of java.lang.Object
getAllInterfaces of org.apache.dubbo.common.convert.multiple.StringToMultiValueConverter
getAllInterfaces of org.apache.dubbo.common.convert.multiple.MultiValueConverter
getAllInterfaces of org.apache.dubbo.common.lang.Prioritized
getAllInterfaces of java.lang.Comparable
getAllInterfaces of java.lang.Object
getAllInterfaces of org.apache.dubbo.common.convert.multiple.StringToBlockingDequeConverter
getAllInterfaces of org.apache.dubbo.common.convert.multiple.StringToIterableConverter
getAllInterfaces of java.lang.Object
getAllInterfaces of org.apache.dubbo.common.convert.multiple.StringToMultiValueConverter
getAllInterfaces of org.apache.dubbo.common.convert.multiple.MultiValueConverter
getAllInterfaces of org.apache.dubbo.common.lang.Prioritized
getAllInterfaces of java.lang.Comparable
getAllInterfaces of java.lang.Object
getAllInterfaces of org.apache.dubbo.common.convert.multiple.StringToBlockingDequeConverter
getAllInterfaces of org.apache.dubbo.common.convert.multiple.StringToIterableConverter
getAllInterfaces of java.lang.Object
getAllInterfaces of org.apache.dubbo.common.convert.multiple.StringToMultiValueConverter
getAllInterfaces of org.apache.dubbo.common.convert.multiple.MultiValueConverter
getAllInterfaces of org.apache.dubbo.common.lang.Prioritized
getAllInterfaces of java.lang.Comparable
getAllInterfaces of java.lang.Object
getAllInterfaces of org.apache.dubbo.common.convert.multiple.StringToBlockingDequeConverter
getAllInterfaces of org.apache.dubbo.common.convert.multiple.StringToIterableConverter
getAllInterfaces of java.lang.Object
getAllInterfaces of org.apache.dubbo.common.convert.multiple.StringToMultiValueConverter
getAllInterfaces of org.apache.dubbo.common.convert.multiple.MultiValueConverter
getAllInterfaces of org.apache.dubbo.common.lang.Prioritized
getAllInterfaces of java.lang.Comparable
getAllInterfaces of java.lang.Object
getAllInterfaces of org.apache.dubbo.common.convert.multiple.StringToBlockingDequeConverter
getAllInterfaces of org.apache.dubbo.common.convert.multiple.StringToIterableConverter
getAllInterfaces of java.lang.Object
getAllInterfaces of org.apache.dubbo.common.convert.multiple.StringToMultiValueConverter
getAllInterfaces of org.apache.dubbo.common.convert.multiple.MultiValueConverter
getAllInterfaces of org.apache.dubbo.common.lang.Prioritized
getAllInterfaces of java.lang.Comparable
getAllInterfaces of java.lang.Object
getAllInterfaces of org.apache.dubbo.common.convert.multiple.StringToBlockingDequeConverter
getAllInterfaces of org.apache.dubbo.common.convert.multiple.StringToIterableConverter
getAllInterfaces of java.lang.Object
getAllInterfaces of org.apache.dubbo.common.convert.multiple.StringToMultiValueConverter
getAllInterfaces of org.apache.dubbo.common.convert.multiple.MultiValueConverter
getAllInterfaces of org.apache.dubbo.common.lang.Prioritized
getAllInterfaces of java.lang.Comparable
getAllInterfaces of java.lang.Object
getAllInterfaces of org.apache.dubbo.common.convert.multiple.StringToBlockingDequeConverter
getAllInterfaces of org.apache.dubbo.common.convert.multiple.StringToIterableConverter
getAllInterfaces of java.lang.Object
getAllInterfaces of org.apache.dubbo.common.convert.multiple.StringToMultiValueConverter
getAllInterfaces of org.apache.dubbo.common.convert.multiple.MultiValueConverter
getAllInterfaces of org.apache.dubbo.common.lang.Prioritized
getAllInterfaces of java.lang.Comparable
getAllInterfaces of java.lang.Object
```

- The log output is reduced from 432 lines to 198 lines.

- Fell free to close it if it has be included in other PRs or It is not expected to change.

## Brief changelog

- use loop instead of recursion in `getAllInterfaces`/`getAllSuperClasses`.

## Verifying this change

Run test cases.

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a [GITHUB_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [x] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Run `mvn clean install -DskipTests=false` & `mvn clean test-compile failsafe:integration-test` to make sure unit-test and integration-test pass.
- [x] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
