### PR TITLE
增加DubboBootstrap启动停止事件扩展

### DIFF
--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/bootstrap/DubboBootstrap.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/bootstrap/DubboBootstrap.java
@@ -915,12 +915,16 @@ public class DubboBootstrap extends GenericEventListener {
                     if (logger.isInfoEnabled()) {
                         logger.info(NAME + " is ready.");
                     }
+                    ExtensionLoader<DubboBootstrapStartStopListener> exts = getExtensionLoader(DubboBootstrapStartStopListener.class);
+                    exts.getSupportedExtensionInstances().forEach(ext -> ext.onStart(this));
                 }).start();
             } else {
                 ready.set(true);
                 if (logger.isInfoEnabled()) {
                     logger.info(NAME + " is ready.");
                 }
+                ExtensionLoader<DubboBootstrapStartStopListener> exts = getExtensionLoader(DubboBootstrapStartStopListener.class);
+                exts.getSupportedExtensionInstances().forEach(ext -> ext.onStart(this));
             }
             if (logger.isInfoEnabled()) {
                 logger.info(NAME + " has started.");
@@ -985,6 +989,7 @@ public class DubboBootstrap extends GenericEventListener {
     public boolean isReady() {
         return ready.get();
     }
+
 
     public DubboBootstrap stop() throws IllegalStateException {
         destroy();
@@ -1268,6 +1273,8 @@ public class DubboBootstrap extends GenericEventListener {
                     clear();
                     shutdown();
                     release();
+                    ExtensionLoader<DubboBootstrapStartStopListener> exts = getExtensionLoader(DubboBootstrapStartStopListener.class);
+                    exts.getSupportedExtensionInstances().forEach(ext -> ext.onStop(this));
                 }
             } finally {
                 destroyLock.unlock();

--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/bootstrap/DubboBootstrapStartStopListener.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/bootstrap/DubboBootstrapStartStopListener.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.dubbo.config.bootstrap;
+
+import org.apache.dubbo.common.extension.SPI;
+
+/**
+ * call on DubboBootstrap start or stop.
+ *
+ * @author <a href="mailto:chenxilzx1@gmail.com">theonefx</a>
+ * @scene 2.7.9
+ * @see DubboBootstrap
+ */
+@SPI
+public interface DubboBootstrapStartStopListener {
+
+    void onStart(DubboBootstrap bootstrap);
+
+    void onStop(DubboBootstrap bootstrap);
+}

--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/bootstrap/DubboBootstrapStartStopListener.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/bootstrap/DubboBootstrapStartStopListener.java
@@ -22,7 +22,6 @@ import org.apache.dubbo.common.extension.SPI;
 /**
  * call on DubboBootstrap start or stop.
  *
- * @author <a href="mailto:chenxilzx1@gmail.com">theonefx</a>
  * @scene 2.7.9
  * @see DubboBootstrap
  */

--- a/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/context/DubboBootstrapApplicationListener.java
+++ b/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/context/DubboBootstrapApplicationListener.java
@@ -46,6 +46,7 @@ public class DubboBootstrapApplicationListener extends OnceApplicationContextEve
     public DubboBootstrapApplicationListener(ApplicationContext applicationContext) {
         super(applicationContext);
         this.dubboBootstrap = DubboBootstrap.getInstance();
+        DubboBootstrapStartStopListenerSpringAdapter.applicationContext = applicationContext;
     }
 
     @Override

--- a/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/context/DubboBootstrapStartStopListenerSpringAdapter.java
+++ b/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/context/DubboBootstrapStartStopListenerSpringAdapter.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.dubbo.config.spring.context;
 
 import org.apache.dubbo.config.bootstrap.DubboBootstrap;

--- a/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/context/DubboBootstrapStartStopListenerSpringAdapter.java
+++ b/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/context/DubboBootstrapStartStopListenerSpringAdapter.java
@@ -1,0 +1,33 @@
+package org.apache.dubbo.config.spring.context;
+
+import org.apache.dubbo.config.bootstrap.DubboBootstrap;
+import org.apache.dubbo.config.bootstrap.DubboBootstrapStartStopListener;
+import org.apache.dubbo.config.spring.context.event.DubboBootstrapStatedEvent;
+import org.apache.dubbo.config.spring.context.event.DubboBootstrapStopedEvent;
+
+import org.springframework.context.ApplicationContext;
+
+/**
+ * convcert Dubbo bootstrap event to spring environment.
+ *
+ * @author <a href="mailto:chenxilzx1@gmail.com">theonefx</a>
+ * @scene 2.7.9
+ */
+public class DubboBootstrapStartStopListenerSpringAdapter implements DubboBootstrapStartStopListener {
+
+    static ApplicationContext applicationContext;
+
+    @Override
+    public void onStart(DubboBootstrap bootstrap) {
+        if (applicationContext != null) {
+            applicationContext.publishEvent(new DubboBootstrapStatedEvent(bootstrap));
+        }
+    }
+
+    @Override
+    public void onStop(DubboBootstrap bootstrap) {
+        if (applicationContext != null) {
+            applicationContext.publishEvent(new DubboBootstrapStopedEvent(bootstrap));
+        }
+    }
+}

--- a/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/context/DubboBootstrapStartStopListenerSpringAdapter.java
+++ b/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/context/DubboBootstrapStartStopListenerSpringAdapter.java
@@ -10,7 +10,6 @@ import org.springframework.context.ApplicationContext;
 /**
  * convcert Dubbo bootstrap event to spring environment.
  *
- * @author <a href="mailto:chenxilzx1@gmail.com">theonefx</a>
  * @scene 2.7.9
  */
 public class DubboBootstrapStartStopListenerSpringAdapter implements DubboBootstrapStartStopListener {

--- a/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/context/event/DubboBootstrapStatedEvent.java
+++ b/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/context/event/DubboBootstrapStatedEvent.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.config.spring.context.event;
+
+import org.springframework.context.ApplicationEvent;
+
+import org.apache.dubbo.config.bootstrap.DubboBootstrap;
+
+/**
+ * A {@link org.springframework.context.ApplicationEvent} after {@link org.apache.dubbo.config.bootstrap.DubboBootstrap#start()} success
+ *
+ * @author <mailto:chenxilzx1@gmail.com>theonefx</mailto:>
+ * @see org.springframework.context.ApplicationEvent
+ * @see org.springframework.context.ApplicationListener
+ * @see org.apache.dubbo.config.bootstrap.DubboBootstrap
+ * @since 2.7.9
+ */
+public class DubboBootstrapStatedEvent extends ApplicationEvent {
+
+    /**
+     * Create a new ApplicationEvent.
+     *
+     * @param bootstrap {@link org.apache.dubbo.config.bootstrap.DubboBootstrap} bootstrap
+     */
+    public DubboBootstrapStatedEvent(DubboBootstrap bootstrap) {
+        super(bootstrap);
+    }
+
+    /**
+     * Get {@link org.apache.dubbo.config.bootstrap.DubboBootstrap} instance
+     *
+     * @return non-null
+     */
+    public DubboBootstrap getDubboBootstrap() {
+        return (DubboBootstrap) super.getSource();
+    }
+}

--- a/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/context/event/DubboBootstrapStatedEvent.java
+++ b/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/context/event/DubboBootstrapStatedEvent.java
@@ -23,7 +23,6 @@ import org.apache.dubbo.config.bootstrap.DubboBootstrap;
 /**
  * A {@link org.springframework.context.ApplicationEvent} after {@link org.apache.dubbo.config.bootstrap.DubboBootstrap#start()} success
  *
- * @author <mailto:chenxilzx1@gmail.com>theonefx</mailto:>
  * @see org.springframework.context.ApplicationEvent
  * @see org.springframework.context.ApplicationListener
  * @see org.apache.dubbo.config.bootstrap.DubboBootstrap

--- a/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/context/event/DubboBootstrapStopedEvent.java
+++ b/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/context/event/DubboBootstrapStopedEvent.java
@@ -23,7 +23,6 @@ import org.apache.dubbo.config.bootstrap.DubboBootstrap;
 /**
  * A {@link org.springframework.context.ApplicationEvent} after {@link org.apache.dubbo.config.bootstrap.DubboBootstrap#stop()} success
  *
- * @author <mailto:chenxilzx1@gmail.com>theonefx</mailto:>
  * @see org.springframework.context.ApplicationEvent
  * @see org.springframework.context.ApplicationListener
  * @see org.apache.dubbo.config.bootstrap.DubboBootstrap

--- a/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/context/event/DubboBootstrapStopedEvent.java
+++ b/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/context/event/DubboBootstrapStopedEvent.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.config.spring.context.event;
+
+import org.springframework.context.ApplicationEvent;
+
+import org.apache.dubbo.config.bootstrap.DubboBootstrap;
+
+/**
+ * A {@link org.springframework.context.ApplicationEvent} after {@link org.apache.dubbo.config.bootstrap.DubboBootstrap#stop()} success
+ *
+ * @author <mailto:chenxilzx1@gmail.com>theonefx</mailto:>
+ * @see org.springframework.context.ApplicationEvent
+ * @see org.springframework.context.ApplicationListener
+ * @see org.apache.dubbo.config.bootstrap.DubboBootstrap
+ * @since 2.7.9
+ */
+public class DubboBootstrapStopedEvent extends ApplicationEvent {
+
+    /**
+     * Create a new ApplicationEvent.
+     *
+     * @param bootstrap {@link org.apache.dubbo.config.bootstrap.DubboBootstrap} bootstrap
+     */
+    public DubboBootstrapStopedEvent(DubboBootstrap bootstrap) {
+        super(bootstrap);
+    }
+
+    /**
+     * Get {@link org.apache.dubbo.config.bootstrap.DubboBootstrap} instance
+     *
+     * @return non-null
+     */
+    public DubboBootstrap getDubboBootstrap() {
+        return (DubboBootstrap) super.getSource();
+    }
+}

--- a/dubbo-config/dubbo-config-spring/src/main/resources/META-INF/dubbo/internal/org.apache.dubbo.config.bootstrap.DubboBootstrapStartStopListener
+++ b/dubbo-config/dubbo-config-spring/src/main/resources/META-INF/dubbo/internal/org.apache.dubbo.config.bootstrap.DubboBootstrapStartStopListener
@@ -1,0 +1,1 @@
+default=org.apache.dubbo.config.spring.context.DubboBootstrapStartStopListenerSpringAdapter


### PR DESCRIPTION
增加 DubboBootstrapStartStopListener 来对外通知 DubboBootstarp 的启动停止回调扩展；
向Spring环境抛出DubboBootstarp 的启动停止事件。

#7150 