### PR TITLE
[Dubbo-7054]消费者端Executor改为全局共享，不再按提供者Port共享。

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/threadpool/manager/DefaultExecutorRepository.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/threadpool/manager/DefaultExecutorRepository.java
@@ -156,6 +156,19 @@ public class DefaultExecutorRepository implements ExecutorRepository {
         return SHARED_EXECUTOR;
     }
 
+    @Override
+    public void destroyAll() {
+        data.values().forEach(executors -> {
+            if (executors != null) {
+                executors.values().forEach(executor -> {
+                    if (executor != null && !executor.isShutdown()) {
+                        executor.shutdownNow();
+                    }
+                });
+            }
+        });
+    }
+
     private ExecutorService createExecutor(URL url) {
         return (ExecutorService) ExtensionLoader.getExtensionLoader(ThreadPool.class).getAdaptiveExtension().getExecutor(url);
     }

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/threadpool/manager/DefaultExecutorRepository.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/threadpool/manager/DefaultExecutorRepository.java
@@ -103,9 +103,9 @@ public class DefaultExecutorRepository implements ExecutorRepository {
             executors.remove(portKey);
             // Does not re-create a shutdown executor, use SHARED_EXECUTOR for downgrade.
             executor = null;
+            logger.info("Executor for " + url + " is shutdown.");
         }
         if (executor == null) {
-            logger.warn("Executor of key + '" + portKey + "' has shutdown, return 'DubboSharedHandler' instead.");
             return SHARED_EXECUTOR;
         } else {
             return executor;

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/threadpool/manager/DefaultExecutorRepository.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/threadpool/manager/DefaultExecutorRepository.java
@@ -21,6 +21,7 @@ import org.apache.dubbo.common.extension.ExtensionLoader;
 import org.apache.dubbo.common.logger.Logger;
 import org.apache.dubbo.common.logger.LoggerFactory;
 import org.apache.dubbo.common.threadpool.ThreadPool;
+import org.apache.dubbo.common.utils.ExecutorUtil;
 import org.apache.dubbo.common.utils.NamedThreadFactory;
 
 import java.util.Map;
@@ -162,7 +163,7 @@ public class DefaultExecutorRepository implements ExecutorRepository {
             if (executors != null) {
                 executors.values().forEach(executor -> {
                     if (executor != null && !executor.isShutdown()) {
-                        executor.shutdownNow();
+                        ExecutorUtil.shutdownNow(executor, 100);
                     }
                 });
             }

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/threadpool/manager/ExecutorRepository.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/threadpool/manager/ExecutorRepository.java
@@ -64,4 +64,8 @@ public interface ExecutorRepository {
      */
     ExecutorService getSharedExecutor();
 
+    /**
+     * Destroy all Executors
+     */
+    void destroyAll();
 }

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/threadpool/manager/ExecutorRepository.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/threadpool/manager/ExecutorRepository.java
@@ -65,7 +65,7 @@ public interface ExecutorRepository {
     ExecutorService getSharedExecutor();
 
     /**
-     * Destroy all Executors
+     * Destroy all executors that are not in shutdown state
      */
     void destroyAll();
 }

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/threadpool/manager/ExecutorRepositoryTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/threadpool/manager/ExecutorRepositoryTest.java
@@ -30,34 +30,15 @@ public class ExecutorRepositoryTest {
 
     @Test
     public void testGetExecutor() {
-        testGet(URL.valueOf("dubbo://127.0.0.1:23456"), true);
-        testGet(URL.valueOf("dubbo://127.0.0.1:23456?side=consumer"), false);
+        testGet(URL.valueOf("dubbo://127.0.0.1:23456"));
+        testGet(URL.valueOf("dubbo://127.0.0.1:23456?side=consumer"));
 
         Assertions.assertNotNull(executorRepository.getSharedExecutor());
         Assertions.assertNotNull(executorRepository.getServiceExporterExecutor());
         executorRepository.nextScheduledExecutor();
     }
 
-    private void testGet(URL url, Boolean isFirst) {
-        if (isFirst) {
-            Assertions.assertNull(executorRepository.getExecutor(url));
-        } else {
-            Assertions.assertEquals(executorRepository.getExecutor(url), executorRepository.getSharedExecutor());
-        }
-
-        ExecutorService executorService = executorRepository.createExecutorIfAbsent(url);
-        executorService.shutdown();
-        executorService = executorRepository.createExecutorIfAbsent(url);
-        Assertions.assertFalse(executorService.isShutdown());
-
-        Assertions.assertEquals(executorService, executorRepository.getExecutor(url));
-        executorService.shutdown();
-        Assertions.assertNotEquals(executorService, executorRepository.getExecutor(url));
-    }
-
-    private void testGetNotShared(URL url) {
-        Assertions.assertNull(executorRepository.getExecutor(url));
-
+    private void testGet(URL url) {
         ExecutorService executorService = executorRepository.createExecutorIfAbsent(url);
         executorService.shutdown();
         executorService = executorRepository.createExecutorIfAbsent(url);

--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/bootstrap/DubboBootstrap.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/bootstrap/DubboBootstrap.java
@@ -1257,7 +1257,7 @@ public class DubboBootstrap extends GenericEventListener {
                     destroyRegistries();
                     DubboShutdownHook.destroyProtocols();
                     destroyServiceDiscoveries();
-
+                    destroyExecutorRepository();
                     clear();
                     shutdown();
                     release();
@@ -1266,6 +1266,10 @@ public class DubboBootstrap extends GenericEventListener {
                 destroyLock.unlock();
             }
         }
+    }
+
+    private void destroyExecutorRepository() {
+        ExtensionLoader.getExtensionLoader(ExecutorRepository.class).getDefaultExtension().destroyAll();
     }
 
     private void destroyRegistries() {

--- a/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/transport/AbstractClient.java
+++ b/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/transport/AbstractClient.java
@@ -22,7 +22,6 @@ import org.apache.dubbo.common.extension.ExtensionLoader;
 import org.apache.dubbo.common.logger.Logger;
 import org.apache.dubbo.common.logger.LoggerFactory;
 import org.apache.dubbo.common.threadpool.manager.ExecutorRepository;
-import org.apache.dubbo.common.utils.ExecutorUtil;
 import org.apache.dubbo.common.utils.NetUtils;
 import org.apache.dubbo.remoting.Channel;
 import org.apache.dubbo.remoting.ChannelHandler;
@@ -38,6 +37,7 @@ import java.util.concurrent.locks.ReentrantLock;
 
 import static org.apache.dubbo.common.constants.CommonConstants.DEFAULT_CLIENT_THREADPOOL;
 import static org.apache.dubbo.common.constants.CommonConstants.THREADPOOL_KEY;
+import static org.apache.dubbo.common.constants.CommonConstants.THREAD_NAME_KEY;
 
 /**
  * AbstractClient
@@ -90,7 +90,8 @@ public abstract class AbstractClient extends AbstractEndpoint implements Client 
     }
 
     private void initExecutor(URL url) {
-        url = ExecutorUtil.setThreadName(url, CLIENT_THREAD_POOL_NAME);
+        //消费着端executor共享，线程名中不需要url中的ip地址
+        url = url.addParameter(THREAD_NAME_KEY, CLIENT_THREAD_POOL_NAME);
         url = url.addParameterIfAbsent(THREADPOOL_KEY, DEFAULT_CLIENT_THREADPOOL);
         executor = executorRepository.createExecutorIfAbsent(url);
     }
@@ -278,14 +279,6 @@ public abstract class AbstractClient extends AbstractEndpoint implements Client 
             }
 
             try {
-                if (executor != null) {
-                    ExecutorUtil.shutdownNow(executor, 100);
-                }
-            } catch (Throwable e) {
-                logger.warn(e.getMessage(), e);
-            }
-
-            try {
                 disconnect();
             } catch (Throwable e) {
                 logger.warn(e.getMessage(), e);
@@ -304,7 +297,6 @@ public abstract class AbstractClient extends AbstractEndpoint implements Client 
 
     @Override
     public void close(int timeout) {
-        ExecutorUtil.gracefulShutdown(executor, timeout);
         close();
     }
 

--- a/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/transport/AbstractClient.java
+++ b/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/transport/AbstractClient.java
@@ -48,6 +48,7 @@ public abstract class AbstractClient extends AbstractEndpoint implements Client 
     private static final Logger logger = LoggerFactory.getLogger(AbstractClient.class);
     private final Lock connectLock = new ReentrantLock();
     private final boolean needReconnect;
+    //issue-7054:Consumer's executor is sharing globally.
     protected volatile ExecutorService executor;
     private ExecutorRepository executorRepository = ExtensionLoader.getExtensionLoader(ExecutorRepository.class).getDefaultExtension();
 
@@ -90,7 +91,7 @@ public abstract class AbstractClient extends AbstractEndpoint implements Client 
     }
 
     private void initExecutor(URL url) {
-        //消费着端executor共享，线程名中不需要url中的ip地址
+        //issue-7054:Consumer's executor is sharing globally, thread name not require provider ip.
         url = url.addParameter(THREAD_NAME_KEY, CLIENT_THREAD_POOL_NAME);
         url = url.addParameterIfAbsent(THREADPOOL_KEY, DEFAULT_CLIENT_THREADPOOL);
         executor = executorRepository.createExecutorIfAbsent(url);

--- a/dubbo-remoting/dubbo-remoting-netty/src/test/java/org/apache/dubbo/remoting/transport/netty/ThreadNameTest.java
+++ b/dubbo-remoting/dubbo-remoting-netty/src/test/java/org/apache/dubbo/remoting/transport/netty/ThreadNameTest.java
@@ -39,7 +39,7 @@ public class ThreadNameTest {
     private ThreadNameVerifyHandler clientHandler;
 
     private static String serverRegex = "DubboServerHandler\\-localhost:(\\d+)\\-thread\\-(\\d+)";
-    private static String clientRegex = "DubboClientHandler\\-localhost:(\\d+)\\-thread\\-(\\d+)";
+    private static String clientRegex = "DubboClientHandler\\-thread\\-(\\d+)";
 
     @BeforeEach
     public void before() throws Exception {


### PR DESCRIPTION
## What is the purpose of the change

目前社区版本消费者端的executor线程池是按提供者的Port的做了共享，当一个提供者下线时，AbstractClient就会将executor销毁，造成后续处理ChannelState.DISCONNECTED事件，以及消费者再调用其他提供者时无可用的executor，就会重新在创建一个executor，这个模式会导致#7054 所描述的问题。
同时考虑到消费者维护N个executor的开销，因此将消费者端的executor改为全局1个，在节点shutdown时再销毁。

## Brief changelog

1，DefaultExecutorRepository分配executor时，消费者的key使用Integer.MAX_VALUE，保证消费者使用1个executor，提供者保持原装（按协议的port分配executor）；同时getExecutor()内不再createExecutor，当executor为null则直接降级返回SHARED_EXECUTOR；
2，AbstractClient在close0时不关闭其持有的executor；
3，DubboBootstrap.destroy()时销毁ExecutorRepository；

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a [GITHUB_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [x] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Run `mvn clean install -DskipTests=false` & `mvn clean test-compile failsafe:integration-test` to make sure unit-test and integration-test pass.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
