### PR TITLE
[Dubbo-7178] Fix 'java.io.FileNotFoundException' when 'dump.directory' not exists

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/threadpool/support/AbortPolicyWithReport.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/threadpool/support/AbortPolicyWithReport.java
@@ -144,10 +144,14 @@ public class AbortPolicyWithReport extends ThreadPoolExecutor.AbortPolicy {
             return USER_HOME;
         }
         final File dumpDirectory = new File(dumpPath);
-        if (!dumpDirectory.exists() && !dumpDirectory.mkdirs()) {
-            logger.warn(format("Dubbo dump directory[%s] can't be created, use the 'user.home'[%s]",
-                    dumpDirectory.getAbsolutePath(), USER_HOME));
-            return USER_HOME;
+        if (!dumpDirectory.exists()) {
+            if (dumpDirectory.mkdirs()) {
+                logger.info(format("Dubbo dump directory[%s] created", dumpDirectory.getAbsolutePath()));
+            } else {
+                logger.warn(format("Dubbo dump directory[%s] can't be created, use the 'user.home'[%s]",
+                        dumpDirectory.getAbsolutePath(), USER_HOME));
+                return USER_HOME;
+            }
         }
         return dumpPath;
     }

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/threadpool/support/AbortPolicyWithReport.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/threadpool/support/AbortPolicyWithReport.java
@@ -31,8 +31,10 @@ import org.apache.dubbo.common.logger.Logger;
 import org.apache.dubbo.common.logger.LoggerFactory;
 import org.apache.dubbo.common.threadpool.event.ThreadPoolExhaustedEvent;
 import org.apache.dubbo.common.utils.JVMUtil;
+import org.apache.dubbo.common.utils.StringUtils;
 import org.apache.dubbo.event.EventDispatcher;
 
+import static java.lang.String.format;
 import static org.apache.dubbo.common.constants.CommonConstants.DUMP_DIRECTORY;
 
 /**
@@ -60,6 +62,8 @@ public class AbortPolicyWithReport extends ThreadPoolExecutor.AbortPolicy {
     private static final String DEFAULT_DATETIME_FORMAT = "yyyy-MM-dd_HH:mm:ss";
 
     private static Semaphore guard = new Semaphore(1);
+
+    private static final String USER_HOME = System.getProperty("user.home");
 
     public AbortPolicyWithReport(String threadName, URL url) {
         this.threadName = threadName;
@@ -104,7 +108,7 @@ public class AbortPolicyWithReport extends ThreadPoolExecutor.AbortPolicy {
 
         ExecutorService pool = Executors.newSingleThreadExecutor();
         pool.execute(() -> {
-            String dumpPath = url.getParameter(DUMP_DIRECTORY, System.getProperty("user.home"));
+            String dumpPath = getDumpPath();
 
             SimpleDateFormat sdf;
 
@@ -134,4 +138,17 @@ public class AbortPolicyWithReport extends ThreadPoolExecutor.AbortPolicy {
 
     }
 
+    private String getDumpPath() {
+        final String dumpPath = url.getParameter(DUMP_DIRECTORY);
+        if (StringUtils.isEmpty(dumpPath)) {
+            return USER_HOME;
+        }
+        final File dumpDirectory = new File(dumpPath);
+        if (!dumpDirectory.exists() && !dumpDirectory.mkdirs()) {
+            logger.warn(format("Dubbo dump directory[%s] can't be created, use the 'user.home'[%s]",
+                    dumpDirectory.getAbsolutePath(), USER_HOME));
+            return USER_HOME;
+        }
+        return dumpPath;
+    }
 }

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/threadpool/support/AbortPolicyWithReportTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/threadpool/support/AbortPolicyWithReportTest.java
@@ -46,7 +46,7 @@ public class AbortPolicyWithReportTest {
     }
 
     @Test
-    public void jStackDumpTest_dumpDirectoryCannotBeCreated_useUserHome() throws InterruptedException {
+    public void jStackDumpTest_dumpDirectoryNotExists_cannotBeCreatedTakeUserHome() throws InterruptedException {
         final String dumpDirectory = dumpDirectoryCannotBeCreated();
 
         URL url = URL.valueOf("dubbo://admin:hello1234@10.20.130.230:20880/context/path?dump.directory="
@@ -76,5 +76,28 @@ public class AbortPolicyWithReportTest {
         } else {
             return "/dev/full/" + UUID.randomUUID().toString();
         }
+    }
+
+    @Test
+    public void jStackDumpTest_dumpDirectoryNotExists_canBeCreated() throws InterruptedException {
+        final String dumpDirectory = UUID.randomUUID().toString();
+
+        URL url = URL.valueOf("dubbo://admin:hello1234@10.20.130.230:20880/context/path?dump.directory="
+                + dumpDirectory
+                + "&version=1.0.0&application=morgan&noValue");
+        AbortPolicyWithReport abortPolicyWithReport = new AbortPolicyWithReport("Test", url);
+
+        try {
+            abortPolicyWithReport.rejectedExecution(new Runnable() {
+                @Override
+                public void run() {
+                    System.out.println("hello");
+                }
+            }, (ThreadPoolExecutor) Executors.newFixedThreadPool(1));
+        } catch (RejectedExecutionException rj) {
+            // ignore
+        }
+
+        Thread.sleep(1000);
     }
 }

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/threadpool/support/AbortPolicyWithReportTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/threadpool/support/AbortPolicyWithReportTest.java
@@ -17,9 +17,9 @@
 package org.apache.dubbo.common.threadpool.support;
 
 import org.apache.dubbo.common.URL;
-import org.apache.dubbo.common.threadpool.support.AbortPolicyWithReport;
 import org.junit.jupiter.api.Test;
 
+import java.util.UUID;
 import java.util.concurrent.Executors;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ThreadPoolExecutor;
@@ -43,5 +43,38 @@ public class AbortPolicyWithReportTest {
 
         Thread.sleep(1000);
 
+    }
+
+    @Test
+    public void jStackDumpTest_dumpDirectoryCannotBeCreated_useUserHome() throws InterruptedException {
+        final String dumpDirectory = dumpDirectoryCannotBeCreated();
+
+        URL url = URL.valueOf("dubbo://admin:hello1234@10.20.130.230:20880/context/path?dump.directory="
+                + dumpDirectory
+                + "&version=1.0.0&application=morgan&noValue");
+        AbortPolicyWithReport abortPolicyWithReport = new AbortPolicyWithReport("Test", url);
+
+        try {
+            abortPolicyWithReport.rejectedExecution(new Runnable() {
+                @Override
+                public void run() {
+                    System.out.println("hello");
+                }
+            }, (ThreadPoolExecutor) Executors.newFixedThreadPool(1));
+        } catch (RejectedExecutionException rj) {
+            // ignore
+        }
+
+        Thread.sleep(1000);
+    }
+
+    private String dumpDirectoryCannotBeCreated() {
+        final String os = System.getProperty("os.name").toLowerCase();
+        if (os.contains("win")) {
+            // "con" is one of Windows reserved names, https://docs.microsoft.com/en-us/windows/win32/fileio/naming-a-file
+            return "con";
+        } else {
+            return "/dev/full/" + UUID.randomUUID().toString();
+        }
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

Fix 'java.io.FileNotFoundException' when 'dump.directory' not exists

## Brief changelog

Try to create if not exists, if can't be created, use 'user.home' as dump directory. 

## Verifying this change

Link to issue: [#7178](https://github.com/apache/dubbo/issues/7178)