### PR TITLE
[Dubbo-#6126] Fix old async compatible with FutureAdapter

### DIFF
--- a/dubbo-compatible/src/main/java/com/alibaba/dubbo/rpc/protocol/dubbo/FutureAdapter.java
+++ b/dubbo-compatible/src/main/java/com/alibaba/dubbo/rpc/protocol/dubbo/FutureAdapter.java
@@ -51,9 +51,7 @@ public class FutureAdapter<V> implements Future<V> {
             public Object get() throws RemotingException {
                 try {
                     return future.get();
-                } catch (InterruptedException e) {
-                    throw new RemotingException(e);
-                } catch (ExecutionException e) {
+                } catch (InterruptedException | ExecutionException e) {
                     throw new RemotingException(e);
                 }
             }
@@ -62,11 +60,7 @@ public class FutureAdapter<V> implements Future<V> {
             public Object get(int timeoutInMillis) throws RemotingException {
                 try {
                     return future.get(timeoutInMillis, TimeUnit.MILLISECONDS);
-                } catch (InterruptedException e) {
-                    throw new RemotingException(e);
-                } catch (ExecutionException e) {
-                    throw new RemotingException(e);
-                } catch (TimeoutException e) {
+                } catch (InterruptedException | ExecutionException | TimeoutException e) {
                     throw new RemotingException(e);
                 }
             }

--- a/dubbo-compatible/src/test/java/org/apache/dubbo/rpc/protocol/dubbo/FutureAdapterTest.java
+++ b/dubbo-compatible/src/test/java/org/apache/dubbo/rpc/protocol/dubbo/FutureAdapterTest.java
@@ -1,0 +1,35 @@
+package org.apache.dubbo.rpc.protocol.dubbo;
+
+import com.alibaba.dubbo.remoting.exchange.ResponseCallback;
+import com.alibaba.dubbo.rpc.Result;
+import com.alibaba.dubbo.rpc.protocol.dubbo.FutureAdapter;
+import org.apache.dubbo.rpc.AppResponse;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CompletableFuture;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+/**
+ * @author zhenyu.nie created on 2020 2020/5/9 16:23
+ */
+public class FutureAdapterTest {
+
+    @Test
+    public void testCallbackResponseInstanceOfOldResult() {
+        AppResponse response = new AppResponse("response");
+        FutureAdapter<Object> futureAdapter = new FutureAdapter<>(CompletableFuture.completedFuture(response));
+        futureAdapter.getFuture().setCallback(new ResponseCallback() {
+            @Override
+            public void done(Object response) {
+                assertThat(response, instanceOf(Result.class));
+            }
+
+            @Override
+            public void caught(Throwable exception) {
+
+            }
+        });
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

Fix old async compatible with FutureAdapter. (#6126)

修复FutureAdapter类的兼容性问题

## Brief changelog

#6126 
the process logic of class FutureAdapter's callback is diferent from 2.6.x to 2.7.x.
maybe return a value object with response is better than return a Result object, but same code have different behavior is uncomfortable after update

在2.7和之前的dubbo版本里面，从FutureAdapter处获取ResponseFuture后的callback处理逻辑不一样。
也许直接返回值的处理更好，但是如果我们升级工程后运行，所有类似的调用全都会挂掉，必须得找出所有地方并改掉，这不合理。  

## Verifying this change

see unit test

见单元测试
