### PR TITLE
[Dubbo-6020] fixbug getServiceDefinition get serviceInterface,group and version error.

### DIFF
--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/metadata/proxy/RemoteMetadataServiceProxy.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/metadata/proxy/RemoteMetadataServiceProxy.java
@@ -18,6 +18,7 @@ package org.apache.dubbo.registry.client.metadata.proxy;
 
 import org.apache.dubbo.common.logger.Logger;
 import org.apache.dubbo.common.logger.LoggerFactory;
+import org.apache.dubbo.common.utils.StringUtils;
 import org.apache.dubbo.common.utils.UrlUtils;
 import org.apache.dubbo.metadata.MetadataService;
 import org.apache.dubbo.metadata.report.MetadataReport;
@@ -73,15 +74,15 @@ public class RemoteMetadataServiceProxy implements MetadataService {
     @Override
     public String getServiceDefinition(String serviceKey) {
         String[] services = UrlUtils.parseServiceKey(serviceKey);
-        String serviceInterface = services[0];
+        String serviceInterface = services[1];
         // if version or group is not exist
-        String version = null;
-        if (services.length > 1) {
-            version = services[1];
-        }
         String group = null;
-        if (services.length > 2) {
-            group = services[2];
+        if (StringUtils.isNotEmpty(services[0])) {
+            group = services[0];
+        }
+        String version = null;
+        if (StringUtils.isNotEmpty(services[2])) {
+            version = services[2];
         }
         return getMetadataReport().getServiceDefinition(new MetadataIdentifier(serviceInterface,
                 version, group, PROVIDER_SIDE, serviceName));

--- a/dubbo-registry/dubbo-registry-api/src/test/java/org/apache/dubbo/registry/client/metadata/proxy/RemoteMetadataServiceProxyTest.java
+++ b/dubbo-registry/dubbo-registry-api/src/test/java/org/apache/dubbo/registry/client/metadata/proxy/RemoteMetadataServiceProxyTest.java
@@ -2,13 +2,10 @@ package org.apache.dubbo.registry.client.metadata.proxy;
 
 import org.apache.dubbo.common.utils.StringUtils;
 import org.apache.dubbo.common.utils.UrlUtils;
-import org.apache.dubbo.registry.client.DefaultServiceInstance;
-import org.apache.dubbo.registry.client.ServiceInstance;
 
-import junit.framework.Assert;
 import org.junit.jupiter.api.Test;
 
-import static java.lang.String.valueOf;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * {@link RemoteMetadataServiceProxy} Test
@@ -32,9 +29,9 @@ public class RemoteMetadataServiceProxyTest {
         if (StringUtils.isNotEmpty(services[2])) {
             version = services[2];
         }
-        Assert.assertEquals(serviceInterface, "org.apache.dubbo.demo.DemoService");
-        Assert.assertEquals(version, "1.0.0");
-        Assert.assertEquals(group, "a");
+        assertEquals(serviceInterface, "org.apache.dubbo.demo.DemoService");
+        assertEquals(version, "1.0.0");
+        assertEquals(group, "a");
 
         serviceKey = "org.apache.dubbo.demo.DemoService";
 
@@ -49,8 +46,8 @@ public class RemoteMetadataServiceProxyTest {
         if (StringUtils.isNotEmpty(services[2])) {
             version = services[2];
         }
-        Assert.assertEquals(serviceInterface, "org.apache.dubbo.demo.DemoService");
-        Assert.assertEquals(version, null);
-        Assert.assertEquals(group, null);
+        assertEquals(serviceInterface, "org.apache.dubbo.demo.DemoService");
+        assertEquals(version, null);
+        assertEquals(group, null);
     }
 }

--- a/dubbo-registry/dubbo-registry-api/src/test/java/org/apache/dubbo/registry/client/metadata/proxy/RemoteMetadataServiceProxyTest.java
+++ b/dubbo-registry/dubbo-registry-api/src/test/java/org/apache/dubbo/registry/client/metadata/proxy/RemoteMetadataServiceProxyTest.java
@@ -1,0 +1,56 @@
+package org.apache.dubbo.registry.client.metadata.proxy;
+
+import org.apache.dubbo.common.utils.StringUtils;
+import org.apache.dubbo.common.utils.UrlUtils;
+import org.apache.dubbo.registry.client.DefaultServiceInstance;
+import org.apache.dubbo.registry.client.ServiceInstance;
+
+import junit.framework.Assert;
+import org.junit.jupiter.api.Test;
+
+import static java.lang.String.valueOf;
+
+/**
+ * {@link RemoteMetadataServiceProxy} Test
+ *
+ * @since 2.7.5
+ */
+public class RemoteMetadataServiceProxyTest {
+
+    @Test
+    public void testGetServiceDefinition() {
+        String serviceKey = "a/org.apache.dubbo.demo.DemoService:1.0.0";
+
+        String[] services = UrlUtils.parseServiceKey(serviceKey);
+        String serviceInterface = services[1];
+        // if version or group is not exist
+        String group = null;
+        if (StringUtils.isNotEmpty(services[0])) {
+            group = services[0];
+        }
+        String version = null;
+        if (StringUtils.isNotEmpty(services[2])) {
+            version = services[2];
+        }
+        Assert.assertEquals(serviceInterface, "org.apache.dubbo.demo.DemoService");
+        Assert.assertEquals(version, "1.0.0");
+        Assert.assertEquals(group, "a");
+
+        serviceKey = "org.apache.dubbo.demo.DemoService";
+
+        services = UrlUtils.parseServiceKey(serviceKey);
+        serviceInterface = services[1];
+        // if version or group is not exist
+        group = null;
+        if (StringUtils.isNotEmpty(services[0])) {
+            group = services[0];
+        }
+        version = null;
+        if (StringUtils.isNotEmpty(services[2])) {
+            version = services[2];
+        }
+        Assert.assertEquals(serviceInterface, "org.apache.dubbo.demo.DemoService");
+        Assert.assertEquals(version, null);
+        Assert.assertEquals(group, null);
+    }
+}

--- a/dubbo-registry/dubbo-registry-api/src/test/java/org/apache/dubbo/registry/client/metadata/proxy/RemoteMetadataServiceProxyTest.java
+++ b/dubbo-registry/dubbo-registry-api/src/test/java/org/apache/dubbo/registry/client/metadata/proxy/RemoteMetadataServiceProxyTest.java
@@ -1,10 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.dubbo.registry.client.metadata.proxy;
 
 import org.apache.dubbo.common.utils.StringUtils;
 import org.apache.dubbo.common.utils.UrlUtils;
-
 import org.junit.jupiter.api.Test;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**

--- a/dubbo-registry/dubbo-registry-api/src/test/java/org/apache/dubbo/registry/client/metadata/proxy/RemoteMetadataServiceProxyTest.java
+++ b/dubbo-registry/dubbo-registry-api/src/test/java/org/apache/dubbo/registry/client/metadata/proxy/RemoteMetadataServiceProxyTest.java
@@ -20,6 +20,7 @@ import org.apache.dubbo.common.utils.StringUtils;
 import org.apache.dubbo.common.utils.UrlUtils;
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 /**
  * {@link RemoteMetadataServiceProxy} Test
@@ -61,7 +62,7 @@ public class RemoteMetadataServiceProxyTest {
             version = services[2];
         }
         assertEquals(serviceInterface, "org.apache.dubbo.demo.DemoService");
-        assertEquals(version, null);
-        assertEquals(group, null);
+        assertNull(version);
+        assertNull(group);
     }
 }

--- a/dubbo-registry/dubbo-registry-api/src/test/resources/META-INF/dubbo/org.apache.dubbo.metadata.report.MetadataReportFactory
+++ b/dubbo-registry/dubbo-registry-api/src/test/resources/META-INF/dubbo/org.apache.dubbo.metadata.report.MetadataReportFactory
@@ -1,0 +1,1 @@
+JTest=org.apache.dubbo.metadata.test.JTestMetadataReportFactory4Test

--- a/dubbo-registry/dubbo-registry-api/src/test/resources/META-INF/dubbo/org.apache.dubbo.metadata.report.MetadataReportFactory
+++ b/dubbo-registry/dubbo-registry-api/src/test/resources/META-INF/dubbo/org.apache.dubbo.metadata.report.MetadataReportFactory
@@ -1,1 +1,0 @@
-JTest=org.apache.dubbo.metadata.test.JTestMetadataReportFactory4Test


### PR DESCRIPTION
## What is the purpose of the change

bugfix method RemoteMetadataServiceProxy#getServiceDefinition.

## Brief changelog

get serviceInterface,group and version from UrlUtils.parseServiceKey results

## Verifying this change

run test method org.apache.dubbo.registry.client.metadata.proxy.RemoteMetadataServiceProxyTest#testGetServiceDefinition

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a [GITHUB_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [x] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Run `mvn clean install -DskipTests=false` & `mvn clean test-compile failsafe:integration-test` to make sure unit-test and integration-test pass.
- [x] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
