### PR TITLE
improve execution efficiency in some cases

### DIFF
--- a/dubbo-rpc/dubbo-rpc-dubbo/src/main/java/org/apache/dubbo/rpc/protocol/dubbo/DefaultExchangeClientChooserFactory.java
+++ b/dubbo-rpc/dubbo-rpc-dubbo/src/main/java/org/apache/dubbo/rpc/protocol/dubbo/DefaultExchangeClientChooserFactory.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.rpc.protocol.dubbo;
+
+import org.apache.dubbo.common.utils.AtomicPositiveInteger;
+import org.apache.dubbo.remoting.exchange.ExchangeClient;
+
+/**
+ * DefaultExchangeClientChooserFactory
+ */
+public class DefaultExchangeClientChooserFactory implements ExchangeClientChooserFactory {
+
+    private static boolean isPowerOfTwo(int val) {
+        //2^n,& is better than %
+        return (val & -val) == val;
+    }
+
+    public ExchangeClientChooser newChooser(ExchangeClient[] exchangeClients) {
+        if (exchangeClients.length == 0) {
+            return new SingleExchangeClientChooser(exchangeClients);
+        } else if (isPowerOfTwo(exchangeClients.length)) {
+            return new PowerOfTwoExchangeClientChooser(exchangeClients);
+        } else {
+            return new GenericExchangeClientChooser(exchangeClients);
+        }
+    }
+
+    private static final class PowerOfTwoExchangeClientChooser implements ExchangeClientChooser {
+
+        private final AtomicPositiveInteger idx = new AtomicPositiveInteger();
+
+        private final ExchangeClient[] exchangeClients;
+
+        PowerOfTwoExchangeClientChooser(ExchangeClient[] exchangeClients) {
+            this.exchangeClients = exchangeClients;
+        }
+
+        @Override
+        public ExchangeClient next() {
+            return exchangeClients[idx.getAndIncrement() & exchangeClients.length - 1];
+        }
+    }
+
+    private static final class GenericExchangeClientChooser implements ExchangeClientChooser {
+
+        private final AtomicPositiveInteger idx = new AtomicPositiveInteger();
+
+        private final ExchangeClient[] exchangeClients;
+
+        GenericExchangeClientChooser(ExchangeClient[] exchangeClients) {
+            this.exchangeClients = exchangeClients;
+        }
+
+        @Override
+        public ExchangeClient next() {
+            return exchangeClients[Math.abs(idx.getAndIncrement() % exchangeClients.length)];
+        }
+    }
+
+    private static final class SingleExchangeClientChooser implements ExchangeClientChooser {
+
+        private final ExchangeClient exchangeClient;
+
+        SingleExchangeClientChooser(ExchangeClient[] exchangeClients) {
+            this.exchangeClient = exchangeClients[0];
+        }
+
+        @Override
+        public ExchangeClient next() {
+            return exchangeClient;
+        }
+    }
+
+}

--- a/dubbo-rpc/dubbo-rpc-dubbo/src/main/java/org/apache/dubbo/rpc/protocol/dubbo/DubboInvoker.java
+++ b/dubbo-rpc/dubbo-rpc-dubbo/src/main/java/org/apache/dubbo/rpc/protocol/dubbo/DubboInvoker.java
@@ -18,7 +18,6 @@ package org.apache.dubbo.rpc.protocol.dubbo;
 
 import org.apache.dubbo.common.URL;
 import org.apache.dubbo.common.config.ConfigurationUtils;
-import org.apache.dubbo.common.extension.ExtensionLoader;
 import org.apache.dubbo.remoting.Constants;
 import org.apache.dubbo.remoting.RemotingException;
 import org.apache.dubbo.remoting.TimeoutException;
