### PR TITLE
[Dubbo-6960] fix bug: avoid npe when encode request

### DIFF
--- a/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/exchange/Request.java
+++ b/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/exchange/Request.java
@@ -127,6 +127,16 @@ public class Request {
         }
     }
 
+    public Request copy() {
+        Request copy = new Request(mId);
+        copy.mVersion = this.mVersion;
+        copy.mTwoWay = this.mTwoWay;
+        copy.mEvent = this.mEvent;
+        copy.mBroken = this.mBroken;
+        copy.mData = this.mData;
+        return copy;
+    }
+
     @Override
     public String toString() {
         return "Request [id=" + mId + ", version=" + mVersion + ", twoway=" + mTwoWay + ", event=" + mEvent

--- a/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/exchange/support/DefaultFuture.java
+++ b/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/exchange/support/DefaultFuture.java
@@ -261,7 +261,7 @@ public class DefaultFuture extends CompletableFuture<Object> {
     }
 
     private Request getRequestWithoutData() {
-        Request newRequest = request;
+        Request newRequest = request.copy();
         newRequest.setData(null);
         return newRequest;
     }


### PR DESCRIPTION
fix #6960 npe。
垃圾处理器非常擅长处理这种稍纵即逝的对象，没有必要做这个优化，反而导致了npe。