### PR TITLE
change the comments of Annotation Class [org.apache.dubbo.config.spring.context.annotation.EnableDubboConfig]

### DIFF
--- a/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/context/annotation/EnableDubboConfig.java
+++ b/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/context/annotation/EnableDubboConfig.java
@@ -72,8 +72,8 @@ public @interface EnableDubboConfig {
     /**
      * It indicates whether binding to multiple Spring Beans.
      *
-     * @return the default value is <code>false</code>
-     * @revised 2.5.9
+     * @return the default value is <code>true</code>
+     * @revised 2.6.6
      */
     boolean multiple() default true;
 


### PR DESCRIPTION
In Annotation Class org.apache.dubbo.config.spring.context.annotation.EnableDubboConfig, we can see  the current comments  is:
 /**
     * It indicates whether binding to multiple Spring Beans.
     *
     * @return the default value is <code>false</code>
     * @revised 2.5.9
     */
we know after version 2.6.6, the default value of multiple is true, so the comments need to update, otherwise it will cause confusion, so change it to: 
/**
     * It indicates whether binding to multiple Spring Beans.
     *
     * @return the default value is <code>true</code>
     * @revised 2.6.6
     */