### PR TITLE
NettyChannel can be added to CHANNEL_MAP cache

### DIFF
--- a/dubbo-remoting/dubbo-remoting-netty4/src/main/java/org/apache/dubbo/remoting/transport/netty4/NettyChannel.java
+++ b/dubbo-remoting/dubbo-remoting-netty4/src/main/java/org/apache/dubbo/remoting/transport/netty4/NettyChannel.java
@@ -89,8 +89,8 @@ final class NettyChannel extends AbstractChannel {
             NettyChannel nettyChannel = new NettyChannel(ch, url, handler);
             if (ch.isActive()) {
                 nettyChannel.markActive(true);
-                ret = CHANNEL_MAP.putIfAbsent(ch, nettyChannel);
             }
+            ret = CHANNEL_MAP.putIfAbsent(ch, nettyChannel);
             if (ret == null) {
                 ret = nettyChannel;
             }


### PR DESCRIPTION
## What is the purpose of the change

Amend the use of CHANNEL_MAP cache.

## Brief changelog

NettyChannel (which encapsulates the netty channel) should be added to CHANNEL_MAP cache whether the netty channel is ACTIVE or INACTIVE. I think what determines this is only gc, then we considering the garbage reclaiming mechanism. But in fact, the netty channel state (exists or does not exist) will never affect whether the NettyChannel cleaned by gc or not.

## Verifying this change

See Commits.

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a [GITHUB_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Run `mvn clean install -DskipTests=false` & `mvn clean test-compile failsafe:integration-test` to make sure unit-test and integration-test pass.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).