### PR TITLE
[Dubbo-6830] refactor: use mockito to replace unnecessary coupling #6830

### DIFF
--- a/dubbo-compatible/src/test/java/org/apache/dubbo/serialization/MySerialization.java
+++ b/dubbo-compatible/src/test/java/org/apache/dubbo/serialization/MySerialization.java
@@ -21,16 +21,38 @@ import com.alibaba.dubbo.common.URL;
 import com.alibaba.dubbo.common.serialize.ObjectInput;
 import com.alibaba.dubbo.common.serialize.ObjectOutput;
 import com.alibaba.dubbo.common.serialize.Serialization;
+import org.mockito.Mockito;
 
+import java.io.BufferedWriter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.io.OutputStreamWriter;
 
 public class MySerialization implements Serialization {
 
+    private ObjectOutput mockObjectOutput(OutputStream output) {
+        ObjectOutput res = Mockito.mock(ObjectOutput.class);
+        final BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(output));
+        try {
+            Mockito.doAnswer(invo -> {
+                writer.write((String) invo.getArgument(1));
+                writer.write('\n');
+                return null;
+            }).when(res).writeUTF(Mockito.anyString());
+            Mockito.doAnswer(invo -> {
+                writer.flush();
+                return null;
+            }).when(res).flushBuffer();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        return res;
+    }
+
     @Override
     public ObjectOutput serialize(URL url, OutputStream output) throws IOException {
-        return new MyObjectOutput(output);
+        return mockObjectOutput(output);
     }
 
     @Override

--- a/dubbo-compatible/src/test/java/org/apache/dubbo/serialization/SerializationTest.java
+++ b/dubbo-compatible/src/test/java/org/apache/dubbo/serialization/SerializationTest.java
@@ -65,7 +65,7 @@ public class SerializationTest {
     @Test
     public void testObjectOutput() throws IOException {
         ObjectOutput objectOutput = mySerialization.serialize(null, mock(OutputStream.class));
-        assertThat(objectOutput, Matchers.<ObjectOutput>instanceOf(MyObjectOutput.class));
+        assertThat(objectOutput, Matchers.<ObjectOutput>instanceOf(com.alibaba.dubbo.common.serialize.ObjectOutput.class));
     }
 
     @Test

--- a/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/url/InvokerSideConfigUrlTest.java
+++ b/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/url/InvokerSideConfigUrlTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.dubbo.config.url;
 
+import org.apache.dubbo.common.URL;
 import org.apache.dubbo.common.logger.Logger;
 import org.apache.dubbo.common.logger.LoggerFactory;
 import org.apache.dubbo.config.ConsumerConfig;
@@ -24,17 +25,18 @@ import org.apache.dubbo.config.ReferenceConfig;
 import org.apache.dubbo.config.RegistryConfig;
 import org.apache.dubbo.config.api.DemoService;
 import org.apache.dubbo.config.mock.MockRegistry;
+import org.apache.dubbo.registry.Registry;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 import java.util.Arrays;
 
 import static org.apache.dubbo.rpc.Constants.SCOPE_REMOTE;
-
 
 public class InvokerSideConfigUrlTest extends UrlTestBase {
     private static final Logger log = LoggerFactory.getLogger(InvokerSideConfigUrlTest.class);

--- a/dubbo-configcenter/dubbo-configcenter-zookeeper/src/test/java/org/apache/dubbo/configcenter/support/zookeeper/ZookeeperDynamicConfigurationTest.java
+++ b/dubbo-configcenter/dubbo-configcenter-zookeeper/src/test/java/org/apache/dubbo/configcenter/support/zookeeper/ZookeeperDynamicConfigurationTest.java
@@ -32,6 +32,7 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -95,13 +96,29 @@ public class ZookeeperDynamicConfigurationTest {
         Assertions.assertEquals("The content from dubbo.properties", configuration.getConfig("dubbo.properties", "dubbo"));
     }
 
+    private ConfigurationListener mockListener(CountDownLatch latch, String[] value, Map<String, Integer> countMap) {
+        ConfigurationListener listener = Mockito.mock(ConfigurationListener.class);
+        Mockito.doAnswer(invo -> {
+            ConfigChangedEvent event = invo.getArgument(0);
+            Integer count = countMap.computeIfAbsent(event.getKey(), k -> new Integer(0));
+            countMap.put(event.getKey(), ++count);
+            value[0] = event.getContent();
+            latch.countDown();
+            return null;
+        }).when(listener).process(Mockito.any());
+        return listener;
+    }
+
     @Test
     public void testAddListener() throws Exception {
         CountDownLatch latch = new CountDownLatch(4);
-        TestListener listener1 = new TestListener(latch);
-        TestListener listener2 = new TestListener(latch);
-        TestListener listener3 = new TestListener(latch);
-        TestListener listener4 = new TestListener(latch);
+
+        String[] value1 = new String[1], value2 = new String[1], value3 = new String[1], value4 = new String[1];
+        Map<String, Integer> countMap1 = new HashMap<>(), countMap2 = new HashMap<>(), countMap3 = new HashMap<>(), countMap4 = new HashMap<>();
+        ConfigurationListener listener1 = mockListener(latch, value1, countMap1);
+        ConfigurationListener listener2 = mockListener(latch, value2, countMap2);
+        ConfigurationListener listener3 = mockListener(latch, value3, countMap3);
+        ConfigurationListener listener4 = mockListener(latch, value4, countMap4);
         configuration.addListener("service:version:group.configurators", listener1);
         configuration.addListener("service:version:group.configurators", listener2);
         configuration.addListener("appname.tag-router", listener3);
@@ -116,15 +133,15 @@ public class ZookeeperDynamicConfigurationTest {
         Thread.sleep(5000);
 
         latch.await();
-        Assertions.assertEquals(1, listener1.getCount("service:version:group.configurators"));
-        Assertions.assertEquals(1, listener2.getCount("service:version:group.configurators"));
-        Assertions.assertEquals(1, listener3.getCount("appname.tag-router"));
-        Assertions.assertEquals(1, listener4.getCount("appname.tag-router"));
+        Assertions.assertEquals(1, countMap1.get("service:version:group.configurators"));
+        Assertions.assertEquals(1, countMap2.get("service:version:group.configurators"));
+        Assertions.assertEquals(1, countMap3.get("appname.tag-router"));
+        Assertions.assertEquals(1, countMap4.get("appname.tag-router"));
 
-        Assertions.assertEquals("new value1", listener1.getValue());
-        Assertions.assertEquals("new value1", listener2.getValue());
-        Assertions.assertEquals("new value2", listener3.getValue());
-        Assertions.assertEquals("new value2", listener4.getValue());
+        Assertions.assertEquals("new value1", value1[0]);
+        Assertions.assertEquals("new value1", value2[0]);
+        Assertions.assertEquals("new value2", value3[0]);
+        Assertions.assertEquals("new value2", value4[0]);
     }
 
     @Test
@@ -152,34 +169,6 @@ public class ZookeeperDynamicConfigurationTest {
         Set<String> configKeys = configuration.getConfigKeys(group);
 
         assertEquals(new TreeSet(asList(key, key2)), configKeys);
-    }
-
-    private class TestListener implements ConfigurationListener {
-        private CountDownLatch latch;
-        private String value;
-        private Map<String, Integer> countMap = new HashMap<>();
-
-        public TestListener(CountDownLatch latch) {
-            this.latch = latch;
-        }
-
-        @Override
-        public void process(ConfigChangedEvent event) {
-            System.out.println(this + ": " + event);
-            Integer count = countMap.computeIfAbsent(event.getKey(), k -> new Integer(0));
-            countMap.put(event.getKey(), ++count);
-
-            value = event.getContent();
-            latch.countDown();
-        }
-
-        public int getCount(String key) {
-            return countMap.get(key);
-        }
-
-        public String getValue() {
-            return value;
-        }
     }
 
 }

--- a/dubbo-remoting/dubbo-remoting-mina/src/test/java/org/apache/remoting/transport/mina/ClientToServerTest.java
+++ b/dubbo-remoting/dubbo-remoting-mina/src/test/java/org/apache/remoting/transport/mina/ClientToServerTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 import java.util.concurrent.CompletableFuture;
 
@@ -40,7 +41,7 @@ public abstract class ClientToServerTest {
 
     protected ExchangeChannel client;
 
-    protected WorldHandler handler = new WorldHandler();
+    protected Replier<World> handler;
 
     protected abstract ExchangeServer newServer(int port, Replier<?> receiver) throws RemotingException;
 
@@ -48,6 +49,8 @@ public abstract class ClientToServerTest {
 
     @BeforeEach
     protected void setUp() throws Exception {
+        handler = Mockito.mock(Replier.class);
+        Mockito.when(handler.reply(Mockito.any(ExchangeChannel.class), Mockito.any(World.class))).thenAnswer(invo -> new Hello("hello," + ((World) invo.getArgument(1)).getName()));
         int port = NetUtils.getAvailablePort();
         server = newServer(port, handler);
         client = newClient(port);

--- a/pom.xml
+++ b/pom.xml
@@ -95,7 +95,7 @@
         <el_api_version>2.2.4</el_api_version>
         <jaxb_api_version>2.2.7</jaxb_api_version>
         <cglib_version>2.2</cglib_version>
-        <mockito_version>2.23.4</mockito_version>
+        <mockito_version>3.5.15</mockito_version>
         <!-- Build args -->
         <argline>-server -Xms256m -Xmx512m -Dfile.encoding=UTF-8
             -Djava.net.preferIPv4Stack=true -XX:MetaspaceSize=64m -XX:MaxMetaspaceSize=128m


### PR DESCRIPTION

## What is the purpose of the change

Use Mockito framework to replace the original test to production inheritance structure. This could decrease the coupling between test and irrelevant production class and make test logic more clear.