### PR TITLE
Heartbeat skip serialize and deserialize

### DIFF
--- a/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/exchange/codec/ExchangeCodec.java
+++ b/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/exchange/codec/ExchangeCodec.java
@@ -236,7 +236,7 @@ public class ExchangeCodec extends TelnetCodec {
 
         if (req.isHeartbeat()) {
             // heartbeat request data is always null
-            bos.write(CodecSupport.getNullBytes(serialization));
+            bos.write(CodecSupport.getNullBytesOf(serialization));
         } else {
             ObjectOutput out = serialization.serialize(channel.getUrl(), bos);
             if (req.isEvent()) {
@@ -288,7 +288,7 @@ public class ExchangeCodec extends TelnetCodec {
             if (status == Response.OK) {
                 if(res.isHeartbeat()){
                     // heartbeat response data is always null
-                    bos.write(CodecSupport.getNullBytes(serialization));
+                    bos.write(CodecSupport.getNullBytesOf(serialization));
                 }else {
                     ObjectOutput out = serialization.serialize(channel.getUrl(), bos);
                     if (res.isEvent()) {

--- a/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/exchange/codec/ExchangeCodec.java
+++ b/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/exchange/codec/ExchangeCodec.java
@@ -148,19 +148,20 @@ public class ExchangeCodec extends TelnetCodec {
             byte status = header[3];
             res.setStatus(status);
             try {
-                ObjectInput in = CodecSupport.deserialize(channel.getUrl(), is, proto);
                 if (status == Response.OK) {
                     Object data;
                     if (res.isHeartbeat()) {
-                        data = decodeHeartbeatData(channel, in);
+                        // heart beat response data is always null;
+                        is.skip(64);
+                        data = null;
                     } else if (res.isEvent()) {
-                        data = decodeEventData(channel, in);
+                        data = decodeEventData(channel, CodecSupport.deserialize(channel.getUrl(), is, proto));
                     } else {
-                        data = decodeResponseData(channel, in, getRequestData(id));
+                        data = decodeResponseData(channel, CodecSupport.deserialize(channel.getUrl(), is, proto), getRequestData(id));
                     }
                     res.setResult(data);
                 } else {
-                    res.setErrorMessage(in.readUTF());
+                    res.setErrorMessage(CodecSupport.deserialize(channel.getUrl(), is, proto).readUTF());
                 }
             } catch (Throwable t) {
                 res.setStatus(Response.CLIENT_ERROR);
@@ -176,14 +177,15 @@ public class ExchangeCodec extends TelnetCodec {
                 req.setEvent(true);
             }
             try {
-                ObjectInput in = CodecSupport.deserialize(channel.getUrl(), is, proto);
                 Object data;
                 if (req.isHeartbeat()) {
-                    data = decodeHeartbeatData(channel, in);
+                    // heart beat request data is always null;
+                    is.skip(64);
+                    data = null;
                 } else if (req.isEvent()) {
-                    data = decodeEventData(channel, in);
+                    data = decodeEventData(channel, CodecSupport.deserialize(channel.getUrl(), is, proto));
                 } else {
-                    data = decodeRequestData(channel, in);
+                    data = decodeRequestData(channel, CodecSupport.deserialize(channel.getUrl(), is, proto));
                 }
                 req.setData(data);
             } catch (Throwable t) {
@@ -231,16 +233,23 @@ public class ExchangeCodec extends TelnetCodec {
         int savedWriteIndex = buffer.writerIndex();
         buffer.writerIndex(savedWriteIndex + HEADER_LENGTH);
         ChannelBufferOutputStream bos = new ChannelBufferOutputStream(buffer);
-        ObjectOutput out = serialization.serialize(channel.getUrl(), bos);
-        if (req.isEvent()) {
-            encodeEventData(channel, out, req.getData());
+
+        if (req.isHeartbeat()) {
+            // heartbeat request data is always null
+            bos.write(CodecSupport.getNullBytes(serialization));
         } else {
-            encodeRequestData(channel, out, req.getData(), req.getVersion());
+            ObjectOutput out = serialization.serialize(channel.getUrl(), bos);
+            if (req.isEvent()) {
+                encodeEventData(channel, out, req.getData());
+            } else {
+                encodeRequestData(channel, out, req.getData(), req.getVersion());
+            }
+            out.flushBuffer();
+            if (out instanceof Cleanable) {
+                ((Cleanable) out).cleanup();
+            }
         }
-        out.flushBuffer();
-        if (out instanceof Cleanable) {
-            ((Cleanable) out).cleanup();
-        }
+
         bos.flush();
         bos.close();
         int len = bos.writtenBytes();
@@ -274,21 +283,33 @@ public class ExchangeCodec extends TelnetCodec {
 
             buffer.writerIndex(savedWriteIndex + HEADER_LENGTH);
             ChannelBufferOutputStream bos = new ChannelBufferOutputStream(buffer);
-            ObjectOutput out = serialization.serialize(channel.getUrl(), bos);
+
             // encode response data or error message.
             if (status == Response.OK) {
-                if (res.isHeartbeat()) {
-                    encodeEventData(channel, out, res.getResult());
-                } else {
-                    encodeResponseData(channel, out, res.getResult(), res.getVersion());
+                if(res.isHeartbeat()){
+                    // heartbeat response data is always null
+                    bos.write(CodecSupport.getNullBytes(serialization));
+                }else {
+                    ObjectOutput out = serialization.serialize(channel.getUrl(), bos);
+                    if (res.isEvent()) {
+                        encodeEventData(channel, out, res.getResult());
+                    } else {
+                        encodeResponseData(channel, out, res.getResult(), res.getVersion());
+                    }
+                    out.flushBuffer();
+                    if (out instanceof Cleanable) {
+                        ((Cleanable) out).cleanup();
+                    }
                 }
             } else {
+                ObjectOutput out = serialization.serialize(channel.getUrl(), bos);
                 out.writeUTF(res.getErrorMessage());
+                out.flushBuffer();
+                if (out instanceof Cleanable) {
+                    ((Cleanable) out).cleanup();
+                }
             }
-            out.flushBuffer();
-            if (out instanceof Cleanable) {
-                ((Cleanable) out).cleanup();
-            }
+
             bos.flush();
             bos.close();
 

--- a/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/transport/CodecSupport.java
+++ b/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/transport/CodecSupport.java
@@ -102,7 +102,6 @@ public class CodecSupport {
      * if not, generate it first.
      *
      * @param s Serialization Instances
-     *
      * @return serialize result of null object
      */
     public static byte[] getNullBytesOf(Serialization s) {

--- a/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/transport/CodecSupport.java
+++ b/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/transport/CodecSupport.java
@@ -105,7 +105,7 @@ public class CodecSupport {
      *
      * @return serialize result of null object
      */
-    public static byte[] getNullBytes(Serialization s) {
+    public static byte[] getNullBytesOf(Serialization s) {
         return ID_NULLBYTES_MAP.computeIfAbsent(s.getContentTypeId(), k -> {
             //Pre-generated Null object bytes
             ByteArrayOutputStream baos = new ByteArrayOutputStream();

--- a/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/transport/CodecSupport.java
+++ b/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/transport/CodecSupport.java
@@ -22,9 +22,11 @@ import org.apache.dubbo.common.extension.ExtensionLoader;
 import org.apache.dubbo.common.logger.Logger;
 import org.apache.dubbo.common.logger.LoggerFactory;
 import org.apache.dubbo.common.serialize.ObjectInput;
+import org.apache.dubbo.common.serialize.ObjectOutput;
 import org.apache.dubbo.common.serialize.Serialization;
 import org.apache.dubbo.remoting.Constants;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.HashMap;
@@ -41,6 +43,8 @@ public class CodecSupport {
     private static Map<Byte, Serialization> ID_SERIALIZATION_MAP = new HashMap<Byte, Serialization>();
     private static Map<Byte, String> ID_SERIALIZATIONNAME_MAP = new HashMap<Byte, String>();
     private static Map<String, Byte> SERIALIZATIONNAME_ID_MAP = new HashMap<String, Byte>();
+    // Cache null object serialize results, for heartbeat request/response serialize use.
+    private static Map<Byte, byte[]> ID_NULLBYTES_MAP = new HashMap<Byte, byte[]>();
 
     static {
         Set<String> supportedExtensions = ExtensionLoader.getExtensionLoader(Serialization.class).getSupportedExtensions();
@@ -91,5 +95,31 @@ public class CodecSupport {
     public static ObjectInput deserialize(URL url, InputStream is, byte proto) throws IOException {
         Serialization s = getSerialization(url, proto);
         return s.deserialize(url, is);
+    }
+
+    /**
+     * Get the null object serialize result byte[] of Serialization from the cache,
+     * if not, generate it first.
+     *
+     * @param s Serialization Instances
+     *
+     * @return serialize result of null object
+     */
+    public static byte[] getNullBytes(Serialization s) {
+        return ID_NULLBYTES_MAP.computeIfAbsent(s.getContentTypeId(), k -> {
+            //Pre-generated Null object bytes
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            byte[] nullBytes = new byte[0];
+            try {
+                ObjectOutput out = s.serialize(null, baos);
+                out.writeObject(null);
+                out.flushBuffer();
+                nullBytes = baos.toByteArray();
+                baos.close();
+            } catch (Exception e) {
+                logger.warn("Serialization extension " + s.getClass().getName() + " not support serializing null object, return an empty bytes instead.");
+            }
+            return nullBytes;
+        });
     }
 }

--- a/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/transport/CodecSupport.java
+++ b/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/transport/CodecSupport.java
@@ -29,6 +29,7 @@ import org.apache.dubbo.remoting.Constants;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -120,5 +121,34 @@ public class CodecSupport {
             }
             return nullBytes;
         });
+    }
+
+    /**
+     * Read all payload to byte[]
+     *
+     * @param is
+     * @return
+     * @throws IOException
+     */
+    public static byte[] getPayload(InputStream is) throws IOException {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        byte[] buffer = new byte[1024];
+        int len;
+        while ((len = is.read(buffer)) > -1) {
+            baos.write(buffer, 0, len);
+        }
+        baos.flush();
+        return baos.toByteArray();
+    }
+
+    /**
+     * Check if payload is null object serialize result byte[] of serialization
+     *
+     * @param payload
+     * @param proto
+     * @return
+     */
+    public static boolean isHeartBeat(byte[] payload, byte proto) {
+        return Arrays.equals(payload, getNullBytesOf(getSerializationById(proto)));
     }
 }

--- a/dubbo-rpc/dubbo-rpc-dubbo/src/main/java/org/apache/dubbo/rpc/protocol/dubbo/DubboCodec.java
+++ b/dubbo-rpc/dubbo-rpc-dubbo/src/main/java/org/apache/dubbo/rpc/protocol/dubbo/DubboCodec.java
@@ -78,7 +78,11 @@ public class DubboCodec extends ExchangeCodec {
             try {
                 if (status == Response.OK) {
                     Object data;
-                    if (res.isEvent()) {
+                    if (res.isHeartbeat()) {
+                        // heart beat response data is always null;
+                        is.skip(64);
+                        data = null;
+                    } else if (res.isEvent()) {
                         ObjectInput in = CodecSupport.deserialize(channel.getUrl(), is, proto);
                         data = decodeEventData(channel, in);
                     } else {
@@ -117,7 +121,11 @@ public class DubboCodec extends ExchangeCodec {
             }
             try {
                 Object data;
-                if (req.isEvent()) {
+                if (req.isHeartbeat()) {
+                    // heart beat request data is always null;
+                    is.skip(64);
+                    data = null;
+                } else if (req.isEvent()) {
                     ObjectInput in = CodecSupport.deserialize(channel.getUrl(), is, proto);
                     data = decodeEventData(channel, in);
                 } else {


### PR DESCRIPTION
## What is the purpose of the change

提供者和消费者之间的心跳，Request和Response的Data都为null：

```
//org.apache.dubbo.remoting.exchange.support.header.HeartbeatTimerTask#doTask
Request req = new Request();
req.setVersion(Version.getProtocolVersion());
req.setTwoWay(true);
req.setEvent(HEARTBEAT_EVENT);//HEARTBEAT_EVENT = null
```

```
//org.apache.dubbo.remoting.exchange.support.header.HeartbeatHandler#received
Response res = new Response(req.getId(), req.getVersion());
res.setEvent(HEARTBEAT_EVENT);//HEARTBEAT_EVENT = null
```

当提供者和消费者数量非常大时，每个节点都需要发送/接受大量的心跳Requet和Response，这些Requet、Response也会和服务调用一样经过serialize+encode、decode+deserialize，而其中的serialize/deserialize需要消耗过多的CPU资源。
这个优化的目的是对于心跳Requet/Response跳过serialize/deserialize处理，serialize改为赋值为null对象的序列化后字节，deserialize改为直接赋值null。

## Brief changelog

在CodecSupport中增加getNullBytesOf(Serialization s)方法，首次访问时根据serialization获得null对象的字节数组并缓存到ID_NULLBYTES_MAP
DubboCodec、ExchangeCodec中在调整encodeRequest、encodeResponse、decodeBody逻辑，实现上述目标。

备注：目前DUBBO的Serialization的实现中，以下三个实现其实尚不支持null对象的序列化，在CodecSupport.getNullBytesOf中降级为返回空字符串。

1. KryoSerialization2
2. GenericProtobufSerialization
3. GenericProtobufJsonSerialization

Follow this checklist to help us incorporate your contribution quickly and easily:

- [ ] Make sure there is a [GITHUB_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Run `mvn clean install -DskipTests=false` & `mvn clean test-compile failsafe:integration-test` to make sure unit-test and integration-test pass.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
