### PR TITLE
[Dubbo-Nacos-NamingService] fix dubbo create nacos multiple identical NamingService

### DIFF
--- a/dubbo-registry/dubbo-registry-nacos/src/main/java/org/apache/dubbo/registry/nacos/NacosRegistryFactory.java
+++ b/dubbo-registry/dubbo-registry-nacos/src/main/java/org/apache/dubbo/registry/nacos/NacosRegistryFactory.java
@@ -23,6 +23,7 @@ import org.apache.dubbo.registry.RegistryFactory;
 import org.apache.dubbo.registry.support.AbstractRegistryFactory;
 
 import static org.apache.dubbo.common.constants.CommonConstants.CONFIG_NAMESPACE_KEY;
+import static org.apache.dubbo.common.constants.CommonConstants.TIMESTAMP_KEY;
 import static org.apache.dubbo.registry.nacos.util.NacosNamingServiceUtils.createNamingService;
 
 /**
@@ -39,7 +40,13 @@ public class NacosRegistryFactory extends AbstractRegistryFactory {
         if (StringUtils.isNotEmpty(namespace)) {
             url = url.addParameter(CONFIG_NAMESPACE_KEY, namespace);
         }
-        return url.toFullString();
+        // only remove timestamp for cache key, avoid effect source url timestamp
+        URL cacheUrl = url;
+        if (StringUtils.isNotEmpty(url.getParameter(TIMESTAMP_KEY))) {
+            cacheUrl = URL.valueOf(url.toServiceStringWithoutResolving());
+            cacheUrl = cacheUrl.removeParameter(TIMESTAMP_KEY);
+        }
+        return cacheUrl.toFullString();
     }
 
     @Override


### PR DESCRIPTION
## What is the purpose of the change

fix dubbo create nacos multiple identical NamingService

more detail: in issue #6988 
https://github.com/apache/dubbo/issues/6988

## Brief changelog

1. change `NacosRegistryFactory createRegistryCacheKey` method
2. remove the timestamp from url as registry cache key

## Verifying this change

XXXXX

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a [GITHUB_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [x] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Run `mvn clean install -DskipTests=false` & `mvn clean test-compile failsafe:integration-test` to make sure unit-test and integration-test pass.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
