### PR TITLE
update dubbo3.0, make servicename compatible

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/URL.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/URL.java
@@ -23,11 +23,7 @@ import org.apache.dubbo.common.url.component.PathURLAddress;
 import org.apache.dubbo.common.url.component.ServiceConfigURL;
 import org.apache.dubbo.common.url.component.URLAddress;
 import org.apache.dubbo.common.url.component.URLParam;
-import org.apache.dubbo.common.utils.ArrayUtils;
-import org.apache.dubbo.common.utils.CollectionUtils;
-import org.apache.dubbo.common.utils.LRUCache;
-import org.apache.dubbo.common.utils.NetUtils;
-import org.apache.dubbo.common.utils.StringUtils;
+import org.apache.dubbo.common.utils.*;
 
 import java.io.Serializable;
 import java.io.UnsupportedEncodingException;
@@ -35,35 +31,11 @@ import java.net.InetSocketAddress;
 import java.net.MalformedURLException;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.TreeMap;
+import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Predicate;
 
-import static org.apache.dubbo.common.constants.CommonConstants.ANYHOST_KEY;
-import static org.apache.dubbo.common.constants.CommonConstants.ANYHOST_VALUE;
-import static org.apache.dubbo.common.constants.CommonConstants.APPLICATION_KEY;
-import static org.apache.dubbo.common.constants.CommonConstants.COMMA_SPLIT_PATTERN;
-import static org.apache.dubbo.common.constants.CommonConstants.GROUP_KEY;
-import static org.apache.dubbo.common.constants.CommonConstants.HOST_KEY;
-import static org.apache.dubbo.common.constants.CommonConstants.INTERFACE_KEY;
-import static org.apache.dubbo.common.constants.CommonConstants.LOCALHOST_KEY;
-import static org.apache.dubbo.common.constants.CommonConstants.PASSWORD_KEY;
-import static org.apache.dubbo.common.constants.CommonConstants.PATH_KEY;
-import static org.apache.dubbo.common.constants.CommonConstants.PORT_KEY;
-import static org.apache.dubbo.common.constants.CommonConstants.PROTOCOL_KEY;
-import static org.apache.dubbo.common.constants.CommonConstants.REMOTE_APPLICATION_KEY;
-import static org.apache.dubbo.common.constants.CommonConstants.SIDE_KEY;
-import static org.apache.dubbo.common.constants.CommonConstants.USERNAME_KEY;
-import static org.apache.dubbo.common.constants.CommonConstants.VERSION_KEY;
+import static org.apache.dubbo.common.constants.CommonConstants.*;
 import static org.apache.dubbo.common.constants.RegistryConstants.CATEGORY_KEY;
 import static org.apache.dubbo.common.convert.Converter.convertIfPossible;
 import static org.apache.dubbo.common.utils.StringUtils.isBlank;
@@ -180,13 +152,13 @@ class URL implements Serializable {
     }
 
     protected URL(String protocol,
-               String username,
-               String password,
-               String host,
-               int port,
-               String path,
-               Map<String, String> parameters,
-               boolean modifiable) {
+                  String username,
+                  String password,
+                  String host,
+                  int port,
+                  String path,
+                  Map<String, String> parameters,
+                  boolean modifiable) {
         if (StringUtils.isEmpty(username)
                 && StringUtils.isNotEmpty(password)) {
             throw new IllegalArgumentException("Invalid url, password without username!");
@@ -197,7 +169,7 @@ class URL implements Serializable {
     }
 
     public static URL cacheableValueOf(String url) {
-        URL cachedURL =  cachedURLs.get(url);
+        URL cachedURL = cachedURLs.get(url);
         if (cachedURL != null) {
             return cachedURL;
         }
@@ -1275,7 +1247,7 @@ class URL implements Serializable {
             }
             target.append(parameterValue);
         } else {
-            target.append(":");
+            target.append(this.getParameter(SEPARATOR_VERSION_KEY, DEFAULT_SEPARATOR_VERSION).equals(DEFAULT_SEPARATOR_VERSION) ? "" : ":");
         }
     }
 

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/constants/CommonConstants.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/constants/CommonConstants.java
@@ -185,6 +185,10 @@ public interface CommonConstants {
 
     String VERSION_KEY = "version";
 
+    String SEPARATOR_VERSION_KEY = "separator-version";
+
+    String DEFAULT_SEPARATOR_VERSION = "false";
+
     String REVISION_KEY = "revision";
 
     String METADATA_KEY = "metadata-type";


### PR DESCRIPTION
## What is the purpose of the change

update dubbo3.0, make service_name compatible with dubbo2.0

## Brief changelog

update dubbo3.0, make service_name compatible with dubbo2.0

## Verifying this change

for example, we have two projects:
project A is a provider, using dubbo2.0, nacos registry info is "providers:com.test.TestService:staging".
project B is a consumer, using dubbo2.0, nacos registry info is "consumers:com.test.TestService:staging".
now, project A changes its dubbo-version to 3.0, and its nacos registry info changes too, becoming "providers:com.test.TestService::staging". project B cannot finds providers anymore.

this is a simple example, the actual situation is more complicated


Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a [GITHUB_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [x] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Run `mvn clean install -DskipTests=false` & `mvn clean test-compile failsafe:integration-test` to make sure unit-test and integration-test pass.
- [x] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
