### PR TITLE
[Dubbo-6027] Fix ConcurrentModificationException in ShutdownHookCallbacks#callback

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/lang/ShutdownHookCallbacks.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/lang/ShutdownHookCallbacks.java
@@ -19,10 +19,11 @@ package org.apache.dubbo.common.lang;
 import org.apache.dubbo.common.extension.ExtensionLoader;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.stream.Collectors;
 
-import static java.util.Collections.sort;
 import static org.apache.dubbo.common.function.ThrowableAction.execute;
 
 /**
@@ -47,10 +48,17 @@ public class ShutdownHookCallbacks {
         return this;
     }
 
+    public ShutdownHookCallbacks addCallbacks(Collection<ShutdownHookCallback> callbacks) {
+        synchronized (this) {
+            this.callbacks.addAll(callbacks);
+        }
+        return this;
+    }
+
     public Collection<ShutdownHookCallback> getCallbacks() {
         synchronized (this) {
-            sort(this.callbacks);
-            return this.callbacks;
+            return Collections.unmodifiableList(this.callbacks.stream()
+                    .sorted().collect(Collectors.toList()));
         }
     }
 
@@ -63,7 +71,7 @@ public class ShutdownHookCallbacks {
     private void loadCallbacks() {
         ExtensionLoader<ShutdownHookCallback> loader =
                 ExtensionLoader.getExtensionLoader(ShutdownHookCallback.class);
-        loader.getSupportedExtensionInstances().forEach(this::addCallback);
+        addCallbacks(loader.getSupportedExtensionInstances());
     }
 
     public void callback() {

--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/bootstrap/DubboBootstrap.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/bootstrap/DubboBootstrap.java
@@ -21,7 +21,6 @@ import org.apache.dubbo.common.config.Environment;
 import org.apache.dubbo.common.config.configcenter.DynamicConfiguration;
 import org.apache.dubbo.common.config.configcenter.wrapper.CompositeDynamicConfiguration;
 import org.apache.dubbo.common.extension.ExtensionLoader;
-import org.apache.dubbo.common.lang.ShutdownHookCallback;
 import org.apache.dubbo.common.lang.ShutdownHookCallbacks;
 import org.apache.dubbo.common.logger.Logger;
 import org.apache.dubbo.common.logger.LoggerFactory;
@@ -187,12 +186,7 @@ public class DubboBootstrap extends GenericEventListener {
         environment = ApplicationModel.getEnvironment();
 
         DubboShutdownHook.getDubboShutdownHook().register();
-        ShutdownHookCallbacks.INSTANCE.addCallback(new ShutdownHookCallback() {
-            @Override
-            public void callback() throws Throwable {
-                DubboBootstrap.this.destroy();
-            }
-        });
+        ShutdownHookCallbacks.INSTANCE.addCallback(this::destroy);
     }
 
     public void unRegisterShutdownHook() {


### PR DESCRIPTION
## What is the purpose of the change

- fix #6027
- Polish ShutdownHookCallbacks to fix ConcurrentModificationException in `ShutdownHookCallbacks#callback`

## Brief changelog

- return `unmodifiableList` in `getCallbacks `
- use `addCallbacks ` instead of `foreach(::addCallback)`

## Verifying this change

- run test case `ShutdownHookCallbacksTest:: testConcurrenceCallback`

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a [GITHUB_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [x] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Run `mvn clean install -DskipTests=false` & `mvn clean test-compile failsafe:integration-test` to make sure unit-test and integration-test pass.
- [x] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
