### PR TITLE
Fix ReflectUtils not support generic call with Future

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/utils/ReflectUtils.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/utils/ReflectUtils.java
@@ -31,6 +31,7 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
+import java.lang.reflect.TypeVariable;
 import java.net.URL;
 import java.security.CodeSource;
 import java.security.ProtectionDomain;
@@ -1201,6 +1202,9 @@ public final class ReflectUtils {
                 Type actualArgType = ((ParameterizedType) genericReturnType).getActualTypeArguments()[0];
                 if (actualArgType instanceof ParameterizedType) {
                     returnType = (Class<?>) ((ParameterizedType) actualArgType).getRawType();
+                    genericReturnType = actualArgType;
+                } else if (actualArgType instanceof TypeVariable) {
+                    returnType = (Class<?>) ((TypeVariable<?>) actualArgType).getBounds()[0];
                     genericReturnType = actualArgType;
                 } else {
                     returnType = (Class<?>) actualArgType;

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/utils/ReflectUtilsTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/utils/ReflectUtilsTest.java
@@ -416,18 +416,44 @@ public class ReflectUtilsTest {
         Assertions.assertEquals("java.lang.String", types1[0].getTypeName());
         Assertions.assertEquals("java.lang.String", types1[1].getTypeName());
 
-        Type[] types2 = ReflectUtils.getReturnTypes(clazz.getMethod("getListFuture"));
-        Assertions.assertEquals("java.util.List", types2[0].getTypeName());
-        Assertions.assertEquals("java.util.List<java.lang.String>", types2[1].getTypeName());
+        Type[] types2 = ReflectUtils.getReturnTypes(clazz.getMethod("getT"));
+        Assertions.assertEquals("java.lang.String", types2[0].getTypeName());
+        Assertions.assertEquals("T", types2[1].getTypeName());
+
+        Type[] types3 = ReflectUtils.getReturnTypes(clazz.getMethod("getS"));
+        Assertions.assertEquals("java.lang.Object", types3[0].getTypeName());
+        Assertions.assertEquals("S", types3[1].getTypeName());
+
+        Type[] types4 = ReflectUtils.getReturnTypes(clazz.getMethod("getListFuture"));
+        Assertions.assertEquals("java.util.List", types4[0].getTypeName());
+        Assertions.assertEquals("java.util.List<java.lang.String>", types4[1].getTypeName());
+
+        Type[] types5 = ReflectUtils.getReturnTypes(clazz.getMethod("getGenericWithUpperFuture"));
+        // T extends String, the first arg should be the upper bound of param
+        Assertions.assertEquals("java.lang.String", types5[0].getTypeName());
+        Assertions.assertEquals("T", types5[1].getTypeName());
+
+        Type[] types6 = ReflectUtils.getReturnTypes(clazz.getMethod("getGenericFuture"));
+        // default upper bound is Object
+        Assertions.assertEquals("java.lang.Object", types6[0].getTypeName());
+        Assertions.assertEquals("S", types6[1].getTypeName());
     }
 
-    public interface TypeClass {
+    public interface TypeClass<T extends String, S> {
 
         CompletableFuture<String> getFuture();
 
         String getString();
 
+        T getT();
+
+        S getS();
+
         CompletableFuture<List<String>> getListFuture();
+
+        CompletableFuture<T> getGenericWithUpperFuture();
+
+        CompletableFuture<S> getGenericFuture();
     }
 
     public static class EmptyClass {


### PR DESCRIPTION
## What is the purpose of the change

Add TypeVariable support for ReflectUtils

Fix #7040

Interface example:
``` java
public interface TypeClass<T> {
    CompletableFuture<T> getGenericFuture();
}
```