### PR TITLE
[Dubbo-6694] Fix URL compatible with "default." prefix

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/URLStrParser.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/URLStrParser.java
@@ -16,6 +16,9 @@
  */
 package org.apache.dubbo.common;
 
+
+import org.apache.dubbo.common.constants.CommonConstants;
+
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -223,14 +226,19 @@ public final class URLStrParser {
             valueStart = valueEnd + 1;
         }
 
+        String name;
+        String value;
         if (isEncoded) {
-            String name = decodeComponent(str, nameStart, valueStart - 3, false, tempBuf);
-            String value = decodeComponent(str, valueStart, valueEnd, false, tempBuf);
-            params.put(name, value);
+            name = decodeComponent(str, nameStart, valueStart - 3, false, tempBuf);
+            value = decodeComponent(str, valueStart, valueEnd, false, tempBuf);
         } else {
-            String name = str.substring(nameStart, valueStart -1);
-            String value = str.substring(valueStart, valueEnd);
-            params.put(name, value);
+            name = str.substring(nameStart, valueStart -1);
+            value = str.substring(valueStart, valueEnd);
+        }
+        params.put(name, value);
+        // compatible with lower versions registering "default." keys
+        if (name.startsWith(CommonConstants.DEFAULT_KEY_PREFIX)) {
+            params.putIfAbsent(name.substring(CommonConstants.DEFAULT_KEY_PREFIX.length()), value);
         }
         return true;
     }


### PR DESCRIPTION
## What is the purpose of the change

Fix issue #6694

## Brief changelog

Fix URLStrParser.parseEncodedStr() method,make it compatible with "default." prefix config parameter

## Verifying this change

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a [GITHUB_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [x] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Run `mvn clean install -DskipTests=false` & `mvn clean test-compile failsafe:integration-test` to make sure unit-test and integration-test pass.
- [x] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
