### PR TITLE
[Enhancement] Resolving the placeholders of XML BeanDefinition in the Configuration Class

### DIFF
--- a/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/schema/DubboBeanDefinitionParser.java
+++ b/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/schema/DubboBeanDefinitionParser.java
@@ -42,6 +42,7 @@ import org.springframework.beans.factory.support.ManagedMap;
 import org.springframework.beans.factory.support.RootBeanDefinition;
 import org.springframework.beans.factory.xml.BeanDefinitionParser;
 import org.springframework.beans.factory.xml.ParserContext;
+import org.springframework.core.env.Environment;
 import org.w3c.dom.Element;
 import org.w3c.dom.NamedNodeMap;
 import org.w3c.dom.Node;
@@ -83,14 +84,14 @@ public class DubboBeanDefinitionParser implements BeanDefinitionParser {
         RootBeanDefinition beanDefinition = new RootBeanDefinition();
         beanDefinition.setBeanClass(beanClass);
         beanDefinition.setLazyInit(false);
-        String id = element.getAttribute("id");
+        String id = resolveAttribute(element, "id", parserContext);
         if (StringUtils.isEmpty(id) && required) {
-            String generatedBeanName = element.getAttribute("name");
+            String generatedBeanName = resolveAttribute(element, "name", parserContext);
             if (StringUtils.isEmpty(generatedBeanName)) {
                 if (ProtocolConfig.class.equals(beanClass)) {
                     generatedBeanName = "dubbo";
                 } else {
-                    generatedBeanName = element.getAttribute("interface");
+                    generatedBeanName = resolveAttribute(element, "interface", parserContext);
                 }
             }
             if (StringUtils.isEmpty(generatedBeanName)) {
@@ -121,21 +122,21 @@ public class DubboBeanDefinitionParser implements BeanDefinitionParser {
                 }
             }
         } else if (ServiceBean.class.equals(beanClass)) {
-            String className = element.getAttribute("class");
+            String className = resolveAttribute(element, "class", parserContext);
             if (StringUtils.isNotEmpty(className)) {
                 RootBeanDefinition classDefinition = new RootBeanDefinition();
                 classDefinition.setBeanClass(ReflectUtils.forName(className));
                 classDefinition.setLazyInit(false);
-                parseProperties(element.getChildNodes(), classDefinition);
+                parseProperties(element.getChildNodes(), classDefinition, parserContext);
                 beanDefinition.getPropertyValues().addPropertyValue("ref", new BeanDefinitionHolder(classDefinition, id + "Impl"));
             }
-        }  else if(ReferenceBean.class.equals(beanClass)){
-            String interfaceClassName = element.getAttribute("interface");
-            if(StringUtils.isNotEmpty(interfaceClassName)){
+        } else if (ReferenceBean.class.equals(beanClass)) {
+            String interfaceClassName = resolveAttribute(element, "interface", parserContext);
+            if (StringUtils.isNotEmpty(interfaceClassName)) {
                 Class<?> interfaceClass = ReflectUtils.forName(interfaceClassName);
                 beanDefinition.setTargetType(interfaceClass);
             }
-        }else if (ProviderConfig.class.equals(beanClass)) {
+        } else if (ProviderConfig.class.equals(beanClass)) {
             parseNested(element, parserContext, ServiceBean.class, true, "service", "provider", id, beanDefinition);
         } else if (ConsumerConfig.class.equals(beanClass)) {
             parseNested(element, parserContext, ReferenceBean.class, false, "reference", "consumer", id, beanDefinition);
@@ -169,13 +170,13 @@ public class DubboBeanDefinitionParser implements BeanDefinitionParser {
                     continue;
                 }
                 if ("parameters".equals(property)) {
-                    parameters = parseParameters(element.getChildNodes(), beanDefinition);
+                    parameters = parseParameters(element.getChildNodes(), beanDefinition, parserContext);
                 } else if ("methods".equals(property)) {
                     parseMethods(id, element.getChildNodes(), beanDefinition, parserContext);
                 } else if ("arguments".equals(property)) {
                     parseArguments(id, element.getChildNodes(), beanDefinition, parserContext);
                 } else {
-                    String value = element.getAttribute(property);
+                    String value = resolveAttribute(element, property, parserContext);
                     if (value != null) {
                         value = value.trim();
                         if (value.length() > 0) {
@@ -267,7 +268,7 @@ public class DubboBeanDefinitionParser implements BeanDefinitionParser {
                     || tag.equals(node.getLocalName())) {
                 if (first) {
                     first = false;
-                    String isDefault = element.getAttribute("default");
+                    String isDefault = resolveAttribute(element, "default", parserContext);
                     if (StringUtils.isEmpty(isDefault)) {
                         beanDefinition.getPropertyValues().addPropertyValue("default", "false");
                     }
@@ -280,7 +281,7 @@ public class DubboBeanDefinitionParser implements BeanDefinitionParser {
         }
     }
 
-    private static void parseProperties(NodeList nodeList, RootBeanDefinition beanDefinition) {
+    private static void parseProperties(NodeList nodeList, RootBeanDefinition beanDefinition, ParserContext parserContext) {
         if (nodeList == null) {
             return;
         }
@@ -291,10 +292,10 @@ public class DubboBeanDefinitionParser implements BeanDefinitionParser {
             Element element = (Element) nodeList.item(i);
             if ("property".equals(element.getNodeName())
                     || "property".equals(element.getLocalName())) {
-                String name = element.getAttribute("name");
+                String name = resolveAttribute(element, "name", parserContext);
                 if (StringUtils.isNotEmpty(name)) {
-                    String value = element.getAttribute("value");
-                    String ref = element.getAttribute("ref");
+                    String value = resolveAttribute(element, "value", parserContext);
+                    String ref = resolveAttribute(element, "ref", parserContext);
                     if (StringUtils.isNotEmpty(value)) {
                         beanDefinition.getPropertyValues().addPropertyValue(name, value);
                     } else if (StringUtils.isNotEmpty(ref)) {
@@ -308,7 +309,7 @@ public class DubboBeanDefinitionParser implements BeanDefinitionParser {
     }
 
     @SuppressWarnings("unchecked")
-    private static ManagedMap parseParameters(NodeList nodeList, RootBeanDefinition beanDefinition) {
+    private static ManagedMap parseParameters(NodeList nodeList, RootBeanDefinition beanDefinition, ParserContext parserContext) {
         if (nodeList == null) {
             return null;
         }
@@ -323,9 +324,9 @@ public class DubboBeanDefinitionParser implements BeanDefinitionParser {
                 if (parameters == null) {
                     parameters = new ManagedMap();
                 }
-                String key = element.getAttribute("key");
-                String value = element.getAttribute("value");
-                boolean hide = "true".equals(element.getAttribute("hide"));
+                String key = resolveAttribute(element, "key", parserContext);
+                String value = resolveAttribute(element, "value", parserContext);
+                boolean hide = "true".equals(resolveAttribute(element, "hide", parserContext));
                 if (hide) {
                     key = HIDE_KEY_PREFIX + key;
                 }
@@ -348,7 +349,7 @@ public class DubboBeanDefinitionParser implements BeanDefinitionParser {
             }
             Element element = (Element) nodeList.item(i);
             if ("method".equals(element.getNodeName()) || "method".equals(element.getLocalName())) {
-                String methodName = element.getAttribute("name");
+                String methodName = resolveAttribute(element, "name", parserContext);
                 if (StringUtils.isEmpty(methodName)) {
                     throw new IllegalStateException("<dubbo:method> name attribute == null");
                 }
@@ -381,7 +382,7 @@ public class DubboBeanDefinitionParser implements BeanDefinitionParser {
             }
             Element element = (Element) nodeList.item(i);
             if ("argument".equals(element.getNodeName()) || "argument".equals(element.getLocalName())) {
-                String argumentIndex = element.getAttribute("index");
+                String argumentIndex = resolveAttribute(element, "index", parserContext);
                 if (arguments == null) {
                     arguments = new ManagedList();
                 }
@@ -414,5 +415,11 @@ public class DubboBeanDefinitionParser implements BeanDefinitionParser {
      */
     private void registerDubboConfigAliasPostProcessor(BeanDefinitionRegistry registry) {
         registerInfrastructureBean(registry, DubboConfigAliasPostProcessor.BEAN_NAME, DubboConfigAliasPostProcessor.class);
+    }
+
+    private static String resolveAttribute(Element element, String attributeName, ParserContext parserContext) {
+        String attributeValue = element.getAttribute(attributeName);
+        Environment environment = parserContext.getReaderContext().getEnvironment();
+        return environment.resolvePlaceholders(attributeValue);
     }
 }

--- a/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/schema/DubboNamespaceHandlerTest.java
+++ b/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/schema/DubboNamespaceHandlerTest.java
@@ -32,6 +32,11 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.BeanCreationException;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.ImportResource;
+import org.springframework.context.annotation.PropertySource;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 
 import java.util.Map;
@@ -52,21 +57,43 @@ public class DubboNamespaceHandlerTest {
         ApplicationModel.getConfigManager().clear();
     }
 
+    @Configuration
+    @PropertySource("classpath:/META-INF/demo-provider.properties")
+    @ImportResource(locations = "classpath:/org/apache/dubbo/config/spring/demo-provider.xml")
+    static class XmlConfiguration {
+
+    }
+
+    @Test
+    public void testProviderXmlOnConfigurationClass() {
+        AnnotationConfigApplicationContext applicationContext = new AnnotationConfigApplicationContext();
+        applicationContext.register(XmlConfiguration.class);
+        applicationContext.refresh();
+        testProviderXml(applicationContext);
+    }
+
     @Test
     public void testProviderXml() {
-        ClassPathXmlApplicationContext ctx = new ClassPathXmlApplicationContext(ConfigTest.class.getPackage().getName().replace('.', '/') + "/demo-provider.xml");
+        ClassPathXmlApplicationContext ctx = new ClassPathXmlApplicationContext(
+                ConfigTest.class.getPackage().getName().replace('.', '/') + "/demo-provider.xml",
+                ConfigTest.class.getPackage().getName().replace('.', '/') + "/demo-provider-properties.xml"
+        );
         ctx.start();
 
-        ProtocolConfig protocolConfig = ctx.getBean(ProtocolConfig.class);
+        testProviderXml(ctx);
+    }
+
+    private void testProviderXml(ApplicationContext context) {
+        ProtocolConfig protocolConfig = context.getBean(ProtocolConfig.class);
         assertThat(protocolConfig, not(nullValue()));
         assertThat(protocolConfig.getName(), is("dubbo"));
         assertThat(protocolConfig.getPort(), is(20813));
 
-        ApplicationConfig applicationConfig = ctx.getBean(ApplicationConfig.class);
+        ApplicationConfig applicationConfig = context.getBean(ApplicationConfig.class);
         assertThat(applicationConfig, not(nullValue()));
         assertThat(applicationConfig.getName(), is("demo-provider"));
 
-        DemoService service = ctx.getBean(DemoService.class);
+        DemoService service = context.getBean(DemoService.class);
         assertThat(service, not(nullValue()));
     }
 

--- a/dubbo-config/dubbo-config-spring/src/test/resources/META-INF/demo-provider.properties
+++ b/dubbo-config/dubbo-config-spring/src/test/resources/META-INF/demo-provider.properties
@@ -1,0 +1,12 @@
+# The properties for org/apache/dubbo/config/spring/demo-provider.xml
+
+# <dubbo:application name="${dubbo.application.name}"/>
+dubbo.application.name = demo-provider
+
+# <dubbo:registry address="${dubbo.registry.address}"/>
+dubbo.registry.address = N/A
+
+# <dubbo:protocol name="${dubbo.protocol.name}" port="${dubbo.protocol.port}"/>
+dubbo.protocol.name = dubbo
+dubbo.protocol.port = 20813
+

--- a/dubbo-config/dubbo-config-spring/src/test/resources/org/apache/dubbo/config/spring/demo-provider-properties.xml
+++ b/dubbo-config/dubbo-config-spring/src/test/resources/org/apache/dubbo/config/spring/demo-provider-properties.xml
@@ -15,23 +15,11 @@
   limitations under the License.
   -->
 <beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:dubbo="http://dubbo.apache.org/schema/dubbo"
        xmlns="http://www.springframework.org/schema/beans"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.3.xsd
-    http://dubbo.apache.org/schema/dubbo http://dubbo.apache.org/schema/dubbo/dubbo.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.3.xsd">
 
-    <!-- current application configuration -->
-    <dubbo:application name="${dubbo.application.name}"/>
-
-    <!-- registry center configuration -->
-    <dubbo:registry address="${dubbo.registry.address}"/>
-
-    <!-- service protocol configuration -->
-    <dubbo:protocol name="${dubbo.protocol.name}" port="${dubbo.protocol.port}"/>
-
-    <!-- service configuration -->
-    <dubbo:service interface="org.apache.dubbo.config.spring.api.DemoService" ref="demoService"/>
-
-    <bean id="demoService" class="org.apache.dubbo.config.spring.impl.DemoServiceImpl"/>
+    <bean class="org.springframework.context.support.PropertySourcesPlaceholderConfigurer">
+        <property name="location" value="classpath:/META-INF/demo-provider.properties"/>
+    </bean>
 
 </beans>


### PR DESCRIPTION
It does not work in Dubbo 2.7.6 

```java
    @Configuration
    @PropertySource("classpath:/META-INF/demo-provider.properties")
    @ImportResource(locations = "classpath:/org/apache/dubbo/config/spring/demo-provider.xml")
    static class XmlConfiguration {

    }
```