### PR TITLE
fix init protocol

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/config/ProtocolConfig.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/config/ProtocolConfig.java
@@ -16,10 +16,12 @@
  */
 package org.apache.dubbo.config;
 
+import org.apache.dubbo.common.extension.ExtensionLoader;
 import org.apache.dubbo.common.utils.StringUtils;
 import org.apache.dubbo.config.support.Parameter;
 
 import java.util.Map;
+import java.util.Set;
 
 import static org.apache.dubbo.common.constants.CommonConstants.DUBBO_VERSION_KEY;
 import static org.apache.dubbo.common.constants.CommonConstants.SSL_ENABLED_KEY;
@@ -218,8 +220,22 @@ public class ProtocolConfig extends AbstractConfig {
     }
 
     public final void setName(String name) {
+        if (!checkName(name)){
+            return;
+        }
         this.name = name;
         this.updateIdIfAbsent(name);
+    }
+
+    private boolean checkName(String name) {
+        try {
+            Set<String> se = ExtensionLoader.getExtensionLoader(Class.forName("org.apache.dubbo.rpc.Protocol")).getSupportedExtensions();
+            if (!se.contains(name)) {
+                return false;
+            }
+        } catch (ClassNotFoundException e) {
+        }
+        return true;
     }
 
     @Parameter(excluded = true)


### PR DESCRIPTION
## What is the purpose of the change

dubbo 2.X.X 的ProtocolConfig 通过refresh 刷新如name(如果name,没有指定,默认值dubbo),但3.0版本如果不指定就会取方法名字然后set进去,这就造成了refresh永远不会生效,因为永远有值了.这就造成了和dubbo2代码的不兼容(除非开始就指定name).通过此修改,可以保证是和2完全兼容.策略就是先验证下name是否在protocl范围内,如果不在,直接忽略,然后指定默认

## Brief changelog

XXXXX

## Verifying this change

XXXXX

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a [GITHUB_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Run `mvn clean install -DskipTests=false` & `mvn clean test-compile failsafe:integration-test` to make sure unit-test and integration-test pass.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
