### PR TITLE
fixbug reference methods parameters not effect

### DIFF
--- a/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/api/HelloService.java
+++ b/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/api/HelloService.java
@@ -19,4 +19,5 @@ package org.apache.dubbo.config.spring.api;
 
 public interface HelloService {
     String sayHello(String name);
+    String retry();
 }

--- a/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/beans/factory/annotation/ReferenceAnnotationBeanPostProcessorTest.java
+++ b/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/beans/factory/annotation/ReferenceAnnotationBeanPostProcessorTest.java
@@ -21,6 +21,7 @@ import org.apache.dubbo.config.annotation.Reference;
 import org.apache.dubbo.config.spring.ReferenceBean;
 import org.apache.dubbo.config.spring.api.DemoService;
 import org.apache.dubbo.config.spring.api.HelloService;
+import org.apache.dubbo.config.spring.impl.HelloServiceImpl;
 import org.apache.dubbo.config.utils.ReferenceConfigCache;
 
 import org.aspectj.lang.ProceedingJoinPoint;
@@ -101,7 +102,7 @@ public class ReferenceAnnotationBeanPostProcessorTest {
     private HelloService helloServiceImpl;
 
     // #4 ReferenceBean (Field Injection #2)
-    @Reference(id = "helloService", methods = @Method(name = "sayHello", timeout = 100))
+    @Reference(id = "helloService", methods = @Method(name = "sayHello", timeout = 100, retries = 5))
     private HelloService helloService;
 
     // #5 ReferenceBean (Field Injection #3)
@@ -131,7 +132,8 @@ public class ReferenceAnnotationBeanPostProcessorTest {
         Assert.assertEquals("Greeting, Mercy", defaultHelloService.sayHello("Mercy"));
         Assert.assertEquals("Hello, Mercy", helloServiceImpl.sayHello("Mercy"));
         Assert.assertEquals("Greeting, Mercy", helloService.sayHello("Mercy"));
-
+        helloService.retry();
+        Assert.assertEquals(HelloServiceImpl.retries.get(), 5);
 
         Assert.assertEquals(expectedResult, testBean.getDemoServiceFromAncestor().sayName("Mercy"));
         Assert.assertEquals(expectedResult, testBean.getDemoServiceFromParent().sayName("Mercy"));

--- a/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/context/annotation/provider/DefaultHelloService.java
+++ b/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/context/annotation/provider/DefaultHelloService.java
@@ -35,4 +35,9 @@ public class DefaultHelloService implements HelloService {
         return "Greeting, " + name;
     }
 
+    @Override
+    public String retry() {
+        return "";
+    }
+
 }

--- a/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/context/annotation/provider/HelloServiceImpl.java
+++ b/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/context/annotation/provider/HelloServiceImpl.java
@@ -20,6 +20,8 @@ import org.apache.dubbo.config.spring.api.HelloService;
 
 import com.alibaba.dubbo.config.annotation.Service;
 
+import java.util.concurrent.atomic.AtomicInteger;
+
 /**
  * {@link HelloService} Implementation just annotating Dubbo's {@link Service}
  *
@@ -31,5 +33,10 @@ public class HelloServiceImpl implements HelloService {
     @Override
     public String sayHello(String name) {
         return "Hello, " + name;
+    }
+
+    @Override
+    public String retry() {
+        return "";
     }
 }

--- a/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/impl/HelloServiceImpl.java
+++ b/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/impl/HelloServiceImpl.java
@@ -18,9 +18,24 @@ package org.apache.dubbo.config.spring.impl;
 
 import org.apache.dubbo.config.spring.api.HelloService;
 
+import java.util.concurrent.atomic.AtomicInteger;
+
 public class HelloServiceImpl implements HelloService {
+
+    public static AtomicInteger retries = new AtomicInteger(0);
 
     public String sayHello(String name) {
         return "Hello, " + name;
+    }
+
+    @Override
+    public String retry() {
+        try {
+            retries.incrementAndGet();
+            Thread.sleep(2000);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+        return "success";
     }
 }


### PR DESCRIPTION
## What is the purpose of the change
fixbug reference methods parameters not effect

## Brief changelog

The configuration method parameter is not set when the Reference annotation is initialized.

## Verifying this change

add test to verify the change.

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a [GITHUB_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [x] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Run `mvn clean install -DskipTests=false` & `mvn clean test-compile failsafe:integration-test` to make sure unit-test and integration-test pass.
- [x] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
