### PR TITLE
1、configuration.publishConfig returns false，without throw exception

### DIFF
--- a/dubbo-common/src/test/java/org/apache/dubbo/common/config/configcenter/AbstractDynamicConfigurationTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/config/configcenter/AbstractDynamicConfigurationTest.java
@@ -33,6 +33,7 @@ import static org.apache.dubbo.common.config.configcenter.AbstractDynamicConfigu
 import static org.apache.dubbo.common.config.configcenter.AbstractDynamicConfiguration.THREAD_POOL_PREFIX_PARAM_NAME;
 import static org.apache.dubbo.common.config.configcenter.AbstractDynamicConfiguration.THREAD_POOL_SIZE_PARAM_NAME;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -112,7 +113,7 @@ public class AbstractDynamicConfigurationTest {
 
     @Test
     public void testGetConfigKeys() {
-        assertThrows(UnsupportedOperationException.class, () -> configuration.getConfigKeys(null), "No support");
+        assertTrue(configuration.getConfigKeys(null).isEmpty());
     }
 
     @Test

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/config/configcenter/AbstractDynamicConfigurationTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/config/configcenter/AbstractDynamicConfigurationTest.java
@@ -33,6 +33,7 @@ import static org.apache.dubbo.common.config.configcenter.AbstractDynamicConfigu
 import static org.apache.dubbo.common.config.configcenter.AbstractDynamicConfiguration.THREAD_POOL_PREFIX_PARAM_NAME;
 import static org.apache.dubbo.common.config.configcenter.AbstractDynamicConfiguration.THREAD_POOL_SIZE_PARAM_NAME;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -105,8 +106,8 @@ public class AbstractDynamicConfigurationTest {
 
     @Test
     public void testPublishConfig() {
-        assertThrows(UnsupportedOperationException.class, () -> configuration.publishConfig(null, null), "No support");
-        assertThrows(UnsupportedOperationException.class, () -> configuration.publishConfig(null, null, null), "No support");
+        assertFalse(configuration.publishConfig(null, null));
+        assertFalse(configuration.publishConfig(null, null, null));
     }
 
     @Test


### PR DESCRIPTION
## What is the purpose of the change

fixes [#6093 ]

## Brief changelog

configuration.publishConfig默认方法不再抛出异常，默认返回false，所以单元测试需要同步修改

## Verifying this change

本地已完成测试