### PR TITLE
[Unit Test] Fix error in PublishingServiceDefinitionListenerTest

### DIFF
--- a/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/event/listener/PublishingServiceDefinitionListenerTest.java
+++ b/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/event/listener/PublishingServiceDefinitionListenerTest.java
@@ -47,6 +47,7 @@ public class PublishingServiceDefinitionListenerTest {
 
     @BeforeEach
     public void init() {
+        ApplicationModel.reset();
         String metadataType = DEFAULT_METADATA_STORAGE_TYPE;
         ConfigManager configManager = ApplicationModel.getConfigManager();
         ApplicationConfig applicationConfig = new ApplicationConfig("dubbo-demo-provider");


### PR DESCRIPTION
## What is the purpose of the change

- Add `ApplicationModel` reset before test case.

The reason is new version of environment will cause order difference of test cases, and some test cases will pollute the static environment like `ApplicationModel` and `Spring`.