### PR TITLE
fix #6379. Track the stacktrace of consumer-side while exceptoin happened in server-side.

### DIFF
--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/AppResponse.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/AppResponse.java
@@ -67,11 +67,12 @@ public class AppResponse implements Result {
     }
 
     @Override
-    public Object recreate() throws Throwable {
+    public Object recreate() {
         if (exception != null) {
             // fix issue#619
             try {
                 // get Throwable class
+                @SuppressWarnings("rawtypes")
                 Class clazz = exception.getClass();
                 while (!clazz.getName().equals(Throwable.class.getName())) {
                     clazz = clazz.getSuperclass();
@@ -86,7 +87,7 @@ public class AppResponse implements Result {
             } catch (Exception e) {
                 // ignore
             }
-            throw exception;
+            throw new RpcException(exception);
         }
         return result;
     }


### PR DESCRIPTION
fix #6379. While exception happened in server-side, make stacktrace of consumer-side can be tracked.
(cherry picked from commit 70d3934bf1f91168b928c29025724d5519b5aa79)

## What is the purpose of the change

track the stacktrace of consumer-side by wrapping the server-side exception with a new RpcException.

## Brief changelog
wrap server-side's exception with RpcException.


## Verifying this change
throw an exception in server-side, throw or log the excetion in consumer-side, we can see where we invoke the remote method form the stack trace.

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a [GITHUB_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [x] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Run `mvn clean install -DskipTests=false` & `mvn clean test-compile failsafe:integration-test` to make sure unit-test and integration-test pass.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
