### PR TITLE
[Dubbo-6954] Reset ExtensionLoader in ExtensionLoaderTest

### DIFF
--- a/dubbo-common/src/test/java/org/apache/dubbo/common/extension/ExtensionLoaderTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/extension/ExtensionLoaderTest.java
@@ -69,6 +69,7 @@ import java.util.Set;
 import static org.apache.dubbo.common.constants.CommonConstants.GROUP_KEY;
 import static org.apache.dubbo.common.extension.ExtensionLoader.getExtensionLoader;
 import static org.apache.dubbo.common.extension.ExtensionLoader.getLoadingStrategies;
+import static org.apache.dubbo.common.extension.ExtensionLoader.resetExtensionLoader;
 import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.CoreMatchers.anyOf;
 import static org.hamcrest.CoreMatchers.instanceOf;
@@ -255,6 +256,7 @@ public class ExtensionLoaderTest {
 
         assertThat(ext, instanceOf(AddExt1_ManualAdd1.class));
         assertEquals("Manual1", getExtensionLoader(AddExt1.class).getExtensionName(AddExt1_ManualAdd1.class));
+        ExtensionLoader.resetExtensionLoader(AddExt1.class);
     }
 
     @Test
@@ -324,6 +326,7 @@ public class ExtensionLoaderTest {
             assertThat(ext, instanceOf(AddExt1_ManualAdd2.class));
             assertEquals("impl1", getExtensionLoader(AddExt1.class).getExtensionName(AddExt1_ManualAdd2.class));
         }
+        ExtensionLoader.resetExtensionLoader(AddExt1.class);
     }
 
     @Test
@@ -337,6 +340,7 @@ public class ExtensionLoaderTest {
 
         adaptive = loader.getAdaptiveExtension();
         assertTrue(adaptive instanceof AddExt3_ManualAdaptive);
+        ExtensionLoader.resetExtensionLoader(AddExt3.class);
     }
 
     @Test


### PR DESCRIPTION
## What is the purpose of the change
The tests are not idempotent and fails if run twice in the same JVM, because each of the tests pollutes state shared among tests:
* `dubbo-common,org.apache.dubbo.common.extension.ExtensionLoaderTest.test_replaceExtension_Adaptive`
* `dubbo-common,org.apache.dubbo.common.extension.ExtensionLoaderTest.test_AddExtension`
* `dubbo-common,org.apache.dubbo.common.extension.ExtensionLoaderTest.test_replaceExtension`

It may be good to clean this state pollution so that some other tests do not fail in the future due to the shared state polluted by these tests.

## Brief changelog

Call `ExtensionLoader.resetExtensionLoader()` to reset the ExtensionLoader for the certain extension types used in each tests in `test_replaceExtension_Adaptive`, `test_AddExtension`, and `test_replaceExtension`.

## Verifying this change
With the proposed fix, the test does not pollute the shared state (and passes when run twice in the same JVM).

Link to issue: https://github.com/apache/dubbo/issues/6954