### PR TITLE
update all version to 2.7.9-SNAPSHOT

### DIFF
--- a/dubbo-dependencies-bom/pom.xml
+++ b/dubbo-dependencies-bom/pom.xml
@@ -163,7 +163,7 @@
         <mortbay_jetty_version>6.1.26</mortbay_jetty_version>
         <portlet_version>2.0</portlet_version>
         <maven_flatten_version>1.1.0</maven_flatten_version>
-        <revision>2.7.8</revision>
+        <revision>2.7.9-SNAPSHOT</revision>
     </properties>
 
     <dependencyManagement>

--- a/dubbo-dependencies/dubbo-dependencies-zookeeper/pom.xml
+++ b/dubbo-dependencies/dubbo-dependencies-zookeeper/pom.xml
@@ -32,7 +32,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <revision>2.7.8</revision>
+        <revision>2.7.9-SNAPSHOT</revision>
         <maven_flatten_version>1.1.0</maven_flatten_version>
     </properties>
 


### PR DESCRIPTION
there are still two subject project is using 2.7.8 which will fail CI deployment.

a issue is raised https://github.com/apache/dubbo/issues/6530 for future investigate.