### PR TITLE
fix#6613：UrlUtils.parseURL()默认端口号问题

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/utils/UrlUtils.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/utils/UrlUtils.java
@@ -131,9 +131,6 @@ public class UrlUtils {
             if (defaultPort > 0) {
                 changed = true;
                 port = defaultPort;
-            } else {
-                changed = true;
-                port = 9090;
             }
         }
         if (path == null || path.length() == 0) {

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/utils/UrlUtilsTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/utils/UrlUtilsTest.java
@@ -68,9 +68,9 @@ public class UrlUtilsTest {
     public void testDefaultUrl() {
         String address = "127.0.0.1";
         URL url = UrlUtils.parseURL(address, null);
-        assertEquals(localAddress + ":9090", url.getAddress());
-        assertEquals(9090, url.getPort());
+        assertEquals(localAddress, url.getAddress());
         assertEquals("dubbo", url.getProtocol());
+        assertEquals(0, url.getPort());
         assertNull(url.getUsername());
         assertNull(url.getPassword());
         assertNull(url.getPath());


### PR DESCRIPTION

问题一：当配置中心和监控中心使用域名时，默认添加端口号9090，导致连接无法建立。
问题二：9090端口号，是prometheus默认端口号。

目前只有配置中心和监控中心以及simpleRegistry在使用这个方法，我觉得去掉这个默认端口号是可以的，simpleRegistry应该配置他的端口号。