### PR TITLE
fix NPE when check=false is set and provider is empty.

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/rpc/model/ConsumerModel.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/rpc/model/ConsumerModel.java
@@ -138,7 +138,12 @@ public class ConsumerModel {
     }
 
     public void initMethodModels() {
-        Class[] interfaceList = serviceMetadata.getTarget().getClass().getInterfaces();
+        Class[] interfaceList = null;
+        if (proxyObject == null) {
+            interfaceList = new Class[]{referenceConfig.getActualInterface()};
+        } else {
+            interfaceList = proxyObject.getClass().getInterfaces();
+        }
         for (Class interfaceClass : interfaceList) {
             for (Method method : interfaceClass.getMethods()) {
                 methodModels.put(method, new ConsumerMethodModel(method));


### PR DESCRIPTION
1. Consumer process starts first with check='false' set
<dubbo:reference check="false" />