### PR TITLE
fix AbstractRegistryFactory bug

### DIFF
--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/Constants.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/Constants.java
@@ -95,6 +95,8 @@ public interface Constants {
      * The key name for reference URL in register center
      */
     String REFER_KEY = "refer";
+
+    String TIMESTAMP_KEY = "timestamp";
     /**
      * The key name for export URL in register center
      */

--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/support/AbstractRegistryFactory.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/support/AbstractRegistryFactory.java
@@ -40,6 +40,7 @@ import java.util.stream.Collectors;
 import static org.apache.dubbo.common.constants.CommonConstants.INTERFACE_KEY;
 import static org.apache.dubbo.rpc.cluster.Constants.EXPORT_KEY;
 import static org.apache.dubbo.rpc.cluster.Constants.REFER_KEY;
+import static org.apache.dubbo.rpc.cluster.Constants.TIMESTAMP_KEY;
 
 /**
  * AbstractRegistryFactory. (SPI, Singleton, ThreadSafe)
@@ -120,7 +121,7 @@ public abstract class AbstractRegistryFactory implements RegistryFactory {
         url = URLBuilder.from(url)
                 .setPath(RegistryService.class.getName())
                 .addParameter(INTERFACE_KEY, RegistryService.class.getName())
-                .removeParameters(EXPORT_KEY, REFER_KEY)
+                .removeParameters(EXPORT_KEY, REFER_KEY, TIMESTAMP_KEY)
                 .build();
         String key = createRegistryCacheKey(url);
         // Lock the registry access process to ensure a single instance of the registry


### PR DESCRIPTION
## What is the purpose of the change
Remove timestamp from key to prevent the creation of multiple registries
每次调用getRegistry 都会创建新的Registry.造成会生成大量的HostReactor(里边又有serviceInfoMap),造成内存泄露.
问题的原因是没有删除时间戳(dubbo2 生成的key,不会包含时间戳).
正常使用不会有问题,但是会随着时间的发展oom

NacosRegistryFactory 中的 createRegistryCacheKey 获取的是 toFullString ,因此也不可能过滤(但也可以修改这里)

我们这里修改时间戳,是认为这算一个比较公共的属性 

## Brief changelog

XXXXX

## Verifying this change

XXXXX

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a [GITHUB_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Run `mvn clean install -DskipTests=false` & `mvn clean test-compile failsafe:integration-test` to make sure unit-test and integration-test pass.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
