### PR TITLE
Fix export provider error, change to catch throwable, handle NoClassDefFoundError

### DIFF
--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/support/registry/ZoneAwareClusterInvoker.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/support/registry/ZoneAwareClusterInvoker.java
@@ -32,7 +32,10 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import static org.apache.dubbo.common.constants.CommonConstants.PREFERRED_KEY;
-import static org.apache.dubbo.common.constants.RegistryConstants.*;
+import static org.apache.dubbo.common.constants.RegistryConstants.REGISTRY_KEY;
+import static org.apache.dubbo.common.constants.RegistryConstants.REGISTRY_ZONE;
+import static org.apache.dubbo.common.constants.RegistryConstants.REGISTRY_ZONE_FORCE;
+import static org.apache.dubbo.common.constants.RegistryConstants.ZONE_KEY;
 
 /**
  * When there're more than one registry for subscription.

--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/support/registry/ZoneAwareClusterInvoker.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/support/registry/ZoneAwareClusterInvoker.java
@@ -57,9 +57,6 @@ public class ZoneAwareClusterInvoker<T> extends AbstractClusterInvoker<T> {
         // First, pick the invoker (XXXClusterInvoker) that comes from the local registry, distinguish by a 'preferred' key.
         for (Invoker<T> invoker : invokers) {
             // FIXME, the invoker is a cluster invoker representing one Registry, so it will automatically wrapped by MockClusterInvoker.
-            if (!(invoker instanceof MockClusterInvoker)) {
-                throw new RpcException("invoker should be MockClusterInvoker but actual is " + invoker.getClass());
-            }
             MockClusterInvoker<T> mockClusterInvoker = (MockClusterInvoker<T>) invoker;
             if (mockClusterInvoker.isAvailable() && mockClusterInvoker.getRegistryUrl()
                     .getParameter(REGISTRY_KEY + "." + PREFERRED_KEY, false)) {

--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/support/registry/ZoneAwareClusterInvoker.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/support/registry/ZoneAwareClusterInvoker.java
@@ -32,14 +32,11 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import static org.apache.dubbo.common.constants.CommonConstants.PREFERRED_KEY;
-import static org.apache.dubbo.common.constants.RegistryConstants.REGISTRY_KEY;
-import static org.apache.dubbo.common.constants.RegistryConstants.REGISTRY_ZONE;
-import static org.apache.dubbo.common.constants.RegistryConstants.REGISTRY_ZONE_FORCE;
-import static org.apache.dubbo.common.constants.RegistryConstants.ZONE_KEY;
+import static org.apache.dubbo.common.constants.RegistryConstants.*;
 
 /**
  * When there're more than one registry for subscription.
- *
+ * <p>
  * This extension provides a strategy to decide how to distribute traffics among them:
  * 1. registry marked as 'preferred=true' has the highest priority.
  * 2. check the zone the current request belongs, pick the registry that has the same zone first.
@@ -60,6 +57,9 @@ public class ZoneAwareClusterInvoker<T> extends AbstractClusterInvoker<T> {
         // First, pick the invoker (XXXClusterInvoker) that comes from the local registry, distinguish by a 'preferred' key.
         for (Invoker<T> invoker : invokers) {
             // FIXME, the invoker is a cluster invoker representing one Registry, so it will automatically wrapped by MockClusterInvoker.
+            if (!(invoker instanceof MockClusterInvoker)) {
+                throw new RpcException("invoker should be MockClusterInvoker but actual is " + invoker.getClass());
+            }
             MockClusterInvoker<T> mockClusterInvoker = (MockClusterInvoker<T>) invoker;
             if (mockClusterInvoker.isAvailable() && mockClusterInvoker.getRegistryUrl()
                     .getParameter(REGISTRY_KEY + "." + PREFERRED_KEY, false)) {

--- a/dubbo-metadata/dubbo-metadata-api/src/main/java/org/apache/dubbo/metadata/store/InMemoryWritableMetadataService.java
+++ b/dubbo-metadata/dubbo-metadata-api/src/main/java/org/apache/dubbo/metadata/store/InMemoryWritableMetadataService.java
@@ -144,9 +144,9 @@ public class InMemoryWritableMetadataService implements WritableMetadataService 
                 return;
             }
             logger.error("publishProvider interfaceName is empty . providerUrl: " + providerUrl.toFullString());
-        } catch (ClassNotFoundException e) {
+        } catch (Throwable t) {
             //ignore error
-            logger.error("publishProvider getServiceDescriptor error. providerUrl: " + providerUrl.toFullString(), e);
+            logger.error("publishProvider getServiceDescriptor error. providerUrl: " + providerUrl.toFullString(), t.getCause());
         }
     }
 

--- a/dubbo-metadata/dubbo-metadata-api/src/main/java/org/apache/dubbo/metadata/store/RemoteWritableMetadataService.java
+++ b/dubbo-metadata/dubbo-metadata-api/src/main/java/org/apache/dubbo/metadata/store/RemoteWritableMetadataService.java
@@ -100,9 +100,9 @@ public class RemoteWritableMetadataService implements WritableMetadataService {
                 return;
             }
             logger.error("publishProvider interfaceName is empty . providerUrl: " + providerUrl.toFullString());
-        } catch (ClassNotFoundException e) {
+        } catch (Throwable t) {
             //ignore error
-            logger.error("publishProvider getServiceDescriptor error. providerUrl: " + providerUrl.toFullString(), e);
+            logger.error("publishProvider getServiceDescriptor error. providerUrl: " + providerUrl.toFullString(), t.getCause());
         }
     }
 


### PR DESCRIPTION
Fix export provider error, change to catch throwable, handle NoClassDefFoundError

## What is the purpose of the change
In org.apache.dubbo.metadata.store.InMemoryWritableMetadataService.publishServiceDefinition() and org.apache.dubbo.metadata.store.RemoteWritableMetadataService.publishProvider(), call the org.apache.dubbo.metadata.definition.ServiceDefinitionBuilder.build(java.lang.Class<?>) method, where NoClassDefFoundError may occur, So you need to catch the throwable in the outer layer, otherwise it will be difficult to find  the root cause of class loading failure

Please review this pull request, thank you

## Brief changelog

## Verifying this change


Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a [GITHUB_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Run `mvn clean install -DskipTests=false` & `mvn clean test-compile failsafe:integration-test` to make sure unit-test and integration-test pass.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
