### PR TITLE
Remove RPC context in RpcContextTest.testObject

### DIFF
--- a/dubbo-rpc/dubbo-rpc-api/src/test/java/org/apache/dubbo/rpc/RpcContextTest.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/test/java/org/apache/dubbo/rpc/RpcContextTest.java
@@ -139,6 +139,7 @@ public class RpcContextTest {
 
         map.keySet().forEach(context::remove);
         Assertions.assertNull(context.get("_11"));
+        RpcContext.removeContext();
     }
 
     @Test


### PR DESCRIPTION
## What is the purpose of the change
The test `org.apache.dubbo.rpc.RpcContextTest.testObject` is not idempotent and fails if run twice in the same JVM, because it pollutes state shared among tests. It may be good to clean this state pollution so that some other tests do not fail in the future due to the shared state polluted by this test. (See [PR #6314](https://github.com/apache/dubbo/pull/6314) for an example of how this could cause issues)

## Brief changelog

In `RpcContextTest.testObject()`, call `RpcContext.removeContext()` to clear remove the RPC context when the test finishes.

## Verifying this change
With the proposed fix, the test does not pollute the shared state (and passes when run twice in the same JVM).

This fixes https://github.com/apache/dubbo/issues/6996 .