### PR TITLE
[Dubbo-7107] Reset TestProxyFactory.count after ServiceConfigTest.testProxy

### DIFF
--- a/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/ServiceConfigTest.java
+++ b/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/ServiceConfigTest.java
@@ -160,6 +160,7 @@ public class ServiceConfigTest {
 
         assertThat(service2.getExportedUrls(), hasSize(1));
         assertEquals(2, TestProxyFactory.count); // local injvm and registry protocol, so expected is 2
+        TestProxyFactory.count = 0;
     }
 
 


### PR DESCRIPTION
## What is the purpose of the change
The test `org.apache.dubbo.config.ServiceConfigTest.testProxy` is not idempotent and fails if run twice in the same JVM, because each of the tests pollutes state shared among tests. It may be good to clean this state pollution so that some other tests do not fail in the future due to the shared state polluted by these tests.

## Brief changelog

Reset `TestProxyFactory.count` to 0 at the end of `ServiceConfigTest.testProxy()`.

## Verifying this change
With the proposed fix, the test does not pollute the shared state (and passes when run twice in the same JVM).

Link to issue: https://github.com/apache/dubbo/issues/7107