### PR TITLE
delete Repeat method

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/config/context/ConfigManager.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/config/context/ConfigManager.java
@@ -523,8 +523,4 @@ public class ConfigManager extends LifecycleAdapter implements FrameworkExt {
                 .collect(Collectors.toList());
     }
 
-    @Override
-    public void destroy() throws IllegalStateException {
-        clear();
-    }
 }


### PR DESCRIPTION
destroy() is exist

build fail

Error:(527, 17) java: 已在类 org.apache.dubbo.config.context.ConfigManager中定义了方法 destroy()