### PR TITLE
Memory usage is too high。frequently GC

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/timer/HashedWheelTimer.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/timer/HashedWheelTimer.java
@@ -805,8 +805,8 @@ public class HashedWheelTimer implements Timer {
             return head;
         }
     }
-
+    private static boolean isWindows = System.getProperty("os.name", "").toLowerCase(Locale.US).contains("win");
     private boolean isWindows() {
-        return System.getProperty("os.name", "").toLowerCase(Locale.US).contains("win");
+    	return isWindows;
     }
 }


### PR DESCRIPTION
### Memory usage is too high。frequently GC

#6820 
#6808 

bug 所在文件 https://github.com/apache/dubbo/blob/master/dubbo-common/src/main/java/org/apache/dubbo/common/timer/HashedWheelTimer.java

出现问题的方法:
private boolean isWindows() { return System.getProperty("os.name", "").toLowerCase(Locale.US).contains("win"); }
问题产生原因：
1.waitForNextTick() 中无限调用 isWindows();

2.toLowerCase(Locale.US) 将急速产生 char[] 对象。导致内存占用过高。

解决方案：
` private static boolean isWindows = System.getProperty("os.name", "").toLowerCase(Locale.US).contains("win");

private boolean isWindows() {
	return isWindows;
}`