@@ -67,7 +66,7 @@ public class DubboInvoker<T> extends AbstractInvoker<T> {
 
     private final ExchangeClientChooser exchangeClientChooser;
 
-    private static final ExchangeClientChooserFactory EXCHANGE_CLIENT_CHOOSER_FACTORY = ExtensionLoader.getExtensionLoader(ExchangeClientChooserFactory.class).getDefaultExtension();
+    private static final ExchangeClientChooserFactory EXCHANGE_CLIENT_CHOOSER_FACTORY = new DefaultExchangeClientChooserFactory();
 
     public DubboInvoker(Class<T> serviceType, URL url, ExchangeClient[] clients) {
         this(serviceType, url, clients, null);

--- a/dubbo-rpc/dubbo-rpc-dubbo/src/main/java/org/apache/dubbo/rpc/protocol/dubbo/ExchangeClientChooser.java
+++ b/dubbo-rpc/dubbo-rpc-dubbo/src/main/java/org/apache/dubbo/rpc/protocol/dubbo/ExchangeClientChooser.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.rpc.protocol.dubbo;
+
+import org.apache.dubbo.remoting.exchange.ExchangeClient;
+
+/**
+ * ExchangeClientChooser
+ */
+public interface ExchangeClientChooser {
+
+    /**
+     * Chooses the next {@link ExchangeClient} to use.
+     */
+    ExchangeClient next();
+
+}

--- a/dubbo-rpc/dubbo-rpc-dubbo/src/main/java/org/apache/dubbo/rpc/protocol/dubbo/ExchangeClientChooserFactory.java
+++ b/dubbo-rpc/dubbo-rpc-dubbo/src/main/java/org/apache/dubbo/rpc/protocol/dubbo/ExchangeClientChooserFactory.java
@@ -23,7 +23,6 @@ import org.apache.dubbo.remoting.exchange.ExchangeClient;
  * ExchangeClientChooserFactory
  */
 
-@SPI("default")
 public interface ExchangeClientChooserFactory {
 
     /**

--- a/dubbo-rpc/dubbo-rpc-dubbo/src/main/java/org/apache/dubbo/rpc/protocol/dubbo/ExchangeClientChooserFactory.java
+++ b/dubbo-rpc/dubbo-rpc-dubbo/src/main/java/org/apache/dubbo/rpc/protocol/dubbo/ExchangeClientChooserFactory.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.rpc.protocol.dubbo;
+
+import org.apache.dubbo.common.extension.SPI;
+import org.apache.dubbo.remoting.exchange.ExchangeClient;
+
+/**
+ * ExchangeClientChooserFactory
+ */
+
+@SPI("default")
+public interface ExchangeClientChooserFactory {
+
+    /**
+     * Returns a new {@link ExchangeClientChooser}.
+     */
+    ExchangeClientChooser newChooser(ExchangeClient[] exchangeClients);
+
+}

--- a/dubbo-rpc/dubbo-rpc-dubbo/src/main/resources/META-INF/dubbo/internal/org.apache.dubbo.rpc.protocol.dubbo.ExchangeClientChooserFactory
+++ b/dubbo-rpc/dubbo-rpc-dubbo/src/main/resources/META-INF/dubbo/internal/org.apache.dubbo.rpc.protocol.dubbo.ExchangeClientChooserFactory
@@ -1,1 +1,0 @@
-default=org.apache.dubbo.rpc.protocol.dubbo.DefaultExchangeClientChooserFactory

--- a/dubbo-rpc/dubbo-rpc-dubbo/src/main/resources/META-INF/dubbo/internal/org.apache.dubbo.rpc.protocol.dubbo.ExchangeClientChooserFactory
+++ b/dubbo-rpc/dubbo-rpc-dubbo/src/main/resources/META-INF/dubbo/internal/org.apache.dubbo.rpc.protocol.dubbo.ExchangeClientChooserFactory
@@ -1,0 +1,1 @@
+default=org.apache.dubbo.rpc.protocol.dubbo.DefaultExchangeClientChooserFactory


### PR DESCRIPTION
## What is the purpose of the change

The purpose is to **improve execution efficiency** in some cases.

Using Strategy Pattern to improve efficiency.When the count of clients is is the power of two,using '&' to choose next client instead of '%',which is also used in **netty** to improve efficiency.

As for ThriftInvoker, which is deprecated, there's no need to apply changes on it.