### PR TITLE
Save memory usage in TagRouter

### DIFF
--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/router/tag/TagRouter.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/router/tag/TagRouter.java
@@ -193,6 +193,18 @@ public class TagRouter extends AbstractRouter implements ConfigurationListener {
     }
 
     private <T> List<Invoker<T>> filterInvoker(List<Invoker<T>> invokers, Predicate<Invoker<T>> predicate) {
+        boolean filter = false;
+        for (int i = 0; i < invokers.size(); ++i) {
+            Invoker<T> invoker = invokers.get(i);
+            if (!predicate.test(invoker)) {
+                filter = true;
+                break;
+            }
+        }
+        if (!filter) {
+            return invokers;
+        }
+
         return invokers.stream()
                 .filter(predicate)
                 .collect(Collectors.toList());


### PR DESCRIPTION
## What is the purpose of the change

Related issue: https://github.com/apache/dubbo/issues/6082

Save memory usage in `TagRoute#route()` method.  
In default call, none invokers will be filtered by `TagRouter`, but `TagRouter` will create a new `List<Invoker<T>>` when every RPC comes. We can use a pre-loop to check whether there have any changes in origin list. If not, we can return origin list directly, otherwise a new `List<Invoker<T>>` will be created.  
In default circumstance, the time complexity is same with original code, but the space complexity is more less than original's.  

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a [GITHUB_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [x] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Run `mvn clean install -DskipTests=false` & `mvn clean test-compile failsafe:integration-test` to make sure unit-test and integration-test pass.
- [x] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
