### PR TITLE
upgrade fastjson to 1.2.70

### DIFF
--- a/dubbo-dependencies-bom/pom.xml
+++ b/dubbo-dependencies-bom/pom.xml
@@ -97,7 +97,7 @@
         <grizzly_version>2.1.4</grizzly_version>
         <httpclient_version>4.5.3</httpclient_version>
         <httpcore_version>4.4.6</httpcore_version>
-        <fastjson_version>1.2.68</fastjson_version>
+        <fastjson_version>1.2.70</fastjson_version>
         <zookeeper_version>3.4.13</zookeeper_version>
         <curator_version>4.0.1</curator_version>
         <curator_test_version>2.12.0</curator_test_version>


### PR DESCRIPTION
https://help.aliyun.com/noticelist/articleid/1060343604.html?spm=a2c4g.789004748.n2.6.3f576141SGmGhG

# 漏洞描述

fastjson采用黑白名单的方法来防御反序列化漏洞，导致当黑客不断发掘新的反序列化Gadgets类时，在autoType关闭的情况下仍然可能可以绕过黑白名单防御机制，造成远程命令执行漏洞。经研究，该漏洞利用门槛较低，可绕过autoType限制，风险影响较大。阿里云应急响应中心提醒fastjson用户尽快采取安全措施阻止漏洞攻击。

# 影响版本

fastjson <=1.2.68

fastjson sec版本 <= sec9

# 安全版本

fastjson >=1.2.69

fastjson sec版本 >= sec10

