### PR TITLE
A new class (InternalRunnable) is added to wrap the ordinary Runnable…

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/threadlocal/InternalRunnable.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/threadlocal/InternalRunnable.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.dubbo.common.threadlocal;
 
 

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/threadlocal/InternalRunnable.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/threadlocal/InternalRunnable.java
@@ -1,18 +1,20 @@
 /*
- * Copyright 2014 The Netty Project
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- * The Netty Project licenses this file to you under the Apache License,
- * version 2.0 (the "License"); you may not use this file except in compliance
- * with the License. You may obtain a copy of the License at:
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
+
 package org.apache.dubbo.common.threadlocal;
 
 

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/threadlocal/InternalRunnable.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/threadlocal/InternalRunnable.java
@@ -1,0 +1,36 @@
+package org.apache.dubbo.common.threadlocal;
+
+
+/**
+ * InternalRunnable
+ * There is a risk of memory leak when using {@link InternalThreadLocal} without calling
+ * {@link InternalThreadLocal#removeAll()}.
+ * This design is learning from {@see io.netty.util.concurrent.FastThreadLocalRunnable} which is in Netty.
+ */
+public class InternalRunnable implements Runnable{
+    private final Runnable runnable;
+
+    public InternalRunnable(Runnable runnable){
+        this.runnable=runnable;
+    }
+
+    /**
+     * After the task execution is completed, it will call {@link InternalThreadLocal#removeAll()} to clear
+     * unnecessary variables in the thread.
+     */
+    @Override
+    public void run() {
+        try{
+            runnable.run();
+        }finally {
+            InternalThreadLocal.removeAll();
+        }
+    }
+
+    /**
+     * Wrap ordinary Runnable into {@link InternalThreadLocal}.
+     */
+    public static Runnable Wrap(Runnable runnable){
+        return runnable instanceof InternalRunnable?runnable:new InternalRunnable(runnable);
+    }
+}

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/threadlocal/InternalRunnable.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/threadlocal/InternalRunnable.java
@@ -20,7 +20,7 @@ package org.apache.dubbo.common.threadlocal;
 
 /**
  * InternalRunnable
- * There is a risk of memory leak :when using {@link InternalThreadLocal} without calling
+ * There is a risk of memory leak when using {@link InternalThreadLocal} without calling
  * {@link InternalThreadLocal#removeAll()}.
  * This design is learning from {@see io.netty.util.concurrent.FastThreadLocalRunnable} which is in Netty.
  */
@@ -47,7 +47,7 @@ public class InternalRunnable implements Runnable{
     /**
      * Wrap ordinary Runnable into {@link InternalThreadLocal}.
      */
-    public static Runnable Wrap(Runnable runnable){
+     static Runnable Wrap(Runnable runnable){
         return runnable instanceof InternalRunnable?runnable:new InternalRunnable(runnable);
     }
 }

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/threadlocal/InternalRunnable.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/threadlocal/InternalRunnable.java
@@ -20,7 +20,7 @@ package org.apache.dubbo.common.threadlocal;
 
 /**
  * InternalRunnable
- * There is a risk of memory leak when using {@link InternalThreadLocal} without calling
+ * There is a risk of memory leak :when using {@link InternalThreadLocal} without calling
  * {@link InternalThreadLocal#removeAll()}.
  * This design is learning from {@see io.netty.util.concurrent.FastThreadLocalRunnable} which is in Netty.
  */

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/threadlocal/NamedInternalThreadFactory.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/threadlocal/NamedInternalThreadFactory.java
@@ -40,7 +40,7 @@ public class NamedInternalThreadFactory extends NamedThreadFactory {
     @Override
     public Thread newThread(Runnable runnable) {
         String name = mPrefix + mThreadNum.getAndIncrement();
-        InternalThread ret = new InternalThread(mGroup, runnable, name, 0);
+        InternalThread ret = new InternalThread(mGroup, InternalRunnable.Wrap(runnable), name, 0);
         ret.setDaemon(mDaemon);
         return ret;
     }


### PR DESCRIPTION

## What is the purpose of the change

If subsequent internal components need to use InternalThreadLocal, improper use still has the risk of memory leaks. Using InternalRunnable to wrap ordinary Runnable can automatically clean up the InternalThreadLocal variable of the current thread after the task is completed.

## Brief changelog

dubbo-common/src/main/java/org/apache/dubbo/common/threadlocal/InternalRunnable.java
dubbo-common/src/main/java/org/apache/dubbo/common/threadlocal/NamedInternalThreadFactory.java
## Verifying this change



Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a [GITHUB_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Run `mvn clean install -DskipTests=false` & `mvn clean test-compile failsafe:integration-test` to make sure unit-test and integration-test pass.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
