### PR TITLE
[Dubbo-6686] init paramter in default construction at org.apache.dubbo.common.URL

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/URL.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/URL.java
@@ -146,8 +146,8 @@ class URL implements Serializable {
         this.port = 0;
         this.address = null;
         this.path = null;
-        this.parameters = null;
-        this.methodParameters = null;
+        this.parameters = new HashMap<>();
+        this.methodParameters = new HashMap<>();
     }
 
     public URL(String protocol, String host, int port) {


### PR DESCRIPTION
## What is the purpose of the change

fix-6686