### PR TITLE
[Dubbo-6935] Clear all stored thread local variables in InternalThreadLocalTest.testSize

### DIFF
--- a/dubbo-common/src/test/java/org/apache/dubbo/common/threadlocal/InternalThreadLocalTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/threadlocal/InternalThreadLocalTest.java
@@ -79,6 +79,7 @@ public class InternalThreadLocalTest {
         final InternalThreadLocal<String> internalThreadLocalString = new InternalThreadLocal<String>();
         internalThreadLocalString.set("value");
         Assertions.assertEquals(2, InternalThreadLocal.size(), "size method is wrong!");
+        InternalThreadLocal.removeAll();
     }
 
     @Test


### PR DESCRIPTION
## What is the purpose of the change
The test `dubbo-common,org.apache.dubbo.common.threadlocal.InternalThreadLocalTest.testSize` is not idempotent and fails if run twice in the same JVM, because it pollutes state shared among tests. It may be good to clean this state pollution so that some other tests do not fail in the future due to the shared state polluted by this test.

Issue link: [Dubbo-6935](https://github.com/apache/dubbo/issues/6935)

## Brief changelog

In `InternalThreadLocalTest.testSize()`, call `InternalThreadLocal.removeAll()` to clear all the thread local variables stored in the test run.

## Verifying this change
With the proposed fix, the test does not pollute the shared state (and passes when run twice in the same JVM).


Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a [GITHUB_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [x] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Run `mvn clean install -DskipTests=false` & `mvn clean test-compile failsafe:integration-test` to make sure unit-test and integration-test pass.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
