### PR TITLE
To prevent nodes that did not succeed at one time, the calculated estimateResponse is the lowest

### DIFF
--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/loadbalance/ShortestResponseLoadBalance.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/loadbalance/ShortestResponseLoadBalance.java
@@ -60,7 +60,7 @@ public class ShortestResponseLoadBalance extends AbstractLoadBalance {
             Invoker<T> invoker = invokers.get(i);
             RpcStatus rpcStatus = RpcStatus.getStatus(invoker.getUrl(), invocation.getMethodName());
             // Calculate the estimated response time from the product of active connections and succeeded average elapsed time.
-            long succeededAverageElapsed = rpcStatus.getSucceededAverageElapsed();
+            long succeededAverageElapsed = rpcStatus.getSucceeded() == 0 ? Integer.MAX_VALUE : rpcStatus.getSucceededAverageElapsed();
             int active = rpcStatus.getActive();
             long estimateResponse = succeededAverageElapsed * active;
             int afterWarmup = getWeight(invoker, invocation);


### PR DESCRIPTION
## What is the purpose of the change

To prevent nodes that did not succeed at one time, the calculated estimateResponse is the lowest

## Brief changelog
dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/loadbalance/ShortestResponseLoadBalance.java
