### PR TITLE
DecodeableRpcResult解码参数丢失

### DIFF
--- a/dubbo-rpc/dubbo-rpc-dubbo/src/main/java/org/apache/dubbo/rpc/protocol/dubbo/DecodeableRpcResult.java
+++ b/dubbo-rpc/dubbo-rpc-dubbo/src/main/java/org/apache/dubbo/rpc/protocol/dubbo/DecodeableRpcResult.java
@@ -160,7 +160,7 @@ public class DecodeableRpcResult extends AppResponse implements Codec, Decodeabl
 
     private void handleAttachment(ObjectInput in) throws IOException {
         try {
-            setObjectAttachments(in.readAttachments());
+            addObjectAttachments(in.readAttachments());
         } catch (ClassNotFoundException e) {
             rethrow(e);
         }


### PR DESCRIPTION
- Dubbo version: 2.7.8

```
public class DecodeableRpcResult{

public void setObjectAttachments(Map<String, Object> map) {
        this.attachments = map == null ? new HashMap<>() : map;
    }
}
```
DecodeableRpcResult解码的时候使用`setObjectAttachments`会丢失已经在IO线程解码的部分参数，例如input,output。

该方法应该替换为

```
  public void addObjectAttachments(Map<String, Object> map) {
        if (map == null) {
            return;
        }
        if (this.attachments == null) {
            this.attachments = new HashMap<>();
        }
        this.attachments.putAll(map);
    }
```