### PR TITLE
fixed memory waste and fixed typo

### DIFF
--- a/dubbo-container/dubbo-container-api/src/main/java/org/apache/dubbo/container/Main.java
+++ b/dubbo-container/dubbo-container-api/src/main/java/org/apache/dubbo/container/Main.java
@@ -58,7 +58,7 @@ public class Main {
                 args = COMMA_SPLIT_PATTERN.split(config);
             }
 
-            final List<Container> containers = new ArrayList<Container>();
+            final List<Container> containers = new ArrayList<>();
             for (int i = 0; i < args.length; i++) {
                 containers.add(LOADER.getExtension(args[i]));
             }

--- a/dubbo-container/dubbo-container-logback/src/main/java/org/apache/dubbo/container/logback/LogbackContainer.java
+++ b/dubbo-container/dubbo-container-logback/src/main/java/org/apache/dubbo/container/logback/LogbackContainer.java
@@ -76,14 +76,14 @@ public class LogbackContainer implements Container {
         rootLogger.detachAndStopAllAppenders();
 
         // appender
-        RollingFileAppender<ILoggingEvent> fileAppender = new RollingFileAppender<ILoggingEvent>();
+        RollingFileAppender<ILoggingEvent> fileAppender = new RollingFileAppender<>();
         fileAppender.setContext(loggerContext);
         fileAppender.setName("application");
         fileAppender.setFile(file);
         fileAppender.setAppend(true);
 
         // policy
-        TimeBasedRollingPolicy<ILoggingEvent> policy = new TimeBasedRollingPolicy<ILoggingEvent>();
+        TimeBasedRollingPolicy<ILoggingEvent> policy = new TimeBasedRollingPolicy<>();
         policy.setContext(loggerContext);
         policy.setMaxHistory(maxHistory);
         policy.setFileNamePattern(file + ".%d{yyyy-MM-dd}");

--- a/dubbo-filter/dubbo-filter-validation/src/test/java/org/apache/dubbo/validation/support/jvalidation/JValidatorTest.java
+++ b/dubbo-filter/dubbo-filter-validation/src/test/java/org/apache/dubbo/validation/support/jvalidation/JValidatorTest.java
@@ -23,10 +23,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import javax.validation.ConstraintViolationException;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 public class JValidatorTest {
     @Test
@@ -72,7 +69,7 @@ public class JValidatorTest {
     public void testItWithCollectionArg() throws Exception {
         URL url = URL.valueOf("test://test:11/org.apache.dubbo.validation.support.jvalidation.mock.JValidatorTestTarget");
         JValidator jValidator = new JValidator(url);
-        jValidator.validate("someMethod4", new Class<?>[]{List.class}, new Object[]{Arrays.asList("parameter")});
+        jValidator.validate("someMethod4", new Class<?>[]{List.class}, new Object[]{Collections.singletonList("parameter")});
     }
 
     @Test

--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/ServiceDiscovery.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/ServiceDiscovery.java
@@ -121,15 +121,13 @@ public interface ServiceDiscovery extends Prioritized {
      */
     default List<ServiceInstance> getInstances(String serviceName) throws NullPointerException {
 
-        List<ServiceInstance> allInstances = new LinkedList<>();
-
         int offset = 0;
 
         int pageSize = getDefaultPageSize();
 
         Page<ServiceInstance> page = getInstances(serviceName, offset, pageSize);
 
-        allInstances.addAll(page.getData());
+        List<ServiceInstance> allInstances = new LinkedList<>(page.getData());
 
         while (page.hasNext()) {
             offset += page.getDataSize();

--- a/dubbo-registry/dubbo-registry-consul/src/main/java/org/apache/dubbo/registry/consul/ConsulServiceDiscovery.java
+++ b/dubbo-registry/dubbo-registry-consul/src/main/java/org/apache/dubbo/registry/consul/ConsulServiceDiscovery.java
@@ -325,8 +325,7 @@ public class ConsulServiceDiscovery implements ServiceDiscovery, EventListener<S
     }
 
     private Map<String, String> buildMetadata(ServiceInstance serviceInstance) {
-        Map<String, String> metadata = new LinkedHashMap<>();
-        metadata.putAll(getScCompatibleMetadata(registeringTags));
+        Map<String, String> metadata = new LinkedHashMap<>(getScCompatibleMetadata(registeringTags));
         if (CollectionUtils.isNotEmptyMap(serviceInstance.getMetadata())) {
             metadata.putAll(serviceInstance.getMetadata());
         }

--- a/dubbo-registry/dubbo-registry-multicast/src/main/java/org/apache/dubbo/registry/multicast/MulticastRegistry.java
+++ b/dubbo-registry/dubbo-registry-multicast/src/main/java/org/apache/dubbo/registry/multicast/MulticastRegistry.java
@@ -361,9 +361,7 @@ public class MulticastRegistry extends FailbackRegistry {
     private List<URL> toList(Set<URL> urls) {
         List<URL> list = new ArrayList<URL>();
         if (CollectionUtils.isNotEmpty(urls)) {
-            for (URL url : urls) {
-                list.add(url);
-            }
+            list.addAll(urls);
         }
         return list;
     }

--- a/dubbo-registry/dubbo-registry-nacos/src/main/java/org/apache/dubbo/registry/nacos/NacosRegistry.java
+++ b/dubbo-registry/dubbo-registry-nacos/src/main/java/org/apache/dubbo/registry/nacos/NacosRegistry.java
@@ -37,15 +37,7 @@ import com.alibaba.nacos.api.naming.listener.NamingEvent;
 import com.alibaba.nacos.api.naming.pojo.Instance;
 import com.alibaba.nacos.api.naming.pojo.ListView;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.LinkedHashSet;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -537,7 +529,7 @@ public class NacosRegistry extends FailbackRegistry {
      */
     private List<String> getCategories(URL url) {
         return ANY_VALUE.equals(url.getServiceInterface()) ?
-                ALL_SUPPORTED_CATEGORIES : Arrays.asList(DEFAULT_CATEGORY);
+                ALL_SUPPORTED_CATEGORIES : Collections.singletonList(DEFAULT_CATEGORY);
     }
 
     private URL buildURL(Instance instance) {

--- a/dubbo-registry/dubbo-registry-zookeeper/src/test/java/org/apache/dubbo/registry/zookeeper/ZookeeperServiceDiscoveryTest.java
+++ b/dubbo-registry/dubbo-registry-zookeeper/src/test/java/org/apache/dubbo/registry/zookeeper/ZookeeperServiceDiscoveryTest.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -82,7 +83,7 @@ public class ZookeeperServiceDiscoveryTest {
         List<ServiceInstance> serviceInstances = discovery.getInstances(SERVICE_NAME);
 
         assertTrue(serviceInstances.contains(serviceInstance));
-        assertEquals(asList(serviceInstance), serviceInstances);
+        assertEquals(Collections.singletonList(serviceInstance), serviceInstances);
 
         Map<String, String> metadata = new HashMap<>();
         metadata.put("message", "Hello,World");


### PR DESCRIPTION
there is have some method  With too few parameters will cause memory waste And remove unnecessary paradigm parameters. eg:Arrays.asList()  Can be replaced with Collections.singletonList() to save memory overhead. Thanks!