### PR TITLE
fix issue: System property dubbo.service.delay is invalid

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/config/ReferenceConfigBase.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/config/ReferenceConfigBase.java
@@ -31,7 +31,6 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.util.Properties;
 
-import static org.apache.dubbo.common.constants.CommonConstants.DUBBO;
 
 /**
  * ReferenceConfig
@@ -215,12 +214,6 @@ public abstract class ReferenceConfigBase<T> extends AbstractReferenceConfig {
 
     public ServiceMetadata getServiceMetadata() {
         return serviceMetadata;
-    }
-
-    @Override
-    @Parameter(excluded = true)
-    public String getPrefix() {
-        return DUBBO + ".reference." + interfaceName;
     }
 
     public void resolveFile() {

--- a/dubbo-common/src/main/java/org/apache/dubbo/config/ServiceConfigBase.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/config/ServiceConfigBase.java
@@ -32,7 +32,6 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.apache.dubbo.common.constants.CommonConstants.COMMA_SPLIT_PATTERN;
-import static org.apache.dubbo.common.constants.CommonConstants.DUBBO;
 
 /**
  * ServiceConfig
@@ -390,12 +389,6 @@ public abstract class ServiceConfigBase<T> extends AbstractServiceConfig {
     @Deprecated
     public void setProviders(List<ProviderConfig> providers) {
         this.protocols = convertProviderToProtocol(providers);
-    }
-
-    @Override
-    @Parameter(excluded = true)
-    public String getPrefix() {
-        return DUBBO + ".service." + interfaceName;
     }
 
     @Parameter(excluded = true)


### PR DESCRIPTION
## What is the purpose of the change

Fixed issue #1728：System property dubbo.service.delay is invalid

## Brief changelog

ReferenceConfigBase.java
ServiceConfigBase.java

## Verifying this change

As described in issue #1728：we can't set dubbo.service.delay to dubbo through System Property，and System-Enviroment、Property-File mechanism also can't work. furthermore, other similar-style config(eg: dubbo.service.filter、dubbo.service.retries) are also invalid.

The troublemaker which caused this problem is:

**public String getPrefix() { return DUBBO + ".service." + interfaceName; }**

Due to these above codes，when getProperty through **CompositeConfiguration**, the packed key is （for examle）: **dubbo.service.org.yiocio.testService.org.yiocio.testService.delay**，this key's format is wrong according to dubbo's config strategy. In my view, dubbo's property-style config have a namespace concept: the first segment is **dubbo** at all times, the second segment is tag for config category（eg: application、registry、service），and the third segment is the id of config object with specific category，of course，the third segment is optional, the last segment is config key. So the override of getPrefix for ServiceConfigBase will break the namespace rule of dubbo config.

**ReferenceConfig's** situation is similar with **ServiceConfig**.
