### PR TITLE
fix concurrent bug (avoid NullPointerException)

### DIFF
--- a/dubbo-rpc/dubbo-rpc-dubbo/src/main/java/org/apache/dubbo/rpc/protocol/dubbo/DubboProtocol.java
+++ b/dubbo-rpc/dubbo-rpc-dubbo/src/main/java/org/apache/dubbo/rpc/protocol/dubbo/DubboProtocol.java
@@ -453,7 +453,7 @@ public class DubboProtocol extends AbstractProtocol {
             batchClientRefIncr(clients);
             return clients;
         }
-        synchronized (this) {
+        synchronized (referenceClientMap) {
             clients = referenceClientMap.get(key);
             // dubbo check
             if (checkClientCanUse(clients)) {


### PR DESCRIPTION
## What is the purpose of the change

Resolve concurrent bug (or NullPointerException) in DubboProtocol.java

## Brief changelog

The statement "locks.get(key)" will get NULL after "locks.remove(key);", and then "synchronized(null)" will throw NullPointerException. Obviously, this two statement, "locks.putIfAbsent(key, new Object());" and "locks.get(key)", are not an atomic operation.

I can't find a better way to reduce lock granularity, maybe we have to sacrifice some performance to ensure safety here.

## Verifying this change

XXXXX

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a [GITHUB_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Run `mvn clean install -DskipTests=false` & `mvn clean test-compile failsafe:integration-test` to make sure unit-test and integration-test pass.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
