### PR TITLE
[Dubbo-6992] Clear DubboAppender in AccessLogFilterTest

### DIFF
--- a/dubbo-rpc/dubbo-rpc-api/src/test/java/org/apache/dubbo/rpc/filter/AccessLogFilterTest.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/test/java/org/apache/dubbo/rpc/filter/AccessLogFilterTest.java
@@ -17,6 +17,7 @@
 package org.apache.dubbo.rpc.filter;
 
 import org.apache.dubbo.common.URL;
+import org.apache.dubbo.common.utils.DubboAppender;
 import org.apache.dubbo.common.utils.LogUtil;
 import org.apache.dubbo.rpc.Filter;
 import org.apache.dubbo.rpc.Invocation;
@@ -51,6 +52,7 @@ public class AccessLogFilterTest {
         accessLogFilter.invoke(invoker, invocation);
         assertEquals(1, LogUtil.findMessage("Exception in AccessLogFilter of service"));
         LogUtil.stop();
+        DubboAppender.clear();
     }
 
     // TODO how to assert thread action


### PR DESCRIPTION
## What is the purpose of the change
The test `org.apache.dubbo.rpc.filter.AccessLogFilterTest.testInvokeException` is not idempotent and fails if run twice in the same JVM, because it pollutes state shared among tests. It may be good to clean this state pollution so that some other tests do not fail in the future due to the shared state polluted by this test.

## Brief changelog

In `AccessLogFilterTest.testInvokeException()`, call `DubboAppender.clear()` to clear all the logs from the log list when the test finishes.

## Verifying this change
With the proposed fix, the test does not pollute the shared state (and passes when run twice in the same JVM).

This change fixes https://github.com/apache/dubbo/issues/6992