### PR TITLE
Upgrade netty, grpc and surefire to latest version

### DIFF
--- a/dubbo-dependencies-bom/pom.xml
+++ b/dubbo-dependencies-bom/pom.xml
@@ -92,7 +92,7 @@
         <spring_version>4.3.16.RELEASE</spring_version>
         <javassist_version>3.20.0-GA</javassist_version>
         <netty_version>3.2.5.Final</netty_version>
-        <netty4_version>4.1.25.Final</netty4_version>
+        <netty4_version>4.1.51.Final</netty4_version>
         <mina_version>1.1.7</mina_version>
         <grizzly_version>2.1.4</grizzly_version>
         <httpclient_version>4.5.3</httpclient_version>
@@ -131,7 +131,7 @@
         <tomcat_embed_version>8.5.31</tomcat_embed_version>
         <jetcd_version>0.4.1</jetcd_version>
         <nacos_version>1.3.1</nacos_version>
-        <grpc.version>1.22.1</grpc.version>
+        <grpc.version>1.31.0</grpc.version>
         <!-- Log libs -->
         <slf4j_version>1.7.25</slf4j_version>
         <jcl_version>1.2</jcl_version>

--- a/pom.xml
+++ b/pom.xml
@@ -112,7 +112,7 @@
         <file_encoding>UTF-8</file_encoding>
         <!-- Maven plugins -->
         <maven_jar_version>3.2.0</maven_jar_version>
-        <maven_surefire_version>2.22.1</maven_surefire_version>
+        <maven_surefire_version>3.0.0-M5</maven_surefire_version>
         <maven_deploy_version>2.8.2</maven_deploy_version>
         <maven_compiler_version>3.6.0</maven_compiler_version>
         <maven_source_version>3.2.1</maven_source_version>


### PR DESCRIPTION
- Update netty to 4.1.51 which includes both security fixes and AArch64 performance improvements. Refer release notes for detail:
  - https://netty.io/news/2020/05/13/4-1-50-Final.html
  - https://netty.io/news/2020/07/09/4-1-51-Final.html
- Update grpc version to latest version 1.31.0
- Update surefire to 3.0.0-M5 due to compatibility