### PR TITLE
Dubbo-#6827: fix the problem of race conditions in RpcStatus's endCount

### DIFF
--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/RpcStatus.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/RpcStatus.java
@@ -137,21 +137,28 @@ public class RpcStatus {
         status.total.incrementAndGet();
         status.totalElapsed.addAndGet(elapsed);
 
-        if (status.maxElapsed.get() < elapsed) {
-            status.maxElapsed.set(elapsed);
+        synchronized (status.maxElapsed) {
+            if (status.maxElapsed.get() < elapsed) {
+                status.maxElapsed.set(elapsed);
+            }
         }
 
         if (succeeded) {
-            if (status.succeededMaxElapsed.get() < elapsed) {
-                status.succeededMaxElapsed.set(elapsed);
+            synchronized (status.succeededMaxElapsed) {
+                if (status.succeededMaxElapsed.get() < elapsed) {
+                    status.succeededMaxElapsed.set(elapsed);
+                }
             }
-
         } else {
             status.failed.incrementAndGet();
             status.failedElapsed.addAndGet(elapsed);
-            if (status.failedMaxElapsed.get() < elapsed) {
-                status.failedMaxElapsed.set(elapsed);
+
+            synchronized (status.failedMaxElapsed) {
+                if (status.failedMaxElapsed.get() < elapsed) {
+                    status.failedMaxElapsed.set(elapsed);
+                }
             }
+
         }
     }
 


### PR DESCRIPTION
## What is the purpose of the change

fix the race conditions in RpcStatus's endCount function.

see issue: #6827

## Brief changelog

add synchronize operations when set the value of maxElapsed , and so on.




Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a [GITHUB_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [x] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Run `mvn clean install -DskipTests=false` & `mvn clean test-compile failsafe:integration-test` to make sure unit-test and integration-test pass.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
