### PR TITLE
Incorrect comments about multipleConfig

### DIFF
--- a/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/context/annotation/EnableDubbo.java
+++ b/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/context/annotation/EnableDubbo.java
@@ -72,7 +72,7 @@ public @interface EnableDubbo {
     /**
      * It indicates whether {@link AbstractConfig} binding to multiple Spring Beans.
      *
-     * @return the default value is <code>false</code>
+     * @return the default value is <code>true</code>
      * @see EnableDubboConfig#multiple()
      */
     @AliasFor(annotation = EnableDubboConfig.class, attribute = "multiple")

--- a/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/context/annotation/EnableDubboConfig.java
+++ b/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/context/annotation/EnableDubboConfig.java
@@ -72,7 +72,7 @@ public @interface EnableDubboConfig {
     /**
      * It indicates whether binding to multiple Spring Beans.
      *
-     * @return the default value is <code>false</code>
+     * @return the default value is <code>true</code>
      * @revised 2.5.9
      */
     boolean multiple() default true;


### PR DESCRIPTION
## What is the purpose of the change

The comment is wrong, which is easy to cause misunderstanding。
org.apache.dubbo.config.spring.context.annotation.EnableDubboConfig#multiple
org.apache.dubbo.config.spring.context.annotation.EnableDubbo#multipleConfig

The default value is true but the comment is false