### PR TITLE
maybe we can remove null judge in this case

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/extension/support/ActivateComparator.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/extension/support/ActivateComparator.java
@@ -75,10 +75,8 @@ public class ActivateComparator implements Comparator<Object> {
                 }
             }
         }
-        int n1 = a1.order;
-        int n2 = a2.order;
         // never return 0 even if n1 equals n2, otherwise, o1 and o2 will override each other in collection like HashSet
-        return n1 > n2 ? 1 : -1;
+        return a1.order > a2.order ? 1 : -1;
     }
 
     private Class<?> findSpi(Class clazz) {

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/extension/support/ActivateComparator.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/extension/support/ActivateComparator.java
@@ -75,8 +75,8 @@ public class ActivateComparator implements Comparator<Object> {
                 }
             }
         }
-        int n1 = a1 == null ? 0 : a1.order;
-        int n2 = a2 == null ? 0 : a2.order;
+        int n1 = a1.order;
+        int n2 = a2.order;
         // never return 0 even if n1 equals n2, otherwise, o1 and o2 will override each other in collection like HashSet
         return n1 > n2 ? 1 : -1;
     }


### PR DESCRIPTION
## What is the purpose of the change

i have check object `a1` and `a2` carefully, their predecessor `o1`,`o2` had `NPE` check, and in this method context , no more where have changed them, so , object `a1` and `a2` always not be null.

![image](https://user-images.githubusercontent.com/19544562/84615756-6c49f800-aefc-11ea-8399-9512a68b4c8c.png)

![image](https://user-images.githubusercontent.com/19544562/84615957-fc883d00-aefc-11ea-9b68-c94630bbc9c3.png)


## Brief changelog

dubbo-common/src/main/java/org/apache/dubbo/common/extension/support/ActivateComparator.java
