### PR TITLE
fixed broken links in <README.md>

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Apache Dubbo Project
 
-[![Build Status](https://travis-ci.org/apache/dubbo.svg?branch=master)](https://travis-ci.org/apache/dubbo)
+[![Build Status](https://travis-ci.com/apache/dubbo.svg?branch=master)](https://travis-ci.com/apache/dubbo)
 [![codecov](https://codecov.io/gh/apache/dubbo/branch/master/graph/badge.svg)](https://codecov.io/gh/apache/dubbo)
 ![maven](https://img.shields.io/maven-central/v/org.apache.dubbo/dubbo.svg)
 ![license](https://img.shields.io/github/license/alibaba/dubbo.svg)
@@ -16,7 +16,7 @@ We are now collecting Dubbo user info to help us to improve Dubbo further. Kindl
 
 ## Architecture
 
-![Architecture](http://dubbo.apache.org/img/architecture.png)
+![Architecture](https://dubbo.apache.org/imgs/architecture.png)
 
 ## Features
 
@@ -167,7 +167,7 @@ The consumer will print out `hi, dubbo` on the screen.
 
 ### Next steps
 
-* [Your first Dubbo application](http://dubbo.apache.org/en-us/blog/dubbo-101.html) - A 101 tutorial to reveal more details, with the same code above.
+* [Your first Dubbo application](http://dubbo.apache.org/blog/2018/08/07/dubbo-101/) - A 101 tutorial to reveal more details, with the same code above.
 * [Dubbo user manual](http://dubbo.apache.org/docs/v2.7/user/preface/background/) - How to use Dubbo and all its features.
 * [Dubbo developer guide](http://dubbo.apache.org/docs/v2.7/dev/build/) - How to involve in Dubbo development.
 * [Dubbo admin manual](http://dubbo.apache.org/docs/v2.7/admin/install/provider-demo/) - How to admin and manage Dubbo services.


### PR DESCRIPTION
fixed broken links in <README.md>  from issue: #7031 
include:   
1. build status svg, change domain from .org to .com
2. `Architecture` img link
3. link of `Your first Dubbo application`