### PR TITLE
Lambda replaced with method reference

### DIFF
--- a/dubbo-compatible/src/main/java/com/alibaba/dubbo/registry/support/FailbackRegistry.java
+++ b/dubbo-compatible/src/main/java/com/alibaba/dubbo/registry/support/FailbackRegistry.java
@@ -76,12 +76,12 @@ public abstract class FailbackRegistry implements org.apache.dubbo.registry.Regi
     }
 
     protected void notify(URL url, NotifyListener listener, List<URL> urls) {
-        List<org.apache.dubbo.common.URL> urlResult = urls.stream().map(e -> e.getOriginalURL()).collect(Collectors.toList());
+        List<org.apache.dubbo.common.URL> urlResult = urls.stream().map(URL::getOriginalURL).collect(Collectors.toList());
         failbackRegistry.notify(url.getOriginalURL(), new com.alibaba.dubbo.registry.NotifyListener.ReverseCompatibleNotifyListener(listener), urlResult);
     }
 
     protected void doNotify(URL url, NotifyListener listener, List<URL> urls) {
-        List<org.apache.dubbo.common.URL> urlResult = urls.stream().map(e -> e.getOriginalURL()).collect(Collectors.toList());
+        List<org.apache.dubbo.common.URL> urlResult = urls.stream().map(URL::getOriginalURL).collect(Collectors.toList());
         failbackRegistry.doNotify(url.getOriginalURL(), new com.alibaba.dubbo.registry.NotifyListener.ReverseCompatibleNotifyListener(listener), urlResult);
     }
 
@@ -91,7 +91,7 @@ public abstract class FailbackRegistry implements org.apache.dubbo.registry.Regi
 
     @Override
     public List<URL> lookup(URL url) {
-        return failbackRegistry.lookup(url.getOriginalURL()).stream().map(e -> new URL(e)).collect(Collectors.toList());
+        return failbackRegistry.lookup(url.getOriginalURL()).stream().map(URL::new).collect(Collectors.toList());
     }
 
     @Override

--- a/dubbo-compatible/src/main/java/com/alibaba/dubbo/registry/support/FailbackRegistry.java
+++ b/dubbo-compatible/src/main/java/com/alibaba/dubbo/registry/support/FailbackRegistry.java
@@ -91,7 +91,7 @@ public abstract class FailbackRegistry implements org.apache.dubbo.registry.Regi
 
     @Override
     public List<URL> lookup(URL url) {
-        return failbackRegistry.lookup(url.getOriginalURL()).stream().map(URL::new).collect(Collectors.toList());
+        return failbackRegistry.lookup(url.getOriginalURL()).stream().map(e -> new URL(e)).collect(Collectors.toList());
     }
 
     @Override

--- a/dubbo-compatible/src/main/java/com/alibaba/dubbo/rpc/cluster/Directory.java
+++ b/dubbo-compatible/src/main/java/com/alibaba/dubbo/rpc/cluster/Directory.java
@@ -37,6 +37,6 @@ public interface Directory<T> extends org.apache.dubbo.rpc.cluster.Directory<T> 
     @Override
     default List<Invoker<T>> list(Invocation invocation) throws RpcException {
         List<com.alibaba.dubbo.rpc.Invoker<T>> res = this.list(new com.alibaba.dubbo.rpc.Invocation.CompatibleInvocation(invocation));
-        return res.stream().map(i -> i.getOriginal()).collect(Collectors.toList());
+        return res.stream().map(com.alibaba.dubbo.rpc.Invoker::getOriginal).collect(Collectors.toList());
     }
 }

--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/bootstrap/DubboBootstrap.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/bootstrap/DubboBootstrap.java
@@ -1092,9 +1092,7 @@ public class DubboBootstrap extends GenericEventListener {
 
     private void destroyServiceDiscoveries() {
         getServiceDiscoveries().forEach(serviceDiscovery -> {
-            execute(() -> {
-                serviceDiscovery.destroy();
-            });
+            execute(serviceDiscovery::destroy);
         });
         if (logger.isDebugEnabled()) {
             logger.debug(NAME + "'s all ServiceDiscoveries have been destroyed.");


### PR DESCRIPTION
Replace lambda expressions with method references to improve code simplicity.