### PR TITLE
[Dubbo-6463] fix issue: start.sh can't work when dubbo.properties contain commented dubbo.protocol.port  property

### DIFF
--- a/dubbo-container/dubbo-container-api/src/main/resources/META-INF/assembly/bin/start.sh
+++ b/dubbo-container/dubbo-container-api/src/main/resources/META-INF/assembly/bin/start.sh
@@ -21,11 +21,11 @@ cd ..
 DEPLOY_DIR=`pwd`
 CONF_DIR=$DEPLOY_DIR/conf
 
-SERVER_NAME=`sed '/dubbo.application.name/!d;s/.*=//' conf/dubbo.properties | tr -d '\r'`
-SERVER_PROTOCOL=`sed '/dubbo.protocol.name/!d;s/.*=//' conf/dubbo.properties | tr -d '\r'`
-SERVER_HOST=`sed '/dubbo.protocol.host/!d;s/.*=//' conf/dubbo.properties | tr -d '\r'`
-SERVER_PORT=`sed '/dubbo.protocol.port/!d;s/.*=//' conf/dubbo.properties | tr -d '\r'`
-LOGS_FILE=`sed '/dubbo.log4j.file/!d;s/.*=//' conf/dubbo.properties | tr -d '\r'`
+SERVER_NAME=`sed '/^dubbo.application.name/!d;s/.*=//' conf/dubbo.properties | tr -d '\r'`
+SERVER_PROTOCOL=`sed '/^dubbo.protocol.name/!d;s/.*=//' conf/dubbo.properties | tr -d '\r'`
+SERVER_HOST=`sed '/^dubbo.protocol.host/!d;s/.*=//' conf/dubbo.properties | tr -d '\r'`
+SERVER_PORT=`sed '/^dubbo.protocol.port/!d;s/.*=//' conf/dubbo.properties | tr -d '\r'`
+LOGS_FILE=`sed '/^dubbo.log4j.file/!d;s/.*=//' conf/dubbo.properties | tr -d '\r'`
 VM_ARGS_PERM_SIZE='PermSize'
 VM_ARGS_METASPACE_SIZE='MetaspaceSize'
 JAVA_8_VERSION="180"


### PR DESCRIPTION
## What is the purpose of the change

fix issue #6463 : start.sh can't work when dubbo.properties contain commented dubbo.protocol.port  property

## Brief changelog

dubbo-container/dubbo-container-api/src/main/resources/META-INF/assembly/bin/start.sh

## Verifying this change

When configure the port of dubbo protocol in dubbo.properties file, start.sh will parse dubbo.properties using sed and get the dubbo protocol port number, then determine whether the application starts successfully by checking whether the port is opened.

But the mechanism of parsing dubbo protocol port isn't rigorous, when my dubbo.properties contains commented dubbo.protocol.port like this:

**#dubbo.protocol.port=20943
dubbo.protocol.port=20945**

start.sh will get wrong port number, and can't work normally.
