### PR TITLE
[Dubbo-DynamicConfig] compatible configurators url with type JsonArray in ConfigCenter

### DIFF
--- a/dubbo-all/pom.xml
+++ b/dubbo-all/pom.xml
@@ -570,6 +570,10 @@
             <groupId>org.yaml</groupId>
             <artifactId>snakeyaml</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.alibaba</groupId>
+            <artifactId>fastjson</artifactId>
+        </dependency>
 
         <!-- Temporarily add this part to exclude transitive dependency -->
         <dependency>

--- a/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/configurator/parser/ConfigParserTest.java
+++ b/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/configurator/parser/ConfigParserTest.java
@@ -175,19 +175,19 @@ public class ConfigParserTest {
     }
 
     @Test
-    public void parseURLJsonArrayCompatible() throws Exception {
+    public void parseURLJsonArrayCompatible() {
 
-        try (InputStream jsonStream = this.getClass().getResourceAsStream("/urlJsonArray.json")) {
-            List<URL> urls = ConfigParser.parseConfigurators(streamToString(jsonStream));
+        String configData = "[\"override://0.0.0.0/com.xx.Service?category=configurators&timeout=6666&disabled=true&dynamic=false&enabled=true&group=dubbo&priority=1&version=1.0\" ]";
 
-            Assertions.assertNotNull(urls);
-            Assertions.assertEquals(1, urls.size());
-            URL url = urls.get(0);
+        List<URL> urls = ConfigParser.parseConfigurators(configData);
 
-            Assertions.assertEquals("0.0.0.0", url.getAddress());
-            Assertions.assertEquals("com.xx.Service", url.getServiceInterface());
-            Assertions.assertEquals(6666, url.getParameter(TIMEOUT_KEY, 0));
-        }
+        Assertions.assertNotNull(urls);
+        Assertions.assertEquals(1, urls.size());
+        URL url = urls.get(0);
+
+        Assertions.assertEquals("0.0.0.0", url.getAddress());
+        Assertions.assertEquals("com.xx.Service", url.getServiceInterface());
+        Assertions.assertEquals(6666, url.getParameter(TIMEOUT_KEY, 0));
     }
 
 }

--- a/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/configurator/parser/ConfigParserTest.java
+++ b/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/configurator/parser/ConfigParserTest.java
@@ -174,4 +174,20 @@ public class ConfigParserTest {
         }
     }
 
+    @Test
+    public void parseURLJsonArrayCompatible() throws Exception {
+
+        try (InputStream jsonStream = this.getClass().getResourceAsStream("/urlJsonArray.json")) {
+            List<URL> urls = ConfigParser.parseConfigurators(streamToString(jsonStream));
+
+            Assertions.assertNotNull(urls);
+            Assertions.assertEquals(1, urls.size());
+            URL url = urls.get(0);
+
+            Assertions.assertEquals("0.0.0.0", url.getAddress());
+            Assertions.assertEquals("com.xx.Service", url.getServiceInterface());
+            Assertions.assertEquals(6666, url.getParameter(TIMEOUT_KEY, 0));
+        }
+    }
+
 }

--- a/dubbo-cluster/src/test/resources/urlJsonArray.json
+++ b/dubbo-cluster/src/test/resources/urlJsonArray.json
@@ -1,0 +1,3 @@
+[
+  "override://0.0.0.0/com.xx.Service?category=configurators&timeout=6666&disabled=true&dynamic=false&enabled=true&group=dubbo&priority=1&version=1.0"
+]

--- a/dubbo-cluster/src/test/resources/urlJsonArray.json
+++ b/dubbo-cluster/src/test/resources/urlJsonArray.json
@@ -1,3 +1,0 @@
-[
-  "override://0.0.0.0/com.xx.Service?category=configurators&timeout=6666&disabled=true&dynamic=false&enabled=true&group=dubbo&priority=1&version=1.0"
-]


### PR DESCRIPTION
Support URL Configurators with JsonArray in Dynamic Configuration
such as

``` json
[
  "override://0.0.0.0/com.xx.Service?category=configurators&timeout=6666&disabled=true&dynamic=false&enabled=true&group=dubbo&priority=1&version=1.0"
]
```
