### PR TITLE
1、support for merger when use @Reference or @Method or @DubboReference

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/config/annotation/DubboReference.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/config/annotation/DubboReference.java
@@ -263,9 +263,12 @@ public @interface DubboReference {
     String tag() default "";
 
     /**
+     * Service merger
+     */
+    String merger() default "";
+
+    /**
      * methods support
-     *
-     * @return
      */
     Method[] methods() default {};
 

--- a/dubbo-common/src/main/java/org/apache/dubbo/config/annotation/Method.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/config/annotation/Method.java
@@ -65,5 +65,7 @@ public @interface Method {
 
     String validation() default "";
 
+    String merger() default "";
+
     Argument[] arguments() default {};
 }

--- a/dubbo-common/src/main/java/org/apache/dubbo/config/annotation/Reference.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/config/annotation/Reference.java
@@ -266,9 +266,12 @@ public @interface Reference {
     String tag() default "";
 
     /**
+     * Service merger
+     */
+    String merger() default "";
+
+    /**
      * methods support
-     *
-     * @return
      */
     Method[] methods() default {};
 


### PR DESCRIPTION
## What is the purpose of the change

fixes [#6090 ]

## Brief changelog

修改@Method、@Reference、@DubboReference，增加merger；
因为ReferenceConfig、MethodConfig都是继承自AbstractConfig，AbstractConfig中包含merger属性，所以注解中增加merger后，创建config时会进行填充

## Verifying this change

我已经完成测试