### PR TITLE
[Dubbo-6546]Support a failover cluster that do NOT retry when invocation timeout

### DIFF
--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/support/Failover2Cluster.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/support/Failover2Cluster.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.rpc.cluster.support;
+
+import org.apache.dubbo.rpc.RpcException;
+import org.apache.dubbo.rpc.cluster.Directory;
+import org.apache.dubbo.rpc.cluster.support.wrapper.AbstractCluster;
+
+/**
+ * Nearly the same strategy with FailoverCluster, except that this cluster will not attempt to retry when timeout occurs.
+ * {@link FailoverClusterInvoker}
+ *
+ */
+public class Failover2Cluster extends AbstractCluster {
+
+    public final static String NAME = "failover2";
+
+    @Override
+    public <T> AbstractClusterInvoker<T> doJoin(Directory<T> directory) throws RpcException {
+        return new FailoverClusterInvoker<>(directory, false);
+    }
+
+}

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/constants/CommonConstants.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/constants/CommonConstants.java
@@ -349,4 +349,7 @@ public interface CommonConstants {
      */
     String DEFAULT_SERVICE_NAME_MAPPING_PROPERTIES_PATH = "META-INF/dubbo/service-name-mapping.properties";
 
+
+    String DISABLE_FAILOVER_RETRY_WHEN_TIMEOUT = "disableFailOverRetryWhenTimeout";
+
 }

--- a/dubbo-common/src/main/java/org/apache/dubbo/config/AbstractReferenceConfig.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/config/AbstractReferenceConfig.java
@@ -88,6 +88,12 @@ public abstract class AbstractReferenceConfig extends AbstractInterfaceConfig {
 
     protected String router;
 
+    /**
+     * When failover cluster is used, whether or not to disable retry when a timeout occur. By default retry will be enable, to disable retry in this case, set this value to true.
+     */
+    protected Boolean disableFailOverRetryWhenTimeout;
+
+
     public Boolean isCheck() {
         return check;
     }
@@ -244,5 +250,13 @@ public abstract class AbstractReferenceConfig extends AbstractInterfaceConfig {
 
     public void setRouter(String router) {
         this.router = router;
+    }
+
+    public Boolean getDisableFailOverRetryWhenTimeout() {
+        return disableFailOverRetryWhenTimeout;
+    }
+
+    public void setDisableFailOverRetryWhenTimeout(Boolean disableFailOverRetryWhenTimeout) {
+        this.disableFailOverRetryWhenTimeout = disableFailOverRetryWhenTimeout;
     }
 }

--- a/dubbo-common/src/main/java/org/apache/dubbo/config/annotation/DubboService.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/config/annotation/DubboService.java
@@ -125,7 +125,7 @@ public @interface DubboService {
     String stub() default "";
 
     /**
-     * Cluster strategy, legal values include: failover, failfast, failsafe, failback, forking
+     * Cluster strategy, legal values include: failover, failover2, failfast, failsafe, failback, forking
      */
     String cluster() default "";
 


### PR DESCRIPTION
## What is the purpose of the change

#6546 

## Brief changelog

Add a new cluster call failover2, and change FailoverClusterInvoker a litter to make it support ignore timeout exception.

## Verifying this change

Use failover2 cluster, and provide two servers, then make a timeout for that service, no retries will happen

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a [GITHUB_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [x] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Run `mvn clean install -DskipTests=false` & `mvn clean test-compile failsafe:integration-test` to make sure unit-test and integration-test pass.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
