### PR TITLE
fix ListenableRouter return own priority rather than DEFAULT_PRIORITY

### DIFF
--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/router/condition/config/ListenableRouter.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/router/condition/config/ListenableRouter.java
@@ -92,7 +92,7 @@ public abstract class ListenableRouter extends AbstractRouter implements Configu
 
     @Override
     public int getPriority() {
-        return DEFAULT_PRIORITY;
+        return this.priority;
     }
 
     @Override


### PR DESCRIPTION
## What is the purpose of the change

Fix ListenableRouter return own priority rather than DEFAULT_PRIORITY.
I see dubbo's  original intention is AppRouter should after ServiceRouter. AppRouter and ServiceRouter are all extend form ListenableRouter ,they have set their own priority ,but not override supper's method getPrioprity. So it will invoke supper's method when invoke getPrioprity. Supper's getPrioprity will return DEFAULT_PRIORITY(Integer.MAX_VALUE). This will make  AppRouter before ServiceRouter .

## Brief changelog

Fix ListenableRouter return own priority rather than DEFAULT_PRIORITY

## Verifying this change

I have validated at my local.

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a [GITHUB_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Run `mvn clean install -DskipTests=false` & `mvn clean test-compile failsafe:integration-test` to make sure unit-test and integration-test pass.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
