### PR TITLE
Refactoring (move method) to AccessLogData class

### DIFF
--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/filter/AccessLogFilter.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/filter/AccessLogFilter.java
@@ -103,7 +103,8 @@ public class AccessLogFilter implements Filter {
         try {
             String accessLogKey = invoker.getUrl().getParameter(ACCESS_LOG_KEY);
             if (ConfigUtils.isNotEmpty(accessLogKey)) {
-                AccessLogData logData = buildAccessLogData(invoker, inv);
+                AccessLogData logData = AccessLogData.newLogData(); 
+                logData.buildAccessLogData(invoker, inv);
                 log(accessLogKey, logData);
             }
         } catch (Throwable t) {
@@ -164,18 +165,6 @@ public class AccessLogFilter implements Filter {
             }
             writer.flush();
         }
-    }
-
-    private AccessLogData buildAccessLogData(Invoker<?> invoker, Invocation inv) {
-        AccessLogData logData = AccessLogData.newLogData();
-        logData.setServiceName(invoker.getInterface().getName());
-        logData.setMethodName(inv.getMethodName());
-        logData.setVersion(invoker.getUrl().getParameter(VERSION_KEY));
-        logData.setGroup(invoker.getUrl().getParameter(GROUP_KEY));
-        logData.setInvocationTime(new Date());
-        logData.setTypes(inv.getParameterTypes());
-        logData.setArguments(inv.getArguments());
-        return logData;
     }
 
     private void processWithServiceLogger(Set<AccessLogData> logSet) {

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/support/AccessLogData.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/support/AccessLogData.java
@@ -17,9 +17,14 @@
 package org.apache.dubbo.rpc.support;
 
 import org.apache.dubbo.common.utils.StringUtils;
+import org.apache.dubbo.rpc.Invocation;
+import org.apache.dubbo.rpc.Invoker;
 import org.apache.dubbo.rpc.RpcContext;
 
 import com.alibaba.fastjson.JSON;
+
+import static org.apache.dubbo.common.constants.CommonConstants.GROUP_KEY;
+import static org.apache.dubbo.common.constants.CommonConstants.VERSION_KEY;
 
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
@@ -261,6 +266,16 @@ public final class AccessLogData {
      */
     private void set(String key, Object value) {
         data.put(key, value);
+    }
+    
+    public void buildAccessLogData(Invoker<?> invoker, Invocation inv) {
+        setServiceName(invoker.getInterface().getName());
+        setMethodName(inv.getMethodName());
+        setVersion(invoker.getUrl().getParameter(VERSION_KEY));
+        setGroup(invoker.getUrl().getParameter(GROUP_KEY));
+        setInvocationTime(new Date());
+        setTypes(inv.getParameterTypes());
+        setArguments(inv.getArguments());
     }
 
 }


### PR DESCRIPTION
Hi everyone,

I discovered an opportunity to improve Dubbo. I believe that the buildAccessLogData method should be in the AccessLogData class because it uses only operations from that class.