### PR TITLE
fix boolean data type issue for Pojoutils.java#getDefaultValue

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/utils/PojoUtils.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/utils/PojoUtils.java
@@ -607,7 +607,7 @@ public class PojoUtils {
         if ("char".equals(parameterType.getName())) {
             return Character.MIN_VALUE;
         }
-        if ("bool".equals(parameterType.getName())) {
+        if ("boolean".equals(parameterType.getName())) {
             return false;
         }
         return parameterType.isPrimitive() ? 0 : null;

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/model/SerializablePerson.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/model/SerializablePerson.java
@@ -27,6 +27,9 @@ public class SerializablePerson implements Serializable {
 
     private String[] value = {"value1", "value2"};
 
+    public SerializablePerson(char description , boolean adult){
+
+    }
     public String getName() {
         return name;
     }

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/utils/PojoUtilsTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/utils/PojoUtilsTest.java
@@ -133,7 +133,7 @@ public class PojoUtilsTest {
     @Test
     public void test_pojo() throws Exception {
         assertObject(new Person());
-        assertObject(new SerializablePerson());
+        assertObject(new SerializablePerson(Character.MIN_VALUE, false));
     }
 
     @Test
@@ -147,7 +147,7 @@ public class PojoUtilsTest {
 
         List<Object> list = new ArrayList<Object>();
         list.add(new Person());
-        list.add(new SerializablePerson());
+        list.add(new SerializablePerson(Character.MIN_VALUE, false));
 
         map.put("k", list);
 


### PR DESCRIPTION
## What is the purpose of the change

Getting the default value of boolean is incorrect, resulting in an error in the PojoUtils#newInstance method, if the construction method of the instantiated object requires the boolean type

## Brief changelog

let 'bool' to 'boolean'

## Verifying this change

I modified the PojoUtilsTest#test_Map_List_pojo test case to add the construction method of SerializablePerson to the boolean type

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a [GITHUB_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.

 issue: https://github.com/apache/dubbo/issues/6854

- [ ] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Run `mvn clean install -DskipTests=false` & `mvn clean test-compile failsafe:integration-test` to make sure unit-test and integration-test pass.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
