### PR TITLE
[Dubbo-Configuration] Compatible Configurators url with JsonArray in Configuration

### DIFF
--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/configurator/parser/ConfigParser.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/configurator/parser/ConfigParser.java
@@ -16,6 +16,8 @@
  */
 package org.apache.dubbo.rpc.cluster.configurator.parser;
 
+import com.alibaba.fastjson.JSON;
+import com.alibaba.fastjson.JSONValidator;
 import org.apache.dubbo.common.URL;
 import org.apache.dubbo.common.utils.CollectionUtils;
 import org.apache.dubbo.common.utils.StringUtils;
@@ -41,6 +43,12 @@ import static org.apache.dubbo.common.constants.RegistryConstants.DYNAMIC_CONFIG
 public class ConfigParser {
 
     public static List<URL> parseConfigurators(String rawConfig) {
+
+        // compatible url JsonArray, such as [ "override://xxx", "override://xxx" ]
+        if (isJsonArray(rawConfig)) {
+            return parseJsonArray(rawConfig);
+        }
+
         List<URL> urls = new ArrayList<>();
         ConfiguratorConfig configuratorConfig = parseObject(rawConfig);
 
@@ -52,6 +60,15 @@ public class ConfigParser {
         } else {
             // service scope by default.
             items.forEach(item -> urls.addAll(serviceItemToUrls(item, configuratorConfig)));
+        }
+        return urls;
+    }
+
+    private static List<URL> parseJsonArray(String rawConfig) {
+        List<URL> urls = new ArrayList<>();
+        List<String> list = JSON.parseArray(rawConfig, String.class);
+        if (!CollectionUtils.isEmpty(list)) {
+            list.forEach(u -> urls.add(URL.valueOf(u)));
         }
         return urls;
     }
@@ -200,4 +217,15 @@ public class ConfigParser {
         }
         return addresses;
     }
+
+    private static boolean isJsonArray(String rawConfig) {
+        try {
+            JSONValidator validator = JSONValidator.from(rawConfig);
+            return validator.validate() && validator.getType() == JSONValidator.Type.Array;
+        } catch (Exception e) {
+            // ignore exception and return false
+        }
+        return false;
+    }
+
 }

--- a/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/configurator/parser/ConfigParserTest.java
+++ b/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/configurator/parser/ConfigParserTest.java
@@ -174,4 +174,19 @@ public class ConfigParserTest {
         }
     }
 
+    @Test
+    public void parseURLJsonArrayCompatible() throws Exception {
+
+        try (InputStream jsonStream = this.getClass().getResourceAsStream("/urlJsonArray.json")) {
+            List<URL> urls = ConfigParser.parseConfigurators(streamToString(jsonStream));
+
+            Assertions.assertNotNull(urls);
+            Assertions.assertEquals(1, urls.size());
+            URL url = urls.get(0);
+
+            Assertions.assertEquals("0.0.0.0:20880", url.getAddress());
+            Assertions.assertEquals("com.xx.Service", url.getServiceInterface());
+            Assertions.assertEquals(6666, url.getParameter(TIMEOUT_KEY, 0));
+        }
+    }
 }

--- a/dubbo-cluster/src/test/resources/urlJsonArray.json
+++ b/dubbo-cluster/src/test/resources/urlJsonArray.json
@@ -1,0 +1,3 @@
+[
+  "override://0.0.0.0:20880/com.xx.Service?category=configurators&timeout=6666&disabled=true&dynamic=false&enabled=true&group=dubbo&priority=1&version=1.0"
+]


### PR DESCRIPTION
## What is the purpose of the change

Support URL Configurators with JsonArray in Dynamic Configuration
such as
``` json
[
  "override://0.0.0.0:20880/com.xx.Service?category=configurators&timeout=6666&disabled=true&dynamic=false&enabled=true&group=dubbo&priority=1&version=1.0"
]
```
