### PR TITLE
[Dubbo-2.7.7] Fix problem: Rest Protocol can't work when use Tomcat 8.0.x as Web Container

### DIFF
--- a/dubbo-remoting/dubbo-remoting-http/src/main/java/org/apache/dubbo/remoting/http/tomcat/TomcatHttpServer.java
+++ b/dubbo-remoting/dubbo-remoting-http/src/main/java/org/apache/dubbo/remoting/http/tomcat/TomcatHttpServer.java
@@ -51,14 +51,13 @@ public class TomcatHttpServer extends AbstractHttpServer {
         String baseDir = new File(System.getProperty("java.io.tmpdir")).getAbsolutePath();
         tomcat = new Tomcat();
 
-        Connector connector = new Connector("org.apache.coyote.http11.Http11NioProtocol");
+        Connector connector = tomcat.getConnector();
         connector.setPort(url.getPort());
         connector.setProperty("maxThreads", String.valueOf(url.getParameter(THREADS_KEY, DEFAULT_THREADS)));
         connector.setProperty("maxConnections", String.valueOf(url.getParameter(ACCEPTS_KEY, -1)));
         connector.setProperty("URIEncoding", "UTF-8");
         connector.setProperty("connectionTimeout", "60000");
         connector.setProperty("maxKeepAliveRequests", "-1");
-        tomcat.setConnector(connector);
 
         tomcat.setBaseDir(baseDir);
         tomcat.setPort(url.getPort());


### PR DESCRIPTION
## What is the purpose of the change

fix the problem: Rest Protocol can't work when use Tomcat 8.0.x as Web Container which is described by issue #6399

## Brief changelog

TomcatHttpServer.java

## Verifying this change

When we start Tomcat server by program for embedded Tomcat with version **8.0.x**，

We **can't** set the connector by following steps:
1. create a connector using the code: _**new Connector("org.apache.coyote.http11.Http11NioProtocol")**_;
2. set appropriate property for the created connector , eg: **_connector.setPort(url.getPort()), connector.setProperty("","")_**;
3. set the ready connector to tomcat , eg: **_tomcat.setConnector(connector)_**;

We **should** set the connector as follow:
1. got a connector by tomcat's method，pseudocode is :  **_Connector connector = tomcat.getConnector()_**;
2. set appropriate property for the connector returned by tomcat , eg: **_connector.setPort(url.getPort()), connector.setProperty("","")_**;

The point is the connector returned by tomcat would be added to **service** object  which belong to tomcat, it's important for tomcat to start connector and listen on given port. But the key action is missed when using the first solution. one thing to note, the first solution is OK for tomcat with higher version(eg: 8.5.31). But, the second solution is compatible with all versions of Tomcat.

Additionally, we should create connector object by **new Connector("HTTP/1.1")** instead of **new Connector("org.apache.coyote.http11.Http11NioProtocol")**, because the first practice is more semantic. actually, **org.apache.coyote.http11.Http11NioProtocol** isn't protocol name, it just the name of implementation class for **HTTP/1.1** protocol.