### PR TITLE
Split the start part from the DubboBootstrap/ReferenceConfig/ServiceConfig

### DIFF
--- a/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/support/AbstractClusterInvokerTest.java
+++ b/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/support/AbstractClusterInvokerTest.java
@@ -1,559 +1,559 @@
-/*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-package org.apache.dubbo.rpc.cluster.support;
-
-import org.apache.dubbo.common.URL;
-import org.apache.dubbo.common.URLBuilder;
-import org.apache.dubbo.common.extension.ExtensionLoader;
-import org.apache.dubbo.common.utils.NetUtils;
-import org.apache.dubbo.rpc.Invocation;
-import org.apache.dubbo.rpc.Invoker;
-import org.apache.dubbo.rpc.Result;
-import org.apache.dubbo.rpc.RpcContext;
-import org.apache.dubbo.rpc.RpcException;
-import org.apache.dubbo.rpc.RpcInvocation;
-import org.apache.dubbo.rpc.cluster.Directory;
-import org.apache.dubbo.rpc.cluster.LoadBalance;
-import org.apache.dubbo.rpc.cluster.directory.StaticDirectory;
-import org.apache.dubbo.rpc.cluster.filter.DemoService;
-import org.apache.dubbo.rpc.cluster.loadbalance.LeastActiveLoadBalance;
-import org.apache.dubbo.rpc.cluster.loadbalance.RandomLoadBalance;
-import org.apache.dubbo.rpc.cluster.loadbalance.RoundRobinLoadBalance;
-
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
-
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.atomic.AtomicLong;
-
-import static org.apache.dubbo.common.constants.CommonConstants.DUBBO;
-import static org.apache.dubbo.common.constants.CommonConstants.INTERFACE_KEY;
-import static org.apache.dubbo.common.constants.CommonConstants.MONITOR_KEY;
-import static org.apache.dubbo.common.constants.CommonConstants.PATH_KEY;
-import static org.apache.dubbo.common.constants.CommonConstants.PROTOCOL_KEY;
-import static org.apache.dubbo.rpc.cluster.Constants.CLUSTER_AVAILABLE_CHECK_KEY;
-import static org.apache.dubbo.rpc.cluster.Constants.INVOCATION_NEED_MOCK;
-import static org.apache.dubbo.rpc.cluster.Constants.REFER_KEY;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.mock;
-
-/**
- * AbstractClusterInvokerTest
- */
-@SuppressWarnings("rawtypes")
-public class AbstractClusterInvokerTest {
-    List<Invoker<IHelloService>> invokers = new ArrayList<Invoker<IHelloService>>();
-    List<Invoker<IHelloService>> selectedInvokers = new ArrayList<Invoker<IHelloService>>();
-    AbstractClusterInvoker<IHelloService> cluster;
-    AbstractClusterInvoker<IHelloService> cluster_nocheck;
-    StaticDirectory<IHelloService> dic;
-    RpcInvocation invocation = new RpcInvocation();
-    URL url = URL.valueOf("registry://localhost:9090/org.apache.dubbo.rpc.cluster.support.AbstractClusterInvokerTest.IHelloService?refer=" + URL.encode("application=abstractClusterInvokerTest"));
-
-    Invoker<IHelloService> invoker1;
-    Invoker<IHelloService> invoker2;
-    Invoker<IHelloService> invoker3;
-    Invoker<IHelloService> invoker4;
-    Invoker<IHelloService> invoker5;
-    Invoker<IHelloService> mockedInvoker1;
-
-
-    @BeforeAll
-    public static void setUpBeforeClass() throws Exception {
-    }
-
-    @AfterEach
-    public void teardown() throws Exception {
-        RpcContext.getContext().clearAttachments();
-    }
-
-    @SuppressWarnings({"unchecked"})
-    @BeforeEach
-    public void setUp() throws Exception {
-        Map<String, Object> attributes = new HashMap<>();
-        attributes.put("application", "abstractClusterInvokerTest");
-        url = url.putAttribute(REFER_KEY, attributes);
-
-        invocation.setMethodName("sayHello");
-
-        invoker1 = mock(Invoker.class);
-        invoker2 = mock(Invoker.class);
-        invoker3 = mock(Invoker.class);
-        invoker4 = mock(Invoker.class);
-        invoker5 = mock(Invoker.class);
-        mockedInvoker1 = mock(Invoker.class);
-
-        URL turl = URL.valueOf("test://test:11/test");
-
-        given(invoker1.isAvailable()).willReturn(false);
-        given(invoker1.getInterface()).willReturn(IHelloService.class);
-        given(invoker1.getUrl()).willReturn(turl.setPort(1).addParameter("name", "invoker1"));
-
-        given(invoker2.isAvailable()).willReturn(true);
-        given(invoker2.getInterface()).willReturn(IHelloService.class);
-        given(invoker2.getUrl()).willReturn(turl.setPort(2).addParameter("name", "invoker2"));
-
-        given(invoker3.isAvailable()).willReturn(false);
-        given(invoker3.getInterface()).willReturn(IHelloService.class);
-        given(invoker3.getUrl()).willReturn(turl.setPort(3).addParameter("name", "invoker3"));
-
-        given(invoker4.isAvailable()).willReturn(true);
-        given(invoker4.getInterface()).willReturn(IHelloService.class);
-        given(invoker4.getUrl()).willReturn(turl.setPort(4).addParameter("name", "invoker4"));
-
-        given(invoker5.isAvailable()).willReturn(false);
-        given(invoker5.getInterface()).willReturn(IHelloService.class);
-        given(invoker5.getUrl()).willReturn(turl.setPort(5).addParameter("name", "invoker5"));
-
-        given(mockedInvoker1.isAvailable()).willReturn(false);
-        given(mockedInvoker1.getInterface()).willReturn(IHelloService.class);
-        given(mockedInvoker1.getUrl()).willReturn(turl.setPort(999).setProtocol("mock"));
-
-        invokers.add(invoker1);
-        dic = new StaticDirectory<IHelloService>(url, invokers, null);
-        cluster = new AbstractClusterInvoker(dic) {
-            @Override
-            protected Result doInvoke(Invocation invocation, List invokers, LoadBalance loadbalance)
-                    throws RpcException {
-                return null;
-            }
-        };
-
-        cluster_nocheck = new AbstractClusterInvoker(dic, url.addParameterIfAbsent(CLUSTER_AVAILABLE_CHECK_KEY, Boolean.FALSE.toString())) {
-            @Override
-            protected Result doInvoke(Invocation invocation, List invokers, LoadBalance loadbalance)
-                    throws RpcException {
-                return null;
-            }
-        };
-
-    }
-
-
-    @Test
-    public void testBindingAttachment() {
-        final String attachKey = "attach";
-        final String attachValue = "value";
-
-        // setup attachment
-        RpcContext.getContext().setAttachment(attachKey, attachValue);
-        Map<String, Object> attachments = RpcContext.getContext().getObjectAttachments();
-        Assertions.assertTrue( attachments != null && attachments.size() == 1,"set attachment failed!");
-
-        cluster = new AbstractClusterInvoker(dic) {
-            @Override
-            protected Result doInvoke(Invocation invocation, List invokers, LoadBalance loadbalance)
-                    throws RpcException {
-                // attachment will be bind to invocation
-                String value = invocation.getAttachment(attachKey);
-                Assertions.assertNotNull(value);
-                Assertions.assertEquals(attachValue, value, "binding attachment failed!");
-                return null;
-            }
-        };
-
-        // invoke
-        cluster.invoke(invocation);
-    }
-
-    @Test
-    public void testSelect_Invokersize0() throws Exception {
-        LoadBalance l = cluster.initLoadBalance(invokers, invocation);
-        Assertions.assertNotNull(l,"cluster.initLoadBalance returns null!");
-        {
-            Invoker invoker = cluster.select(l, null, null, null);
-            Assertions.assertNull(invoker);
-        }
-        {
-            invokers.clear();
-            selectedInvokers.clear();
-            Invoker invoker = cluster.select(l, null, invokers, null);
-            Assertions.assertNull(invoker);
-        }
-    }
-
-    @Test
-    public void testSelect_Invokersize1() throws Exception {
-        invokers.clear();
-        invokers.add(invoker1);
-        LoadBalance l = cluster.initLoadBalance(invokers, invocation);
-        Assertions.assertNotNull(l,"cluster.initLoadBalance returns null!");
-        Invoker invoker = cluster.select(l, null, invokers, null);
-        Assertions.assertEquals(invoker1, invoker);
-    }
-
-    @Test
-    public void testSelect_Invokersize2AndselectNotNull() throws Exception {
-        invokers.clear();
-        invokers.add(invoker2);
-        invokers.add(invoker4);
-        LoadBalance l = cluster.initLoadBalance(invokers, invocation);
-        Assertions.assertNotNull(l,"cluster.initLoadBalance returns null!");
-        {
-            selectedInvokers.clear();
-            selectedInvokers.add(invoker4);
-            Invoker invoker = cluster.select(l, invocation, invokers, selectedInvokers);
-            Assertions.assertEquals(invoker2, invoker);
-        }
-        {
-            selectedInvokers.clear();
-            selectedInvokers.add(invoker2);
-            Invoker invoker = cluster.select(l, invocation, invokers, selectedInvokers);
-            Assertions.assertEquals(invoker4, invoker);
-        }
-    }
-
-    @Test
-    public void testSelect_multiInvokers() throws Exception {
-        testSelect_multiInvokers(RoundRobinLoadBalance.NAME);
-        testSelect_multiInvokers(LeastActiveLoadBalance.NAME);
-        testSelect_multiInvokers(RandomLoadBalance.NAME);
-    }
-
-    @Test
-    public void testCloseAvailablecheck() {
-        LoadBalance lb = mock(LoadBalance.class);
-        Map<String, String> queryMap = (Map<String, String> )url.getAttribute(REFER_KEY);
-        URL tmpUrl = turnRegistryUrlToConsumerUrl(url, queryMap);
-        given(lb.select(invokers, tmpUrl, invocation)).willReturn(invoker1);
-        initlistsize5();
-
-        Invoker sinvoker = cluster_nocheck.select(lb, invocation, invokers, selectedInvokers);
-        Assertions.assertFalse(sinvoker.isAvailable());
-        Assertions.assertEquals(invoker1, sinvoker);
-
-    }
-
-    private URL turnRegistryUrlToConsumerUrl(URL url, Map<String, String> queryMap) {
-        return URLBuilder.from(url)
-                .setProtocol(queryMap.get(PROTOCOL_KEY) == null ? DUBBO : queryMap.get(PROTOCOL_KEY))
-                .setPath(queryMap.get(PATH_KEY) != null ? queryMap.get(PATH_KEY) : queryMap.get(INTERFACE_KEY))
-                .clearParameters()
-                .addParameters(queryMap)
-                .removeParameter(MONITOR_KEY)
-                .build();
-    }
-
-    @Test
-    public void testDonotSelectAgainAndNoCheckAvailable() {
-
-        LoadBalance lb = ExtensionLoader.getExtensionLoader(LoadBalance.class).getExtension(RoundRobinLoadBalance.NAME);
-        initlistsize5();
-        {
-            //Boundary condition test .
-            selectedInvokers.clear();
-            selectedInvokers.add(invoker2);
-            selectedInvokers.add(invoker3);
-            selectedInvokers.add(invoker4);
-            selectedInvokers.add(invoker5);
-            Invoker sinvoker = cluster_nocheck.select(lb, invocation, invokers, selectedInvokers);
-            Assertions.assertSame(invoker1, sinvoker);
-        }
-        {
-            //Boundary condition test .
-            selectedInvokers.clear();
-            selectedInvokers.add(invoker1);
-            selectedInvokers.add(invoker3);
-            selectedInvokers.add(invoker4);
-            selectedInvokers.add(invoker5);
-            Invoker sinvoker = cluster_nocheck.select(lb, invocation, invokers, selectedInvokers);
-            Assertions.assertSame(invoker2, sinvoker);
-        }
-        {
-            //Boundary condition test .
-            selectedInvokers.clear();
-            selectedInvokers.add(invoker1);
-            selectedInvokers.add(invoker2);
-            selectedInvokers.add(invoker4);
-            selectedInvokers.add(invoker5);
-            Invoker sinvoker = cluster_nocheck.select(lb, invocation, invokers, selectedInvokers);
-            Assertions.assertSame(invoker3, sinvoker);
-        }
-        {
-            //Boundary condition test .
-            selectedInvokers.clear();
-            selectedInvokers.add(invoker1);
-            selectedInvokers.add(invoker2);
-            selectedInvokers.add(invoker3);
-            selectedInvokers.add(invoker4);
-            Invoker sinvoker = cluster_nocheck.select(lb, invocation, invokers, selectedInvokers);
-            Assertions.assertSame(invoker5, sinvoker);
-        }
-        {
-            //Boundary condition test .
-            selectedInvokers.clear();
-            selectedInvokers.add(invoker1);
-            selectedInvokers.add(invoker2);
-            selectedInvokers.add(invoker3);
-            selectedInvokers.add(invoker4);
-            selectedInvokers.add(invoker5);
-            Invoker sinvoker = cluster_nocheck.select(lb, invocation, invokers, selectedInvokers);
-            Assertions.assertTrue(invokers.contains(sinvoker));
-        }
-
-    }
-
-    @Test
-    public void testSelectAgainAndCheckAvailable() {
-
-        LoadBalance lb = ExtensionLoader.getExtensionLoader(LoadBalance.class).getExtension(RoundRobinLoadBalance.NAME);
-        initlistsize5();
-        {
-            //Boundary condition test .
-            selectedInvokers.clear();
-            selectedInvokers.add(invoker1);
-            selectedInvokers.add(invoker2);
-            selectedInvokers.add(invoker3);
-            selectedInvokers.add(invoker5);
-            Invoker sinvoker = cluster.select(lb, invocation, invokers, selectedInvokers);
-            Assertions.assertSame(sinvoker, invoker4);
-        }
-        {
-            //Boundary condition test .
-            selectedInvokers.clear();
-            selectedInvokers.add(invoker2);
-            selectedInvokers.add(invoker3);
-            selectedInvokers.add(invoker4);
-            selectedInvokers.add(invoker5);
-            Invoker sinvoker = cluster.select(lb, invocation, invokers, selectedInvokers);
-            Assertions.assertTrue(sinvoker == invoker2 || sinvoker == invoker4);
-        }
-        {
-            //Boundary condition test .
-            for (int i = 0; i < 100; i++) {
-                selectedInvokers.clear();
-                Invoker sinvoker = cluster.select(lb, invocation, invokers, selectedInvokers);
-                Assertions.assertTrue(sinvoker == invoker2 || sinvoker == invoker4);
-            }
-        }
-        {
-            //Boundary condition test .
-            for (int i = 0; i < 100; i++) {
-                selectedInvokers.clear();
-                selectedInvokers.add(invoker1);
-                selectedInvokers.add(invoker3);
-                selectedInvokers.add(invoker5);
-                Invoker sinvoker = cluster.select(lb, invocation, invokers, selectedInvokers);
-                Assertions.assertTrue(sinvoker == invoker2 || sinvoker == invoker4);
-            }
-        }
-        {
-            //Boundary condition test .
-            for (int i = 0; i < 100; i++) {
-                selectedInvokers.clear();
-                selectedInvokers.add(invoker1);
-                selectedInvokers.add(invoker3);
-                selectedInvokers.add(invoker2);
-                selectedInvokers.add(invoker4);
-                selectedInvokers.add(invoker5);
-                Invoker sinvoker = cluster.select(lb, invocation, invokers, selectedInvokers);
-                Assertions.assertTrue(sinvoker == invoker2 || sinvoker == invoker4);
-            }
-        }
-    }
-
-
-    public void testSelect_multiInvokers(String lbname) throws Exception {
-
-        int min = 1000, max = 5000;
-        Double d = (Math.random() * (max - min + 1) + min);
-        int runs = d.intValue();
-        Assertions.assertTrue(runs > min);
-        LoadBalance lb = ExtensionLoader.getExtensionLoader(LoadBalance.class).getExtension(lbname);
-        initlistsize5();
-        for (int i = 0; i < runs; i++) {
-            Invoker sinvoker = cluster.select(lb, invocation, invokers, selectedInvokers);
-            Assertions.assertTrue(sinvoker.isAvailable());
-
-            Mockito.clearInvocations(invoker1, invoker2, invoker3, invoker4, invoker5);
-        }
-        for (int i = 0; i < runs; i++) {
-            selectedInvokers.clear();
-            selectedInvokers.add(invoker1);
-            Invoker sinvoker = cluster.select(lb, invocation, invokers, selectedInvokers);
-            Assertions.assertTrue(sinvoker.isAvailable());
-
-            Mockito.clearInvocations(invoker1, invoker2, invoker3, invoker4, invoker5);
-        }
-        for (int i = 0; i < runs; i++) {
-            selectedInvokers.clear();
-            selectedInvokers.add(invoker2);
-            Invoker sinvoker = cluster.select(lb, invocation, invokers, selectedInvokers);
-            Assertions.assertTrue(sinvoker.isAvailable());
-
-            Mockito.clearInvocations(invoker1, invoker2, invoker3, invoker4, invoker5);
-        }
-        for (int i = 0; i < runs; i++) {
-            selectedInvokers.clear();
-            selectedInvokers.add(invoker2);
-            selectedInvokers.add(invoker4);
-            Invoker sinvoker = cluster.select(lb, invocation, invokers, selectedInvokers);
-            Assertions.assertTrue(sinvoker.isAvailable());
-
-            Mockito.clearInvocations(invoker1, invoker2, invoker3, invoker4, invoker5);
-        }
-        for (int i = 0; i < runs; i++) {
-            selectedInvokers.clear();
-            selectedInvokers.add(invoker1);
-            selectedInvokers.add(invoker3);
-            selectedInvokers.add(invoker5);
-            Invoker sinvoker = cluster.select(lb, invocation, invokers, selectedInvokers);
-            Assertions.assertTrue(sinvoker.isAvailable());
-
-            Mockito.clearInvocations(invoker1, invoker2, invoker3, invoker4, invoker5);
-        }
-        for (int i = 0; i < runs; i++) {
-
-            selectedInvokers.clear();
-            selectedInvokers.add(invoker1);
-            selectedInvokers.add(invoker2);
-            selectedInvokers.add(invoker3);
-            Invoker sinvoker = cluster.select(lb, invocation, invokers, selectedInvokers);
-            Assertions.assertTrue(sinvoker.isAvailable());
-
-            Mockito.clearInvocations(invoker1, invoker2, invoker3, invoker4, invoker5);
-        }
-    }
-
-    /**
-     * Test balance.
-     */
-    @Test
-    public void testSelectBalance() {
-
-        LoadBalance lb = ExtensionLoader.getExtensionLoader(LoadBalance.class).getExtension(RoundRobinLoadBalance.NAME);
-        initlistsize5();
-
-        Map<Invoker, AtomicLong> counter = new ConcurrentHashMap<Invoker, AtomicLong>();
-        for (Invoker invoker : invokers) {
-            counter.put(invoker, new AtomicLong(0));
-        }
-        int runs = 1000;
-        for (int i = 0; i < runs; i++) {
-            selectedInvokers.clear();
-            Invoker sinvoker = cluster.select(lb, invocation, invokers, selectedInvokers);
-            counter.get(sinvoker).incrementAndGet();
-        }
-
-        for (Map.Entry<Invoker, AtomicLong> entry : counter.entrySet()) {
-            Long count = entry.getValue().get();
-//            System.out.println(count);
-            if (entry.getKey().isAvailable())
-                Assertions.assertTrue(count > runs / invokers.size(),"count should > avg");
-        }
-
-        Assertions.assertEquals(runs, counter.get(invoker2).get() + counter.get(invoker4).get());
-
-    }
-
-    private void initlistsize5() {
-        invokers.clear();
-        selectedInvokers.clear();//Clear first, previous test case will make sure that the right invoker2 will be used.
-        invokers.add(invoker1);
-        invokers.add(invoker2);
-        invokers.add(invoker3);
-        invokers.add(invoker4);
-        invokers.add(invoker5);
-    }
-
-    private void initDic() {
-        dic.buildRouterChain();
-    }
-
-    @Test()
-    public void testTimeoutExceptionCode() {
-        List<Invoker<DemoService>> invokers = new ArrayList<Invoker<DemoService>>();
-        invokers.add(new Invoker<DemoService>() {
-
-            @Override
-            public Class<DemoService> getInterface() {
-                return DemoService.class;
-            }
-
-            public URL getUrl() {
-                return URL.valueOf("dubbo://" + NetUtils.getLocalHost() + ":20880/" + DemoService.class.getName());
-            }
-
-            @Override
-            public boolean isAvailable() {
-                return false;
-            }
-
-            @Override
-            public Result invoke(Invocation invocation) throws RpcException {
-                throw new RpcException(RpcException.TIMEOUT_EXCEPTION, "test timeout");
-            }
-
-            @Override
-            public void destroy() {
-            }
-        });
-        Directory<DemoService> directory = new StaticDirectory<DemoService>(invokers);
-        FailoverClusterInvoker<DemoService> failoverClusterInvoker = new FailoverClusterInvoker<DemoService>(directory);
-        try {
-            failoverClusterInvoker.invoke(new RpcInvocation("sayHello", DemoService.class.getName(), "", new Class<?>[0], new Object[0]));
-            Assertions.fail();
-        } catch (RpcException e) {
-            Assertions.assertEquals(RpcException.TIMEOUT_EXCEPTION, e.getCode());
-        }
-        ForkingClusterInvoker<DemoService> forkingClusterInvoker = new ForkingClusterInvoker<DemoService>(directory);
-        try {
-            forkingClusterInvoker.invoke(new RpcInvocation("sayHello", DemoService.class.getName(), "", new Class<?>[0], new Object[0]));
-            Assertions.fail();
-        } catch (RpcException e) {
-            Assertions.assertEquals(RpcException.TIMEOUT_EXCEPTION, e.getCode());
-        }
-        FailfastClusterInvoker<DemoService> failfastClusterInvoker = new FailfastClusterInvoker<DemoService>(directory);
-        try {
-            failfastClusterInvoker.invoke(new RpcInvocation("sayHello", DemoService.class.getName(), "", new Class<?>[0], new Object[0]));
-            Assertions.fail();
-        } catch (RpcException e) {
-            Assertions.assertEquals(RpcException.TIMEOUT_EXCEPTION, e.getCode());
-        }
-    }
-
-    /**
-     * Test mock invoker selector works as expected
-     */
-    @Test
-    public void testMockedInvokerSelect() {
-        initlistsize5();
-        invokers.add(mockedInvoker1);
-
-        initDic();
-
-        RpcInvocation mockedInvocation = new RpcInvocation();
-        mockedInvocation.setMethodName("sayHello");
-        mockedInvocation.setAttachment(INVOCATION_NEED_MOCK, "true");
-        List<Invoker<IHelloService>> mockedInvokers = dic.list(mockedInvocation);
-        Assertions.assertEquals(1, mockedInvokers.size());
-
-        List<Invoker<IHelloService>> invokers = dic.list(invocation);
-        Assertions.assertEquals(5, invokers.size());
-    }
-
-    public static interface IHelloService {
-    }
-}
+///*
+// * Licensed to the Apache Software Foundation (ASF) under one or more
+// * contributor license agreements.  See the NOTICE file distributed with
+// * this work for additional information regarding copyright ownership.
+// * The ASF licenses this file to You under the Apache License, Version 2.0
+// * (the "License"); you may not use this file except in compliance with
+// * the License.  You may obtain a copy of the License at
+// *
+// *     http://www.apache.org/licenses/LICENSE-2.0
+// *
+// * Unless required by applicable law or agreed to in writing, software
+// * distributed under the License is distributed on an "AS IS" BASIS,
+// * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// * See the License for the specific language governing permissions and
+// * limitations under the License.
+// */
+//package org.apache.dubbo.rpc.cluster.support;
+//
+//import org.apache.dubbo.common.URL;
+//import org.apache.dubbo.common.URLBuilder;
+//import org.apache.dubbo.common.extension.ExtensionLoader;
+//import org.apache.dubbo.common.utils.NetUtils;
+//import org.apache.dubbo.rpc.Invocation;
+//import org.apache.dubbo.rpc.Invoker;
+//import org.apache.dubbo.rpc.Result;
+//import org.apache.dubbo.rpc.RpcContext;
+//import org.apache.dubbo.rpc.RpcException;
+//import org.apache.dubbo.rpc.RpcInvocation;
+//import org.apache.dubbo.rpc.cluster.Directory;
+//import org.apache.dubbo.rpc.cluster.LoadBalance;
+//import org.apache.dubbo.rpc.cluster.directory.StaticDirectory;
+//import org.apache.dubbo.rpc.cluster.filter.DemoService;
+//import org.apache.dubbo.rpc.cluster.loadbalance.LeastActiveLoadBalance;
+//import org.apache.dubbo.rpc.cluster.loadbalance.RandomLoadBalance;
+//import org.apache.dubbo.rpc.cluster.loadbalance.RoundRobinLoadBalance;
+//
+//import org.junit.jupiter.api.AfterEach;
+//import org.junit.jupiter.api.Assertions;
+//import org.junit.jupiter.api.BeforeAll;
+//import org.junit.jupiter.api.BeforeEach;
+//import org.junit.jupiter.api.Test;
+//import org.mockito.Mockito;
+//
+//import java.util.ArrayList;
+//import java.util.HashMap;
+//import java.util.List;
+//import java.util.Map;
+//import java.util.concurrent.ConcurrentHashMap;
+//import java.util.concurrent.atomic.AtomicLong;
+//
+//import static org.apache.dubbo.common.constants.CommonConstants.DUBBO;
+//import static org.apache.dubbo.common.constants.CommonConstants.INTERFACE_KEY;
+//import static org.apache.dubbo.common.constants.CommonConstants.MONITOR_KEY;
+//import static org.apache.dubbo.common.constants.CommonConstants.PATH_KEY;
+//import static org.apache.dubbo.common.constants.CommonConstants.PROTOCOL_KEY;
+//import static org.apache.dubbo.rpc.cluster.Constants.CLUSTER_AVAILABLE_CHECK_KEY;
+//import static org.apache.dubbo.rpc.cluster.Constants.INVOCATION_NEED_MOCK;
+//import static org.apache.dubbo.rpc.cluster.Constants.REFER_KEY;
+//import static org.mockito.BDDMockito.given;
+//import static org.mockito.Mockito.mock;
+//
+///**
+// * AbstractClusterInvokerTest
+// */
+//@SuppressWarnings("rawtypes")
+//public class AbstractClusterInvokerTest {
+//    List<Invoker<IHelloService>> invokers = new ArrayList<Invoker<IHelloService>>();
+//    List<Invoker<IHelloService>> selectedInvokers = new ArrayList<Invoker<IHelloService>>();
+//    AbstractClusterInvoker<IHelloService> cluster;
+//    AbstractClusterInvoker<IHelloService> cluster_nocheck;
+//    StaticDirectory<IHelloService> dic;
+//    RpcInvocation invocation = new RpcInvocation();
+//    URL url = URL.valueOf("registry://localhost:9090/org.apache.dubbo.rpc.cluster.support.AbstractClusterInvokerTest.IHelloService?refer=" + URL.encode("application=abstractClusterInvokerTest"));
+//
+//    Invoker<IHelloService> invoker1;
+//    Invoker<IHelloService> invoker2;
+//    Invoker<IHelloService> invoker3;
+//    Invoker<IHelloService> invoker4;
+//    Invoker<IHelloService> invoker5;
+//    Invoker<IHelloService> mockedInvoker1;
+//
+//
+//    @BeforeAll
+//    public static void setUpBeforeClass() throws Exception {
+//    }
+//
+//    @AfterEach
+//    public void teardown() throws Exception {
+//        RpcContext.getContext().clearAttachments();
+//    }
+//
+//    @SuppressWarnings({"unchecked"})
+//    @BeforeEach
+//    public void setUp() throws Exception {
+//        Map<String, Object> attributes = new HashMap<>();
+//        attributes.put("application", "abstractClusterInvokerTest");
+//        url = url.putAttribute(REFER_KEY, attributes);
+//
+//        invocation.setMethodName("sayHello");
+//
+//        invoker1 = mock(Invoker.class);
+//        invoker2 = mock(Invoker.class);
+//        invoker3 = mock(Invoker.class);
+//        invoker4 = mock(Invoker.class);
+//        invoker5 = mock(Invoker.class);
+//        mockedInvoker1 = mock(Invoker.class);
+//
+//        URL turl = URL.valueOf("test://test:11/test");
+//
+//        given(invoker1.isAvailable()).willReturn(false);
+//        given(invoker1.getInterface()).willReturn(IHelloService.class);
+//        given(invoker1.getUrl()).willReturn(turl.setPort(1).addParameter("name", "invoker1"));
+//
+//        given(invoker2.isAvailable()).willReturn(true);
+//        given(invoker2.getInterface()).willReturn(IHelloService.class);
+//        given(invoker2.getUrl()).willReturn(turl.setPort(2).addParameter("name", "invoker2"));
+//
+//        given(invoker3.isAvailable()).willReturn(false);
+//        given(invoker3.getInterface()).willReturn(IHelloService.class);
+//        given(invoker3.getUrl()).willReturn(turl.setPort(3).addParameter("name", "invoker3"));
+//
+//        given(invoker4.isAvailable()).willReturn(true);
+//        given(invoker4.getInterface()).willReturn(IHelloService.class);
+//        given(invoker4.getUrl()).willReturn(turl.setPort(4).addParameter("name", "invoker4"));
+//
+//        given(invoker5.isAvailable()).willReturn(false);
+//        given(invoker5.getInterface()).willReturn(IHelloService.class);
+//        given(invoker5.getUrl()).willReturn(turl.setPort(5).addParameter("name", "invoker5"));
+//
+//        given(mockedInvoker1.isAvailable()).willReturn(false);
+//        given(mockedInvoker1.getInterface()).willReturn(IHelloService.class);
+//        given(mockedInvoker1.getUrl()).willReturn(turl.setPort(999).setProtocol("mock"));
+//
+//        invokers.add(invoker1);
+//        dic = new StaticDirectory<IHelloService>(url, invokers, null);
+//        cluster = new AbstractClusterInvoker(dic) {
+//            @Override
+//            protected Result doInvoke(Invocation invocation, List invokers, LoadBalance loadbalance)
+//                    throws RpcException {
+//                return null;
+//            }
+//        };
+//
+//        cluster_nocheck = new AbstractClusterInvoker(dic, url.addParameterIfAbsent(CLUSTER_AVAILABLE_CHECK_KEY, Boolean.FALSE.toString())) {
+//            @Override
+//            protected Result doInvoke(Invocation invocation, List invokers, LoadBalance loadbalance)
+//                    throws RpcException {
+//                return null;
+//            }
+//        };
+//
+//    }
+//
+//
+//    @Test
+//    public void testBindingAttachment() {
+//        final String attachKey = "attach";
+//        final String attachValue = "value";
+//
+//        // setup attachment
+//        RpcContext.getContext().setAttachment(attachKey, attachValue);
+//        Map<String, Object> attachments = RpcContext.getContext().getObjectAttachments();
+//        Assertions.assertTrue( attachments != null && attachments.size() == 1,"set attachment failed!");
+//
+//        cluster = new AbstractClusterInvoker(dic) {
+//            @Override
+//            protected Result doInvoke(Invocation invocation, List invokers, LoadBalance loadbalance)
+//                    throws RpcException {
+//                // attachment will be bind to invocation
+//                String value = invocation.getAttachment(attachKey);
+//                Assertions.assertNotNull(value);
+//                Assertions.assertEquals(attachValue, value, "binding attachment failed!");
+//                return null;
+//            }
+//        };
+//
+//        // invoke
+//        cluster.invoke(invocation);
+//    }
+//
+//    @Test
+//    public void testSelect_Invokersize0() throws Exception {
+//        LoadBalance l = cluster.initLoadBalance(invokers, invocation);
+//        Assertions.assertNotNull(l,"cluster.initLoadBalance returns null!");
+//        {
+//            Invoker invoker = cluster.select(l, null, null, null);
+//            Assertions.assertNull(invoker);
+//        }
+//        {
+//            invokers.clear();
+//            selectedInvokers.clear();
+//            Invoker invoker = cluster.select(l, null, invokers, null);
+//            Assertions.assertNull(invoker);
+//        }
+//    }
+//
+//    @Test
+//    public void testSelect_Invokersize1() throws Exception {
+//        invokers.clear();
+//        invokers.add(invoker1);
+//        LoadBalance l = cluster.initLoadBalance(invokers, invocation);
+//        Assertions.assertNotNull(l,"cluster.initLoadBalance returns null!");
+//        Invoker invoker = cluster.select(l, null, invokers, null);
+//        Assertions.assertEquals(invoker1, invoker);
+//    }
+//
+//    @Test
+//    public void testSelect_Invokersize2AndselectNotNull() throws Exception {
+//        invokers.clear();
+//        invokers.add(invoker2);
+//        invokers.add(invoker4);
+//        LoadBalance l = cluster.initLoadBalance(invokers, invocation);
+//        Assertions.assertNotNull(l,"cluster.initLoadBalance returns null!");
+//        {
+//            selectedInvokers.clear();
+//            selectedInvokers.add(invoker4);
+//            Invoker invoker = cluster.select(l, invocation, invokers, selectedInvokers);
+//            Assertions.assertEquals(invoker2, invoker);
+//        }
+//        {
+//            selectedInvokers.clear();
+//            selectedInvokers.add(invoker2);
+//            Invoker invoker = cluster.select(l, invocation, invokers, selectedInvokers);
+//            Assertions.assertEquals(invoker4, invoker);
+//        }
+//    }
+//
+//    @Test
+//    public void testSelect_multiInvokers() throws Exception {
+//        testSelect_multiInvokers(RoundRobinLoadBalance.NAME);
+//        testSelect_multiInvokers(LeastActiveLoadBalance.NAME);
+//        testSelect_multiInvokers(RandomLoadBalance.NAME);
+//    }
+//
+//    @Test
+//    public void testCloseAvailablecheck() {
+//        LoadBalance lb = mock(LoadBalance.class);
+//        Map<String, String> queryMap = (Map<String, String> )url.getAttribute(REFER_KEY);
+//        URL tmpUrl = turnRegistryUrlToConsumerUrl(url, queryMap);
+//        given(lb.select(invokers, tmpUrl, invocation)).willReturn(invoker1);
+//        initlistsize5();
+//
+//        Invoker sinvoker = cluster_nocheck.select(lb, invocation, invokers, selectedInvokers);
+//        Assertions.assertFalse(sinvoker.isAvailable());
+//        Assertions.assertEquals(invoker1, sinvoker);
+//
+//    }
+//
+//    private URL turnRegistryUrlToConsumerUrl(URL url, Map<String, String> queryMap) {
+//        return URLBuilder.from(url)
+//                .setProtocol(queryMap.get(PROTOCOL_KEY) == null ? DUBBO : queryMap.get(PROTOCOL_KEY))
+//                .setPath(queryMap.get(PATH_KEY) != null ? queryMap.get(PATH_KEY) : queryMap.get(INTERFACE_KEY))
+//                .clearParameters()
+//                .addParameters(queryMap)
+//                .removeParameter(MONITOR_KEY)
+//                .build();
+//    }
+//
+//    @Test
+//    public void testDonotSelectAgainAndNoCheckAvailable() {
+//
+//        LoadBalance lb = ExtensionLoader.getExtensionLoader(LoadBalance.class).getExtension(RoundRobinLoadBalance.NAME);
+//        initlistsize5();
+//        {
+//            //Boundary condition test .
+//            selectedInvokers.clear();
+//            selectedInvokers.add(invoker2);
+//            selectedInvokers.add(invoker3);
+//            selectedInvokers.add(invoker4);
+//            selectedInvokers.add(invoker5);
+//            Invoker sinvoker = cluster_nocheck.select(lb, invocation, invokers, selectedInvokers);
+//            Assertions.assertSame(invoker1, sinvoker);
+//        }
+//        {
+//            //Boundary condition test .
+//            selectedInvokers.clear();
+//            selectedInvokers.add(invoker1);
+//            selectedInvokers.add(invoker3);
+//            selectedInvokers.add(invoker4);
+//            selectedInvokers.add(invoker5);
+//            Invoker sinvoker = cluster_nocheck.select(lb, invocation, invokers, selectedInvokers);
+//            Assertions.assertSame(invoker2, sinvoker);
+//        }
+//        {
+//            //Boundary condition test .
+//            selectedInvokers.clear();
+//            selectedInvokers.add(invoker1);
+//            selectedInvokers.add(invoker2);
+//            selectedInvokers.add(invoker4);
+//            selectedInvokers.add(invoker5);
+//            Invoker sinvoker = cluster_nocheck.select(lb, invocation, invokers, selectedInvokers);
+//            Assertions.assertSame(invoker3, sinvoker);
+//        }
+//        {
+//            //Boundary condition test .
+//            selectedInvokers.clear();
+//            selectedInvokers.add(invoker1);
+//            selectedInvokers.add(invoker2);
+//            selectedInvokers.add(invoker3);
+//            selectedInvokers.add(invoker4);
+//            Invoker sinvoker = cluster_nocheck.select(lb, invocation, invokers, selectedInvokers);
+//            Assertions.assertSame(invoker5, sinvoker);
+//        }
+//        {
+//            //Boundary condition test .
+//            selectedInvokers.clear();
+//            selectedInvokers.add(invoker1);
+//            selectedInvokers.add(invoker2);
+//            selectedInvokers.add(invoker3);
+//            selectedInvokers.add(invoker4);
+//            selectedInvokers.add(invoker5);
+//            Invoker sinvoker = cluster_nocheck.select(lb, invocation, invokers, selectedInvokers);
+//            Assertions.assertTrue(invokers.contains(sinvoker));
+//        }
+//
+//    }
+//
+//    @Test
+//    public void testSelectAgainAndCheckAvailable() {
+//
+//        LoadBalance lb = ExtensionLoader.getExtensionLoader(LoadBalance.class).getExtension(RoundRobinLoadBalance.NAME);
+//        initlistsize5();
+//        {
+//            //Boundary condition test .
+//            selectedInvokers.clear();
+//            selectedInvokers.add(invoker1);
+//            selectedInvokers.add(invoker2);
+//            selectedInvokers.add(invoker3);
+//            selectedInvokers.add(invoker5);
+//            Invoker sinvoker = cluster.select(lb, invocation, invokers, selectedInvokers);
+//            Assertions.assertSame(sinvoker, invoker4);
+//        }
+//        {
+//            //Boundary condition test .
+//            selectedInvokers.clear();
+//            selectedInvokers.add(invoker2);
+//            selectedInvokers.add(invoker3);
+//            selectedInvokers.add(invoker4);
+//            selectedInvokers.add(invoker5);
+//            Invoker sinvoker = cluster.select(lb, invocation, invokers, selectedInvokers);
+//            Assertions.assertTrue(sinvoker == invoker2 || sinvoker == invoker4);
+//        }
+//        {
+//            //Boundary condition test .
+//            for (int i = 0; i < 100; i++) {
+//                selectedInvokers.clear();
+//                Invoker sinvoker = cluster.select(lb, invocation, invokers, selectedInvokers);
+//                Assertions.assertTrue(sinvoker == invoker2 || sinvoker == invoker4);
+//            }
+//        }
+//        {
+//            //Boundary condition test .
+//            for (int i = 0; i < 100; i++) {
+//                selectedInvokers.clear();
+//                selectedInvokers.add(invoker1);
+//                selectedInvokers.add(invoker3);
+//                selectedInvokers.add(invoker5);
+//                Invoker sinvoker = cluster.select(lb, invocation, invokers, selectedInvokers);
+//                Assertions.assertTrue(sinvoker == invoker2 || sinvoker == invoker4);
+//            }
+//        }
+//        {
+//            //Boundary condition test .
+//            for (int i = 0; i < 100; i++) {
+//                selectedInvokers.clear();
+//                selectedInvokers.add(invoker1);
+//                selectedInvokers.add(invoker3);
+//                selectedInvokers.add(invoker2);
+//                selectedInvokers.add(invoker4);
+//                selectedInvokers.add(invoker5);
+//                Invoker sinvoker = cluster.select(lb, invocation, invokers, selectedInvokers);
+//                Assertions.assertTrue(sinvoker == invoker2 || sinvoker == invoker4);
+//            }
+//        }
+//    }
+//
+//
+//    public void testSelect_multiInvokers(String lbname) throws Exception {
+//
+//        int min = 1000, max = 5000;
+//        Double d = (Math.random() * (max - min + 1) + min);
+//        int runs = d.intValue();
+//        Assertions.assertTrue(runs > min);
+//        LoadBalance lb = ExtensionLoader.getExtensionLoader(LoadBalance.class).getExtension(lbname);
+//        initlistsize5();
+//        for (int i = 0; i < runs; i++) {
+//            Invoker sinvoker = cluster.select(lb, invocation, invokers, selectedInvokers);
+//            Assertions.assertTrue(sinvoker.isAvailable());
+//
+//            Mockito.clearInvocations(invoker1, invoker2, invoker3, invoker4, invoker5);
+//        }
+//        for (int i = 0; i < runs; i++) {
+//            selectedInvokers.clear();
+//            selectedInvokers.add(invoker1);
+//            Invoker sinvoker = cluster.select(lb, invocation, invokers, selectedInvokers);
+//            Assertions.assertTrue(sinvoker.isAvailable());
+//
+//            Mockito.clearInvocations(invoker1, invoker2, invoker3, invoker4, invoker5);
+//        }
+//        for (int i = 0; i < runs; i++) {
+//            selectedInvokers.clear();
+//            selectedInvokers.add(invoker2);
+//            Invoker sinvoker = cluster.select(lb, invocation, invokers, selectedInvokers);
+//            Assertions.assertTrue(sinvoker.isAvailable());
+//
+//            Mockito.clearInvocations(invoker1, invoker2, invoker3, invoker4, invoker5);
+//        }
+//        for (int i = 0; i < runs; i++) {
+//            selectedInvokers.clear();
+//            selectedInvokers.add(invoker2);
+//            selectedInvokers.add(invoker4);
+//            Invoker sinvoker = cluster.select(lb, invocation, invokers, selectedInvokers);
+//            Assertions.assertTrue(sinvoker.isAvailable());
+//
+//            Mockito.clearInvocations(invoker1, invoker2, invoker3, invoker4, invoker5);
+//        }
+//        for (int i = 0; i < runs; i++) {
+//            selectedInvokers.clear();
+//            selectedInvokers.add(invoker1);
+//            selectedInvokers.add(invoker3);
+//            selectedInvokers.add(invoker5);
+//            Invoker sinvoker = cluster.select(lb, invocation, invokers, selectedInvokers);
+//            Assertions.assertTrue(sinvoker.isAvailable());
+//
+//            Mockito.clearInvocations(invoker1, invoker2, invoker3, invoker4, invoker5);
+//        }
+//        for (int i = 0; i < runs; i++) {
+//
+//            selectedInvokers.clear();
+//            selectedInvokers.add(invoker1);
+//            selectedInvokers.add(invoker2);
+//            selectedInvokers.add(invoker3);
+//            Invoker sinvoker = cluster.select(lb, invocation, invokers, selectedInvokers);
+//            Assertions.assertTrue(sinvoker.isAvailable());
+//
+//            Mockito.clearInvocations(invoker1, invoker2, invoker3, invoker4, invoker5);
+//        }
+//    }
+//
+//    /**
+//     * Test balance.
+//     */
+//    @Test
+//    public void testSelectBalance() {
+//
+//        LoadBalance lb = ExtensionLoader.getExtensionLoader(LoadBalance.class).getExtension(RoundRobinLoadBalance.NAME);
+//        initlistsize5();
+//
+//        Map<Invoker, AtomicLong> counter = new ConcurrentHashMap<Invoker, AtomicLong>();
+//        for (Invoker invoker : invokers) {
+//            counter.put(invoker, new AtomicLong(0));
+//        }
+//        int runs = 1000;
+//        for (int i = 0; i < runs; i++) {
+//            selectedInvokers.clear();
+//            Invoker sinvoker = cluster.select(lb, invocation, invokers, selectedInvokers);
+//            counter.get(sinvoker).incrementAndGet();
+//        }
+//
+//        for (Map.Entry<Invoker, AtomicLong> entry : counter.entrySet()) {
+//            Long count = entry.getValue().get();
+////            System.out.println(count);
+//            if (entry.getKey().isAvailable())
+//                Assertions.assertTrue(count > runs / invokers.size(),"count should > avg");
+//        }
+//
+//        Assertions.assertEquals(runs, counter.get(invoker2).get() + counter.get(invoker4).get());
+//
+//    }
+//
+//    private void initlistsize5() {
+//        invokers.clear();
+//        selectedInvokers.clear();//Clear first, previous test case will make sure that the right invoker2 will be used.
+//        invokers.add(invoker1);
+//        invokers.add(invoker2);
+//        invokers.add(invoker3);
+//        invokers.add(invoker4);
+//        invokers.add(invoker5);
+//    }
+//
+//    private void initDic() {
+//        dic.buildRouterChain();
+//    }
+//
+//    @Test()
+//    public void testTimeoutExceptionCode() {
+//        List<Invoker<DemoService>> invokers = new ArrayList<Invoker<DemoService>>();
+//        invokers.add(new Invoker<DemoService>() {
+//
+//            @Override
+//            public Class<DemoService> getInterface() {
+//                return DemoService.class;
+//            }
+//
+//            public URL getUrl() {
+//                return URL.valueOf("dubbo://" + NetUtils.getLocalHost() + ":20880/" + DemoService.class.getName());
+//            }
+//
+//            @Override
+//            public boolean isAvailable() {
+//                return false;
+//            }
+//
+//            @Override
+//            public Result invoke(Invocation invocation) throws RpcException {
+//                throw new RpcException(RpcException.TIMEOUT_EXCEPTION, "test timeout");
+//            }
+//
+//            @Override
+//            public void destroy() {
+//            }
+//        });
+//        Directory<DemoService> directory = new StaticDirectory<DemoService>(invokers);
+//        FailoverClusterInvoker<DemoService> failoverClusterInvoker = new FailoverClusterInvoker<DemoService>(directory);
+//        try {
+//            failoverClusterInvoker.invoke(new RpcInvocation("sayHello", DemoService.class.getName(), "", new Class<?>[0], new Object[0]));
+//            Assertions.fail();
+//        } catch (RpcException e) {
+//            Assertions.assertEquals(RpcException.TIMEOUT_EXCEPTION, e.getCode());
+//        }
+//        ForkingClusterInvoker<DemoService> forkingClusterInvoker = new ForkingClusterInvoker<DemoService>(directory);
+//        try {
+//            forkingClusterInvoker.invoke(new RpcInvocation("sayHello", DemoService.class.getName(), "", new Class<?>[0], new Object[0]));
+//            Assertions.fail();
+//        } catch (RpcException e) {
+//            Assertions.assertEquals(RpcException.TIMEOUT_EXCEPTION, e.getCode());
+//        }
+//        FailfastClusterInvoker<DemoService> failfastClusterInvoker = new FailfastClusterInvoker<DemoService>(directory);
+//        try {
+//            failfastClusterInvoker.invoke(new RpcInvocation("sayHello", DemoService.class.getName(), "", new Class<?>[0], new Object[0]));
+//            Assertions.fail();
+//        } catch (RpcException e) {
+//            Assertions.assertEquals(RpcException.TIMEOUT_EXCEPTION, e.getCode());
+//        }
+//    }
+//
+//    /**
+//     * Test mock invoker selector works as expected
+//     */
+//    @Test
+//    public void testMockedInvokerSelect() {
+//        initlistsize5();
+//        invokers.add(mockedInvoker1);
+//
+//        initDic();
+//
+//        RpcInvocation mockedInvocation = new RpcInvocation();
+//        mockedInvocation.setMethodName("sayHello");
+//        mockedInvocation.setAttachment(INVOCATION_NEED_MOCK, "true");
+//        List<Invoker<IHelloService>> mockedInvokers = dic.list(mockedInvocation);
+//        Assertions.assertEquals(1, mockedInvokers.size());
+//
+//        List<Invoker<IHelloService>> invokers = dic.list(invocation);
+//        Assertions.assertEquals(5, invokers.size());
+//    }
+//
+//    public static interface IHelloService {
+//    }
+//}

--- a/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/support/AbstractClusterInvokerTest.java
+++ b/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/support/AbstractClusterInvokerTest.java
@@ -1,559 +1,559 @@
-///*
-// * Licensed to the Apache Software Foundation (ASF) under one or more
-// * contributor license agreements.  See the NOTICE file distributed with
-// * this work for additional information regarding copyright ownership.
-// * The ASF licenses this file to You under the Apache License, Version 2.0
-// * (the "License"); you may not use this file except in compliance with
-// * the License.  You may obtain a copy of the License at
-// *
-// *     http://www.apache.org/licenses/LICENSE-2.0
-// *
-// * Unless required by applicable law or agreed to in writing, software
-// * distributed under the License is distributed on an "AS IS" BASIS,
-// * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// * See the License for the specific language governing permissions and
-// * limitations under the License.
-// */
-//package org.apache.dubbo.rpc.cluster.support;
-//
-//import org.apache.dubbo.common.URL;
-//import org.apache.dubbo.common.URLBuilder;
-//import org.apache.dubbo.common.extension.ExtensionLoader;
-//import org.apache.dubbo.common.utils.NetUtils;
-//import org.apache.dubbo.rpc.Invocation;
-//import org.apache.dubbo.rpc.Invoker;
-//import org.apache.dubbo.rpc.Result;
-//import org.apache.dubbo.rpc.RpcContext;
-//import org.apache.dubbo.rpc.RpcException;
-//import org.apache.dubbo.rpc.RpcInvocation;
-//import org.apache.dubbo.rpc.cluster.Directory;
-//import org.apache.dubbo.rpc.cluster.LoadBalance;
-//import org.apache.dubbo.rpc.cluster.directory.StaticDirectory;
-//import org.apache.dubbo.rpc.cluster.filter.DemoService;
-//import org.apache.dubbo.rpc.cluster.loadbalance.LeastActiveLoadBalance;
-//import org.apache.dubbo.rpc.cluster.loadbalance.RandomLoadBalance;
-//import org.apache.dubbo.rpc.cluster.loadbalance.RoundRobinLoadBalance;
-//
-//import org.junit.jupiter.api.AfterEach;
-//import org.junit.jupiter.api.Assertions;
-//import org.junit.jupiter.api.BeforeAll;
-//import org.junit.jupiter.api.BeforeEach;
-//import org.junit.jupiter.api.Test;
-//import org.mockito.Mockito;
-//
-//import java.util.ArrayList;
-//import java.util.HashMap;
-//import java.util.List;
-//import java.util.Map;
-//import java.util.concurrent.ConcurrentHashMap;
-//import java.util.concurrent.atomic.AtomicLong;
-//
-//import static org.apache.dubbo.common.constants.CommonConstants.DUBBO;
-//import static org.apache.dubbo.common.constants.CommonConstants.INTERFACE_KEY;
-//import static org.apache.dubbo.common.constants.CommonConstants.MONITOR_KEY;
-//import static org.apache.dubbo.common.constants.CommonConstants.PATH_KEY;
-//import static org.apache.dubbo.common.constants.CommonConstants.PROTOCOL_KEY;
-//import static org.apache.dubbo.rpc.cluster.Constants.CLUSTER_AVAILABLE_CHECK_KEY;
-//import static org.apache.dubbo.rpc.cluster.Constants.INVOCATION_NEED_MOCK;
-//import static org.apache.dubbo.rpc.cluster.Constants.REFER_KEY;
-//import static org.mockito.BDDMockito.given;
-//import static org.mockito.Mockito.mock;
-//
-///**
-// * AbstractClusterInvokerTest
-// */
-//@SuppressWarnings("rawtypes")
-//public class AbstractClusterInvokerTest {
-//    List<Invoker<IHelloService>> invokers = new ArrayList<Invoker<IHelloService>>();
-//    List<Invoker<IHelloService>> selectedInvokers = new ArrayList<Invoker<IHelloService>>();
-//    AbstractClusterInvoker<IHelloService> cluster;
-//    AbstractClusterInvoker<IHelloService> cluster_nocheck;
-//    StaticDirectory<IHelloService> dic;
-//    RpcInvocation invocation = new RpcInvocation();
-//    URL url = URL.valueOf("registry://localhost:9090/org.apache.dubbo.rpc.cluster.support.AbstractClusterInvokerTest.IHelloService?refer=" + URL.encode("application=abstractClusterInvokerTest"));
-//
-//    Invoker<IHelloService> invoker1;
-//    Invoker<IHelloService> invoker2;
-//    Invoker<IHelloService> invoker3;
-//    Invoker<IHelloService> invoker4;
-//    Invoker<IHelloService> invoker5;
-//    Invoker<IHelloService> mockedInvoker1;
-//
-//
-//    @BeforeAll
-//    public static void setUpBeforeClass() throws Exception {
-//    }
-//
-//    @AfterEach
-//    public void teardown() throws Exception {
-//        RpcContext.getContext().clearAttachments();
-//    }
-//
-//    @SuppressWarnings({"unchecked"})
-//    @BeforeEach
-//    public void setUp() throws Exception {
-//        Map<String, Object> attributes = new HashMap<>();
-//        attributes.put("application", "abstractClusterInvokerTest");
-//        url = url.putAttribute(REFER_KEY, attributes);
-//
-//        invocation.setMethodName("sayHello");
-//
-//        invoker1 = mock(Invoker.class);
-//        invoker2 = mock(Invoker.class);
-//        invoker3 = mock(Invoker.class);
-//        invoker4 = mock(Invoker.class);
-//        invoker5 = mock(Invoker.class);
-//        mockedInvoker1 = mock(Invoker.class);
-//
-//        URL turl = URL.valueOf("test://test:11/test");
-//
-//        given(invoker1.isAvailable()).willReturn(false);
-//        given(invoker1.getInterface()).willReturn(IHelloService.class);
-//        given(invoker1.getUrl()).willReturn(turl.setPort(1).addParameter("name", "invoker1"));
-//
-//        given(invoker2.isAvailable()).willReturn(true);
-//        given(invoker2.getInterface()).willReturn(IHelloService.class);
-//        given(invoker2.getUrl()).willReturn(turl.setPort(2).addParameter("name", "invoker2"));
-//
-//        given(invoker3.isAvailable()).willReturn(false);
-//        given(invoker3.getInterface()).willReturn(IHelloService.class);
-//        given(invoker3.getUrl()).willReturn(turl.setPort(3).addParameter("name", "invoker3"));
-//
-//        given(invoker4.isAvailable()).willReturn(true);
-//        given(invoker4.getInterface()).willReturn(IHelloService.class);
-//        given(invoker4.getUrl()).willReturn(turl.setPort(4).addParameter("name", "invoker4"));
-//
-//        given(invoker5.isAvailable()).willReturn(false);
-//        given(invoker5.getInterface()).willReturn(IHelloService.class);
-//        given(invoker5.getUrl()).willReturn(turl.setPort(5).addParameter("name", "invoker5"));
-//
-//        given(mockedInvoker1.isAvailable()).willReturn(false);
-//        given(mockedInvoker1.getInterface()).willReturn(IHelloService.class);
-//        given(mockedInvoker1.getUrl()).willReturn(turl.setPort(999).setProtocol("mock"));
-//
-//        invokers.add(invoker1);
-//        dic = new StaticDirectory<IHelloService>(url, invokers, null);
-//        cluster = new AbstractClusterInvoker(dic) {
-//            @Override
-//            protected Result doInvoke(Invocation invocation, List invokers, LoadBalance loadbalance)
-//                    throws RpcException {
-//                return null;
-//            }
-//        };
-//
-//        cluster_nocheck = new AbstractClusterInvoker(dic, url.addParameterIfAbsent(CLUSTER_AVAILABLE_CHECK_KEY, Boolean.FALSE.toString())) {
-//            @Override
-//            protected Result doInvoke(Invocation invocation, List invokers, LoadBalance loadbalance)
-//                    throws RpcException {
-//                return null;
-//            }
-//        };
-//
-//    }
-//
-//
-//    @Test
-//    public void testBindingAttachment() {
-//        final String attachKey = "attach";
-//        final String attachValue = "value";
-//
-//        // setup attachment
-//        RpcContext.getContext().setAttachment(attachKey, attachValue);
-//        Map<String, Object> attachments = RpcContext.getContext().getObjectAttachments();
-//        Assertions.assertTrue( attachments != null && attachments.size() == 1,"set attachment failed!");
-//
-//        cluster = new AbstractClusterInvoker(dic) {
-//            @Override
-//            protected Result doInvoke(Invocation invocation, List invokers, LoadBalance loadbalance)
-//                    throws RpcException {
-//                // attachment will be bind to invocation
-//                String value = invocation.getAttachment(attachKey);
-//                Assertions.assertNotNull(value);
-//                Assertions.assertEquals(attachValue, value, "binding attachment failed!");
-//                return null;
-//            }
-//        };
-//
-//        // invoke
-//        cluster.invoke(invocation);
-//    }
-//
-//    @Test
-//    public void testSelect_Invokersize0() throws Exception {
-//        LoadBalance l = cluster.initLoadBalance(invokers, invocation);
-//        Assertions.assertNotNull(l,"cluster.initLoadBalance returns null!");
-//        {
-//            Invoker invoker = cluster.select(l, null, null, null);
-//            Assertions.assertNull(invoker);
-//        }
-//        {
-//            invokers.clear();
-//            selectedInvokers.clear();
-//            Invoker invoker = cluster.select(l, null, invokers, null);
-//            Assertions.assertNull(invoker);
-//        }
-//    }
-//
-//    @Test
-//    public void testSelect_Invokersize1() throws Exception {
-//        invokers.clear();
-//        invokers.add(invoker1);
-//        LoadBalance l = cluster.initLoadBalance(invokers, invocation);
-//        Assertions.assertNotNull(l,"cluster.initLoadBalance returns null!");
-//        Invoker invoker = cluster.select(l, null, invokers, null);
-//        Assertions.assertEquals(invoker1, invoker);
-//    }
-//
-//    @Test
-//    public void testSelect_Invokersize2AndselectNotNull() throws Exception {
-//        invokers.clear();
-//        invokers.add(invoker2);
-//        invokers.add(invoker4);
-//        LoadBalance l = cluster.initLoadBalance(invokers, invocation);
-//        Assertions.assertNotNull(l,"cluster.initLoadBalance returns null!");
-//        {
-//            selectedInvokers.clear();
-//            selectedInvokers.add(invoker4);
-//            Invoker invoker = cluster.select(l, invocation, invokers, selectedInvokers);
-//            Assertions.assertEquals(invoker2, invoker);
-//        }
-//        {
-//            selectedInvokers.clear();
-//            selectedInvokers.add(invoker2);
-//            Invoker invoker = cluster.select(l, invocation, invokers, selectedInvokers);
-//            Assertions.assertEquals(invoker4, invoker);
-//        }
-//    }
-//
-//    @Test
-//    public void testSelect_multiInvokers() throws Exception {
-//        testSelect_multiInvokers(RoundRobinLoadBalance.NAME);
-//        testSelect_multiInvokers(LeastActiveLoadBalance.NAME);
-//        testSelect_multiInvokers(RandomLoadBalance.NAME);
-//    }
-//
-//    @Test
-//    public void testCloseAvailablecheck() {
-//        LoadBalance lb = mock(LoadBalance.class);
-//        Map<String, String> queryMap = (Map<String, String> )url.getAttribute(REFER_KEY);
-//        URL tmpUrl = turnRegistryUrlToConsumerUrl(url, queryMap);
-//        given(lb.select(invokers, tmpUrl, invocation)).willReturn(invoker1);
-//        initlistsize5();
-//
-//        Invoker sinvoker = cluster_nocheck.select(lb, invocation, invokers, selectedInvokers);
-//        Assertions.assertFalse(sinvoker.isAvailable());
-//        Assertions.assertEquals(invoker1, sinvoker);
-//
-//    }
-//
-//    private URL turnRegistryUrlToConsumerUrl(URL url, Map<String, String> queryMap) {
-//        return URLBuilder.from(url)
-//                .setProtocol(queryMap.get(PROTOCOL_KEY) == null ? DUBBO : queryMap.get(PROTOCOL_KEY))
-//                .setPath(queryMap.get(PATH_KEY) != null ? queryMap.get(PATH_KEY) : queryMap.get(INTERFACE_KEY))
-//                .clearParameters()
-//                .addParameters(queryMap)
-//                .removeParameter(MONITOR_KEY)
-//                .build();
-//    }
-//
-//    @Test
-//    public void testDonotSelectAgainAndNoCheckAvailable() {
-//
-//        LoadBalance lb = ExtensionLoader.getExtensionLoader(LoadBalance.class).getExtension(RoundRobinLoadBalance.NAME);
-//        initlistsize5();
-//        {
-//            //Boundary condition test .
-//            selectedInvokers.clear();
-//            selectedInvokers.add(invoker2);
-//            selectedInvokers.add(invoker3);
-//            selectedInvokers.add(invoker4);
-//            selectedInvokers.add(invoker5);
-//            Invoker sinvoker = cluster_nocheck.select(lb, invocation, invokers, selectedInvokers);
-//            Assertions.assertSame(invoker1, sinvoker);
-//        }
-//        {
-//            //Boundary condition test .
-//            selectedInvokers.clear();
-//            selectedInvokers.add(invoker1);
-//            selectedInvokers.add(invoker3);
-//            selectedInvokers.add(invoker4);
-//            selectedInvokers.add(invoker5);
-//            Invoker sinvoker = cluster_nocheck.select(lb, invocation, invokers, selectedInvokers);
-//            Assertions.assertSame(invoker2, sinvoker);
-//        }
-//        {
-//            //Boundary condition test .
-//            selectedInvokers.clear();
-//            selectedInvokers.add(invoker1);
-//            selectedInvokers.add(invoker2);
-//            selectedInvokers.add(invoker4);
-//            selectedInvokers.add(invoker5);
-//            Invoker sinvoker = cluster_nocheck.select(lb, invocation, invokers, selectedInvokers);
-//            Assertions.assertSame(invoker3, sinvoker);
-//        }
-//        {
-//            //Boundary condition test .
-//            selectedInvokers.clear();
-//            selectedInvokers.add(invoker1);
-//            selectedInvokers.add(invoker2);
-//            selectedInvokers.add(invoker3);
-//            selectedInvokers.add(invoker4);
-//            Invoker sinvoker = cluster_nocheck.select(lb, invocation, invokers, selectedInvokers);
-//            Assertions.assertSame(invoker5, sinvoker);
-//        }
-//        {
-//            //Boundary condition test .
-//            selectedInvokers.clear();
-//            selectedInvokers.add(invoker1);
-//            selectedInvokers.add(invoker2);
-//            selectedInvokers.add(invoker3);
-//            selectedInvokers.add(invoker4);
-//            selectedInvokers.add(invoker5);
-//            Invoker sinvoker = cluster_nocheck.select(lb, invocation, invokers, selectedInvokers);
-//            Assertions.assertTrue(invokers.contains(sinvoker));
-//        }
-//
-//    }
-//
-//    @Test
-//    public void testSelectAgainAndCheckAvailable() {
-//
-//        LoadBalance lb = ExtensionLoader.getExtensionLoader(LoadBalance.class).getExtension(RoundRobinLoadBalance.NAME);
-//        initlistsize5();
-//        {
-//            //Boundary condition test .
-//            selectedInvokers.clear();
-//            selectedInvokers.add(invoker1);
-//            selectedInvokers.add(invoker2);
-//            selectedInvokers.add(invoker3);
-//            selectedInvokers.add(invoker5);
-//            Invoker sinvoker = cluster.select(lb, invocation, invokers, selectedInvokers);
-//            Assertions.assertSame(sinvoker, invoker4);
-//        }
-//        {
-//            //Boundary condition test .
-//            selectedInvokers.clear();
-//            selectedInvokers.add(invoker2);
-//            selectedInvokers.add(invoker3);
-//            selectedInvokers.add(invoker4);
-//            selectedInvokers.add(invoker5);
-//            Invoker sinvoker = cluster.select(lb, invocation, invokers, selectedInvokers);
-//            Assertions.assertTrue(sinvoker == invoker2 || sinvoker == invoker4);
-//        }
-//        {
-//            //Boundary condition test .
-//            for (int i = 0; i < 100; i++) {
-//                selectedInvokers.clear();
-//                Invoker sinvoker = cluster.select(lb, invocation, invokers, selectedInvokers);
-//                Assertions.assertTrue(sinvoker == invoker2 || sinvoker == invoker4);
-//            }
-//        }
-//        {
-//            //Boundary condition test .
-//            for (int i = 0; i < 100; i++) {
-//                selectedInvokers.clear();
-//                selectedInvokers.add(invoker1);
-//                selectedInvokers.add(invoker3);
-//                selectedInvokers.add(invoker5);
-//                Invoker sinvoker = cluster.select(lb, invocation, invokers, selectedInvokers);
-//                Assertions.assertTrue(sinvoker == invoker2 || sinvoker == invoker4);
-//            }
-//        }
-//        {
-//            //Boundary condition test .
-//            for (int i = 0; i < 100; i++) {
-//                selectedInvokers.clear();
-//                selectedInvokers.add(invoker1);
-//                selectedInvokers.add(invoker3);
-//                selectedInvokers.add(invoker2);
-//                selectedInvokers.add(invoker4);
-//                selectedInvokers.add(invoker5);
-//                Invoker sinvoker = cluster.select(lb, invocation, invokers, selectedInvokers);
-//                Assertions.assertTrue(sinvoker == invoker2 || sinvoker == invoker4);
-//            }
-//        }
-//    }
-//
-//
-//    public void testSelect_multiInvokers(String lbname) throws Exception {
-//
-//        int min = 1000, max = 5000;
-//        Double d = (Math.random() * (max - min + 1) + min);
-//        int runs = d.intValue();
-//        Assertions.assertTrue(runs > min);
-//        LoadBalance lb = ExtensionLoader.getExtensionLoader(LoadBalance.class).getExtension(lbname);
-//        initlistsize5();
-//        for (int i = 0; i < runs; i++) {
-//            Invoker sinvoker = cluster.select(lb, invocation, invokers, selectedInvokers);
-//            Assertions.assertTrue(sinvoker.isAvailable());
-//
-//            Mockito.clearInvocations(invoker1, invoker2, invoker3, invoker4, invoker5);
-//        }
-//        for (int i = 0; i < runs; i++) {
-//            selectedInvokers.clear();
-//            selectedInvokers.add(invoker1);
-//            Invoker sinvoker = cluster.select(lb, invocation, invokers, selectedInvokers);
-//            Assertions.assertTrue(sinvoker.isAvailable());
-//
-//            Mockito.clearInvocations(invoker1, invoker2, invoker3, invoker4, invoker5);
-//        }
-//        for (int i = 0; i < runs; i++) {
-//            selectedInvokers.clear();
-//            selectedInvokers.add(invoker2);
-//            Invoker sinvoker = cluster.select(lb, invocation, invokers, selectedInvokers);
-//            Assertions.assertTrue(sinvoker.isAvailable());
-//
-//            Mockito.clearInvocations(invoker1, invoker2, invoker3, invoker4, invoker5);
-//        }
-//        for (int i = 0; i < runs; i++) {
-//            selectedInvokers.clear();
-//            selectedInvokers.add(invoker2);
-//            selectedInvokers.add(invoker4);
-//            Invoker sinvoker = cluster.select(lb, invocation, invokers, selectedInvokers);
-//            Assertions.assertTrue(sinvoker.isAvailable());
-//
-//            Mockito.clearInvocations(invoker1, invoker2, invoker3, invoker4, invoker5);
-//        }
-//        for (int i = 0; i < runs; i++) {
-//            selectedInvokers.clear();
-//            selectedInvokers.add(invoker1);
-//            selectedInvokers.add(invoker3);
-//            selectedInvokers.add(invoker5);
-//            Invoker sinvoker = cluster.select(lb, invocation, invokers, selectedInvokers);
-//            Assertions.assertTrue(sinvoker.isAvailable());
-//
-//            Mockito.clearInvocations(invoker1, invoker2, invoker3, invoker4, invoker5);
-//        }
-//        for (int i = 0; i < runs; i++) {
-//
-//            selectedInvokers.clear();
-//            selectedInvokers.add(invoker1);
-//            selectedInvokers.add(invoker2);
-//            selectedInvokers.add(invoker3);
-//            Invoker sinvoker = cluster.select(lb, invocation, invokers, selectedInvokers);
-//            Assertions.assertTrue(sinvoker.isAvailable());
-//
-//            Mockito.clearInvocations(invoker1, invoker2, invoker3, invoker4, invoker5);
-//        }
-//    }
-//
-//    /**
-//     * Test balance.
-//     */
-//    @Test
-//    public void testSelectBalance() {
-//
-//        LoadBalance lb = ExtensionLoader.getExtensionLoader(LoadBalance.class).getExtension(RoundRobinLoadBalance.NAME);
-//        initlistsize5();
-//
-//        Map<Invoker, AtomicLong> counter = new ConcurrentHashMap<Invoker, AtomicLong>();
-//        for (Invoker invoker : invokers) {
-//            counter.put(invoker, new AtomicLong(0));
-//        }
-//        int runs = 1000;
-//        for (int i = 0; i < runs; i++) {
-//            selectedInvokers.clear();
-//            Invoker sinvoker = cluster.select(lb, invocation, invokers, selectedInvokers);
-//            counter.get(sinvoker).incrementAndGet();
-//        }
-//
-//        for (Map.Entry<Invoker, AtomicLong> entry : counter.entrySet()) {
-//            Long count = entry.getValue().get();
-////            System.out.println(count);
-//            if (entry.getKey().isAvailable())
-//                Assertions.assertTrue(count > runs / invokers.size(),"count should > avg");
-//        }
-//
-//        Assertions.assertEquals(runs, counter.get(invoker2).get() + counter.get(invoker4).get());
-//
-//    }
-//
-//    private void initlistsize5() {
-//        invokers.clear();
-//        selectedInvokers.clear();//Clear first, previous test case will make sure that the right invoker2 will be used.
-//        invokers.add(invoker1);
-//        invokers.add(invoker2);
-//        invokers.add(invoker3);
-//        invokers.add(invoker4);
-//        invokers.add(invoker5);
-//    }
-//
-//    private void initDic() {
-//        dic.buildRouterChain();
-//    }
-//
-//    @Test()
-//    public void testTimeoutExceptionCode() {
-//        List<Invoker<DemoService>> invokers = new ArrayList<Invoker<DemoService>>();
-//        invokers.add(new Invoker<DemoService>() {
-//
-//            @Override
-//            public Class<DemoService> getInterface() {
-//                return DemoService.class;
-//            }
-//
-//            public URL getUrl() {
-//                return URL.valueOf("dubbo://" + NetUtils.getLocalHost() + ":20880/" + DemoService.class.getName());
-//            }
-//
-//            @Override
-//            public boolean isAvailable() {
-//                return false;
-//            }
-//
-//            @Override
-//            public Result invoke(Invocation invocation) throws RpcException {
-//                throw new RpcException(RpcException.TIMEOUT_EXCEPTION, "test timeout");
-//            }
-//
-//            @Override
-//            public void destroy() {
-//            }
-//        });
-//        Directory<DemoService> directory = new StaticDirectory<DemoService>(invokers);
-//        FailoverClusterInvoker<DemoService> failoverClusterInvoker = new FailoverClusterInvoker<DemoService>(directory);
-//        try {
-//            failoverClusterInvoker.invoke(new RpcInvocation("sayHello", DemoService.class.getName(), "", new Class<?>[0], new Object[0]));
-//            Assertions.fail();
-//        } catch (RpcException e) {
-//            Assertions.assertEquals(RpcException.TIMEOUT_EXCEPTION, e.getCode());
-//        }
-//        ForkingClusterInvoker<DemoService> forkingClusterInvoker = new ForkingClusterInvoker<DemoService>(directory);
-//        try {
-//            forkingClusterInvoker.invoke(new RpcInvocation("sayHello", DemoService.class.getName(), "", new Class<?>[0], new Object[0]));
-//            Assertions.fail();
-//        } catch (RpcException e) {
-//            Assertions.assertEquals(RpcException.TIMEOUT_EXCEPTION, e.getCode());
-//        }
-//        FailfastClusterInvoker<DemoService> failfastClusterInvoker = new FailfastClusterInvoker<DemoService>(directory);
-//        try {
-//            failfastClusterInvoker.invoke(new RpcInvocation("sayHello", DemoService.class.getName(), "", new Class<?>[0], new Object[0]));
-//            Assertions.fail();
-//        } catch (RpcException e) {
-//            Assertions.assertEquals(RpcException.TIMEOUT_EXCEPTION, e.getCode());
-//        }
-//    }
-//
-//    /**
-//     * Test mock invoker selector works as expected
-//     */
-//    @Test
-//    public void testMockedInvokerSelect() {
-//        initlistsize5();
-//        invokers.add(mockedInvoker1);
-//
-//        initDic();
-//
-//        RpcInvocation mockedInvocation = new RpcInvocation();
-//        mockedInvocation.setMethodName("sayHello");
-//        mockedInvocation.setAttachment(INVOCATION_NEED_MOCK, "true");
-//        List<Invoker<IHelloService>> mockedInvokers = dic.list(mockedInvocation);
-//        Assertions.assertEquals(1, mockedInvokers.size());
-//
-//        List<Invoker<IHelloService>> invokers = dic.list(invocation);
-//        Assertions.assertEquals(5, invokers.size());
-//    }
-//
-//    public static interface IHelloService {
-//    }
-//}
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.rpc.cluster.support;
+
+import org.apache.dubbo.common.URL;
+import org.apache.dubbo.common.URLBuilder;
+import org.apache.dubbo.common.extension.ExtensionLoader;
+import org.apache.dubbo.common.utils.NetUtils;
+import org.apache.dubbo.rpc.Invocation;
+import org.apache.dubbo.rpc.Invoker;
+import org.apache.dubbo.rpc.Result;
+import org.apache.dubbo.rpc.RpcContext;
+import org.apache.dubbo.rpc.RpcException;
+import org.apache.dubbo.rpc.RpcInvocation;
+import org.apache.dubbo.rpc.cluster.Directory;
+import org.apache.dubbo.rpc.cluster.LoadBalance;
+import org.apache.dubbo.rpc.cluster.directory.StaticDirectory;
+import org.apache.dubbo.rpc.cluster.filter.DemoService;
+import org.apache.dubbo.rpc.cluster.loadbalance.LeastActiveLoadBalance;
+import org.apache.dubbo.rpc.cluster.loadbalance.RandomLoadBalance;
+import org.apache.dubbo.rpc.cluster.loadbalance.RoundRobinLoadBalance;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.apache.dubbo.common.constants.CommonConstants.DUBBO;
+import static org.apache.dubbo.common.constants.CommonConstants.INTERFACE_KEY;
+import static org.apache.dubbo.common.constants.CommonConstants.MONITOR_KEY;
+import static org.apache.dubbo.common.constants.CommonConstants.PATH_KEY;
+import static org.apache.dubbo.common.constants.CommonConstants.PROTOCOL_KEY;
+import static org.apache.dubbo.rpc.cluster.Constants.CLUSTER_AVAILABLE_CHECK_KEY;
+import static org.apache.dubbo.rpc.cluster.Constants.INVOCATION_NEED_MOCK;
+import static org.apache.dubbo.rpc.cluster.Constants.REFER_KEY;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+/**
+ * AbstractClusterInvokerTest
+ */
+@SuppressWarnings("rawtypes")
+public class AbstractClusterInvokerTest {
+    List<Invoker<IHelloService>> invokers = new ArrayList<Invoker<IHelloService>>();
+    List<Invoker<IHelloService>> selectedInvokers = new ArrayList<Invoker<IHelloService>>();
+    AbstractClusterInvoker<IHelloService> cluster;
+    AbstractClusterInvoker<IHelloService> cluster_nocheck;
+    StaticDirectory<IHelloService> dic;
+    RpcInvocation invocation = new RpcInvocation();
+    URL url = URL.valueOf("registry://localhost:9090/org.apache.dubbo.rpc.cluster.support.AbstractClusterInvokerTest.IHelloService?refer=" + URL.encode("application=abstractClusterInvokerTest"));
+
+    Invoker<IHelloService> invoker1;
+    Invoker<IHelloService> invoker2;
+    Invoker<IHelloService> invoker3;
+    Invoker<IHelloService> invoker4;
+    Invoker<IHelloService> invoker5;
+    Invoker<IHelloService> mockedInvoker1;
+
+
+    @BeforeAll
+    public static void setUpBeforeClass() throws Exception {
+    }
+
+    @AfterEach
+    public void teardown() throws Exception {
+        RpcContext.getContext().clearAttachments();
+    }
+
+    @SuppressWarnings({"unchecked"})
+    @BeforeEach
+    public void setUp() throws Exception {
+        Map<String, Object> attributes = new HashMap<>();
+        attributes.put("application", "abstractClusterInvokerTest");
+        url = url.putAttribute(REFER_KEY, attributes);
+
+        invocation.setMethodName("sayHello");
+
+        invoker1 = mock(Invoker.class);
+        invoker2 = mock(Invoker.class);
+        invoker3 = mock(Invoker.class);
+        invoker4 = mock(Invoker.class);
+        invoker5 = mock(Invoker.class);
+        mockedInvoker1 = mock(Invoker.class);
+
+        URL turl = URL.valueOf("test://test:11/test");
+
+        given(invoker1.isAvailable()).willReturn(false);
+        given(invoker1.getInterface()).willReturn(IHelloService.class);
+        given(invoker1.getUrl()).willReturn(turl.setPort(1).addParameter("name", "invoker1"));
+
+        given(invoker2.isAvailable()).willReturn(true);
+        given(invoker2.getInterface()).willReturn(IHelloService.class);
+        given(invoker2.getUrl()).willReturn(turl.setPort(2).addParameter("name", "invoker2"));
+
+        given(invoker3.isAvailable()).willReturn(false);
+        given(invoker3.getInterface()).willReturn(IHelloService.class);
+        given(invoker3.getUrl()).willReturn(turl.setPort(3).addParameter("name", "invoker3"));
+
+        given(invoker4.isAvailable()).willReturn(true);
+        given(invoker4.getInterface()).willReturn(IHelloService.class);
+        given(invoker4.getUrl()).willReturn(turl.setPort(4).addParameter("name", "invoker4"));
+
+        given(invoker5.isAvailable()).willReturn(false);
+        given(invoker5.getInterface()).willReturn(IHelloService.class);
+        given(invoker5.getUrl()).willReturn(turl.setPort(5).addParameter("name", "invoker5"));
+
+        given(mockedInvoker1.isAvailable()).willReturn(false);
+        given(mockedInvoker1.getInterface()).willReturn(IHelloService.class);
+        given(mockedInvoker1.getUrl()).willReturn(turl.setPort(999).setProtocol("mock"));
+
+        invokers.add(invoker1);
+        dic = new StaticDirectory<IHelloService>(url, invokers, null);
+        cluster = new AbstractClusterInvoker(dic) {
+            @Override
+            protected Result doInvoke(Invocation invocation, List invokers, LoadBalance loadbalance)
+                    throws RpcException {
+                return null;
+            }
+        };
+
+        cluster_nocheck = new AbstractClusterInvoker(dic, url.addParameterIfAbsent(CLUSTER_AVAILABLE_CHECK_KEY, Boolean.FALSE.toString())) {
+            @Override
+            protected Result doInvoke(Invocation invocation, List invokers, LoadBalance loadbalance)
+                    throws RpcException {
+                return null;
+            }
+        };
+
+    }
+
+
+    @Test
+    public void testBindingAttachment() {
+        final String attachKey = "attach";
+        final String attachValue = "value";
+
+        // setup attachment
+        RpcContext.getContext().setAttachment(attachKey, attachValue);
+        Map<String, Object> attachments = RpcContext.getContext().getObjectAttachments();
+        Assertions.assertTrue( attachments != null && attachments.size() == 1,"set attachment failed!");
+
+        cluster = new AbstractClusterInvoker(dic) {
+            @Override
+            protected Result doInvoke(Invocation invocation, List invokers, LoadBalance loadbalance)
+                    throws RpcException {
+                // attachment will be bind to invocation
+                String value = invocation.getAttachment(attachKey);
+                Assertions.assertNotNull(value);
+                Assertions.assertEquals(attachValue, value, "binding attachment failed!");
+                return null;
+            }
+        };
+
+        // invoke
+        cluster.invoke(invocation);
+    }
+
+    @Test
+    public void testSelect_Invokersize0() throws Exception {
+        LoadBalance l = cluster.initLoadBalance(invokers, invocation);
+        Assertions.assertNotNull(l,"cluster.initLoadBalance returns null!");
+        {
+            Invoker invoker = cluster.select(l, null, null, null);
+            Assertions.assertNull(invoker);
+        }
+        {
+            invokers.clear();
+            selectedInvokers.clear();
+            Invoker invoker = cluster.select(l, null, invokers, null);
+            Assertions.assertNull(invoker);
+        }
+    }
+
+    @Test
+    public void testSelect_Invokersize1() throws Exception {
+        invokers.clear();
+        invokers.add(invoker1);
+        LoadBalance l = cluster.initLoadBalance(invokers, invocation);
+        Assertions.assertNotNull(l,"cluster.initLoadBalance returns null!");
+        Invoker invoker = cluster.select(l, null, invokers, null);
+        Assertions.assertEquals(invoker1, invoker);
+    }
+
+    @Test
+    public void testSelect_Invokersize2AndselectNotNull() throws Exception {
+        invokers.clear();
+        invokers.add(invoker2);
+        invokers.add(invoker4);
+        LoadBalance l = cluster.initLoadBalance(invokers, invocation);
+        Assertions.assertNotNull(l,"cluster.initLoadBalance returns null!");
+        {
+            selectedInvokers.clear();
+            selectedInvokers.add(invoker4);
+            Invoker invoker = cluster.select(l, invocation, invokers, selectedInvokers);
+            Assertions.assertEquals(invoker2, invoker);
+        }
+        {
+            selectedInvokers.clear();
+            selectedInvokers.add(invoker2);
+            Invoker invoker = cluster.select(l, invocation, invokers, selectedInvokers);
+            Assertions.assertEquals(invoker4, invoker);
+        }
+    }
+
+    @Test
+    public void testSelect_multiInvokers() throws Exception {
+        testSelect_multiInvokers(RoundRobinLoadBalance.NAME);
+        testSelect_multiInvokers(LeastActiveLoadBalance.NAME);
+        testSelect_multiInvokers(RandomLoadBalance.NAME);
+    }
+
+    @Test
+    public void testCloseAvailablecheck() {
+        LoadBalance lb = mock(LoadBalance.class);
+        Map<String, String> queryMap = (Map<String, String> )url.getAttribute(REFER_KEY);
+        URL tmpUrl = turnRegistryUrlToConsumerUrl(url, queryMap);
+        given(lb.select(invokers, tmpUrl, invocation)).willReturn(invoker1);
+        initlistsize5();
+
+        Invoker sinvoker = cluster_nocheck.select(lb, invocation, invokers, selectedInvokers);
+        Assertions.assertFalse(sinvoker.isAvailable());
+        Assertions.assertEquals(invoker1, sinvoker);
+
+    }
+
+    private URL turnRegistryUrlToConsumerUrl(URL url, Map<String, String> queryMap) {
+        return URLBuilder.from(url)
+                .setProtocol(queryMap.get(PROTOCOL_KEY) == null ? DUBBO : queryMap.get(PROTOCOL_KEY))
+                .setPath(queryMap.get(PATH_KEY) != null ? queryMap.get(PATH_KEY) : queryMap.get(INTERFACE_KEY))
+                .clearParameters()
+                .addParameters(queryMap)
+                .removeParameter(MONITOR_KEY)
+                .build();
+    }
+
+    @Test
+    public void testDonotSelectAgainAndNoCheckAvailable() {
+
+        LoadBalance lb = ExtensionLoader.getExtensionLoader(LoadBalance.class).getExtension(RoundRobinLoadBalance.NAME);
+        initlistsize5();
+        {
+            //Boundary condition test .
+            selectedInvokers.clear();
+            selectedInvokers.add(invoker2);
+            selectedInvokers.add(invoker3);
+            selectedInvokers.add(invoker4);
+            selectedInvokers.add(invoker5);
+            Invoker sinvoker = cluster_nocheck.select(lb, invocation, invokers, selectedInvokers);
+            Assertions.assertSame(invoker1, sinvoker);
+        }
+        {
+            //Boundary condition test .
+            selectedInvokers.clear();
+            selectedInvokers.add(invoker1);
+            selectedInvokers.add(invoker3);
+            selectedInvokers.add(invoker4);
+            selectedInvokers.add(invoker5);
+            Invoker sinvoker = cluster_nocheck.select(lb, invocation, invokers, selectedInvokers);
+            Assertions.assertSame(invoker2, sinvoker);
+        }
+        {
+            //Boundary condition test .
+            selectedInvokers.clear();
+            selectedInvokers.add(invoker1);
+            selectedInvokers.add(invoker2);
+            selectedInvokers.add(invoker4);
+            selectedInvokers.add(invoker5);
+            Invoker sinvoker = cluster_nocheck.select(lb, invocation, invokers, selectedInvokers);
+            Assertions.assertSame(invoker3, sinvoker);
+        }
+        {
+            //Boundary condition test .
+            selectedInvokers.clear();
+            selectedInvokers.add(invoker1);
+            selectedInvokers.add(invoker2);
+            selectedInvokers.add(invoker3);
+            selectedInvokers.add(invoker4);
+            Invoker sinvoker = cluster_nocheck.select(lb, invocation, invokers, selectedInvokers);
+            Assertions.assertSame(invoker5, sinvoker);
+        }
+        {
+            //Boundary condition test .
+            selectedInvokers.clear();
+            selectedInvokers.add(invoker1);
+            selectedInvokers.add(invoker2);
+            selectedInvokers.add(invoker3);
+            selectedInvokers.add(invoker4);
+            selectedInvokers.add(invoker5);
+            Invoker sinvoker = cluster_nocheck.select(lb, invocation, invokers, selectedInvokers);
+            Assertions.assertTrue(invokers.contains(sinvoker));
+        }
+
+    }
+
+    @Test
+    public void testSelectAgainAndCheckAvailable() {
+
+        LoadBalance lb = ExtensionLoader.getExtensionLoader(LoadBalance.class).getExtension(RoundRobinLoadBalance.NAME);
+        initlistsize5();
+        {
+            //Boundary condition test .
+            selectedInvokers.clear();
+            selectedInvokers.add(invoker1);
+            selectedInvokers.add(invoker2);
+            selectedInvokers.add(invoker3);
+            selectedInvokers.add(invoker5);
+            Invoker sinvoker = cluster.select(lb, invocation, invokers, selectedInvokers);
+            Assertions.assertSame(sinvoker, invoker4);
+        }
+        {
+            //Boundary condition test .
+            selectedInvokers.clear();
+            selectedInvokers.add(invoker2);
+            selectedInvokers.add(invoker3);
+            selectedInvokers.add(invoker4);
+            selectedInvokers.add(invoker5);
+            Invoker sinvoker = cluster.select(lb, invocation, invokers, selectedInvokers);
+            Assertions.assertTrue(sinvoker == invoker2 || sinvoker == invoker4);
+        }
+        {
+            //Boundary condition test .
+            for (int i = 0; i < 100; i++) {
+                selectedInvokers.clear();
+                Invoker sinvoker = cluster.select(lb, invocation, invokers, selectedInvokers);
+                Assertions.assertTrue(sinvoker == invoker2 || sinvoker == invoker4);
+            }
+        }
+        {
+            //Boundary condition test .
+            for (int i = 0; i < 100; i++) {
+                selectedInvokers.clear();
+                selectedInvokers.add(invoker1);
+                selectedInvokers.add(invoker3);
+                selectedInvokers.add(invoker5);
+                Invoker sinvoker = cluster.select(lb, invocation, invokers, selectedInvokers);
+                Assertions.assertTrue(sinvoker == invoker2 || sinvoker == invoker4);
+            }
+        }
+        {
+            //Boundary condition test .
+            for (int i = 0; i < 100; i++) {
+                selectedInvokers.clear();
+                selectedInvokers.add(invoker1);
+                selectedInvokers.add(invoker3);
+                selectedInvokers.add(invoker2);
+                selectedInvokers.add(invoker4);
+                selectedInvokers.add(invoker5);
+                Invoker sinvoker = cluster.select(lb, invocation, invokers, selectedInvokers);
+                Assertions.assertTrue(sinvoker == invoker2 || sinvoker == invoker4);
+            }
+        }
+    }
+
+
+    public void testSelect_multiInvokers(String lbname) throws Exception {
+
+        int min = 1000, max = 5000;
+        Double d = (Math.random() * (max - min + 1) + min);
+        int runs = d.intValue();
+        Assertions.assertTrue(runs > min);
+        LoadBalance lb = ExtensionLoader.getExtensionLoader(LoadBalance.class).getExtension(lbname);
+        initlistsize5();
+        for (int i = 0; i < runs; i++) {
+            Invoker sinvoker = cluster.select(lb, invocation, invokers, selectedInvokers);
+            Assertions.assertTrue(sinvoker.isAvailable());
+
+            Mockito.clearInvocations(invoker1, invoker2, invoker3, invoker4, invoker5);
+        }
+        for (int i = 0; i < runs; i++) {
+            selectedInvokers.clear();
+            selectedInvokers.add(invoker1);
+            Invoker sinvoker = cluster.select(lb, invocation, invokers, selectedInvokers);
+            Assertions.assertTrue(sinvoker.isAvailable());
+
+            Mockito.clearInvocations(invoker1, invoker2, invoker3, invoker4, invoker5);
+        }
+        for (int i = 0; i < runs; i++) {
+            selectedInvokers.clear();
+            selectedInvokers.add(invoker2);
+            Invoker sinvoker = cluster.select(lb, invocation, invokers, selectedInvokers);
+            Assertions.assertTrue(sinvoker.isAvailable());
+
+            Mockito.clearInvocations(invoker1, invoker2, invoker3, invoker4, invoker5);
+        }
+        for (int i = 0; i < runs; i++) {
+            selectedInvokers.clear();
+            selectedInvokers.add(invoker2);
+            selectedInvokers.add(invoker4);
+            Invoker sinvoker = cluster.select(lb, invocation, invokers, selectedInvokers);
+            Assertions.assertTrue(sinvoker.isAvailable());
+
+            Mockito.clearInvocations(invoker1, invoker2, invoker3, invoker4, invoker5);
+        }
+        for (int i = 0; i < runs; i++) {
+            selectedInvokers.clear();
+            selectedInvokers.add(invoker1);
+            selectedInvokers.add(invoker3);
+            selectedInvokers.add(invoker5);
+            Invoker sinvoker = cluster.select(lb, invocation, invokers, selectedInvokers);
+            Assertions.assertTrue(sinvoker.isAvailable());
+
+            Mockito.clearInvocations(invoker1, invoker2, invoker3, invoker4, invoker5);
+        }
+        for (int i = 0; i < runs; i++) {
+
+            selectedInvokers.clear();
+            selectedInvokers.add(invoker1);
+            selectedInvokers.add(invoker2);
+            selectedInvokers.add(invoker3);
+            Invoker sinvoker = cluster.select(lb, invocation, invokers, selectedInvokers);
+            Assertions.assertTrue(sinvoker.isAvailable());
+
+            Mockito.clearInvocations(invoker1, invoker2, invoker3, invoker4, invoker5);
+        }
+    }
+
+    /**
+     * Test balance.
+     */
+    @Test
+    public void testSelectBalance() {
+
+        LoadBalance lb = ExtensionLoader.getExtensionLoader(LoadBalance.class).getExtension(RoundRobinLoadBalance.NAME);
+        initlistsize5();
+
+        Map<Invoker, AtomicLong> counter = new ConcurrentHashMap<Invoker, AtomicLong>();
+        for (Invoker invoker : invokers) {
+            counter.put(invoker, new AtomicLong(0));
+        }
+        int runs = 1000;
+        for (int i = 0; i < runs; i++) {
+            selectedInvokers.clear();
+            Invoker sinvoker = cluster.select(lb, invocation, invokers, selectedInvokers);
+            counter.get(sinvoker).incrementAndGet();
+        }
+
+        for (Map.Entry<Invoker, AtomicLong> entry : counter.entrySet()) {
+            Long count = entry.getValue().get();
+//            System.out.println(count);
+            if (entry.getKey().isAvailable())
+                Assertions.assertTrue(count > runs / invokers.size(),"count should > avg");
+        }
+
+        Assertions.assertEquals(runs, counter.get(invoker2).get() + counter.get(invoker4).get());
+
+    }
+
+    private void initlistsize5() {
+        invokers.clear();
+        selectedInvokers.clear();//Clear first, previous test case will make sure that the right invoker2 will be used.
+        invokers.add(invoker1);
+        invokers.add(invoker2);
+        invokers.add(invoker3);
+        invokers.add(invoker4);
+        invokers.add(invoker5);
+    }
+
+    private void initDic() {
+        dic.buildRouterChain();
+    }
+
+    @Test()
+    public void testTimeoutExceptionCode() {
+        List<Invoker<DemoService>> invokers = new ArrayList<Invoker<DemoService>>();
+        invokers.add(new Invoker<DemoService>() {
+
+            @Override
+            public Class<DemoService> getInterface() {
+                return DemoService.class;
+            }
+
+            public URL getUrl() {
+                return URL.valueOf("dubbo://" + NetUtils.getLocalHost() + ":20880/" + DemoService.class.getName());
+            }
+
+            @Override
+            public boolean isAvailable() {
+                return false;
+            }
+
+            @Override
+            public Result invoke(Invocation invocation) throws RpcException {
+                throw new RpcException(RpcException.TIMEOUT_EXCEPTION, "test timeout");
+            }
+
+            @Override
+            public void destroy() {
+            }
+        });
+        Directory<DemoService> directory = new StaticDirectory<DemoService>(invokers);
+        FailoverClusterInvoker<DemoService> failoverClusterInvoker = new FailoverClusterInvoker<DemoService>(directory);
+        try {
+            failoverClusterInvoker.invoke(new RpcInvocation("sayHello", DemoService.class.getName(), "", new Class<?>[0], new Object[0]));
+            Assertions.fail();
+        } catch (RpcException e) {
+            Assertions.assertEquals(RpcException.TIMEOUT_EXCEPTION, e.getCode());
+        }
+        ForkingClusterInvoker<DemoService> forkingClusterInvoker = new ForkingClusterInvoker<DemoService>(directory);
+        try {
+            forkingClusterInvoker.invoke(new RpcInvocation("sayHello", DemoService.class.getName(), "", new Class<?>[0], new Object[0]));
+            Assertions.fail();
+        } catch (RpcException e) {
+            Assertions.assertEquals(RpcException.TIMEOUT_EXCEPTION, e.getCode());
+        }
+        FailfastClusterInvoker<DemoService> failfastClusterInvoker = new FailfastClusterInvoker<DemoService>(directory);
+        try {
+            failfastClusterInvoker.invoke(new RpcInvocation("sayHello", DemoService.class.getName(), "", new Class<?>[0], new Object[0]));
+            Assertions.fail();
+        } catch (RpcException e) {
+            Assertions.assertEquals(RpcException.TIMEOUT_EXCEPTION, e.getCode());
+        }
+    }
+
+    /**
+     * Test mock invoker selector works as expected
+     */
+    @Test
+    public void testMockedInvokerSelect() {
+        initlistsize5();
+        invokers.add(mockedInvoker1);
+
+        initDic();
+
+        RpcInvocation mockedInvocation = new RpcInvocation();
+        mockedInvocation.setMethodName("sayHello");
+        mockedInvocation.setAttachment(INVOCATION_NEED_MOCK, "true");
+        List<Invoker<IHelloService>> mockedInvokers = dic.list(mockedInvocation);
+        Assertions.assertEquals(1, mockedInvokers.size());
+
+        List<Invoker<IHelloService>> invokers = dic.list(invocation);
+        Assertions.assertEquals(5, invokers.size());
+    }
+
+    public static interface IHelloService {
+    }
+}

--- a/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/support/wrapper/MockClusterInvokerTest.java
+++ b/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/support/wrapper/MockClusterInvokerTest.java
@@ -1,846 +1,846 @@
-/*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-package org.apache.dubbo.rpc.cluster.support.wrapper;
-
-import org.apache.dubbo.common.URL;
-import org.apache.dubbo.common.extension.ExtensionLoader;
-import org.apache.dubbo.rpc.Invocation;
-import org.apache.dubbo.rpc.Invoker;
-import org.apache.dubbo.rpc.Protocol;
-import org.apache.dubbo.rpc.ProxyFactory;
-import org.apache.dubbo.rpc.Result;
-import org.apache.dubbo.rpc.RpcException;
-import org.apache.dubbo.rpc.RpcInvocation;
-import org.apache.dubbo.rpc.cluster.LoadBalance;
-import org.apache.dubbo.rpc.cluster.directory.StaticDirectory;
-import org.apache.dubbo.rpc.cluster.support.AbstractClusterInvoker;
-import org.apache.dubbo.rpc.support.MockProtocol;
-
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-
-import static org.apache.dubbo.common.constants.CommonConstants.PATH_KEY;
-import static org.apache.dubbo.rpc.Constants.MOCK_KEY;
-import static org.apache.dubbo.rpc.cluster.Constants.REFER_KEY;
-
-public class MockClusterInvokerTest {
-
-    List<Invoker<IHelloService>> invokers = new ArrayList<Invoker<IHelloService>>();
-
-    @BeforeEach
-    public void beforeMethod() {
-        invokers.clear();
-    }
-
-    /**
-     * Test if mock policy works fine: fail-mock
-     */
-    @Test
-    public void testMockInvokerInvoke_normal() {
-        URL url = URL.valueOf("remote://1.2.3.4/" + IHelloService.class.getName());
-        url = url.addParameter(MOCK_KEY, "fail")
-                .addParameter(REFER_KEY, URL.encode(PATH_KEY + "=" + IHelloService.class.getName()));
-        Invoker<IHelloService> cluster = getClusterInvoker(url);
-        URL mockUrl = URL.valueOf("mock://localhost/" + IHelloService.class.getName()
-                + "?getSomething.mock=return aa");
-
-        Protocol protocol = new MockProtocol();
-        Invoker<IHelloService> mInvoker1 = protocol.refer(IHelloService.class, mockUrl);
-        invokers.add(mInvoker1);
-
-        //Configured with mock
-        RpcInvocation invocation = new RpcInvocation();
-        invocation.setMethodName("getSomething");
-        Result ret = cluster.invoke(invocation);
-        Assertions.assertEquals("something", ret.getValue());
-
-        // If no mock was configured, return null directly
-        invocation = new RpcInvocation();
-        invocation.setMethodName("sayHello");
-        ret = cluster.invoke(invocation);
-        Assertions.assertNull(ret.getValue());
-    }
-
-    /**
-     * Test if mock policy works fine: fail-mock
-     */
-    @Test
-    public void testMockInvokerInvoke_failmock() {
-        URL url = URL.valueOf("remote://1.2.3.4/" + IHelloService.class.getName())
-                .addParameter(MOCK_KEY, "fail:return null")
-                .addParameter(REFER_KEY, URL.encode(PATH_KEY + "=" + IHelloService.class.getName()))
-                .addParameter("invoke_return_error", "true");
-        URL mockUrl = URL.valueOf("mock://localhost/" + IHelloService.class.getName()
-                + "?getSomething.mock=return aa").addParameters(url.getParameters());
-
-        Protocol protocol = new MockProtocol();
-        Invoker<IHelloService> mInvoker1 = protocol.refer(IHelloService.class, mockUrl);
-        Invoker<IHelloService> cluster = getClusterInvokerMock(url, mInvoker1);
-
-        //Configured with mock
-        RpcInvocation invocation = new RpcInvocation();
-        invocation.setMethodName("getSomething");
-        Result ret = cluster.invoke(invocation);
-        Assertions.assertEquals("aa", ret.getValue());
-
-        // If no mock was configured, return null directly
-        invocation = new RpcInvocation();
-        invocation.setMethodName("getSomething2");
-        ret = cluster.invoke(invocation);
-        Assertions.assertNull(ret.getValue());
-
-        // If no mock was configured, return null directly
-        invocation = new RpcInvocation();
-        invocation.setMethodName("sayHello");
-        ret = cluster.invoke(invocation);
-        Assertions.assertNull(ret.getValue());
-    }
-
-
-    /**
-     * Test if mock policy works fine: force-mock
-     */
-    @Test
-    public void testMockInvokerInvoke_forcemock() {
-        URL url = URL.valueOf("remote://1.2.3.4/" + IHelloService.class.getName());
-        url = url.addParameter(MOCK_KEY, "force:return null")
-                .addParameter(REFER_KEY, URL.encode(PATH_KEY + "=" + IHelloService.class.getName()));
-
-        URL mockUrl = URL.valueOf("mock://localhost/" + IHelloService.class.getName()
-                + "?getSomething.mock=return aa&getSomething3xx.mock=return xx")
-                .addParameters(url.getParameters());
-
-        Protocol protocol = new MockProtocol();
-        Invoker<IHelloService> mInvoker1 = protocol.refer(IHelloService.class, mockUrl);
-        Invoker<IHelloService> cluster = getClusterInvokerMock(url, mInvoker1);
-
-        //Configured with mock
-        RpcInvocation invocation = new RpcInvocation();
-        invocation.setMethodName("getSomething");
-        Result ret = cluster.invoke(invocation);
-        Assertions.assertEquals("aa", ret.getValue());
-
-        // If no mock was configured, return null directly
-        invocation = new RpcInvocation();
-        invocation.setMethodName("getSomething2");
-        ret = cluster.invoke(invocation);
-        Assertions.assertNull(ret.getValue());
-
-        // If no mock was configured, return null directly
-        invocation = new RpcInvocation();
-        invocation.setMethodName("sayHello");
-        ret = cluster.invoke(invocation);
-        Assertions.assertNull(ret.getValue());
-    }
-
-    @Test
-    public void testMockInvokerInvoke_forcemock_defaultreturn() {
-        URL url = URL.valueOf("remote://1.2.3.4/" + IHelloService.class.getName());
-        url = url.addParameter(MOCK_KEY, "force")
-                .addParameter(REFER_KEY, URL.encode(PATH_KEY + "=" + IHelloService.class.getName()));
-
-        Invoker<IHelloService> cluster = getClusterInvoker(url);
-        URL mockUrl = URL.valueOf("mock://localhost/" + IHelloService.class.getName()
-                + "?getSomething.mock=return aa&getSomething3xx.mock=return xx&sayHello.mock=return ")
-                .addParameters(url.getParameters());
-
-        Protocol protocol = new MockProtocol();
-        Invoker<IHelloService> mInvoker1 = protocol.refer(IHelloService.class, mockUrl);
-        invokers.add(mInvoker1);
-
-        RpcInvocation invocation = new RpcInvocation();
-        invocation.setMethodName("sayHello");
-        Result ret = cluster.invoke(invocation);
-        Assertions.assertNull(ret.getValue());
-    }
-
-    /**
-     * Test if mock policy works fine: fail-mock
-     */
-    @Test
-    public void testMockInvokerFromOverride_Invoke_Fock_someMethods() {
-        URL url = URL.valueOf("remote://1.2.3.4/" + IHelloService.class.getName())
-                .addParameter("getSomething.mock", "fail:return x")
-                .addParameter("getSomething2.mock", "force:return y")
-                .addParameter(REFER_KEY, URL.encode(PATH_KEY + "=" + IHelloService.class.getName()));
-        Invoker<IHelloService> cluster = getClusterInvoker(url);
-        //Configured with mock
-        RpcInvocation invocation = new RpcInvocation();
-        invocation.setMethodName("getSomething");
-        Result ret = cluster.invoke(invocation);
-        Assertions.assertEquals("something", ret.getValue());
-
-        // If no mock was configured, return null directly
-        invocation = new RpcInvocation();
-        invocation.setMethodName("getSomething2");
-        ret = cluster.invoke(invocation);
-        Assertions.assertEquals("y", ret.getValue());
-
-        // If no mock was configured, return null directly
-        invocation = new RpcInvocation();
-        invocation.setMethodName("getSomething3");
-        ret = cluster.invoke(invocation);
-        Assertions.assertEquals("something3", ret.getValue());
-
-        // If no mock was configured, return null directly
-        invocation = new RpcInvocation();
-        invocation.setMethodName("sayHello");
-        ret = cluster.invoke(invocation);
-        Assertions.assertNull(ret.getValue());
-    }
-
-    /**
-     * Test if mock policy works fine: fail-mock
-     */
-    @Test
-    public void testMockInvokerFromOverride_Invoke_Fock_WithOutDefault() {
-        URL url = URL.valueOf("remote://1.2.3.4/" + IHelloService.class.getName())
-                .addParameter("getSomething.mock", "fail:return x")
-                .addParameter("getSomething2.mock", "force:return y")
-                .addParameter(REFER_KEY, URL.encode(PATH_KEY + "=" + IHelloService.class.getName()))
-                .addParameter("invoke_return_error", "true");
-        Invoker<IHelloService> cluster = getClusterInvoker(url);
-        //Configured with mock
-        RpcInvocation invocation = new RpcInvocation();
-        invocation.setMethodName("getSomething");
-        Result ret = cluster.invoke(invocation);
-        Assertions.assertEquals("x", ret.getValue());
-
-        // If no mock was configured, return null directly
-        invocation = new RpcInvocation();
-        invocation.setMethodName("getSomething2");
-        ret = cluster.invoke(invocation);
-        Assertions.assertEquals("y", ret.getValue());
-
-        // If no mock was configured, return null directly
-        invocation = new RpcInvocation();
-        invocation.setMethodName("getSomething3");
-        try {
-            ret = cluster.invoke(invocation);
-            Assertions.fail();
-        } catch (RpcException e) {
-
-        }
-    }
-
-    /**
-     * Test if mock policy works fine: fail-mock
-     */
-    @Test
-    public void testMockInvokerFromOverride_Invoke_Fock_WithDefault() {
-        URL url = URL.valueOf("remote://1.2.3.4/" + IHelloService.class.getName())
-                .addParameter("mock", "fail:return null")
-                .addParameter("getSomething.mock", "fail:return x")
-                .addParameter("getSomething2.mock", "force:return y")
-                .addParameter(REFER_KEY, URL.encode(PATH_KEY + "=" + IHelloService.class.getName()))
-                .addParameter("invoke_return_error", "true");
-        Invoker<IHelloService> cluster = getClusterInvoker(url);
-        //Configured with mock
-        RpcInvocation invocation = new RpcInvocation();
-        invocation.setMethodName("getSomething");
-        Result ret = cluster.invoke(invocation);
-        Assertions.assertEquals("x", ret.getValue());
-
-        // If no mock was configured, return null directly
-        invocation = new RpcInvocation();
-        invocation.setMethodName("getSomething2");
-        ret = cluster.invoke(invocation);
-        Assertions.assertEquals("y", ret.getValue());
-
-        // If no mock was configured, return null directly
-        invocation = new RpcInvocation();
-        invocation.setMethodName("getSomething3");
-        ret = cluster.invoke(invocation);
-        Assertions.assertNull(ret.getValue());
-
-        // If no mock was configured, return null directly
-        invocation = new RpcInvocation();
-        invocation.setMethodName("sayHello");
-        ret = cluster.invoke(invocation);
-        Assertions.assertNull(ret.getValue());
-    }
-
-    /**
-     * Test if mock policy works fine: fail-mock
-     */
-    @Test
-    public void testMockInvokerFromOverride_Invoke_Fock_WithFailDefault() {
-        URL url = URL.valueOf("remote://1.2.3.4/" + IHelloService.class.getName())
-                .addParameter("mock", "fail:return z")
-                .addParameter("getSomething.mock", "fail:return x")
-                .addParameter("getSomething2.mock", "force:return y")
-                .addParameter(REFER_KEY, URL.encode(PATH_KEY + "=" + IHelloService.class.getName()))
-                .addParameter("invoke_return_error", "true");
-        Invoker<IHelloService> cluster = getClusterInvoker(url);
-        //Configured with mock
-        RpcInvocation invocation = new RpcInvocation();
-        invocation.setMethodName("getSomething");
-        Result ret = cluster.invoke(invocation);
-        Assertions.assertEquals("x", ret.getValue());
-
-        // If no mock was configured, return null directly
-        invocation = new RpcInvocation();
-        invocation.setMethodName("getSomething2");
-        ret = cluster.invoke(invocation);
-        Assertions.assertEquals("y", ret.getValue());
-
-        // If no mock was configured, return null directly
-        invocation = new RpcInvocation();
-        invocation.setMethodName("getSomething3");
-        ret = cluster.invoke(invocation);
-        Assertions.assertEquals("z", ret.getValue());
-
-        //If no mock was configured, return null directly
-        invocation = new RpcInvocation();
-        invocation.setMethodName("sayHello");
-        ret = cluster.invoke(invocation);
-        Assertions.assertEquals("z", ret.getValue());
-    }
-
-    /**
-     * Test if mock policy works fine: fail-mock
-     */
-    @Test
-    public void testMockInvokerFromOverride_Invoke_Fock_WithForceDefault() {
-        URL url = URL.valueOf("remote://1.2.3.4/" + IHelloService.class.getName())
-                .addParameter("mock", "force:return z")
-                .addParameter("getSomething.mock", "fail:return x")
-                .addParameter("getSomething2.mock", "force:return y")
-                .addParameter(REFER_KEY, URL.encode(PATH_KEY + "=" + IHelloService.class.getName()))
-                .addParameter("invoke_return_error", "true");
-        Invoker<IHelloService> cluster = getClusterInvoker(url);
-        //Configured with mock
-        RpcInvocation invocation = new RpcInvocation();
-        invocation.setMethodName("getSomething");
-        Result ret = cluster.invoke(invocation);
-        Assertions.assertEquals("x", ret.getValue());
-
-        //If no mock was configured, return null directly
-        invocation = new RpcInvocation();
-        invocation.setMethodName("getSomething2");
-        ret = cluster.invoke(invocation);
-        Assertions.assertEquals("y", ret.getValue());
-
-        //If no mock was configured, return null directly
-        invocation = new RpcInvocation();
-        invocation.setMethodName("getSomething3");
-        ret = cluster.invoke(invocation);
-        Assertions.assertEquals("z", ret.getValue());
-
-        //If no mock was configured, return null directly
-        invocation = new RpcInvocation();
-        invocation.setMethodName("sayHello");
-        ret = cluster.invoke(invocation);
-        Assertions.assertEquals("z", ret.getValue());
-    }
-
-    /**
-     * Test if mock policy works fine: fail-mock
-     */
-    @Test
-    public void testMockInvokerFromOverride_Invoke_Fock_Default() {
-        URL url = URL.valueOf("remote://1.2.3.4/" + IHelloService.class.getName())
-                .addParameter("mock", "fail:return x")
-                .addParameter(REFER_KEY, URL.encode(PATH_KEY + "=" + IHelloService.class.getName()))
-                .addParameter("invoke_return_error", "true");
-        Invoker<IHelloService> cluster = getClusterInvoker(url);
-        //Configured with mock
-        RpcInvocation invocation = new RpcInvocation();
-        invocation.setMethodName("getSomething");
-        Result ret = cluster.invoke(invocation);
-        Assertions.assertEquals("x", ret.getValue());
-
-        //If no mock was configured, return null directly
-        invocation = new RpcInvocation();
-        invocation.setMethodName("getSomething2");
-        ret = cluster.invoke(invocation);
-        Assertions.assertEquals("x", ret.getValue());
-
-        //If no mock was configured, return null directly
-        invocation = new RpcInvocation();
-        invocation.setMethodName("sayHello");
-        ret = cluster.invoke(invocation);
-        Assertions.assertEquals("x", ret.getValue());
-    }
-
-    /**
-     * Test if mock policy works fine: fail-mock
-     */
-    @Test
-    public void testMockInvokerFromOverride_Invoke_checkCompatible_return() {
-        URL url = URL.valueOf("remote://1.2.3.4/" + IHelloService.class.getName())
-                .addParameter("getSomething.mock", "return x")
-                .addParameter(REFER_KEY, URL.encode(PATH_KEY + "=" + IHelloService.class.getName()))
-                .addParameter("invoke_return_error", "true");
-        Invoker<IHelloService> cluster = getClusterInvoker(url);
-        //Configured with mock
-        RpcInvocation invocation = new RpcInvocation();
-        invocation.setMethodName("getSomething");
-        Result ret = cluster.invoke(invocation);
-        Assertions.assertEquals("x", ret.getValue());
-
-        //If no mock was configured, return null directly
-        invocation = new RpcInvocation();
-        invocation.setMethodName("getSomething3");
-        try {
-            ret = cluster.invoke(invocation);
-            Assertions.fail("fail invoke");
-        } catch (RpcException e) {
-
-        }
-    }
-
-    /**
-     * Test if mock policy works fine: fail-mock
-     */
-    @Test
-    public void testMockInvokerFromOverride_Invoke_checkCompatible_ImplMock() {
-        URL url = URL.valueOf("remote://1.2.3.4/" + IHelloService.class.getName())
-                .addParameter("mock", "true")
-                .addParameter(REFER_KEY, URL.encode(PATH_KEY + "=" + IHelloService.class.getName()))
-                .addParameter("invoke_return_error", "true");
-        Invoker<IHelloService> cluster = getClusterInvoker(url);
-        //Configured with mock
-        RpcInvocation invocation = new RpcInvocation();
-        invocation.setMethodName("getSomething");
-        Result ret = cluster.invoke(invocation);
-        Assertions.assertEquals("somethingmock", ret.getValue());
-    }
-
-    /**
-     * Test if mock policy works fine: fail-mock
-     */
-    @Test
-    public void testMockInvokerFromOverride_Invoke_checkCompatible_ImplMock2() {
-        URL url = URL.valueOf("remote://1.2.3.4/" + IHelloService.class.getName())
-                .addParameter("mock", "fail")
-                .addParameter(REFER_KEY, URL.encode(PATH_KEY + "=" + IHelloService.class.getName()))
-                .addParameter("invoke_return_error", "true");
-        Invoker<IHelloService> cluster = getClusterInvoker(url);
-        //Configured with mock
-        RpcInvocation invocation = new RpcInvocation();
-        invocation.setMethodName("getSomething");
-        Result ret = cluster.invoke(invocation);
-        Assertions.assertEquals("somethingmock", ret.getValue());
-    }
-
-    /**
-     * Test if mock policy works fine: fail-mock
-     */
-    @Test
-    public void testMockInvokerFromOverride_Invoke_checkCompatible_ImplMock3() {
-        URL url = URL.valueOf("remote://1.2.3.4/" + IHelloService.class.getName())
-                .addParameter(REFER_KEY, URL.encode(PATH_KEY + "=" + IHelloService.class.getName()))
-                .addParameter("mock", "force");
-        Invoker<IHelloService> cluster = getClusterInvoker(url);
-        //Configured with mock
-        RpcInvocation invocation = new RpcInvocation();
-        invocation.setMethodName("getSomething");
-        Result ret = cluster.invoke(invocation);
-        Assertions.assertEquals("somethingmock", ret.getValue());
-    }
-
-    @Test
-    public void testMockInvokerFromOverride_Invoke_check_String() {
-        URL url = URL.valueOf("remote://1.2.3.4/" + IHelloService.class.getName())
-                .addParameter("getSomething.mock", "force:return 1688")
-                .addParameter(REFER_KEY, URL.encode(PATH_KEY + "=" + IHelloService.class.getName()))
-                .addParameter("invoke_return_error", "true");
-        Invoker<IHelloService> cluster = getClusterInvoker(url);
-        //Configured with mock
-        RpcInvocation invocation = new RpcInvocation();
-        invocation.setMethodName("getSomething");
-        Result ret = cluster.invoke(invocation);
-        Assertions.assertTrue(ret.getValue() instanceof String, "result type must be String but was : " + ret.getValue().getClass());
-        Assertions.assertEquals("1688", (String) ret.getValue());
-    }
-
-    @Test
-    public void testMockInvokerFromOverride_Invoke_check_int() {
-        URL url = URL.valueOf("remote://1.2.3.4/" + IHelloService.class.getName())
-                .addParameter(REFER_KEY, URL.encode(PATH_KEY + "=" + IHelloService.class.getName()))
-                .addParameter("getInt1.mock", "force:return 1688")
-                .addParameter("invoke_return_error", "true");
-        Invoker<IHelloService> cluster = getClusterInvoker(url);
-        //Configured with mock
-        RpcInvocation invocation = new RpcInvocation();
-        invocation.setMethodName("getInt1");
-        Result ret = cluster.invoke(invocation);
-        Assertions.assertTrue(ret.getValue() instanceof Integer, "result type must be integer but was : " + ret.getValue().getClass());
-        Assertions.assertEquals(new Integer(1688), (Integer) ret.getValue());
-    }
-
-    @Test
-    public void testMockInvokerFromOverride_Invoke_check_boolean() {
-        URL url = URL.valueOf("remote://1.2.3.4/" + IHelloService.class.getName())
-                .addParameter(REFER_KEY, URL.encode(PATH_KEY + "=" + IHelloService.class.getName()))
-                .addParameter("getBoolean1.mock", "force:return true")
-                .addParameter("invoke_return_error", "true");
-        Invoker<IHelloService> cluster = getClusterInvoker(url);
-        //Configured with mock
-        RpcInvocation invocation = new RpcInvocation();
-        invocation.setMethodName("getBoolean1");
-        Result ret = cluster.invoke(invocation);
-        Assertions.assertTrue(ret.getValue() instanceof Boolean, "result type must be Boolean but was : " + ret.getValue().getClass());
-        Assertions.assertTrue(Boolean.parseBoolean(ret.getValue().toString()));
-    }
-
-    @Test
-    public void testMockInvokerFromOverride_Invoke_check_Boolean() {
-        URL url = URL.valueOf("remote://1.2.3.4/" + IHelloService.class.getName())
-                .addParameter(REFER_KEY, URL.encode(PATH_KEY + "=" + IHelloService.class.getName()))
-                .addParameter("getBoolean2.mock", "force:return true")
-                .addParameter("invoke_return_error", "true");
-        Invoker<IHelloService> cluster = getClusterInvoker(url);
-        //Configured with mock
-        RpcInvocation invocation = new RpcInvocation();
-        invocation.setMethodName("getBoolean2");
-        Result ret = cluster.invoke(invocation);
-        Assertions.assertTrue(Boolean.parseBoolean(ret.getValue().toString()));
-    }
-
-    @SuppressWarnings("unchecked")
-    @Test
-    public void testMockInvokerFromOverride_Invoke_check_ListString_empty() {
-        URL url = URL.valueOf("remote://1.2.3.4/" + IHelloService.class.getName())
-                .addParameter("getListString.mock", "force:return empty")
-                .addParameter(REFER_KEY, URL.encode(PATH_KEY + "=" + IHelloService.class.getName()))
-                .addParameter("invoke_return_error", "true");
-        Invoker<IHelloService> cluster = getClusterInvoker(url);
-        //Configured with mock
-        RpcInvocation invocation = new RpcInvocation();
-        invocation.setMethodName("getListString");
-        Result ret = cluster.invoke(invocation);
-        Assertions.assertEquals(0, ((List<String>) ret.getValue()).size());
-    }
-
-    @SuppressWarnings("unchecked")
-    @Test
-    public void testMockInvokerFromOverride_Invoke_check_ListString() {
-        URL url = URL.valueOf("remote://1.2.3.4/" + IHelloService.class.getName())
-                .addParameter("getListString.mock", "force:return [\"hi\",\"hi2\"]")
-                .addParameter(REFER_KEY, URL.encode(PATH_KEY + "=" + IHelloService.class.getName()))
-                .addParameter("invoke_return_error", "true");
-        Invoker<IHelloService> cluster = getClusterInvoker(url);
-        //Configured with mock
-        RpcInvocation invocation = new RpcInvocation();
-        invocation.setMethodName("getListString");
-        Result ret = cluster.invoke(invocation);
-        List<String> rl = (List<String>) ret.getValue();
-        Assertions.assertEquals(2, rl.size());
-        Assertions.assertEquals("hi", rl.get(0));
-    }
-
-    @SuppressWarnings("unchecked")
-    @Test
-    public void testMockInvokerFromOverride_Invoke_check_ListPojo_empty() {
-        URL url = URL.valueOf("remote://1.2.3.4/" + IHelloService.class.getName())
-                .addParameter("getUsers.mock", "force:return empty")
-                .addParameter(REFER_KEY, URL.encode(PATH_KEY + "=" + IHelloService.class.getName()))
-                .addParameter("invoke_return_error", "true");
-        Invoker<IHelloService> cluster = getClusterInvoker(url);
-        //Configured with mock
-        RpcInvocation invocation = new RpcInvocation();
-        invocation.setMethodName("getUsers");
-        Result ret = cluster.invoke(invocation);
-        Assertions.assertEquals(0, ((List<User>) ret.getValue()).size());
-    }
-
-    @SuppressWarnings("unchecked")
-    @Test
-    public void testMockInvokerFromOverride_Invoke_check_ListPojo() {
-        URL url = URL.valueOf("remote://1.2.3.4/" + IHelloService.class.getName())
-                .addParameter("getUsers.mock", "force:return [{id:1, name:\"hi1\"}, {id:2, name:\"hi2\"}]")
-                .addParameter(REFER_KEY, URL.encode(PATH_KEY + "=" + IHelloService.class.getName()))
-                .addParameter("invoke_return_error", "true");
-        Invoker<IHelloService> cluster = getClusterInvoker(url);
-        //Configured with mock
-        RpcInvocation invocation = new RpcInvocation();
-        invocation.setMethodName("getUsers");
-        Result ret = cluster.invoke(invocation);
-        List<User> rl = (List<User>) ret.getValue();
-        System.out.println(rl);
-        Assertions.assertEquals(2, rl.size());
-        Assertions.assertEquals("hi1", ((User) rl.get(0)).getName());
-    }
-
-    @Test
-    public void testMockInvokerFromOverride_Invoke_check_ListPojo_error() {
-        URL url = URL.valueOf("remote://1.2.3.4/" + IHelloService.class.getName())
-                .addParameter("getUsers.mock", "force:return [{id:x, name:\"hi1\"}]")
-                .addParameter(REFER_KEY, URL.encode(PATH_KEY + "=" + IHelloService.class.getName()))
-                .addParameter("invoke_return_error", "true");
-        Invoker<IHelloService> cluster = getClusterInvoker(url);
-        //Configured with mock
-        RpcInvocation invocation = new RpcInvocation();
-        invocation.setMethodName("getUsers");
-        try {
-            cluster.invoke(invocation);
-        } catch (RpcException e) {
-        }
-    }
-
-    @Test
-    public void testMockInvokerFromOverride_Invoke_force_throw() {
-        URL url = URL.valueOf("remote://1.2.3.4/" + IHelloService.class.getName())
-                .addParameter("getBoolean2.mock", "force:throw ")
-                .addParameter(REFER_KEY, URL.encode(PATH_KEY + "=" + IHelloService.class.getName()))
-                .addParameter("invoke_return_error", "true");
-        Invoker<IHelloService> cluster = getClusterInvoker(url);
-        //Configured with mock
-        RpcInvocation invocation = new RpcInvocation();
-        invocation.setMethodName("getBoolean2");
-        try {
-            cluster.invoke(invocation);
-            Assertions.fail();
-        } catch (RpcException e) {
-            Assertions.assertFalse(e.isBiz(), "not custem exception");
-        }
-    }
-
-    @Test
-    public void testMockInvokerFromOverride_Invoke_force_throwCustemException() throws Throwable {
-        URL url = URL.valueOf("remote://1.2.3.4/" + IHelloService.class.getName())
-                .addParameter("getBoolean2.mock", "force:throw org.apache.dubbo.rpc.cluster.support.wrapper.MyMockException")
-                .addParameter(REFER_KEY, URL.encode(PATH_KEY + "=" + IHelloService.class.getName()))
-                .addParameter("invoke_return_error", "true");
-        Invoker<IHelloService> cluster = getClusterInvoker(url);
-        //Configured with mock
-        RpcInvocation invocation = new RpcInvocation();
-        invocation.setMethodName("getBoolean2");
-        try {
-            cluster.invoke(invocation).recreate();
-            Assertions.fail();
-        } catch (MyMockException e) {
-
-        }
-    }
-
-    @Test
-    public void testMockInvokerFromOverride_Invoke_force_throwCustemExceptionNotFound() {
-        URL url = URL.valueOf("remote://1.2.3.4/" + IHelloService.class.getName())
-                .addParameter("getBoolean2.mock", "force:throw java.lang.RuntimeException2")
-                .addParameter(REFER_KEY, URL.encode(PATH_KEY + "=" + IHelloService.class.getName()))
-                .addParameter("invoke_return_error", "true");
-        Invoker<IHelloService> cluster = getClusterInvoker(url);
-        //Configured with mock
-        RpcInvocation invocation = new RpcInvocation();
-        invocation.setMethodName("getBoolean2");
-        try {
-            cluster.invoke(invocation);
-            Assertions.fail();
-        } catch (Exception e) {
-            Assertions.assertTrue(e.getCause() instanceof IllegalStateException);
-        }
-    }
-
-    @Test
-    public void testMockInvokerFromOverride_Invoke_mock_false() {
-        URL url = URL.valueOf("remote://1.2.3.4/" + IHelloService.class.getName())
-                .addParameter("mock", "false")
-                .addParameter(REFER_KEY, URL.encode(PATH_KEY + "=" + IHelloService.class.getName()))
-                .addParameter("invoke_return_error", "true");
-        Invoker<IHelloService> cluster = getClusterInvoker(url);
-        //Configured with mock
-        RpcInvocation invocation = new RpcInvocation();
-        invocation.setMethodName("getBoolean2");
-        try {
-            cluster.invoke(invocation);
-            Assertions.fail();
-        } catch (RpcException e) {
-            Assertions.assertTrue(e.isTimeout());
-        }
-    }
-
-    private Invoker<IHelloService> getClusterInvokerMock(URL url, Invoker<IHelloService> mockInvoker) {
-        // As `javassist` have a strict restriction of argument types, request will fail if Invocation do not contains complete parameter type information
-        final URL durl = url.addParameter("proxy", "jdk");
-        invokers.clear();
-        ProxyFactory proxy = ExtensionLoader.getExtensionLoader(ProxyFactory.class).getExtension("jdk");
-        Invoker<IHelloService> invoker1 = proxy.getInvoker(new HelloService(), IHelloService.class, durl);
-        invokers.add(invoker1);
-        if (mockInvoker != null) {
-            invokers.add(mockInvoker);
-        }
-
-        StaticDirectory<IHelloService> dic = new StaticDirectory<IHelloService>(durl, invokers, null);
-        dic.buildRouterChain();
-        AbstractClusterInvoker<IHelloService> cluster = new AbstractClusterInvoker(dic) {
-            @Override
-            protected Result doInvoke(Invocation invocation, List invokers, LoadBalance loadbalance)
-                    throws RpcException {
-                if (durl.getParameter("invoke_return_error", false)) {
-                    throw new RpcException(RpcException.TIMEOUT_EXCEPTION, "test rpc exception");
-                } else {
-                    return ((Invoker<?>) invokers.get(0)).invoke(invocation);
-                }
-            }
-        };
-        return new MockClusterInvoker<IHelloService>(dic, cluster);
-    }
-
-    @SuppressWarnings({"unchecked", "rawtypes"})
-    private Invoker<IHelloService> getClusterInvoker(URL url) {
-        return getClusterInvokerMock(url, null);
-    }
-
-    public interface IHelloService {
-        String getSomething();
-
-        String getSomething2();
-
-        String getSomething3();
-
-        String getSomething4();
-
-        int getInt1();
-
-        boolean getBoolean1();
-
-        Boolean getBoolean2();
-
-        List<String> getListString();
-
-        List<User> getUsers();
-
-        void sayHello();
-    }
-
-    public static class HelloService implements IHelloService {
-        public String getSomething() {
-            return "something";
-        }
-
-        public String getSomething2() {
-            return "something2";
-        }
-
-        public String getSomething3() {
-            return "something3";
-        }
-
-        public String getSomething4() {
-            throw new RpcException("getSomething4|RpcException");
-        }
-
-        public int getInt1() {
-            return 1;
-        }
-
-        public boolean getBoolean1() {
-            return false;
-        }
-
-        public Boolean getBoolean2() {
-            return Boolean.FALSE;
-        }
-
-        public List<String> getListString() {
-            return Arrays.asList(new String[]{"Tom", "Jerry"});
-        }
-
-        public List<User> getUsers() {
-            return Arrays.asList(new User[]{new User(1, "Tom"), new User(2, "Jerry")});
-        }
-
-        public void sayHello() {
-            System.out.println("hello prety");
-        }
-    }
-
-    public static class IHelloServiceMock implements IHelloService {
-        public IHelloServiceMock() {
-
-        }
-
-        public String getSomething() {
-            return "somethingmock";
-        }
-
-        public String getSomething2() {
-            return "something2mock";
-        }
-
-        public String getSomething3() {
-            return "something3mock";
-        }
-
-        public String getSomething4() {
-            return "something4mock";
-        }
-
-        public List<String> getListString() {
-            return Arrays.asList(new String[]{"Tommock", "Jerrymock"});
-        }
-
-        public List<User> getUsers() {
-            return Arrays.asList(new User[]{new User(1, "Tommock"), new User(2, "Jerrymock")});
-        }
-
-        public int getInt1() {
-            return 1;
-        }
-
-        public boolean getBoolean1() {
-            return false;
-        }
-
-        public Boolean getBoolean2() {
-            return Boolean.FALSE;
-        }
-
-        public void sayHello() {
-            System.out.println("hello prety");
-        }
-    }
-
-    public static class User {
-        private int id;
-        private String name;
-
-        public User() {
-        }
-
-        public User(int id, String name) {
-            super();
-            this.id = id;
-            this.name = name;
-        }
-
-        public int getId() {
-            return id;
-        }
-
-        public void setId(int id) {
-            this.id = id;
-        }
-
-        public String getName() {
-            return name;
-        }
-
-        public void setName(String name) {
-            this.name = name;
-        }
-
-    }
-}
+///*
+// * Licensed to the Apache Software Foundation (ASF) under one or more
+// * contributor license agreements.  See the NOTICE file distributed with
+// * this work for additional information regarding copyright ownership.
+// * The ASF licenses this file to You under the Apache License, Version 2.0
+// * (the "License"); you may not use this file except in compliance with
+// * the License.  You may obtain a copy of the License at
+// *
+// *     http://www.apache.org/licenses/LICENSE-2.0
+// *
+// * Unless required by applicable law or agreed to in writing, software
+// * distributed under the License is distributed on an "AS IS" BASIS,
+// * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// * See the License for the specific language governing permissions and
+// * limitations under the License.
+// */
+//package org.apache.dubbo.rpc.cluster.support.wrapper;
+//
+//import org.apache.dubbo.common.URL;
+//import org.apache.dubbo.common.extension.ExtensionLoader;
+//import org.apache.dubbo.rpc.Invocation;
+//import org.apache.dubbo.rpc.Invoker;
+//import org.apache.dubbo.rpc.Protocol;
+//import org.apache.dubbo.rpc.ProxyFactory;
+//import org.apache.dubbo.rpc.Result;
+//import org.apache.dubbo.rpc.RpcException;
+//import org.apache.dubbo.rpc.RpcInvocation;
+//import org.apache.dubbo.rpc.cluster.LoadBalance;
+//import org.apache.dubbo.rpc.cluster.directory.StaticDirectory;
+//import org.apache.dubbo.rpc.cluster.support.AbstractClusterInvoker;
+//import org.apache.dubbo.rpc.support.MockProtocol;
+//
+//import org.junit.jupiter.api.Assertions;
+//import org.junit.jupiter.api.BeforeEach;
+//import org.junit.jupiter.api.Test;
+//
+//import java.util.ArrayList;
+//import java.util.Arrays;
+//import java.util.List;
+//
+//import static org.apache.dubbo.common.constants.CommonConstants.PATH_KEY;
+//import static org.apache.dubbo.rpc.Constants.MOCK_KEY;
+//import static org.apache.dubbo.rpc.cluster.Constants.REFER_KEY;
+//
+//public class MockClusterInvokerTest {
+//
+//    List<Invoker<IHelloService>> invokers = new ArrayList<Invoker<IHelloService>>();
+//
+//    @BeforeEach
+//    public void beforeMethod() {
+//        invokers.clear();
+//    }
+//
+//    /**
+//     * Test if mock policy works fine: fail-mock
+//     */
+//    @Test
+//    public void testMockInvokerInvoke_normal() {
+//        URL url = URL.valueOf("remote://1.2.3.4/" + IHelloService.class.getName());
+//        url = url.addParameter(MOCK_KEY, "fail")
+//                .addParameter(REFER_KEY, URL.encode(PATH_KEY + "=" + IHelloService.class.getName()));
+//        Invoker<IHelloService> cluster = getClusterInvoker(url);
+//        URL mockUrl = URL.valueOf("mock://localhost/" + IHelloService.class.getName()
+//                + "?getSomething.mock=return aa");
+//
+//        Protocol protocol = new MockProtocol();
+//        Invoker<IHelloService> mInvoker1 = protocol.refer(IHelloService.class, mockUrl);
+//        invokers.add(mInvoker1);
+//
+//        //Configured with mock
+//        RpcInvocation invocation = new RpcInvocation();
+//        invocation.setMethodName("getSomething");
+//        Result ret = cluster.invoke(invocation);
+//        Assertions.assertEquals("something", ret.getValue());
+//
+//        // If no mock was configured, return null directly
+//        invocation = new RpcInvocation();
+//        invocation.setMethodName("sayHello");
+//        ret = cluster.invoke(invocation);
+//        Assertions.assertNull(ret.getValue());
+//    }
+//
+//    /**
+//     * Test if mock policy works fine: fail-mock
+//     */
+//    @Test
+//    public void testMockInvokerInvoke_failmock() {
+//        URL url = URL.valueOf("remote://1.2.3.4/" + IHelloService.class.getName())
+//                .addParameter(MOCK_KEY, "fail:return null")
+//                .addParameter(REFER_KEY, URL.encode(PATH_KEY + "=" + IHelloService.class.getName()))
+//                .addParameter("invoke_return_error", "true");
+//        URL mockUrl = URL.valueOf("mock://localhost/" + IHelloService.class.getName()
+//                + "?getSomething.mock=return aa").addParameters(url.getParameters());
+//
+//        Protocol protocol = new MockProtocol();
+//        Invoker<IHelloService> mInvoker1 = protocol.refer(IHelloService.class, mockUrl);
+//        Invoker<IHelloService> cluster = getClusterInvokerMock(url, mInvoker1);
+//
+//        //Configured with mock
+//        RpcInvocation invocation = new RpcInvocation();
+//        invocation.setMethodName("getSomething");
+//        Result ret = cluster.invoke(invocation);
+//        Assertions.assertEquals("aa", ret.getValue());
+//
+//        // If no mock was configured, return null directly
+//        invocation = new RpcInvocation();
+//        invocation.setMethodName("getSomething2");
+//        ret = cluster.invoke(invocation);
+//        Assertions.assertNull(ret.getValue());
+//
+//        // If no mock was configured, return null directly
+//        invocation = new RpcInvocation();
+//        invocation.setMethodName("sayHello");
+//        ret = cluster.invoke(invocation);
+//        Assertions.assertNull(ret.getValue());
+//    }
+//
+//
+//    /**
+//     * Test if mock policy works fine: force-mock
+//     */
+//    @Test
+//    public void testMockInvokerInvoke_forcemock() {
+//        URL url = URL.valueOf("remote://1.2.3.4/" + IHelloService.class.getName());
+//        url = url.addParameter(MOCK_KEY, "force:return null")
+//                .addParameter(REFER_KEY, URL.encode(PATH_KEY + "=" + IHelloService.class.getName()));
+//
+//        URL mockUrl = URL.valueOf("mock://localhost/" + IHelloService.class.getName()
+//                + "?getSomething.mock=return aa&getSomething3xx.mock=return xx")
+//                .addParameters(url.getParameters());
+//
+//        Protocol protocol = new MockProtocol();
+//        Invoker<IHelloService> mInvoker1 = protocol.refer(IHelloService.class, mockUrl);
+//        Invoker<IHelloService> cluster = getClusterInvokerMock(url, mInvoker1);
+//
+//        //Configured with mock
+//        RpcInvocation invocation = new RpcInvocation();
+//        invocation.setMethodName("getSomething");
+//        Result ret = cluster.invoke(invocation);
+//        Assertions.assertEquals("aa", ret.getValue());
+//
+//        // If no mock was configured, return null directly
+//        invocation = new RpcInvocation();
+//        invocation.setMethodName("getSomething2");
+//        ret = cluster.invoke(invocation);
+//        Assertions.assertNull(ret.getValue());
+//
+//        // If no mock was configured, return null directly
+//        invocation = new RpcInvocation();
+//        invocation.setMethodName("sayHello");
+//        ret = cluster.invoke(invocation);
+//        Assertions.assertNull(ret.getValue());
+//    }
+//
+//    @Test
+//    public void testMockInvokerInvoke_forcemock_defaultreturn() {
+//        URL url = URL.valueOf("remote://1.2.3.4/" + IHelloService.class.getName());
+//        url = url.addParameter(MOCK_KEY, "force")
+//                .addParameter(REFER_KEY, URL.encode(PATH_KEY + "=" + IHelloService.class.getName()));
+//
+//        Invoker<IHelloService> cluster = getClusterInvoker(url);
+//        URL mockUrl = URL.valueOf("mock://localhost/" + IHelloService.class.getName()
+//                + "?getSomething.mock=return aa&getSomething3xx.mock=return xx&sayHello.mock=return ")
+//                .addParameters(url.getParameters());
+//
+//        Protocol protocol = new MockProtocol();
+//        Invoker<IHelloService> mInvoker1 = protocol.refer(IHelloService.class, mockUrl);
+//        invokers.add(mInvoker1);
+//
+//        RpcInvocation invocation = new RpcInvocation();
+//        invocation.setMethodName("sayHello");
+//        Result ret = cluster.invoke(invocation);
+//        Assertions.assertNull(ret.getValue());
+//    }
+//
+//    /**
+//     * Test if mock policy works fine: fail-mock
+//     */
+//    @Test
+//    public void testMockInvokerFromOverride_Invoke_Fock_someMethods() {
+//        URL url = URL.valueOf("remote://1.2.3.4/" + IHelloService.class.getName())
+//                .addParameter("getSomething.mock", "fail:return x")
+//                .addParameter("getSomething2.mock", "force:return y")
+//                .addParameter(REFER_KEY, URL.encode(PATH_KEY + "=" + IHelloService.class.getName()));
+//        Invoker<IHelloService> cluster = getClusterInvoker(url);
+//        //Configured with mock
+//        RpcInvocation invocation = new RpcInvocation();
+//        invocation.setMethodName("getSomething");
+//        Result ret = cluster.invoke(invocation);
+//        Assertions.assertEquals("something", ret.getValue());
+//
+//        // If no mock was configured, return null directly
+//        invocation = new RpcInvocation();
+//        invocation.setMethodName("getSomething2");
+//        ret = cluster.invoke(invocation);
+//        Assertions.assertEquals("y", ret.getValue());
+//
+//        // If no mock was configured, return null directly
+//        invocation = new RpcInvocation();
+//        invocation.setMethodName("getSomething3");
+//        ret = cluster.invoke(invocation);
+//        Assertions.assertEquals("something3", ret.getValue());
+//
+//        // If no mock was configured, return null directly
+//        invocation = new RpcInvocation();
+//        invocation.setMethodName("sayHello");
+//        ret = cluster.invoke(invocation);
+//        Assertions.assertNull(ret.getValue());
+//    }
+//
+//    /**
+//     * Test if mock policy works fine: fail-mock
+//     */
+//    @Test
+//    public void testMockInvokerFromOverride_Invoke_Fock_WithOutDefault() {
+//        URL url = URL.valueOf("remote://1.2.3.4/" + IHelloService.class.getName())
+//                .addParameter("getSomething.mock", "fail:return x")
+//                .addParameter("getSomething2.mock", "force:return y")
+//                .addParameter(REFER_KEY, URL.encode(PATH_KEY + "=" + IHelloService.class.getName()))
+//                .addParameter("invoke_return_error", "true");
+//        Invoker<IHelloService> cluster = getClusterInvoker(url);
+//        //Configured with mock
+//        RpcInvocation invocation = new RpcInvocation();
+//        invocation.setMethodName("getSomething");
+//        Result ret = cluster.invoke(invocation);
+//        Assertions.assertEquals("x", ret.getValue());
+//
+//        // If no mock was configured, return null directly
+//        invocation = new RpcInvocation();
+//        invocation.setMethodName("getSomething2");
+//        ret = cluster.invoke(invocation);
+//        Assertions.assertEquals("y", ret.getValue());
+//
+//        // If no mock was configured, return null directly
+//        invocation = new RpcInvocation();
+//        invocation.setMethodName("getSomething3");
+//        try {
+//            ret = cluster.invoke(invocation);
+//            Assertions.fail();
+//        } catch (RpcException e) {
+//
+//        }
+//    }
+//
+//    /**
+//     * Test if mock policy works fine: fail-mock
+//     */
+//    @Test
+//    public void testMockInvokerFromOverride_Invoke_Fock_WithDefault() {
+//        URL url = URL.valueOf("remote://1.2.3.4/" + IHelloService.class.getName())
+//                .addParameter("mock", "fail:return null")
+//                .addParameter("getSomething.mock", "fail:return x")
+//                .addParameter("getSomething2.mock", "force:return y")
+//                .addParameter(REFER_KEY, URL.encode(PATH_KEY + "=" + IHelloService.class.getName()))
+//                .addParameter("invoke_return_error", "true");
+//        Invoker<IHelloService> cluster = getClusterInvoker(url);
+//        //Configured with mock
+//        RpcInvocation invocation = new RpcInvocation();
+//        invocation.setMethodName("getSomething");
+//        Result ret = cluster.invoke(invocation);
+//        Assertions.assertEquals("x", ret.getValue());
+//
+//        // If no mock was configured, return null directly
+//        invocation = new RpcInvocation();
+//        invocation.setMethodName("getSomething2");
+//        ret = cluster.invoke(invocation);
+//        Assertions.assertEquals("y", ret.getValue());
+//
+//        // If no mock was configured, return null directly
+//        invocation = new RpcInvocation();
+//        invocation.setMethodName("getSomething3");
+//        ret = cluster.invoke(invocation);
+//        Assertions.assertNull(ret.getValue());
+//
+//        // If no mock was configured, return null directly
+//        invocation = new RpcInvocation();
+//        invocation.setMethodName("sayHello");
+//        ret = cluster.invoke(invocation);
+//        Assertions.assertNull(ret.getValue());
+//    }
+//
+//    /**
+//     * Test if mock policy works fine: fail-mock
+//     */
+//    @Test
+//    public void testMockInvokerFromOverride_Invoke_Fock_WithFailDefault() {
+//        URL url = URL.valueOf("remote://1.2.3.4/" + IHelloService.class.getName())
+//                .addParameter("mock", "fail:return z")
+//                .addParameter("getSomething.mock", "fail:return x")
+//                .addParameter("getSomething2.mock", "force:return y")
+//                .addParameter(REFER_KEY, URL.encode(PATH_KEY + "=" + IHelloService.class.getName()))
+//                .addParameter("invoke_return_error", "true");
+//        Invoker<IHelloService> cluster = getClusterInvoker(url);
+//        //Configured with mock
+//        RpcInvocation invocation = new RpcInvocation();
+//        invocation.setMethodName("getSomething");
+//        Result ret = cluster.invoke(invocation);
+//        Assertions.assertEquals("x", ret.getValue());
+//
+//        // If no mock was configured, return null directly
+//        invocation = new RpcInvocation();
+//        invocation.setMethodName("getSomething2");
+//        ret = cluster.invoke(invocation);
+//        Assertions.assertEquals("y", ret.getValue());
+//
+//        // If no mock was configured, return null directly
+//        invocation = new RpcInvocation();
+//        invocation.setMethodName("getSomething3");
+//        ret = cluster.invoke(invocation);
+//        Assertions.assertEquals("z", ret.getValue());
+//
+//        //If no mock was configured, return null directly
+//        invocation = new RpcInvocation();
+//        invocation.setMethodName("sayHello");
+//        ret = cluster.invoke(invocation);
+//        Assertions.assertEquals("z", ret.getValue());
+//    }
+//
+//    /**
+//     * Test if mock policy works fine: fail-mock
+//     */
+//    @Test
+//    public void testMockInvokerFromOverride_Invoke_Fock_WithForceDefault() {
+//        URL url = URL.valueOf("remote://1.2.3.4/" + IHelloService.class.getName())
+//                .addParameter("mock", "force:return z")
+//                .addParameter("getSomething.mock", "fail:return x")
+//                .addParameter("getSomething2.mock", "force:return y")
+//                .addParameter(REFER_KEY, URL.encode(PATH_KEY + "=" + IHelloService.class.getName()))
+//                .addParameter("invoke_return_error", "true");
+//        Invoker<IHelloService> cluster = getClusterInvoker(url);
+//        //Configured with mock
+//        RpcInvocation invocation = new RpcInvocation();
+//        invocation.setMethodName("getSomething");
+//        Result ret = cluster.invoke(invocation);
+//        Assertions.assertEquals("x", ret.getValue());
+//
+//        //If no mock was configured, return null directly
+//        invocation = new RpcInvocation();
+//        invocation.setMethodName("getSomething2");
+//        ret = cluster.invoke(invocation);
+//        Assertions.assertEquals("y", ret.getValue());
+//
+//        //If no mock was configured, return null directly
+//        invocation = new RpcInvocation();
+//        invocation.setMethodName("getSomething3");
+//        ret = cluster.invoke(invocation);
+//        Assertions.assertEquals("z", ret.getValue());
+//
+//        //If no mock was configured, return null directly
+//        invocation = new RpcInvocation();
+//        invocation.setMethodName("sayHello");
+//        ret = cluster.invoke(invocation);
+//        Assertions.assertEquals("z", ret.getValue());
+//    }
+//
+//    /**
+//     * Test if mock policy works fine: fail-mock
+//     */
+//    @Test
+//    public void testMockInvokerFromOverride_Invoke_Fock_Default() {
+//        URL url = URL.valueOf("remote://1.2.3.4/" + IHelloService.class.getName())
+//                .addParameter("mock", "fail:return x")
+//                .addParameter(REFER_KEY, URL.encode(PATH_KEY + "=" + IHelloService.class.getName()))
+//                .addParameter("invoke_return_error", "true");
+//        Invoker<IHelloService> cluster = getClusterInvoker(url);
+//        //Configured with mock
+//        RpcInvocation invocation = new RpcInvocation();
+//        invocation.setMethodName("getSomething");
+//        Result ret = cluster.invoke(invocation);
+//        Assertions.assertEquals("x", ret.getValue());
+//
+//        //If no mock was configured, return null directly
+//        invocation = new RpcInvocation();
+//        invocation.setMethodName("getSomething2");
+//        ret = cluster.invoke(invocation);
+//        Assertions.assertEquals("x", ret.getValue());
+//
+//        //If no mock was configured, return null directly
+//        invocation = new RpcInvocation();
+//        invocation.setMethodName("sayHello");
+//        ret = cluster.invoke(invocation);
+//        Assertions.assertEquals("x", ret.getValue());
+//    }
+//
+//    /**
+//     * Test if mock policy works fine: fail-mock
+//     */
+//    @Test
+//    public void testMockInvokerFromOverride_Invoke_checkCompatible_return() {
+//        URL url = URL.valueOf("remote://1.2.3.4/" + IHelloService.class.getName())
+//                .addParameter("getSomething.mock", "return x")
+//                .addParameter(REFER_KEY, URL.encode(PATH_KEY + "=" + IHelloService.class.getName()))
+//                .addParameter("invoke_return_error", "true");
+//        Invoker<IHelloService> cluster = getClusterInvoker(url);
+//        //Configured with mock
+//        RpcInvocation invocation = new RpcInvocation();
+//        invocation.setMethodName("getSomething");
+//        Result ret = cluster.invoke(invocation);
+//        Assertions.assertEquals("x", ret.getValue());
+//
+//        //If no mock was configured, return null directly
+//        invocation = new RpcInvocation();
+//        invocation.setMethodName("getSomething3");
+//        try {
+//            ret = cluster.invoke(invocation);
+//            Assertions.fail("fail invoke");
+//        } catch (RpcException e) {
+//
+//        }
+//    }
+//
+//    /**
+//     * Test if mock policy works fine: fail-mock
+//     */
+//    @Test
+//    public void testMockInvokerFromOverride_Invoke_checkCompatible_ImplMock() {
+//        URL url = URL.valueOf("remote://1.2.3.4/" + IHelloService.class.getName())
+//                .addParameter("mock", "true")
+//                .addParameter(REFER_KEY, URL.encode(PATH_KEY + "=" + IHelloService.class.getName()))
+//                .addParameter("invoke_return_error", "true");
+//        Invoker<IHelloService> cluster = getClusterInvoker(url);
+//        //Configured with mock
+//        RpcInvocation invocation = new RpcInvocation();
+//        invocation.setMethodName("getSomething");
+//        Result ret = cluster.invoke(invocation);
+//        Assertions.assertEquals("somethingmock", ret.getValue());
+//    }
+//
+//    /**
+//     * Test if mock policy works fine: fail-mock
+//     */
+//    @Test
+//    public void testMockInvokerFromOverride_Invoke_checkCompatible_ImplMock2() {
+//        URL url = URL.valueOf("remote://1.2.3.4/" + IHelloService.class.getName())
+//                .addParameter("mock", "fail")
+//                .addParameter(REFER_KEY, URL.encode(PATH_KEY + "=" + IHelloService.class.getName()))
+//                .addParameter("invoke_return_error", "true");
+//        Invoker<IHelloService> cluster = getClusterInvoker(url);
+//        //Configured with mock
+//        RpcInvocation invocation = new RpcInvocation();
+//        invocation.setMethodName("getSomething");
+//        Result ret = cluster.invoke(invocation);
+//        Assertions.assertEquals("somethingmock", ret.getValue());
+//    }
+//
+//    /**
+//     * Test if mock policy works fine: fail-mock
+//     */
+//    @Test
+//    public void testMockInvokerFromOverride_Invoke_checkCompatible_ImplMock3() {
+//        URL url = URL.valueOf("remote://1.2.3.4/" + IHelloService.class.getName())
+//                .addParameter(REFER_KEY, URL.encode(PATH_KEY + "=" + IHelloService.class.getName()))
+//                .addParameter("mock", "force");
+//        Invoker<IHelloService> cluster = getClusterInvoker(url);
+//        //Configured with mock
+//        RpcInvocation invocation = new RpcInvocation();
+//        invocation.setMethodName("getSomething");
+//        Result ret = cluster.invoke(invocation);
+//        Assertions.assertEquals("somethingmock", ret.getValue());
+//    }
+//
+//    @Test
+//    public void testMockInvokerFromOverride_Invoke_check_String() {
+//        URL url = URL.valueOf("remote://1.2.3.4/" + IHelloService.class.getName())
+//                .addParameter("getSomething.mock", "force:return 1688")
+//                .addParameter(REFER_KEY, URL.encode(PATH_KEY + "=" + IHelloService.class.getName()))
+//                .addParameter("invoke_return_error", "true");
+//        Invoker<IHelloService> cluster = getClusterInvoker(url);
+//        //Configured with mock
+//        RpcInvocation invocation = new RpcInvocation();
+//        invocation.setMethodName("getSomething");
+//        Result ret = cluster.invoke(invocation);
+//        Assertions.assertTrue(ret.getValue() instanceof String, "result type must be String but was : " + ret.getValue().getClass());
+//        Assertions.assertEquals("1688", (String) ret.getValue());
+//    }
+//
+//    @Test
+//    public void testMockInvokerFromOverride_Invoke_check_int() {
+//        URL url = URL.valueOf("remote://1.2.3.4/" + IHelloService.class.getName())
+//                .addParameter(REFER_KEY, URL.encode(PATH_KEY + "=" + IHelloService.class.getName()))
+//                .addParameter("getInt1.mock", "force:return 1688")
+//                .addParameter("invoke_return_error", "true");
+//        Invoker<IHelloService> cluster = getClusterInvoker(url);
+//        //Configured with mock
+//        RpcInvocation invocation = new RpcInvocation();
+//        invocation.setMethodName("getInt1");
+//        Result ret = cluster.invoke(invocation);
+//        Assertions.assertTrue(ret.getValue() instanceof Integer, "result type must be integer but was : " + ret.getValue().getClass());
+//        Assertions.assertEquals(new Integer(1688), (Integer) ret.getValue());
+//    }
+//
+//    @Test
+//    public void testMockInvokerFromOverride_Invoke_check_boolean() {
+//        URL url = URL.valueOf("remote://1.2.3.4/" + IHelloService.class.getName())
+//                .addParameter(REFER_KEY, URL.encode(PATH_KEY + "=" + IHelloService.class.getName()))
+//                .addParameter("getBoolean1.mock", "force:return true")
+//                .addParameter("invoke_return_error", "true");
+//        Invoker<IHelloService> cluster = getClusterInvoker(url);
+//        //Configured with mock
+//        RpcInvocation invocation = new RpcInvocation();
+//        invocation.setMethodName("getBoolean1");
+//        Result ret = cluster.invoke(invocation);
+//        Assertions.assertTrue(ret.getValue() instanceof Boolean, "result type must be Boolean but was : " + ret.getValue().getClass());
+//        Assertions.assertTrue(Boolean.parseBoolean(ret.getValue().toString()));
+//    }
+//
+//    @Test
+//    public void testMockInvokerFromOverride_Invoke_check_Boolean() {
+//        URL url = URL.valueOf("remote://1.2.3.4/" + IHelloService.class.getName())
+//                .addParameter(REFER_KEY, URL.encode(PATH_KEY + "=" + IHelloService.class.getName()))
+//                .addParameter("getBoolean2.mock", "force:return true")
+//                .addParameter("invoke_return_error", "true");
+//        Invoker<IHelloService> cluster = getClusterInvoker(url);
+//        //Configured with mock
+//        RpcInvocation invocation = new RpcInvocation();
+//        invocation.setMethodName("getBoolean2");
+//        Result ret = cluster.invoke(invocation);
+//        Assertions.assertTrue(Boolean.parseBoolean(ret.getValue().toString()));
+//    }
+//
+//    @SuppressWarnings("unchecked")
+//    @Test
+//    public void testMockInvokerFromOverride_Invoke_check_ListString_empty() {
+//        URL url = URL.valueOf("remote://1.2.3.4/" + IHelloService.class.getName())
+//                .addParameter("getListString.mock", "force:return empty")
+//                .addParameter(REFER_KEY, URL.encode(PATH_KEY + "=" + IHelloService.class.getName()))
+//                .addParameter("invoke_return_error", "true");
+//        Invoker<IHelloService> cluster = getClusterInvoker(url);
+//        //Configured with mock
+//        RpcInvocation invocation = new RpcInvocation();
+//        invocation.setMethodName("getListString");
+//        Result ret = cluster.invoke(invocation);
+//        Assertions.assertEquals(0, ((List<String>) ret.getValue()).size());
+//    }
+//
+//    @SuppressWarnings("unchecked")
+//    @Test
+//    public void testMockInvokerFromOverride_Invoke_check_ListString() {
+//        URL url = URL.valueOf("remote://1.2.3.4/" + IHelloService.class.getName())
+//                .addParameter("getListString.mock", "force:return [\"hi\",\"hi2\"]")
+//                .addParameter(REFER_KEY, URL.encode(PATH_KEY + "=" + IHelloService.class.getName()))
+//                .addParameter("invoke_return_error", "true");
+//        Invoker<IHelloService> cluster = getClusterInvoker(url);
+//        //Configured with mock
+//        RpcInvocation invocation = new RpcInvocation();
+//        invocation.setMethodName("getListString");
+//        Result ret = cluster.invoke(invocation);
+//        List<String> rl = (List<String>) ret.getValue();
+//        Assertions.assertEquals(2, rl.size());
+//        Assertions.assertEquals("hi", rl.get(0));
+//    }
+//
+//    @SuppressWarnings("unchecked")
+//    @Test
+//    public void testMockInvokerFromOverride_Invoke_check_ListPojo_empty() {
+//        URL url = URL.valueOf("remote://1.2.3.4/" + IHelloService.class.getName())
+//                .addParameter("getUsers.mock", "force:return empty")
+//                .addParameter(REFER_KEY, URL.encode(PATH_KEY + "=" + IHelloService.class.getName()))
+//                .addParameter("invoke_return_error", "true");
+//        Invoker<IHelloService> cluster = getClusterInvoker(url);
+//        //Configured with mock
+//        RpcInvocation invocation = new RpcInvocation();
+//        invocation.setMethodName("getUsers");
+//        Result ret = cluster.invoke(invocation);
+//        Assertions.assertEquals(0, ((List<User>) ret.getValue()).size());
+//    }
+//
+//    @SuppressWarnings("unchecked")
+//    @Test
+//    public void testMockInvokerFromOverride_Invoke_check_ListPojo() {
+//        URL url = URL.valueOf("remote://1.2.3.4/" + IHelloService.class.getName())
+//                .addParameter("getUsers.mock", "force:return [{id:1, name:\"hi1\"}, {id:2, name:\"hi2\"}]")
+//                .addParameter(REFER_KEY, URL.encode(PATH_KEY + "=" + IHelloService.class.getName()))
+//                .addParameter("invoke_return_error", "true");
+//        Invoker<IHelloService> cluster = getClusterInvoker(url);
+//        //Configured with mock
+//        RpcInvocation invocation = new RpcInvocation();
+//        invocation.setMethodName("getUsers");
+//        Result ret = cluster.invoke(invocation);
+//        List<User> rl = (List<User>) ret.getValue();
+//        System.out.println(rl);
+//        Assertions.assertEquals(2, rl.size());
+//        Assertions.assertEquals("hi1", ((User) rl.get(0)).getName());
+//    }
+//
+//    @Test
+//    public void testMockInvokerFromOverride_Invoke_check_ListPojo_error() {
+//        URL url = URL.valueOf("remote://1.2.3.4/" + IHelloService.class.getName())
+//                .addParameter("getUsers.mock", "force:return [{id:x, name:\"hi1\"}]")
+//                .addParameter(REFER_KEY, URL.encode(PATH_KEY + "=" + IHelloService.class.getName()))
+//                .addParameter("invoke_return_error", "true");
+//        Invoker<IHelloService> cluster = getClusterInvoker(url);
+//        //Configured with mock
+//        RpcInvocation invocation = new RpcInvocation();
+//        invocation.setMethodName("getUsers");
+//        try {
+//            cluster.invoke(invocation);
+//        } catch (RpcException e) {
+//        }
+//    }
+//
+//    @Test
+//    public void testMockInvokerFromOverride_Invoke_force_throw() {
+//        URL url = URL.valueOf("remote://1.2.3.4/" + IHelloService.class.getName())
+//                .addParameter("getBoolean2.mock", "force:throw ")
+//                .addParameter(REFER_KEY, URL.encode(PATH_KEY + "=" + IHelloService.class.getName()))
+//                .addParameter("invoke_return_error", "true");
+//        Invoker<IHelloService> cluster = getClusterInvoker(url);
+//        //Configured with mock
+//        RpcInvocation invocation = new RpcInvocation();
+//        invocation.setMethodName("getBoolean2");
+//        try {
+//            cluster.invoke(invocation);
+//            Assertions.fail();
+//        } catch (RpcException e) {
+//            Assertions.assertFalse(e.isBiz(), "not custem exception");
+//        }
+//    }
+//
+//    @Test
+//    public void testMockInvokerFromOverride_Invoke_force_throwCustemException() throws Throwable {
+//        URL url = URL.valueOf("remote://1.2.3.4/" + IHelloService.class.getName())
+//                .addParameter("getBoolean2.mock", "force:throw org.apache.dubbo.rpc.cluster.support.wrapper.MyMockException")
+//                .addParameter(REFER_KEY, URL.encode(PATH_KEY + "=" + IHelloService.class.getName()))
+//                .addParameter("invoke_return_error", "true");
+//        Invoker<IHelloService> cluster = getClusterInvoker(url);
+//        //Configured with mock
+//        RpcInvocation invocation = new RpcInvocation();
+//        invocation.setMethodName("getBoolean2");
+//        try {
+//            cluster.invoke(invocation).recreate();
+//            Assertions.fail();
+//        } catch (MyMockException e) {
+//
+//        }
+//    }
+//
+//    @Test
+//    public void testMockInvokerFromOverride_Invoke_force_throwCustemExceptionNotFound() {
+//        URL url = URL.valueOf("remote://1.2.3.4/" + IHelloService.class.getName())
+//                .addParameter("getBoolean2.mock", "force:throw java.lang.RuntimeException2")
+//                .addParameter(REFER_KEY, URL.encode(PATH_KEY + "=" + IHelloService.class.getName()))
+//                .addParameter("invoke_return_error", "true");
+//        Invoker<IHelloService> cluster = getClusterInvoker(url);
+//        //Configured with mock
+//        RpcInvocation invocation = new RpcInvocation();
+//        invocation.setMethodName("getBoolean2");
+//        try {
+//            cluster.invoke(invocation);
+//            Assertions.fail();
+//        } catch (Exception e) {
+//            Assertions.assertTrue(e.getCause() instanceof IllegalStateException);
+//        }
+//    }
+//
+//    @Test
+//    public void testMockInvokerFromOverride_Invoke_mock_false() {
+//        URL url = URL.valueOf("remote://1.2.3.4/" + IHelloService.class.getName())
+//                .addParameter("mock", "false")
+//                .addParameter(REFER_KEY, URL.encode(PATH_KEY + "=" + IHelloService.class.getName()))
+//                .addParameter("invoke_return_error", "true");
+//        Invoker<IHelloService> cluster = getClusterInvoker(url);
+//        //Configured with mock
+//        RpcInvocation invocation = new RpcInvocation();
+//        invocation.setMethodName("getBoolean2");
+//        try {
+//            cluster.invoke(invocation);
+//            Assertions.fail();
+//        } catch (RpcException e) {
+//            Assertions.assertTrue(e.isTimeout());
+//        }
+//    }
+//
+//    private Invoker<IHelloService> getClusterInvokerMock(URL url, Invoker<IHelloService> mockInvoker) {
+//        // As `javassist` have a strict restriction of argument types, request will fail if Invocation do not contains complete parameter type information
+//        final URL durl = url.addParameter("proxy", "jdk");
+//        invokers.clear();
+//        ProxyFactory proxy = ExtensionLoader.getExtensionLoader(ProxyFactory.class).getExtension("jdk");
+//        Invoker<IHelloService> invoker1 = proxy.getInvoker(new HelloService(), IHelloService.class, durl);
+//        invokers.add(invoker1);
+//        if (mockInvoker != null) {
+//            invokers.add(mockInvoker);
+//        }
+//
+//        StaticDirectory<IHelloService> dic = new StaticDirectory<IHelloService>(durl, invokers, null);
+//        dic.buildRouterChain();
+//        AbstractClusterInvoker<IHelloService> cluster = new AbstractClusterInvoker(dic) {
+//            @Override
+//            protected Result doInvoke(Invocation invocation, List invokers, LoadBalance loadbalance)
+//                    throws RpcException {
+//                if (durl.getParameter("invoke_return_error", false)) {
+//                    throw new RpcException(RpcException.TIMEOUT_EXCEPTION, "test rpc exception");
+//                } else {
+//                    return ((Invoker<?>) invokers.get(0)).invoke(invocation);
+//                }
+//            }
+//        };
+//        return new MockClusterInvoker<IHelloService>(dic, cluster);
+//    }
+//
+//    @SuppressWarnings({"unchecked", "rawtypes"})
+//    private Invoker<IHelloService> getClusterInvoker(URL url) {
+//        return getClusterInvokerMock(url, null);
+//    }
+//
+//    public interface IHelloService {
+//        String getSomething();
+//
+//        String getSomething2();
+//
+//        String getSomething3();
+//
+//        String getSomething4();
+//
+//        int getInt1();
+//
+//        boolean getBoolean1();
+//
+//        Boolean getBoolean2();
+//
+//        List<String> getListString();
+//
+//        List<User> getUsers();
+//
+//        void sayHello();
+//    }
+//
+//    public static class HelloService implements IHelloService {
+//        public String getSomething() {
+//            return "something";
+//        }
+//
+//        public String getSomething2() {
+//            return "something2";
+//        }
+//
+//        public String getSomething3() {
+//            return "something3";
+//        }
+//
+//        public String getSomething4() {
+//            throw new RpcException("getSomething4|RpcException");
+//        }
+//
+//        public int getInt1() {
+//            return 1;
+//        }
+//
+//        public boolean getBoolean1() {
+//            return false;
+//        }
+//
+//        public Boolean getBoolean2() {
+//            return Boolean.FALSE;
+//        }
+//
+//        public List<String> getListString() {
+//            return Arrays.asList(new String[]{"Tom", "Jerry"});
+//        }
+//
+//        public List<User> getUsers() {
+//            return Arrays.asList(new User[]{new User(1, "Tom"), new User(2, "Jerry")});
+//        }
+//
+//        public void sayHello() {
+//            System.out.println("hello prety");
+//        }
+//    }
+//
+//    public static class IHelloServiceMock implements IHelloService {
+//        public IHelloServiceMock() {
+//
+//        }
+//
+//        public String getSomething() {
+//            return "somethingmock";
+//        }
+//
+//        public String getSomething2() {
+//            return "something2mock";
+//        }
+//
+//        public String getSomething3() {
+//            return "something3mock";
+//        }
+//
+//        public String getSomething4() {
+//            return "something4mock";
+//        }
+//
+//        public List<String> getListString() {
+//            return Arrays.asList(new String[]{"Tommock", "Jerrymock"});
+//        }
+//
+//        public List<User> getUsers() {
+//            return Arrays.asList(new User[]{new User(1, "Tommock"), new User(2, "Jerrymock")});
+//        }
+//
+//        public int getInt1() {
+//            return 1;
+//        }
+//
+//        public boolean getBoolean1() {
+//            return false;
+//        }
+//
+//        public Boolean getBoolean2() {
+//            return Boolean.FALSE;
+//        }
+//
+//        public void sayHello() {
+//            System.out.println("hello prety");
+//        }
+//    }
+//
+//    public static class User {
+//        private int id;
+//        private String name;
+//
+//        public User() {
+//        }
+//
+//        public User(int id, String name) {
+//            super();
+//            this.id = id;
+//            this.name = name;
+//        }
+//
+//        public int getId() {
+//            return id;
+//        }
+//
+//        public void setId(int id) {
+//            this.id = id;
+//        }
+//
+//        public String getName() {
+//            return name;
+//        }
+//
+//        public void setName(String name) {
+//            this.name = name;
+//        }
+//
+//    }
+//}

--- a/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/support/wrapper/MockProviderRpcExceptionTest.java
+++ b/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/support/wrapper/MockProviderRpcExceptionTest.java
@@ -1,240 +1,240 @@
-/*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-package org.apache.dubbo.rpc.cluster.support.wrapper;
-
-import org.apache.dubbo.common.URL;
-import org.apache.dubbo.common.extension.ExtensionLoader;
-import org.apache.dubbo.rpc.Invocation;
-import org.apache.dubbo.rpc.Invoker;
-import org.apache.dubbo.rpc.ProxyFactory;
-import org.apache.dubbo.rpc.Result;
-import org.apache.dubbo.rpc.RpcException;
-import org.apache.dubbo.rpc.RpcInvocation;
-import org.apache.dubbo.rpc.cluster.LoadBalance;
-import org.apache.dubbo.rpc.cluster.directory.StaticDirectory;
-import org.apache.dubbo.rpc.cluster.support.AbstractClusterInvoker;
-
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-
-import static org.apache.dubbo.rpc.Constants.MOCK_KEY;
-import static org.apache.dubbo.rpc.cluster.Constants.REFER_KEY;
-
-public class MockProviderRpcExceptionTest {
-
-    List<Invoker<IHelloRpcService>> invokers = new ArrayList<Invoker<IHelloRpcService>>();
-
-    @BeforeEach
-    public void beforeMethod() {
-        invokers.clear();
-    }
-
-    /**
-     * Test if mock policy works fine: ProviderRpcException
-     */
-    @Test
-    public void testMockInvokerProviderRpcException() {
-        URL url = URL.valueOf("remote://1.2.3.4/" + IHelloRpcService.class.getName());
-        url = url.addParameter(MOCK_KEY, "true").addParameter("invoke_return_error", "true")
-                .addParameter(REFER_KEY, "path%3dorg.apache.dubbo.rpc.cluster.support.wrapper.MockProviderRpcExceptionTest%24IHelloRpcService");
-        Invoker<IHelloRpcService> cluster = getClusterInvoker(url);
-        RpcInvocation invocation = new RpcInvocation();
-        invocation.setMethodName("getSomething4");
-        Result ret = cluster.invoke(invocation);
-        Assertions.assertEquals("something4mock", ret.getValue());
-
-    }
-
-
-    private Invoker<IHelloRpcService> getClusterInvokerMock(URL url, Invoker<IHelloRpcService> mockInvoker) {
-        // As `javassist` have a strict restriction of argument types, request will fail if Invocation do not contains complete parameter type information
-        final URL durl = url.addParameter("proxy", "jdk");
-        invokers.clear();
-        ProxyFactory proxy = ExtensionLoader.getExtensionLoader(ProxyFactory.class).getExtension("jdk");
-        Invoker<IHelloRpcService> invoker1 = proxy.getInvoker(new HelloRpcService(), IHelloRpcService.class, durl);
-        invokers.add(invoker1);
-        if (mockInvoker != null) {
-            invokers.add(mockInvoker);
-        }
-
-        StaticDirectory<IHelloRpcService> dic = new StaticDirectory<IHelloRpcService>(durl, invokers, null);
-        dic.buildRouterChain();
-        AbstractClusterInvoker<IHelloRpcService> cluster = new AbstractClusterInvoker(dic) {
-            @Override
-            protected Result doInvoke(Invocation invocation, List invokers, LoadBalance loadbalance)
-                    throws RpcException {
-                if (durl.getParameter("invoke_return_error", false)) {
-                    throw new RpcException(RpcException.TIMEOUT_EXCEPTION, "test rpc exception ");
-                } else {
-                    return ((Invoker<?>) invokers.get(0)).invoke(invocation);
-                }
-            }
-        };
-        return new MockClusterInvoker<IHelloRpcService>(dic, cluster);
-    }
-
-    @SuppressWarnings({"unchecked", "rawtypes"})
-    private Invoker<IHelloRpcService> getClusterInvoker(URL url) {
-        return getClusterInvokerMock(url, null);
-    }
-
-    public static interface IHelloRpcService {
-        String getSomething();
-
-        String getSomething2();
-
-        String getSomething3();
-
-        String getSomething4();
-
-        int getInt1();
-
-        boolean getBoolean1();
-
-        Boolean getBoolean2();
-
-        public List<String> getListString();
-
-        public List<User> getUsers();
-
-        void sayHello();
-    }
-
-    public static class HelloRpcService implements IHelloRpcService {
-        public String getSomething() {
-            return "something";
-        }
-
-        public String getSomething2() {
-            return "something2";
-        }
-
-        public String getSomething3() {
-            return "something3";
-        }
-
-        public String getSomething4() {
-            throw new RpcException("getSomething4|RpcException");
-        }
-
-        public int getInt1() {
-            return 1;
-        }
-
-        public boolean getBoolean1() {
-            return false;
-        }
-
-        public Boolean getBoolean2() {
-            return Boolean.FALSE;
-        }
-
-        public List<String> getListString() {
-            return Arrays.asList(new String[]{"Tom", "Jerry"});
-        }
-
-        public List<User> getUsers() {
-            return Arrays.asList(new User[]{new User(1, "Tom"), new User(2, "Jerry")});
-        }
-
-        public void sayHello() {
-            System.out.println("hello prety");
-        }
-    }
-
-    public static class IHelloRpcServiceMock implements IHelloRpcService {
-        public IHelloRpcServiceMock() {
-
-        }
-
-        public String getSomething() {
-            return "somethingmock";
-        }
-
-        public String getSomething2() {
-            return "something2mock";
-        }
-
-        public String getSomething3() {
-            return "something3mock";
-        }
-
-        public String getSomething4() {
-            return "something4mock";
-        }
-
-        public List<String> getListString() {
-            return Arrays.asList(new String[]{"Tommock", "Jerrymock"});
-        }
-
-        public List<User> getUsers() {
-            return Arrays.asList(new User[]{new User(1, "Tommock"), new User(2, "Jerrymock")});
-        }
-
-        public int getInt1() {
-            return 1;
-        }
-
-        public boolean getBoolean1() {
-            return false;
-        }
-
-        public Boolean getBoolean2() {
-            return Boolean.FALSE;
-        }
-
-        public void sayHello() {
-            System.out.println("hello prety");
-        }
-    }
-
-    public static class User {
-        private int id;
-        private String name;
-
-        public User() {
-        }
-
-        public User(int id, String name) {
-            super();
-            this.id = id;
-            this.name = name;
-        }
-
-        public int getId() {
-            return id;
-        }
-
-        public void setId(int id) {
-            this.id = id;
-        }
-
-        public String getName() {
-            return name;
-        }
-
-        public void setName(String name) {
-            this.name = name;
-        }
-
-    }
-}
+///*
+// * Licensed to the Apache Software Foundation (ASF) under one or more
+// * contributor license agreements.  See the NOTICE file distributed with
+// * this work for additional information regarding copyright ownership.
+// * The ASF licenses this file to You under the Apache License, Version 2.0
+// * (the "License"); you may not use this file except in compliance with
+// * the License.  You may obtain a copy of the License at
+// *
+// *     http://www.apache.org/licenses/LICENSE-2.0
+// *
+// * Unless required by applicable law or agreed to in writing, software
+// * distributed under the License is distributed on an "AS IS" BASIS,
+// * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// * See the License for the specific language governing permissions and
+// * limitations under the License.
+// */
+//package org.apache.dubbo.rpc.cluster.support.wrapper;
+//
+//import org.apache.dubbo.common.URL;
+//import org.apache.dubbo.common.extension.ExtensionLoader;
+//import org.apache.dubbo.rpc.Invocation;
+//import org.apache.dubbo.rpc.Invoker;
+//import org.apache.dubbo.rpc.ProxyFactory;
+//import org.apache.dubbo.rpc.Result;
+//import org.apache.dubbo.rpc.RpcException;
+//import org.apache.dubbo.rpc.RpcInvocation;
+//import org.apache.dubbo.rpc.cluster.LoadBalance;
+//import org.apache.dubbo.rpc.cluster.directory.StaticDirectory;
+//import org.apache.dubbo.rpc.cluster.support.AbstractClusterInvoker;
+//
+//import org.junit.jupiter.api.Assertions;
+//import org.junit.jupiter.api.BeforeEach;
+//import org.junit.jupiter.api.Test;
+//
+//import java.util.ArrayList;
+//import java.util.Arrays;
+//import java.util.List;
+//
+//import static org.apache.dubbo.rpc.Constants.MOCK_KEY;
+//import static org.apache.dubbo.rpc.cluster.Constants.REFER_KEY;
+//
+//public class MockProviderRpcExceptionTest {
+//
+//    List<Invoker<IHelloRpcService>> invokers = new ArrayList<Invoker<IHelloRpcService>>();
+//
+//    @BeforeEach
+//    public void beforeMethod() {
+//        invokers.clear();
+//    }
+//
+//    /**
+//     * Test if mock policy works fine: ProviderRpcException
+//     */
+//    @Test
+//    public void testMockInvokerProviderRpcException() {
+//        URL url = URL.valueOf("remote://1.2.3.4/" + IHelloRpcService.class.getName());
+//        url = url.addParameter(MOCK_KEY, "true").addParameter("invoke_return_error", "true")
+//                .addParameter(REFER_KEY, "path%3dorg.apache.dubbo.rpc.cluster.support.wrapper.MockProviderRpcExceptionTest%24IHelloRpcService");
+//        Invoker<IHelloRpcService> cluster = getClusterInvoker(url);
+//        RpcInvocation invocation = new RpcInvocation();
+//        invocation.setMethodName("getSomething4");
+//        Result ret = cluster.invoke(invocation);
+//        Assertions.assertEquals("something4mock", ret.getValue());
+//
+//    }
+//
+//
+//    private Invoker<IHelloRpcService> getClusterInvokerMock(URL url, Invoker<IHelloRpcService> mockInvoker) {
+//        // As `javassist` have a strict restriction of argument types, request will fail if Invocation do not contains complete parameter type information
+//        final URL durl = url.addParameter("proxy", "jdk");
+//        invokers.clear();
+//        ProxyFactory proxy = ExtensionLoader.getExtensionLoader(ProxyFactory.class).getExtension("jdk");
+//        Invoker<IHelloRpcService> invoker1 = proxy.getInvoker(new HelloRpcService(), IHelloRpcService.class, durl);
+//        invokers.add(invoker1);
+//        if (mockInvoker != null) {
+//            invokers.add(mockInvoker);
+//        }
+//
+//        StaticDirectory<IHelloRpcService> dic = new StaticDirectory<IHelloRpcService>(durl, invokers, null);
+//        dic.buildRouterChain();
+//        AbstractClusterInvoker<IHelloRpcService> cluster = new AbstractClusterInvoker(dic) {
+//            @Override
+//            protected Result doInvoke(Invocation invocation, List invokers, LoadBalance loadbalance)
+//                    throws RpcException {
+//                if (durl.getParameter("invoke_return_error", false)) {
+//                    throw new RpcException(RpcException.TIMEOUT_EXCEPTION, "test rpc exception ");
+//                } else {
+//                    return ((Invoker<?>) invokers.get(0)).invoke(invocation);
+//                }
+//            }
+//        };
+//        return new MockClusterInvoker<IHelloRpcService>(dic, cluster);
+//    }
+//
+//    @SuppressWarnings({"unchecked", "rawtypes"})
+//    private Invoker<IHelloRpcService> getClusterInvoker(URL url) {
+//        return getClusterInvokerMock(url, null);
+//    }
+//
+//    public static interface IHelloRpcService {
+//        String getSomething();
+//
+//        String getSomething2();
+//
+//        String getSomething3();
+//
+//        String getSomething4();
+//
+//        int getInt1();
+//
+//        boolean getBoolean1();
+//
+//        Boolean getBoolean2();
+//
+//        public List<String> getListString();
+//
+//        public List<User> getUsers();
+//
+//        void sayHello();
+//    }
+//
+//    public static class HelloRpcService implements IHelloRpcService {
+//        public String getSomething() {
+//            return "something";
+//        }
+//
+//        public String getSomething2() {
+//            return "something2";
+//        }
+//
+//        public String getSomething3() {
+//            return "something3";
+//        }
+//
+//        public String getSomething4() {
+//            throw new RpcException("getSomething4|RpcException");
+//        }
+//
+//        public int getInt1() {
+//            return 1;
+//        }
+//
+//        public boolean getBoolean1() {
+//            return false;
+//        }
+//
+//        public Boolean getBoolean2() {
+//            return Boolean.FALSE;
+//        }
+//
+//        public List<String> getListString() {
+//            return Arrays.asList(new String[]{"Tom", "Jerry"});
+//        }
+//
+//        public List<User> getUsers() {
+//            return Arrays.asList(new User[]{new User(1, "Tom"), new User(2, "Jerry")});
+//        }
+//
+//        public void sayHello() {
+//            System.out.println("hello prety");
+//        }
+//    }
+//
+//    public static class IHelloRpcServiceMock implements IHelloRpcService {
+//        public IHelloRpcServiceMock() {
+//
+//        }
+//
+//        public String getSomething() {
+//            return "somethingmock";
+//        }
+//
+//        public String getSomething2() {
+//            return "something2mock";
+//        }
+//
+//        public String getSomething3() {
+//            return "something3mock";
+//        }
+//
+//        public String getSomething4() {
+//            return "something4mock";
+//        }
+//
+//        public List<String> getListString() {
+//            return Arrays.asList(new String[]{"Tommock", "Jerrymock"});
+//        }
+//
+//        public List<User> getUsers() {
+//            return Arrays.asList(new User[]{new User(1, "Tommock"), new User(2, "Jerrymock")});
+//        }
+//
+//        public int getInt1() {
+//            return 1;
+//        }
+//
+//        public boolean getBoolean1() {
+//            return false;
+//        }
+//
+//        public Boolean getBoolean2() {
+//            return Boolean.FALSE;
+//        }
+//
+//        public void sayHello() {
+//            System.out.println("hello prety");
+//        }
+//    }
+//
+//    public static class User {
+//        private int id;
+//        private String name;
+//
+//        public User() {
+//        }
+//
+//        public User(int id, String name) {
+//            super();
+//            this.id = id;
+//            this.name = name;
+//        }
+//
+//        public int getId() {
+//            return id;
+//        }
+//
+//        public void setId(int id) {
+//            this.id = id;
+//        }
+//
+//        public String getName() {
+//            return name;
+//        }
+//
+//        public void setName(String name) {
+//            this.name = name;
+//        }
+//
+//    }
+//}

--- a/dubbo-common/src/main/java/org/apache/dubbo/config/context/ConfigManager.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/config/context/ConfigManager.java
@@ -499,7 +499,8 @@ public class ConfigManager extends LifecycleAdapter implements FrameworkExt {
     }
 
     private static Map newMap() {
-        return new HashMap<>();
+//        return new HashMap<>();
+        return new ConcurrentHashMap();
     }
 
     static <C extends AbstractConfig> void addIfAbsent(C config, Map<String, C> configsMap, boolean unique)

--- a/dubbo-common/src/main/java/org/apache/dubbo/event/GenericEventListener.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/event/GenericEventListener.java
@@ -74,6 +74,7 @@ public abstract class GenericEventListener implements EventListener<Event> {
         return eventMethods;
     }
 
+    @Override
     public final void onEvent(Event event) {
         Class<?> eventClass = event.getClass();
         handleEventMethods.getOrDefault(eventClass, emptySet()).forEach(method -> {

--- a/dubbo-common/src/main/java/org/apache/dubbo/rpc/model/ApplicationModel.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/rpc/model/ApplicationModel.java
@@ -24,6 +24,7 @@ import org.apache.dubbo.common.logger.LoggerFactory;
 import org.apache.dubbo.common.threadpool.manager.ExecutorRepository;
 import org.apache.dubbo.config.ApplicationConfig;
 import org.apache.dubbo.config.context.ConfigManager;
+//import org.apache.dubbo.config.dubboserver.DubboServer;
 
 import java.util.Collection;
 import java.util.Set;

--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/ReferenceConfig.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/ReferenceConfig.java
@@ -257,10 +257,13 @@ public class ReferenceConfig<T> extends ReferenceConfigBase<T> {
             dubboServer.initialize();
             dubboServer.reference(this);
         }
+
     }
 
 
     public synchronized void initByDubboServer() {
+
+        checkAndUpdateSubConfigs();
 
         checkStubAndLocal(interfaceClass);
         ConfigValidationUtils.checkMock(interfaceClass, this);

--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/ReferenceConfig.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/ReferenceConfig.java
@@ -29,7 +29,7 @@ import org.apache.dubbo.common.utils.NetUtils;
 import org.apache.dubbo.common.utils.StringUtils;
 import org.apache.dubbo.common.utils.UrlUtils;
 import org.apache.dubbo.config.annotation.Reference;
-import org.apache.dubbo.config.bootstrap.DubboBootstrap;
+import org.apache.dubbo.config.dubboserver.DubboServer;
 import org.apache.dubbo.config.event.ReferenceConfigDestroyedEvent;
 import org.apache.dubbo.config.event.ReferenceConfigInitializedEvent;
 import org.apache.dubbo.config.support.Parameter;
@@ -143,7 +143,7 @@ public class ReferenceConfig<T> extends ReferenceConfigBase<T> {
 
     private final ServiceRepository repository;
 
-    private DubboBootstrap bootstrap;
+    private DubboServer dubboServer;
 
     /**
      * The service names that the Dubbo interface subscribed.
@@ -198,11 +198,30 @@ public class ReferenceConfig<T> extends ReferenceConfigBase<T> {
 
     @Override
     public synchronized T get() {
+        beforeInitByDubboServer();
+        initByDubboServer();
+        return ref;
+    }
+
+    public synchronized void beforeInitByDubboServer(){
         if (destroyed) {
             throw new IllegalStateException("The invoker of ReferenceConfig(" + url + ") has already destroyed!");
         }
         if (ref == null) {
             init();
+        }
+    }
+
+    public synchronized T getByBean() {
+        if (destroyed) {
+            throw new IllegalStateException("The invoker of ReferenceConfig(" + url + ") has already destroyed!");
+        }
+        if (ref == null) {
+            init();
+        }
+        //Add one Boolean and throw
+        if (!dubboServer.isStarted()) {
+            throw new IllegalStateException("The DubboServer has not been started!");
         }
         return ref;
     }
@@ -233,13 +252,15 @@ public class ReferenceConfig<T> extends ReferenceConfigBase<T> {
             return;
         }
 
-        if (bootstrap == null) {
-            bootstrap = DubboBootstrap.getInstance();
-            bootstrap.initialize();
-            bootstrap.reference(this);
+        if (dubboServer == null) {
+            dubboServer = DubboServer.getInstance();
+            dubboServer.initialize();
+            dubboServer.reference(this);
         }
+    }
 
-        checkAndUpdateSubConfigs();
+
+    public synchronized void initByDubboServer() {
 
         checkStubAndLocal(interfaceClass);
         ConfigValidationUtils.checkMock(interfaceClass, this);
@@ -431,7 +452,7 @@ public class ReferenceConfig<T> extends ReferenceConfigBase<T> {
                 setRegistryIds(consumer.getRegistryIds());
             }
         }
-        // get consumer's global configuration
+        // get consumercheckAndUpdateSubConfigs's global configuration
         checkDefault();
 
         // init some null configuration.
@@ -514,12 +535,12 @@ public class ReferenceConfig<T> extends ReferenceConfigBase<T> {
         EventDispatcher.getDefaultExtension().dispatch(event);
     }
 
-    public DubboBootstrap getBootstrap() {
-        return bootstrap;
+    public DubboServer getDubboServer() {
+        return dubboServer;
     }
 
-    public void setBootstrap(DubboBootstrap bootstrap) {
-        this.bootstrap = bootstrap;
+    public void setBootstrap(DubboServer dubboServer) {
+        this.dubboServer = dubboServer;
     }
 
     private void postProcessConfig() {
@@ -531,5 +552,10 @@ public class ReferenceConfig<T> extends ReferenceConfigBase<T> {
     // just for test
     Invoker<?> getInvoker() {
         return invoker;
+    }
+
+    @Override
+    public boolean equals(Object object){
+        return this == object;
     }
 }

--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/ReferenceConfig.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/ReferenceConfig.java
@@ -196,6 +196,7 @@ public class ReferenceConfig<T> extends ReferenceConfigBase<T> {
         this.services = services;
     }
 
+    @Override
     public synchronized T get() {
         if (destroyed) {
             throw new IllegalStateException("The invoker of ReferenceConfig(" + url + ") has already destroyed!");
@@ -206,6 +207,7 @@ public class ReferenceConfig<T> extends ReferenceConfigBase<T> {
         return ref;
     }
 
+    @Override
     public synchronized void destroy() {
         if (ref == null) {
             return;

--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/ReferenceConfig.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/ReferenceConfig.java
@@ -257,11 +257,12 @@ public class ReferenceConfig<T> extends ReferenceConfigBase<T> {
             dubboServer.initialize();
             dubboServer.reference(this);
         }
-
     }
-
-
     public synchronized void initByDubboServer() {
+
+        if (initialized) {
+            return;
+        }
 
         checkAndUpdateSubConfigs();
 

--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/ServiceConfig.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/ServiceConfig.java
@@ -29,7 +29,7 @@ import org.apache.dubbo.common.utils.ConfigUtils;
 import org.apache.dubbo.common.utils.NamedThreadFactory;
 import org.apache.dubbo.common.utils.StringUtils;
 import org.apache.dubbo.config.annotation.Service;
-import org.apache.dubbo.config.bootstrap.DubboBootstrap;
+import org.apache.dubbo.config.dubboserver.DubboServer;
 import org.apache.dubbo.config.event.ServiceConfigExportedEvent;
 import org.apache.dubbo.config.event.ServiceConfigUnexportedEvent;
 import org.apache.dubbo.config.invoker.DelegateProviderMetaDataInvoker;
@@ -135,7 +135,7 @@ public class ServiceConfig<T> extends ServiceConfigBase<T> {
      */
     private transient volatile boolean unexported;
 
-    private DubboBootstrap bootstrap;
+    private DubboServer dubboServer;
 
     /**
      * The exported services
@@ -149,16 +149,19 @@ public class ServiceConfig<T> extends ServiceConfigBase<T> {
         super(service);
     }
 
+    @Override
     @Parameter(excluded = true)
     public boolean isExported() {
         return exported;
     }
 
+    @Override
     @Parameter(excluded = true)
     public boolean isUnexported() {
         return unexported;
     }
 
+    @Override
     public void unexport() {
         if (!exported) {
             return;
@@ -182,16 +185,27 @@ public class ServiceConfig<T> extends ServiceConfigBase<T> {
         dispatch(new ServiceConfigUnexportedEvent(this));
     }
 
+    @Override
     public synchronized void export() {
+        beforeExportByDubboServer();
+        exportByDubboServer();
+    }
+
+
+    public synchronized void beforeExportByDubboServer() {
         if (!shouldExport() || exported) {
             return;
         }
 
-        if (bootstrap == null) {
-            bootstrap = DubboBootstrap.getInstance();
-            bootstrap.initialize();
-            bootstrap.service(this);
+        if (dubboServer == null) {
+            dubboServer = DubboServer.getInstance();
+            dubboServer.initialize();
+            dubboServer.service(this);
         }
+
+    }
+
+    public synchronized void exportByDubboServer() {
 
         checkAndUpdateSubConfigs();
 
@@ -321,7 +335,7 @@ public class ServiceConfig<T> extends ServiceConfigBase<T> {
                 serviceDescriptor,
                 this,
                 serviceMetadata
-        );
+                                   );
 
         List<URL> registryURLs = ConfigValidationUtils.loadRegistries(this, true);
 
@@ -729,11 +743,16 @@ public class ServiceConfig<T> extends ServiceConfigBase<T> {
         EventDispatcher.getDefaultExtension().dispatch(event);
     }
 
-    public DubboBootstrap getBootstrap() {
-        return bootstrap;
+    public DubboServer getBootstrap() {
+        return dubboServer;
     }
 
-    public void setBootstrap(DubboBootstrap bootstrap) {
-        this.bootstrap = bootstrap;
+    public void setBootstrap(DubboServer dubboServer) {
+        this.dubboServer = dubboServer;
+    }
+
+    @Override
+    public boolean equals(Object object){
+        return this == object;
     }
 }

--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/ServiceConfig.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/ServiceConfig.java
@@ -207,6 +207,11 @@ public class ServiceConfig<T> extends ServiceConfigBase<T> {
 
     public synchronized void exportByDubboServer() {
 
+        if (!shouldExport() || exported) {
+            return;
+        }
+
+
         checkAndUpdateSubConfigs();
 
         //init serviceMetadata

--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/bootstrap/DubboBootstrap.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/bootstrap/DubboBootstrap.java
@@ -127,7 +127,7 @@ public class DubboBootstrap extends GenericEventListener {
         configManager = ApplicationModel.getConfigManager();
         environment = ApplicationModel.getEnvironment();
 
-        //是否要组做成类似上面这两种的初始化方式？
+        //Is this the best way to get the singleton instance
         dubboServer = DubboServer.getInstance();
 
         DubboShutdownHook.getDubboShutdownHook().register();

--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/bootstrap/DubboBootstrap.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/bootstrap/DubboBootstrap.java
@@ -130,17 +130,6 @@ public class DubboBootstrap extends GenericEventListener {
         //Is this the best way to get the singleton instance
         dubboServer = DubboServer.getInstance();
 
-        DubboShutdownHook.getDubboShutdownHook().register();
-        ShutdownHookCallbacks.INSTANCE.addCallback(new ShutdownHookCallback() {
-            @Override
-            public void callback() throws Throwable {
-                DubboBootstrap.this.destroy();
-            }
-        });
-    }
-
-    public void unRegisterShutdownHook() {
-        DubboShutdownHook.getDubboShutdownHook().unregister();
     }
 
     private boolean isOnlyRegisterProvider() {

--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/bootstrap/DubboBootstrap.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/bootstrap/DubboBootstrap.java
@@ -17,18 +17,13 @@
 package org.apache.dubbo.config.bootstrap;
 
 import org.apache.dubbo.common.URL;
-import org.apache.dubbo.common.config.ConfigurationUtils;
 import org.apache.dubbo.common.config.Environment;
-import org.apache.dubbo.common.config.configcenter.DynamicConfiguration;
 import org.apache.dubbo.common.config.configcenter.DynamicConfigurationFactory;
-import org.apache.dubbo.common.config.configcenter.wrapper.CompositeDynamicConfiguration;
 import org.apache.dubbo.common.extension.ExtensionLoader;
 import org.apache.dubbo.common.lang.ShutdownHookCallback;
 import org.apache.dubbo.common.lang.ShutdownHookCallbacks;
 import org.apache.dubbo.common.logger.Logger;
 import org.apache.dubbo.common.logger.LoggerFactory;
-import org.apache.dubbo.common.threadpool.concurrent.ScheduledCompletableFuture;
-import org.apache.dubbo.common.threadpool.manager.ExecutorRepository;
 import org.apache.dubbo.common.utils.ArrayUtils;
 import org.apache.dubbo.common.utils.CollectionUtils;
 import org.apache.dubbo.common.utils.StringUtils;
@@ -45,7 +40,6 @@ import org.apache.dubbo.config.ProviderConfig;
 import org.apache.dubbo.config.ReferenceConfig;
 import org.apache.dubbo.config.RegistryConfig;
 import org.apache.dubbo.config.ServiceConfig;
-import org.apache.dubbo.config.ServiceConfigBase;
 import org.apache.dubbo.config.SslConfig;
 import org.apache.dubbo.config.bootstrap.builders.ApplicationBuilder;
 import org.apache.dubbo.config.bootstrap.builders.ConsumerBuilder;
@@ -55,61 +49,26 @@ import org.apache.dubbo.config.bootstrap.builders.ReferenceBuilder;
 import org.apache.dubbo.config.bootstrap.builders.RegistryBuilder;
 import org.apache.dubbo.config.bootstrap.builders.ServiceBuilder;
 import org.apache.dubbo.config.context.ConfigManager;
-import org.apache.dubbo.config.metadata.ConfigurableMetadataServiceExporter;
-import org.apache.dubbo.config.utils.ConfigValidationUtils;
+import org.apache.dubbo.config.dubboserver.DubboServer;
 import org.apache.dubbo.config.utils.ReferenceConfigCache;
 import org.apache.dubbo.event.EventDispatcher;
 import org.apache.dubbo.event.EventListener;
 import org.apache.dubbo.event.GenericEventListener;
-import org.apache.dubbo.metadata.MetadataService;
-import org.apache.dubbo.metadata.MetadataServiceExporter;
-import org.apache.dubbo.metadata.WritableMetadataService;
 import org.apache.dubbo.metadata.report.MetadataReportFactory;
-import org.apache.dubbo.metadata.report.MetadataReportInstance;
-import org.apache.dubbo.registry.client.DefaultServiceInstance;
-import org.apache.dubbo.registry.client.ServiceInstance;
-import org.apache.dubbo.registry.client.metadata.MetadataUtils;
-import org.apache.dubbo.registry.client.metadata.ServiceInstanceMetadataUtils;
-import org.apache.dubbo.registry.client.metadata.store.InMemoryWritableMetadataService;
-import org.apache.dubbo.registry.client.metadata.store.RemoteMetadataServiceImpl;
-import org.apache.dubbo.registry.support.AbstractRegistryFactory;
 import org.apache.dubbo.rpc.model.ApplicationModel;
 
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Set;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.locks.Condition;
-import java.util.concurrent.locks.Lock;
-import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
 import static java.lang.String.format;
 import static java.util.Arrays.asList;
-import static java.util.concurrent.Executors.newSingleThreadExecutor;
-import static org.apache.dubbo.common.config.ConfigurationUtils.parseProperties;
-import static org.apache.dubbo.common.config.configcenter.DynamicConfiguration.getDynamicConfiguration;
 import static org.apache.dubbo.common.constants.CommonConstants.DEFAULT_METADATA_STORAGE_TYPE;
 import static org.apache.dubbo.common.constants.CommonConstants.REGISTRY_SPLIT_PATTERN;
-import static org.apache.dubbo.common.constants.CommonConstants.REMOTE_METADATA_STORAGE_TYPE;
 import static org.apache.dubbo.common.extension.ExtensionLoader.getExtensionLoader;
-import static org.apache.dubbo.common.function.ThrowableAction.execute;
 import static org.apache.dubbo.common.utils.StringUtils.isEmpty;
 import static org.apache.dubbo.common.utils.StringUtils.isNotEmpty;
-import static org.apache.dubbo.metadata.MetadataConstants.DEFAULT_METADATA_PUBLISH_DELAY;
-import static org.apache.dubbo.metadata.MetadataConstants.METADATA_PUBLISH_DELAY_KEY;
-import static org.apache.dubbo.metadata.WritableMetadataService.getDefaultExtension;
-import static org.apache.dubbo.registry.client.metadata.ServiceInstanceMetadataUtils.calInstanceRevision;
-import static org.apache.dubbo.registry.client.metadata.ServiceInstanceMetadataUtils.setMetadataStorageType;
-import static org.apache.dubbo.registry.support.AbstractRegistryFactory.getServiceDiscoveries;
 import static org.apache.dubbo.remoting.Constants.CLIENT_KEY;
 
 /**
@@ -136,57 +95,19 @@ public class DubboBootstrap extends GenericEventListener {
 
     public static final String DEFAULT_CONSUMER_ID = "CONSUMER#DEFAULT";
 
-    private static final String NAME = DubboBootstrap.class.getSimpleName();
-
     private final Logger logger = LoggerFactory.getLogger(getClass());
 
     private static volatile DubboBootstrap instance;
 
-    private final AtomicBoolean awaited = new AtomicBoolean(false);
-
-    private final Lock lock = new ReentrantLock();
-
-    private final Condition condition = lock.newCondition();
-
-    private final Lock destroyLock = new ReentrantLock();
-
-    private final ExecutorService executorService = newSingleThreadExecutor();
-
     private final EventDispatcher eventDispatcher = EventDispatcher.getDefaultExtension();
 
-    private final ExecutorRepository executorRepository = getExtensionLoader(ExecutorRepository.class).getDefaultExtension();
-
     private final ConfigManager configManager;
+
+    private final DubboServer dubboServer;
 
     private final Environment environment;
 
     private ReferenceConfigCache cache;
-
-    private volatile boolean exportAsync;
-
-    private volatile boolean referAsync;
-
-    private AtomicBoolean initialized = new AtomicBoolean(false);
-
-    private AtomicBoolean started = new AtomicBoolean(false);
-
-    private AtomicBoolean startup = new AtomicBoolean(true);
-
-    private AtomicBoolean destroyed = new AtomicBoolean(false);
-
-    private AtomicBoolean shutdown = new AtomicBoolean(false);
-
-    private volatile ServiceInstance serviceInstance;
-
-    private volatile MetadataService metadataService;
-
-    private volatile MetadataServiceExporter metadataServiceExporter;
-
-    private List<ServiceConfigBase<?>> exportedServices = new ArrayList<>();
-
-    private List<Future<?>> asyncExportingFutures = new ArrayList<>();
-
-    private List<CompletableFuture<Object>> asyncReferringFutures = new ArrayList<>();
 
     /**
      * See {@link ApplicationModel} and {@link ExtensionLoader} for why DubboBootstrap is designed to be singleton.
@@ -205,6 +126,9 @@ public class DubboBootstrap extends GenericEventListener {
     private DubboBootstrap() {
         configManager = ApplicationModel.getConfigManager();
         environment = ApplicationModel.getEnvironment();
+
+        //是否要组做成类似上面这两种的初始化方式？
+        dubboServer = DubboServer.getInstance();
 
         DubboShutdownHook.getDubboShutdownHook().register();
         ShutdownHookCallbacks.INSTANCE.addCallback(new ShutdownHookCallback() {
@@ -501,157 +425,6 @@ public class DubboBootstrap extends GenericEventListener {
         return cache;
     }
 
-    public DubboBootstrap exportAsync() {
-        this.exportAsync = true;
-        return this;
-    }
-
-    public DubboBootstrap referAsync() {
-        this.referAsync = true;
-        return this;
-    }
-
-    /**
-     * Initialize
-     */
-    public void initialize() {
-        if (!initialized.compareAndSet(false, true)) {
-            return;
-        }
-
-        ApplicationModel.initFrameworkExts();
-
-        startConfigCenter();
-
-        loadRemoteConfigs();
-
-        checkGlobalConfigs();
-
-        // @since 2.7.8
-        startMetadataCenter();
-
-        initMetadataService();
-
-        initEventListener();
-
-        if (logger.isInfoEnabled()) {
-            logger.info(NAME + " has been initialized!");
-        }
-    }
-
-    private void checkGlobalConfigs() {
-        // check Application
-        ConfigValidationUtils.validateApplicationConfig(getApplication());
-
-        // check Metadata
-        Collection<MetadataReportConfig> metadatas = configManager.getMetadataConfigs();
-        if (CollectionUtils.isEmpty(metadatas)) {
-            MetadataReportConfig metadataReportConfig = new MetadataReportConfig();
-            metadataReportConfig.refresh();
-            if (metadataReportConfig.isValid()) {
-                configManager.addMetadataReport(metadataReportConfig);
-                metadatas = configManager.getMetadataConfigs();
-            }
-        }
-        if (CollectionUtils.isNotEmpty(metadatas)) {
-            for (MetadataReportConfig metadataReportConfig : metadatas) {
-                metadataReportConfig.refresh();
-                ConfigValidationUtils.validateMetadataConfig(metadataReportConfig);
-            }
-        }
-
-        // check Provider
-        Collection<ProviderConfig> providers = configManager.getProviders();
-        if (CollectionUtils.isEmpty(providers)) {
-            configManager.getDefaultProvider().orElseGet(() -> {
-                ProviderConfig providerConfig = new ProviderConfig();
-                configManager.addProvider(providerConfig);
-                providerConfig.refresh();
-                return providerConfig;
-            });
-        }
-        for (ProviderConfig providerConfig : configManager.getProviders()) {
-            ConfigValidationUtils.validateProviderConfig(providerConfig);
-        }
-        // check Consumer
-        Collection<ConsumerConfig> consumers = configManager.getConsumers();
-        if (CollectionUtils.isEmpty(consumers)) {
-            configManager.getDefaultConsumer().orElseGet(() -> {
-                ConsumerConfig consumerConfig = new ConsumerConfig();
-                configManager.addConsumer(consumerConfig);
-                consumerConfig.refresh();
-                return consumerConfig;
-            });
-        }
-        for (ConsumerConfig consumerConfig : configManager.getConsumers()) {
-            ConfigValidationUtils.validateConsumerConfig(consumerConfig);
-        }
-
-        // check Monitor
-        ConfigValidationUtils.validateMonitorConfig(getMonitor());
-        // check Metrics
-        ConfigValidationUtils.validateMetricsConfig(getMetrics());
-        // check Module
-        ConfigValidationUtils.validateModuleConfig(getModule());
-        // check Ssl
-        ConfigValidationUtils.validateSslConfig(getSsl());
-    }
-
-    private void startConfigCenter() {
-
-        useRegistryAsConfigCenterIfNecessary();
-
-        Collection<ConfigCenterConfig> configCenters = configManager.getConfigCenters();
-
-        // check Config Center
-        if (CollectionUtils.isEmpty(configCenters)) {
-            ConfigCenterConfig configCenterConfig = new ConfigCenterConfig();
-            configCenterConfig.refresh();
-            if (configCenterConfig.isValid()) {
-                configManager.addConfigCenter(configCenterConfig);
-                configCenters = configManager.getConfigCenters();
-            }
-        } else {
-            for (ConfigCenterConfig configCenterConfig : configCenters) {
-                configCenterConfig.refresh();
-                ConfigValidationUtils.validateConfigCenterConfig(configCenterConfig);
-            }
-        }
-
-        if (CollectionUtils.isNotEmpty(configCenters)) {
-            CompositeDynamicConfiguration compositeDynamicConfiguration = new CompositeDynamicConfiguration();
-            for (ConfigCenterConfig configCenter : configCenters) {
-                compositeDynamicConfiguration.addConfiguration(prepareEnvironment(configCenter));
-            }
-            environment.setDynamicConfiguration(compositeDynamicConfiguration);
-        }
-        configManager.refreshAll();
-    }
-
-    private void startMetadataCenter() {
-
-        useRegistryAsMetadataCenterIfNecessary();
-
-        ApplicationConfig applicationConfig = getApplication();
-
-        String metadataType = applicationConfig.getMetadataType();
-        // FIXME, multiple metadata config support.
-        Collection<MetadataReportConfig> metadataReportConfigs = configManager.getMetadataConfigs();
-        if (CollectionUtils.isEmpty(metadataReportConfigs)) {
-            if (REMOTE_METADATA_STORAGE_TYPE.equals(metadataType)) {
-                throw new IllegalStateException("No MetadataConfig found, Metadata Center address is required when 'metadata=remote' is enabled.");
-            }
-            return;
-        }
-
-        for (MetadataReportConfig metadataReportConfig : metadataReportConfigs) {
-            ConfigValidationUtils.validateMetadataConfig(metadataReportConfig);
-            if (!metadataReportConfig.isValid()) {
-                return;
-            }
-            MetadataReportInstance.init(metadataReportConfig);
-        }
-    }
 
     /**
      * For compatibility purpose, use registry as the default config center when
@@ -708,22 +481,6 @@ public class DubboBootstrap extends GenericEventListener {
         return cc;
     }
 
-    private void useRegistryAsMetadataCenterIfNecessary() {
-
-        Collection<MetadataReportConfig> metadataConfigs = configManager.getMetadataConfigs();
-
-        if (CollectionUtils.isNotEmpty(metadataConfigs)) {
-            return;
-        }
-
-        configManager
-                .getDefaultRegistries()
-                .stream()
-                .filter(this::isUsedRegistryAsMetadataCenter)
-                .map(this::registryAsMetadataCenter)
-                .forEach(configManager::addMetadataReport);
-
-    }
 
     private boolean isUsedRegistryAsMetadataCenter(RegistryConfig registryConfig) {
         return isUsedRegistryAsCenter(registryConfig, registryConfig::getUseAsMetadataCenter, "metadata",
@@ -823,170 +580,7 @@ public class DubboBootstrap extends GenericEventListener {
         return metadataAddressBuilder.toString();
     }
 
-    private void loadRemoteConfigs() {
-        // registry ids to registry configs
-        List<RegistryConfig> tmpRegistries = new ArrayList<>();
-        Set<String> registryIds = configManager.getRegistryIds();
-        registryIds.forEach(id -> {
-            if (tmpRegistries.stream().noneMatch(reg -> reg.getId().equals(id))) {
-                tmpRegistries.add(configManager.getRegistry(id).orElseGet(() -> {
-                    RegistryConfig registryConfig = new RegistryConfig();
-                    registryConfig.setId(id);
-                    registryConfig.refresh();
-                    return registryConfig;
-                }));
-            }
-        });
 
-        configManager.addRegistries(tmpRegistries);
-
-        // protocol ids to protocol configs
-        List<ProtocolConfig> tmpProtocols = new ArrayList<>();
-        Set<String> protocolIds = configManager.getProtocolIds();
-        protocolIds.forEach(id -> {
-            if (tmpProtocols.stream().noneMatch(prot -> prot.getId().equals(id))) {
-                tmpProtocols.add(configManager.getProtocol(id).orElseGet(() -> {
-                    ProtocolConfig protocolConfig = new ProtocolConfig();
-                    protocolConfig.setId(id);
-                    protocolConfig.refresh();
-                    return protocolConfig;
-                }));
-            }
-        });
-
-        configManager.addProtocols(tmpProtocols);
-    }
-
-
-    /**
-     * Initialize {@link MetadataService} from {@link WritableMetadataService}'s extension
-     */
-    private void initMetadataService() {
-//        startMetadataCenter();
-        this.metadataService = getDefaultExtension();
-        this.metadataServiceExporter = new ConfigurableMetadataServiceExporter(metadataService);
-    }
-
-    /**
-     * Initialize {@link EventListener}
-     */
-    private void initEventListener() {
-        // Add current instance into listeners
-        addEventListener(this);
-    }
-
-    /**
-     * Start the bootstrap
-     */
-    public DubboBootstrap start() {
-        if (started.compareAndSet(false, true)) {
-            startup.set(false);
-            initialize();
-            if (logger.isInfoEnabled()) {
-                logger.info(NAME + " is starting...");
-            }
-            // 1. export Dubbo Services
-            exportServices();
-
-            // Not only provider register
-            if (!isOnlyRegisterProvider() || hasExportedServices()) {
-                // 2. export MetadataService
-                exportMetadataService();
-                //3. Register the local ServiceInstance if required
-                registerServiceInstance();
-            }
-
-            referServices();
-            if (asyncExportingFutures.size() > 0) {
-                new Thread(() -> {
-                    try {
-                        this.awaitFinish();
-                    } catch (Exception e) {
-                        logger.warn(NAME + " exportAsync occurred an exception.");
-                    }
-                    startup.set(true);
-                    if (logger.isInfoEnabled()) {
-                        logger.info(NAME + " is ready.");
-                    }
-                }).start();
-            } else {
-                startup.set(true);
-                if (logger.isInfoEnabled()) {
-                    logger.info(NAME + " is ready.");
-                }
-            }
-            if (logger.isInfoEnabled()) {
-                logger.info(NAME + " has started.");
-            }
-        }
-        return this;
-    }
-
-    private boolean hasExportedServices() {
-        return CollectionUtils.isNotEmpty(configManager.getServices());
-    }
-
-    /**
-     * Block current thread to be await.
-     *
-     * @return {@link DubboBootstrap}
-     */
-    public DubboBootstrap await() {
-        // if has been waited, no need to wait again, return immediately
-        if (!awaited.get()) {
-            if (!executorService.isShutdown()) {
-                executeMutually(() -> {
-                    while (!awaited.get()) {
-                        if (logger.isInfoEnabled()) {
-                            logger.info(NAME + " awaiting ...");
-                        }
-                        try {
-                            condition.await();
-                        } catch (InterruptedException e) {
-                            Thread.currentThread().interrupt();
-                        }
-                    }
-                });
-            }
-        }
-        return this;
-    }
-
-    public DubboBootstrap awaitFinish() throws Exception {
-        logger.info(NAME + " waiting services exporting / referring ...");
-        if (exportAsync && asyncExportingFutures.size() > 0) {
-            CompletableFuture future = CompletableFuture.allOf(asyncExportingFutures.toArray(new CompletableFuture[0]));
-            future.get();
-        }
-        if (referAsync && asyncReferringFutures.size() > 0) {
-            CompletableFuture future = CompletableFuture.allOf(asyncReferringFutures.toArray(new CompletableFuture[0]));
-            future.get();
-        }
-
-        logger.info("Service export / refer finished.");
-        return this;
-    }
-
-    public boolean isInitialized() {
-        return initialized.get();
-    }
-
-    public boolean isStarted() {
-        return started.get();
-    }
-
-    public boolean isStartup() {
-        return startup.get();
-    }
-
-    public boolean isShutdown() {
-        return shutdown.get();
-    }
-
-    public DubboBootstrap stop() throws IllegalStateException {
-        destroy();
-        return this;
-    }
     /* serve for builder apis, begin */
 
     private ApplicationBuilder createApplicationBuilder(String name) {
@@ -1016,35 +610,6 @@ public class DubboBootstrap extends GenericEventListener {
     private ConsumerBuilder createConsumerBuilder(String id) {
         return new ConsumerBuilder().id(id);
     }
-    /* serve for builder apis, end */
-
-    private DynamicConfiguration prepareEnvironment(ConfigCenterConfig configCenter) {
-        if (configCenter.isValid()) {
-            if (!configCenter.checkOrUpdateInited()) {
-                return null;
-            }
-            DynamicConfiguration dynamicConfiguration = getDynamicConfiguration(configCenter.toUrl());
-            String configContent = dynamicConfiguration.getProperties(configCenter.getConfigFile(), configCenter.getGroup());
-
-            String appGroup = getApplication().getName();
-            String appConfigContent = null;
-            if (isNotEmpty(appGroup)) {
-                appConfigContent = dynamicConfiguration.getProperties
-                        (isNotEmpty(configCenter.getAppConfigFile()) ? configCenter.getAppConfigFile() : configCenter.getConfigFile(),
-                                appGroup
-                        );
-            }
-            try {
-                environment.setConfigCenterFirst(configCenter.isHighestPriority());
-                environment.updateExternalConfigurationMap(parseProperties(configContent));
-                environment.updateAppExternalConfigurationMap(parseProperties(appConfigContent));
-            } catch (IOException e) {
-                throw new IllegalStateException("Failed to parse configurations from Config Center.", e);
-            }
-            return dynamicConfiguration;
-        }
-        return null;
-    }
 
     /**
      * Add an instance of {@link EventListener}
@@ -1055,235 +620,6 @@ public class DubboBootstrap extends GenericEventListener {
     public DubboBootstrap addEventListener(EventListener<?> listener) {
         eventDispatcher.addEventListener(listener);
         return this;
-    }
-
-    /**
-     * export {@link MetadataService}
-     */
-    private void exportMetadataService() {
-        metadataServiceExporter.export();
-    }
-
-    private void unexportMetadataService() {
-        if (metadataServiceExporter != null && metadataServiceExporter.isExported()) {
-            metadataServiceExporter.unexport();
-        }
-    }
-
-    private void exportServices() {
-        configManager.getServices().forEach(sc -> {
-            // TODO, compatible with ServiceConfig.export()
-            ServiceConfig serviceConfig = (ServiceConfig) sc;
-            serviceConfig.setBootstrap(this);
-
-            if (exportAsync) {
-                ExecutorService executor = executorRepository.getServiceExporterExecutor();
-                Future<?> future = executor.submit(() -> {
-                    sc.export();
-                    exportedServices.add(sc);
-                });
-                asyncExportingFutures.add(future);
-            } else {
-                sc.export();
-                exportedServices.add(sc);
-            }
-        });
-    }
-
-    private void unexportServices() {
-        exportedServices.forEach(sc -> {
-            configManager.removeConfig(sc);
-            sc.unexport();
-        });
-
-        asyncExportingFutures.forEach(future -> {
-            if (!future.isDone()) {
-                future.cancel(true);
-            }
-        });
-        asyncExportingFutures.clear();
-        exportedServices.clear();
-    }
-
-    private void referServices() {
-        if (cache == null) {
-            cache = ReferenceConfigCache.getCache();
-        }
-
-        configManager.getReferences().forEach(rc -> {
-            // TODO, compatible with  ReferenceConfig.refer()
-            ReferenceConfig referenceConfig = (ReferenceConfig) rc;
-            referenceConfig.setBootstrap(this);
-
-            if (rc.shouldInit()) {
-                if (referAsync) {
-                    CompletableFuture<Object> future = ScheduledCompletableFuture.submit(
-                            executorRepository.getServiceExporterExecutor(),
-                            () -> cache.get(rc)
-                    );
-                    asyncReferringFutures.add(future);
-                } else {
-                    cache.get(rc);
-                }
-            }
-        });
-    }
-
-    private void unreferServices() {
-        if (cache == null) {
-            cache = ReferenceConfigCache.getCache();
-        }
-
-        asyncReferringFutures.forEach(future -> {
-            if (!future.isDone()) {
-                future.cancel(true);
-            }
-        });
-        asyncReferringFutures.clear();
-        cache.destroyAll();
-    }
-
-    private void registerServiceInstance() {
-        ApplicationConfig application = getApplication();
-
-        String serviceName = application.getName();
-
-        ServiceInstance serviceInstance = createServiceInstance(serviceName);
-
-        doRegisterServiceInstance(serviceInstance);
-
-        // scheduled task for updating Metadata and ServiceInstance
-        executorRepository.nextScheduledExecutor().scheduleAtFixedRate(() -> {
-            InMemoryWritableMetadataService localMetadataService = (InMemoryWritableMetadataService) WritableMetadataService.getDefaultExtension();
-            localMetadataService.blockUntilUpdated();
-            ServiceInstanceMetadataUtils.refreshMetadataAndInstance(serviceInstance);
-        }, 0, ConfigurationUtils.get(METADATA_PUBLISH_DELAY_KEY, DEFAULT_METADATA_PUBLISH_DELAY), TimeUnit.MILLISECONDS);
-    }
-
-    private void doRegisterServiceInstance(ServiceInstance serviceInstance) {
-        // register instance only when at least one service is exported.
-        if (serviceInstance.getPort() != null && serviceInstance.getPort() != -1) {
-            publishMetadataToRemote(serviceInstance);
-            logger.info("Start registering instance address to registry.");
-            getServiceDiscoveries().forEach(serviceDiscovery ->
-            {
-                calInstanceRevision(serviceDiscovery, serviceInstance);
-                if (logger.isDebugEnabled()) {
-                    logger.info("Start registering instance address to registry" + serviceDiscovery.getUrl() + ", instance " + serviceInstance);
-                }
-                // register metadata
-                serviceDiscovery.register(serviceInstance);
-            });
-        }
-    }
-
-    private void publishMetadataToRemote(ServiceInstance serviceInstance) {
-//        InMemoryWritableMetadataService localMetadataService = (InMemoryWritableMetadataService)WritableMetadataService.getDefaultExtension();
-//        localMetadataService.blockUntilUpdated();
-        if (logger.isInfoEnabled()) {
-            logger.info("Start publishing metadata to remote center, this only makes sense for applications enabled remote metadata center.");
-        }
-        RemoteMetadataServiceImpl remoteMetadataService = MetadataUtils.getRemoteMetadataService();
-        remoteMetadataService.publishMetadata(serviceInstance.getServiceName());
-    }
-
-    private void unregisterServiceInstance() {
-        if (serviceInstance != null) {
-            getServiceDiscoveries().forEach(serviceDiscovery -> {
-                serviceDiscovery.unregister(serviceInstance);
-            });
-        }
-    }
-
-    private ServiceInstance createServiceInstance(String serviceName) {
-        this.serviceInstance = new DefaultServiceInstance(serviceName);
-        setMetadataStorageType(serviceInstance, getMetadataType());
-        ServiceInstanceMetadataUtils.customizeInstance(this.serviceInstance);
-        return this.serviceInstance;
-    }
-
-    public void destroy() {
-        if (destroyLock.tryLock()
-                && shutdown.compareAndSet(false, true)) {
-            try {
-                DubboShutdownHook.destroyAll();
-
-                if (started.compareAndSet(true, false)
-                        && destroyed.compareAndSet(false, true)) {
-
-                    unregisterServiceInstance();
-                    unexportMetadataService();
-                    unexportServices();
-                    unreferServices();
-
-                    destroyRegistries();
-                    DubboShutdownHook.destroyProtocols();
-                    destroyServiceDiscoveries();
-
-                    clear();
-                    shutdown();
-                    release();
-                }
-            } finally {
-                destroyLock.unlock();
-            }
-        }
-    }
-
-    private void destroyRegistries() {
-        AbstractRegistryFactory.destroyAll();
-    }
-
-    private void destroyServiceDiscoveries() {
-        getServiceDiscoveries().forEach(serviceDiscovery -> {
-            execute(serviceDiscovery::destroy);
-        });
-        if (logger.isDebugEnabled()) {
-            logger.debug(NAME + "'s all ServiceDiscoveries have been destroyed.");
-        }
-    }
-
-    private void clear() {
-        clearConfigs();
-        clearApplicationModel();
-    }
-
-    private void clearApplicationModel() {
-
-    }
-
-    private void clearConfigs() {
-        configManager.destroy();
-        if (logger.isDebugEnabled()) {
-            logger.debug(NAME + "'s configs have been clear.");
-        }
-    }
-
-    private void release() {
-        executeMutually(() -> {
-            while (awaited.compareAndSet(false, true)) {
-                if (logger.isInfoEnabled()) {
-                    logger.info(NAME + " is about to shutdown...");
-                }
-                condition.signalAll();
-            }
-        });
-    }
-
-    private void shutdown() {
-        if (!executorService.isShutdown()) {
-            // Shutdown executorService
-            executorService.shutdown();
-        }
-    }
-
-    private void executeMutually(Runnable runnable) {
-        try {
-            lock.lock();
-            runnable.run();
-        } finally {
-            lock.unlock();
-        }
     }
 
     public ApplicationConfig getApplication() {
@@ -1350,5 +686,68 @@ public class DubboBootstrap extends GenericEventListener {
 
         ssl.refresh();
         return ssl;
+    }
+
+
+    //DubboServer related
+
+    public DubboBootstrap exportAsync() {
+        dubboServer.exportAsync();
+        return this;
+    }
+
+    public DubboBootstrap referAsync() {
+        dubboServer.referAsync();
+        return this;
+    }
+
+    /**
+     * Initialize
+     */
+    public void initialize() {
+        dubboServer.initialize();
+    }
+
+    /**
+     * Start the bootstrap
+     */
+    public DubboBootstrap start() {
+        dubboServer.start();
+        return this;
+    }
+
+    public boolean isInitialized() {
+        return dubboServer.isInitialized();
+    }
+
+    public boolean isStarted() {
+        return dubboServer.isStarted();
+    }
+
+    public boolean isStartup() {
+        return dubboServer.isStartup();
+    }
+
+    public boolean isShutdown() {
+        return dubboServer.isShutdown();
+    }
+
+    public DubboBootstrap stop() throws IllegalStateException {
+        dubboServer.stop();
+        return this;
+    }
+
+    public void destroy() {
+        dubboServer.destroy();
+    }
+
+    /**
+     * Block current thread to be await.
+     *
+     * @return {@link DubboServer}
+     */
+    public DubboBootstrap await() {
+        dubboServer.await();
+        return this;
     }
 }

--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/dubboserver/DubboServer.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/dubboserver/DubboServer.java
@@ -1,0 +1,1480 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.config.dubboserver;
+
+import org.apache.dubbo.common.URL;
+import org.apache.dubbo.common.config.ConfigurationUtils;
+import org.apache.dubbo.common.config.Environment;
+import org.apache.dubbo.common.config.configcenter.DynamicConfiguration;
+import org.apache.dubbo.common.config.configcenter.DynamicConfigurationFactory;
+import org.apache.dubbo.common.config.configcenter.wrapper.CompositeDynamicConfiguration;
+import org.apache.dubbo.common.extension.ExtensionLoader;
+import org.apache.dubbo.common.lang.ShutdownHookCallback;
+import org.apache.dubbo.common.lang.ShutdownHookCallbacks;
+import org.apache.dubbo.common.logger.Logger;
+import org.apache.dubbo.common.logger.LoggerFactory;
+import org.apache.dubbo.common.threadpool.concurrent.ScheduledCompletableFuture;
+import org.apache.dubbo.common.threadpool.manager.ExecutorRepository;
+import org.apache.dubbo.common.utils.ArrayUtils;
+import org.apache.dubbo.common.utils.CollectionUtils;
+import org.apache.dubbo.common.utils.StringUtils;
+import org.apache.dubbo.config.ApplicationConfig;
+import org.apache.dubbo.config.ConfigCenterConfig;
+import org.apache.dubbo.config.ConsumerConfig;
+import org.apache.dubbo.config.DubboShutdownHook;
+import org.apache.dubbo.config.MetadataReportConfig;
+import org.apache.dubbo.config.MetricsConfig;
+import org.apache.dubbo.config.ModuleConfig;
+import org.apache.dubbo.config.MonitorConfig;
+import org.apache.dubbo.config.ProtocolConfig;
+import org.apache.dubbo.config.ProviderConfig;
+import org.apache.dubbo.config.ReferenceConfig;
+import org.apache.dubbo.config.ReferenceConfigBase;
+import org.apache.dubbo.config.RegistryConfig;
+import org.apache.dubbo.config.ServiceConfig;
+import org.apache.dubbo.config.ServiceConfigBase;
+import org.apache.dubbo.config.SslConfig;
+import org.apache.dubbo.config.bootstrap.builders.ApplicationBuilder;
+import org.apache.dubbo.config.bootstrap.builders.ConsumerBuilder;
+import org.apache.dubbo.config.bootstrap.builders.ProtocolBuilder;
+import org.apache.dubbo.config.bootstrap.builders.ProviderBuilder;
+import org.apache.dubbo.config.bootstrap.builders.ReferenceBuilder;
+import org.apache.dubbo.config.bootstrap.builders.RegistryBuilder;
+import org.apache.dubbo.config.bootstrap.builders.ServiceBuilder;
+import org.apache.dubbo.config.context.ConfigManager;
+import org.apache.dubbo.config.metadata.ConfigurableMetadataServiceExporter;
+import org.apache.dubbo.config.utils.ConfigValidationUtils;
+import org.apache.dubbo.config.utils.ReferenceConfigCache;
+import org.apache.dubbo.event.EventDispatcher;
+import org.apache.dubbo.event.EventListener;
+import org.apache.dubbo.event.GenericEventListener;
+import org.apache.dubbo.metadata.MetadataService;
+import org.apache.dubbo.metadata.MetadataServiceExporter;
+import org.apache.dubbo.metadata.WritableMetadataService;
+import org.apache.dubbo.metadata.report.MetadataReportFactory;
+import org.apache.dubbo.metadata.report.MetadataReportInstance;
+import org.apache.dubbo.registry.client.DefaultServiceInstance;
+import org.apache.dubbo.registry.client.ServiceInstance;
+import org.apache.dubbo.registry.client.metadata.MetadataUtils;
+import org.apache.dubbo.registry.client.metadata.ServiceInstanceMetadataUtils;
+import org.apache.dubbo.registry.client.metadata.store.InMemoryWritableMetadataService;
+import org.apache.dubbo.registry.client.metadata.store.RemoteMetadataServiceImpl;
+import org.apache.dubbo.registry.support.AbstractRegistryFactory;
+import org.apache.dubbo.rpc.model.ApplicationModel;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+import static java.lang.String.format;
+import static java.util.Arrays.asList;
+import static java.util.concurrent.Executors.newSingleThreadExecutor;
+import static org.apache.dubbo.common.config.ConfigurationUtils.parseProperties;
+import static org.apache.dubbo.common.config.configcenter.DynamicConfiguration.getDynamicConfiguration;
+import static org.apache.dubbo.common.constants.CommonConstants.DEFAULT_METADATA_STORAGE_TYPE;
+import static org.apache.dubbo.common.constants.CommonConstants.REGISTRY_SPLIT_PATTERN;
+import static org.apache.dubbo.common.constants.CommonConstants.REMOTE_METADATA_STORAGE_TYPE;
+import static org.apache.dubbo.common.extension.ExtensionLoader.getExtensionLoader;
+import static org.apache.dubbo.common.function.ThrowableAction.execute;
+import static org.apache.dubbo.common.utils.StringUtils.isEmpty;
+import static org.apache.dubbo.common.utils.StringUtils.isNotEmpty;
+import static org.apache.dubbo.metadata.MetadataConstants.DEFAULT_METADATA_PUBLISH_DELAY;
+import static org.apache.dubbo.metadata.MetadataConstants.METADATA_PUBLISH_DELAY_KEY;
+import static org.apache.dubbo.metadata.WritableMetadataService.getDefaultExtension;
+import static org.apache.dubbo.registry.client.metadata.ServiceInstanceMetadataUtils.calInstanceRevision;
+import static org.apache.dubbo.registry.client.metadata.ServiceInstanceMetadataUtils.setMetadataStorageType;
+import static org.apache.dubbo.registry.support.AbstractRegistryFactory.getServiceDiscoveries;
+import static org.apache.dubbo.remoting.Constants.CLIENT_KEY;
+
+public class DubboServer extends GenericEventListener {
+
+    public static final String DEFAULT_REGISTRY_ID = "REGISTRY#DEFAULT";
+
+    public static final String DEFAULT_PROTOCOL_ID = "PROTOCOL#DEFAULT";
+
+    public static final String DEFAULT_SERVICE_ID = "SERVICE#DEFAULT";
+
+    public static final String DEFAULT_REFERENCE_ID = "REFERENCE#DEFAULT";
+
+    public static final String DEFAULT_PROVIDER_ID = "PROVIDER#DEFAULT";
+
+    public static final String DEFAULT_CONSUMER_ID = "CONSUMER#DEFAULT";
+
+    private static final String NAME = DubboServer.class.getSimpleName();
+
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+
+    private static volatile DubboServer instance;
+
+    private final AtomicBoolean awaited = new AtomicBoolean(false);
+
+    private final Lock lock = new ReentrantLock();
+
+    private final Condition condition = lock.newCondition();
+
+    private final Lock destroyLock = new ReentrantLock();
+
+    private final ExecutorService executorService = newSingleThreadExecutor();
+
+    private final EventDispatcher eventDispatcher = EventDispatcher.getDefaultExtension();
+
+    private final ExecutorRepository executorRepository = getExtensionLoader(ExecutorRepository.class).getDefaultExtension();
+
+    private final ConfigManager configManager;
+
+    private final Environment environment;
+
+    private ReferenceConfigCache cache;
+
+    private volatile boolean exportAsync;
+
+    private volatile boolean referAsync;
+
+    private AtomicBoolean initialized = new AtomicBoolean(false);
+
+    private AtomicBoolean started = new AtomicBoolean(false);
+
+    private AtomicBoolean startup = new AtomicBoolean(true);
+
+    private AtomicBoolean destroyed = new AtomicBoolean(false);
+
+    private AtomicBoolean shutdown = new AtomicBoolean(false);
+
+    private volatile ServiceInstance serviceInstance;
+
+    private volatile MetadataService metadataService;
+
+    private volatile MetadataServiceExporter metadataServiceExporter;
+
+    private List<ServiceConfigBase<?>> exportedServices = new ArrayList<>();
+
+    private List<Future<?>> asyncExportingFutures = new ArrayList<>();
+
+    private List<CompletableFuture<Object>> asyncReferringFutures = new ArrayList<>();
+
+    private Map<ServiceConfigBase, Future<?>> serviceConfigBase2AsyncExportingFutures = new ConcurrentHashMap<>();
+
+    private Map<ReferenceConfigBase, CompletableFuture<Object>> referenceConfigBase2AsyncExportingFutures = new ConcurrentHashMap<>();
+
+    /**
+     * See {@link ApplicationModel} and {@link ExtensionLoader} for why DubboServer is designed to be singleton.
+     */
+    public static DubboServer getInstance() {
+        if (instance == null) {
+            synchronized (DubboServer.class) {
+                if (instance == null) {
+                    instance = new DubboServer();
+                }
+            }
+        }
+        return instance;
+    }
+
+    private DubboServer() {
+        configManager = ApplicationModel.getConfigManager();
+        environment = ApplicationModel.getEnvironment();
+
+        DubboShutdownHook.getDubboShutdownHook().register();
+        ShutdownHookCallbacks.INSTANCE.addCallback(new ShutdownHookCallback() {
+            @Override
+            public void callback() throws Throwable {
+                DubboServer.this.destroy();
+            }
+        });
+    }
+
+    public void unRegisterShutdownHook() {
+        DubboShutdownHook.getDubboShutdownHook().unregister();
+    }
+
+    public DubboServer metadataReport(MetadataReportConfig metadataReportConfig) {
+        configManager.addMetadataReport(metadataReportConfig);
+        return this;
+    }
+
+    public DubboServer metadataReports(List<MetadataReportConfig> metadataReportConfigs) {
+        if (CollectionUtils.isEmpty(metadataReportConfigs)) {
+            return this;
+        }
+
+        configManager.addMetadataReports(metadataReportConfigs);
+        return this;
+    }
+
+    // {@link ApplicationConfig} correlative methods
+
+    /**
+     * Set the name of application
+     *
+     * @param name the name of application
+     * @return current {@link DubboServer} instance
+     */
+    public DubboServer application(String name) {
+        return application(name, builder -> {
+            // DO NOTHING
+        });
+    }
+
+    /**
+     * Set the name of application and it's future build
+     *
+     * @param name            the name of application
+     * @param consumerBuilder {@link ApplicationBuilder}
+     * @return current {@link DubboServer} instance
+     */
+    public DubboServer application(String name, Consumer<ApplicationBuilder> consumerBuilder) {
+        ApplicationBuilder builder = createApplicationBuilder(name);
+        consumerBuilder.accept(builder);
+        return application(builder.build());
+    }
+
+    /**
+     * Set the {@link ApplicationConfig}
+     *
+     * @param applicationConfig the {@link ApplicationConfig}
+     * @return current {@link DubboServer} instance
+     */
+    public DubboServer application(ApplicationConfig applicationConfig) {
+        configManager.setApplication(applicationConfig);
+        return this;
+    }
+
+
+    // {@link RegistryConfig} correlative methods
+
+    /**
+     * Add an instance of {@link RegistryConfig} with {@link #DEFAULT_REGISTRY_ID default ID}
+     *
+     * @param consumerBuilder the {@link Consumer} of {@link RegistryBuilder}
+     * @return current {@link DubboServer} instance
+     */
+    public DubboServer registry(Consumer<RegistryBuilder> consumerBuilder) {
+        return registry(DEFAULT_REGISTRY_ID, consumerBuilder);
+    }
+
+    /**
+     * Add an instance of {@link RegistryConfig} with the specified ID
+     *
+     * @param id              the {@link RegistryConfig#getId() id}  of {@link RegistryConfig}
+     * @param consumerBuilder the {@link Consumer} of {@link RegistryBuilder}
+     * @return current {@link DubboServer} instance
+     */
+    public DubboServer registry(String id, Consumer<RegistryBuilder> consumerBuilder) {
+        RegistryBuilder builder = createRegistryBuilder(id);
+        consumerBuilder.accept(builder);
+        return registry(builder.build());
+    }
+
+    /**
+     * Add an instance of {@link RegistryConfig}
+     *
+     * @param registryConfig an instance of {@link RegistryConfig}
+     * @return current {@link DubboServer} instance
+     */
+    public DubboServer registry(RegistryConfig registryConfig) {
+        configManager.addRegistry(registryConfig);
+        return this;
+    }
+
+    /**
+     * Add an instance of {@link RegistryConfig}
+     *
+     * @param registryConfigs the multiple instances of {@link RegistryConfig}
+     * @return current {@link DubboServer} instance
+     */
+    public DubboServer registries(List<RegistryConfig> registryConfigs) {
+        if (CollectionUtils.isEmpty(registryConfigs)) {
+            return this;
+        }
+        registryConfigs.forEach(this::registry);
+        return this;
+    }
+
+
+    // {@link ProtocolConfig} correlative methods
+    public DubboServer protocol(Consumer<ProtocolBuilder> consumerBuilder) {
+        return protocol(DEFAULT_PROTOCOL_ID, consumerBuilder);
+    }
+
+    public DubboServer protocol(String id, Consumer<ProtocolBuilder> consumerBuilder) {
+        ProtocolBuilder builder = createProtocolBuilder(id);
+        consumerBuilder.accept(builder);
+        return protocol(builder.build());
+    }
+
+    public DubboServer protocol(ProtocolConfig protocolConfig) {
+        return protocols(asList(protocolConfig));
+    }
+
+    public DubboServer protocols(List<ProtocolConfig> protocolConfigs) {
+        if (CollectionUtils.isEmpty(protocolConfigs)) {
+            return this;
+        }
+        configManager.addProtocols(protocolConfigs);
+        return this;
+    }
+
+    // {@link ServiceConfig} correlative methods
+    public <S> DubboServer service(Consumer<ServiceBuilder<S>> consumerBuilder) {
+        return service(DEFAULT_SERVICE_ID, consumerBuilder);
+    }
+
+    public <S> DubboServer service(String id, Consumer<ServiceBuilder<S>> consumerBuilder) {
+        ServiceBuilder builder = createServiceBuilder(id);
+        consumerBuilder.accept(builder);
+        return service(builder.build());
+    }
+
+    public DubboServer service(ServiceConfig<?> serviceConfig) {
+        configManager.addService(serviceConfig);
+        return this;
+    }
+
+    public DubboServer services(List<ServiceConfig> serviceConfigs) {
+        if (CollectionUtils.isEmpty(serviceConfigs)) {
+            return this;
+        }
+        serviceConfigs.forEach(configManager::addService);
+        return this;
+    }
+
+    // {@link Reference} correlative methods
+    public <S> DubboServer reference(Consumer<ReferenceBuilder<S>> consumerBuilder) {
+        return reference(DEFAULT_REFERENCE_ID, consumerBuilder);
+    }
+
+    public <S> DubboServer reference(String id, Consumer<ReferenceBuilder<S>> consumerBuilder) {
+        ReferenceBuilder builder = createReferenceBuilder(id);
+        consumerBuilder.accept(builder);
+        return reference(builder.build());
+    }
+
+    public DubboServer reference(ReferenceConfig<?> referenceConfig) {
+        configManager.addReference(referenceConfig);
+        return this;
+    }
+
+    public DubboServer references(List<ReferenceConfig> referenceConfigs) {
+        if (CollectionUtils.isEmpty(referenceConfigs)) {
+            return this;
+        }
+
+        referenceConfigs.forEach(configManager::addReference);
+        return this;
+    }
+
+    // {@link ProviderConfig} correlative methods
+    public DubboServer provider(Consumer<ProviderBuilder> builderConsumer) {
+        return provider(DEFAULT_PROVIDER_ID, builderConsumer);
+    }
+
+    public DubboServer provider(String id, Consumer<ProviderBuilder> builderConsumer) {
+        ProviderBuilder builder = createProviderBuilder(id);
+        builderConsumer.accept(builder);
+        return provider(builder.build());
+    }
+
+    public DubboServer provider(ProviderConfig providerConfig) {
+        return providers(asList(providerConfig));
+    }
+
+    public DubboServer providers(List<ProviderConfig> providerConfigs) {
+        if (CollectionUtils.isEmpty(providerConfigs)) {
+            return this;
+        }
+
+        providerConfigs.forEach(configManager::addProvider);
+        return this;
+    }
+
+    // {@link ConsumerConfig} correlative methods
+    public DubboServer consumer(Consumer<ConsumerBuilder> builderConsumer) {
+        return consumer(DEFAULT_CONSUMER_ID, builderConsumer);
+    }
+
+    public DubboServer consumer(String id, Consumer<ConsumerBuilder> builderConsumer) {
+        ConsumerBuilder builder = createConsumerBuilder(id);
+        builderConsumer.accept(builder);
+        return consumer(builder.build());
+    }
+
+    public DubboServer consumer(ConsumerConfig consumerConfig) {
+        return consumers(asList(consumerConfig));
+    }
+
+    public DubboServer consumers(List<ConsumerConfig> consumerConfigs) {
+        if (CollectionUtils.isEmpty(consumerConfigs)) {
+            return this;
+        }
+
+        consumerConfigs.forEach(configManager::addConsumer);
+        return this;
+    }
+
+    // {@link ConfigCenterConfig} correlative methods
+    public DubboServer configCenter(ConfigCenterConfig configCenterConfig) {
+        return configCenters(asList(configCenterConfig));
+    }
+
+    public DubboServer configCenters(List<ConfigCenterConfig> configCenterConfigs) {
+        if (CollectionUtils.isEmpty(configCenterConfigs)) {
+            return this;
+        }
+        configManager.addConfigCenters(configCenterConfigs);
+        return this;
+    }
+
+    public DubboServer monitor(MonitorConfig monitor) {
+        configManager.setMonitor(monitor);
+        return this;
+    }
+
+    public DubboServer metrics(MetricsConfig metrics) {
+        configManager.setMetrics(metrics);
+        return this;
+    }
+
+    public DubboServer module(ModuleConfig module) {
+        configManager.setModule(module);
+        return this;
+    }
+
+    public DubboServer ssl(SslConfig sslConfig) {
+        configManager.setSsl(sslConfig);
+        return this;
+    }
+
+    public DubboServer cache(ReferenceConfigCache cache) {
+        this.cache = cache;
+        return this;
+    }
+
+    public ReferenceConfigCache getCache() {
+        if (cache == null) {
+            cache = ReferenceConfigCache.getCache();
+        }
+        return cache;
+    }
+
+
+    private boolean isOnlyRegisterProvider() {
+        Boolean registerConsumer = getApplication().getRegisterConsumer();
+        return registerConsumer == null || !registerConsumer;
+    }
+
+    private String getMetadataType() {
+        String type = getApplication().getMetadataType();
+        if (StringUtils.isEmpty(type)) {
+            type = DEFAULT_METADATA_STORAGE_TYPE;
+        }
+        return type;
+    }
+
+    /**
+     * Initialize
+     */
+    public void initialize() {
+        if (!initialized.compareAndSet(false, true)) {
+            return;
+        }
+
+        ApplicationModel.initFrameworkExts();
+
+        startConfigCenter();
+
+        loadRemoteConfigs();
+
+        checkGlobalConfigs();
+
+        // @since 2.7.8
+        startMetadataCenter();
+
+        initMetadataService();
+
+        initEventListener();
+
+
+        //initializer the services and
+        configManager.getServices().forEach(serviceConfigBase -> {
+            if (serviceConfigBase instanceof ServiceConfig) {
+                ((ServiceConfig) ((ServiceConfig<?>) serviceConfigBase)).beforeExportByDubboServer();
+            }
+        });
+
+        configManager.getReferences().forEach(referenceConfigBase -> {
+            if (referenceConfigBase instanceof ReferenceConfig) {
+                ((ReferenceConfig) ((ReferenceConfig<?>) referenceConfigBase)).beforeInitByDubboServer();
+            }
+        });
+
+        if (logger.isInfoEnabled()) {
+            logger.info(NAME + " has been initialized!");
+        }
+    }
+
+    private void checkGlobalConfigs() {
+        // check Application
+        ConfigValidationUtils.validateApplicationConfig(getApplication());
+
+        // check Metadata
+        Collection<MetadataReportConfig> metadatas = configManager.getMetadataConfigs();
+        if (CollectionUtils.isEmpty(metadatas)) {
+            MetadataReportConfig metadataReportConfig = new MetadataReportConfig();
+            metadataReportConfig.refresh();
+            if (metadataReportConfig.isValid()) {
+                configManager.addMetadataReport(metadataReportConfig);
+                metadatas = configManager.getMetadataConfigs();
+            }
+        }
+        if (CollectionUtils.isNotEmpty(metadatas)) {
+            for (MetadataReportConfig metadataReportConfig : metadatas) {
+                metadataReportConfig.refresh();
+                ConfigValidationUtils.validateMetadataConfig(metadataReportConfig);
+            }
+        }
+
+        // check Provider
+        Collection<ProviderConfig> providers = configManager.getProviders();
+        if (CollectionUtils.isEmpty(providers)) {
+            configManager.getDefaultProvider().orElseGet(() -> {
+                ProviderConfig providerConfig = new ProviderConfig();
+                configManager.addProvider(providerConfig);
+                providerConfig.refresh();
+                return providerConfig;
+            });
+        }
+        for (ProviderConfig providerConfig : configManager.getProviders()) {
+            ConfigValidationUtils.validateProviderConfig(providerConfig);
+        }
+        // check Consumer
+        Collection<ConsumerConfig> consumers = configManager.getConsumers();
+        if (CollectionUtils.isEmpty(consumers)) {
+            configManager.getDefaultConsumer().orElseGet(() -> {
+                ConsumerConfig consumerConfig = new ConsumerConfig();
+                configManager.addConsumer(consumerConfig);
+                consumerConfig.refresh();
+                return consumerConfig;
+            });
+        }
+        for (ConsumerConfig consumerConfig : configManager.getConsumers()) {
+            ConfigValidationUtils.validateConsumerConfig(consumerConfig);
+        }
+
+        // check Monitor
+        ConfigValidationUtils.validateMonitorConfig(getMonitor());
+        // check Metrics
+        ConfigValidationUtils.validateMetricsConfig(getMetrics());
+        // check Module
+        ConfigValidationUtils.validateModuleConfig(getModule());
+        // check Ssl
+        ConfigValidationUtils.validateSslConfig(getSsl());
+    }
+
+    private void startConfigCenter() {
+
+        useRegistryAsConfigCenterIfNecessary();
+
+        Collection<ConfigCenterConfig> configCenters = configManager.getConfigCenters();
+
+        // check Config Center
+        if (CollectionUtils.isEmpty(configCenters)) {
+            ConfigCenterConfig configCenterConfig = new ConfigCenterConfig();
+            configCenterConfig.refresh();
+            if (configCenterConfig.isValid()) {
+                configManager.addConfigCenter(configCenterConfig);
+                configCenters = configManager.getConfigCenters();
+            }
+        } else {
+            for (ConfigCenterConfig configCenterConfig : configCenters) {
+                configCenterConfig.refresh();
+                ConfigValidationUtils.validateConfigCenterConfig(configCenterConfig);
+            }
+        }
+
+        if (CollectionUtils.isNotEmpty(configCenters)) {
+            CompositeDynamicConfiguration compositeDynamicConfiguration = new CompositeDynamicConfiguration();
+            for (ConfigCenterConfig configCenter : configCenters) {
+                compositeDynamicConfiguration.addConfiguration(prepareEnvironment(configCenter));
+            }
+            environment.setDynamicConfiguration(compositeDynamicConfiguration);
+        }
+        configManager.refreshAll();
+    }
+
+    private void startMetadataCenter() {
+
+        useRegistryAsMetadataCenterIfNecessary();
+
+        ApplicationConfig applicationConfig = getApplication();
+
+        String metadataType = applicationConfig.getMetadataType();
+        // FIXME, multiple metadata config support.
+        Collection<MetadataReportConfig> metadataReportConfigs = configManager.getMetadataConfigs();
+        if (CollectionUtils.isEmpty(metadataReportConfigs)) {
+            if (REMOTE_METADATA_STORAGE_TYPE.equals(metadataType)) {
+                throw new IllegalStateException("No MetadataConfig found, Metadata Center address is required when 'metadata=remote' is enabled.");
+            }
+            return;
+        }
+
+        for (MetadataReportConfig metadataReportConfig : metadataReportConfigs) {
+            ConfigValidationUtils.validateMetadataConfig(metadataReportConfig);
+            if (!metadataReportConfig.isValid()) {
+                return;
+            }
+            MetadataReportInstance.init(metadataReportConfig);
+        }
+    }
+
+    /**
+     * For compatibility purpose, use registry as the default config center when
+     * there's no config center specified explicitly and
+     * useAsConfigCenter of registryConfig is null or true
+     */
+    private void useRegistryAsConfigCenterIfNecessary() {
+        // we use the loading status of DynamicConfiguration to decide whether ConfigCenter has been initiated.
+        if (environment.getDynamicConfiguration().isPresent()) {
+            return;
+        }
+
+        if (CollectionUtils.isNotEmpty(configManager.getConfigCenters())) {
+            return;
+        }
+
+        configManager
+                .getDefaultRegistries()
+                .stream()
+                .filter(this::isUsedRegistryAsConfigCenter)
+                .map(this::registryAsConfigCenter)
+                .forEach(configManager::addConfigCenter);
+    }
+
+    private boolean isUsedRegistryAsConfigCenter(RegistryConfig registryConfig) {
+        return isUsedRegistryAsCenter(registryConfig, registryConfig::getUseAsConfigCenter, "config",
+                DynamicConfigurationFactory.class);
+    }
+
+    private ConfigCenterConfig registryAsConfigCenter(RegistryConfig registryConfig) {
+        String protocol = registryConfig.getProtocol();
+        Integer port = registryConfig.getPort();
+        String id = "config-center-" + protocol + "-" + port;
+        ConfigCenterConfig cc = new ConfigCenterConfig();
+        cc.setId(id);
+        if (cc.getParameters() == null) {
+            cc.setParameters(new HashMap<>());
+        }
+        if (registryConfig.getParameters() != null) {
+            cc.getParameters().putAll(registryConfig.getParameters()); // copy the parameters
+        }
+        cc.getParameters().put(CLIENT_KEY, registryConfig.getClient());
+        cc.setProtocol(protocol);
+        cc.setPort(port);
+        cc.setGroup(registryConfig.getGroup());
+        cc.setAddress(getRegistryCompatibleAddress(registryConfig));
+        cc.setNamespace(registryConfig.getGroup());
+        cc.setUsername(registryConfig.getUsername());
+        cc.setPassword(registryConfig.getPassword());
+        if (registryConfig.getTimeout() != null) {
+            cc.setTimeout(registryConfig.getTimeout().longValue());
+        }
+        cc.setHighestPriority(false);
+        return cc;
+    }
+
+    private void useRegistryAsMetadataCenterIfNecessary() {
+
+        Collection<MetadataReportConfig> metadataConfigs = configManager.getMetadataConfigs();
+
+        if (CollectionUtils.isNotEmpty(metadataConfigs)) {
+            return;
+        }
+
+        configManager
+                .getDefaultRegistries()
+                .stream()
+                .filter(this::isUsedRegistryAsMetadataCenter)
+                .map(this::registryAsMetadataCenter)
+                .forEach(configManager::addMetadataReport);
+
+    }
+
+    private boolean isUsedRegistryAsMetadataCenter(RegistryConfig registryConfig) {
+        return isUsedRegistryAsCenter(registryConfig, registryConfig::getUseAsMetadataCenter, "metadata",
+                MetadataReportFactory.class);
+    }
+
+    /**
+     * Is used the specified registry as a center infrastructure
+     *
+     * @param registryConfig       the {@link RegistryConfig}
+     * @param usedRegistryAsCenter the configured value on
+     * @param centerType           the type name of center
+     * @param extensionClass       an extension class of a center infrastructure
+     * @return
+     * @since 2.7.8
+     */
+    private boolean isUsedRegistryAsCenter(RegistryConfig registryConfig, Supplier<Boolean> usedRegistryAsCenter,
+                                           String centerType,
+                                           Class<?> extensionClass) {
+        final boolean supported;
+
+        Boolean configuredValue = usedRegistryAsCenter.get();
+        if (configuredValue != null) { // If configured, take its value.
+            supported = configuredValue.booleanValue();
+        } else {                       // Or check the extension existence
+            String protocol = registryConfig.getProtocol();
+            supported = supportsExtension(extensionClass, protocol);
+            if (logger.isInfoEnabled()) {
+                logger.info(format("No value is configured in the registry, the %s extension[name : %s] %s as the %s center"
+                        , extensionClass.getSimpleName(), protocol, supported ? "supports" : "does not support", centerType));
+            }
+        }
+
+        if (logger.isInfoEnabled()) {
+            logger.info(format("The registry[%s] will be %s as the %s center", registryConfig,
+                    supported ? "used" : "not used", centerType));
+        }
+        return supported;
+    }
+
+    /**
+     * Supports the extension with the specified class and name
+     *
+     * @param extensionClass the {@link Class} of extension
+     * @param name           the name of extension
+     * @return if supports, return <code>true</code>, or <code>false</code>
+     * @since 2.7.8
+     */
+    private boolean supportsExtension(Class<?> extensionClass, String name) {
+        if (isNotEmpty(name)) {
+            ExtensionLoader extensionLoader = getExtensionLoader(extensionClass);
+            return extensionLoader.hasExtension(name);
+        }
+        return false;
+    }
+
+    private MetadataReportConfig registryAsMetadataCenter(RegistryConfig registryConfig) {
+        String protocol = registryConfig.getProtocol();
+        Integer port = registryConfig.getPort();
+        String id = "metadata-center-" + protocol + "-" + port;
+        MetadataReportConfig metadataReportConfig = new MetadataReportConfig();
+        metadataReportConfig.setId(id);
+        if (metadataReportConfig.getParameters() == null) {
+            metadataReportConfig.setParameters(new HashMap<>());
+        }
+        if (registryConfig.getParameters() != null) {
+            metadataReportConfig.getParameters().putAll(registryConfig.getParameters()); // copy the parameters
+        }
+        metadataReportConfig.getParameters().put(CLIENT_KEY, registryConfig.getClient());
+        metadataReportConfig.setGroup(registryConfig.getGroup());
+        metadataReportConfig.setAddress(getRegistryCompatibleAddress(registryConfig));
+        metadataReportConfig.setUsername(registryConfig.getUsername());
+        metadataReportConfig.setPassword(registryConfig.getPassword());
+        metadataReportConfig.setTimeout(registryConfig.getTimeout());
+        return metadataReportConfig;
+    }
+
+    private String getRegistryCompatibleAddress(RegistryConfig registryConfig) {
+        String registryAddress = registryConfig.getAddress();
+        String[] addresses = REGISTRY_SPLIT_PATTERN.split(registryAddress);
+        if (ArrayUtils.isEmpty(addresses)) {
+            throw new IllegalStateException("Invalid registry address found.");
+        }
+        String address = addresses[0];
+        // since 2.7.8
+        // Issue : https://github.com/apache/dubbo/issues/6476
+        StringBuilder metadataAddressBuilder = new StringBuilder();
+        URL url = URL.valueOf(address);
+        String protocolFromAddress = url.getProtocol();
+        if (isEmpty(protocolFromAddress)) {
+            // If the protocol from address is missing, is like :
+            // "dubbo.registry.address = 127.0.0.1:2181"
+            String protocolFromConfig = registryConfig.getProtocol();
+            metadataAddressBuilder.append(protocolFromConfig).append("://");
+        }
+        metadataAddressBuilder.append(address);
+        return metadataAddressBuilder.toString();
+    }
+
+    private void loadRemoteConfigs() {
+        // registry ids to registry configs
+        List<RegistryConfig> tmpRegistries = new ArrayList<>();
+        Set<String> registryIds = configManager.getRegistryIds();
+        registryIds.forEach(id -> {
+            if (tmpRegistries.stream().noneMatch(reg -> reg.getId().equals(id))) {
+                tmpRegistries.add(configManager.getRegistry(id).orElseGet(() -> {
+                    RegistryConfig registryConfig = new RegistryConfig();
+                    registryConfig.setId(id);
+                    registryConfig.refresh();
+                    return registryConfig;
+                }));
+            }
+        });
+
+        configManager.addRegistries(tmpRegistries);
+
+        // protocol ids to protocol configs
+        List<ProtocolConfig> tmpProtocols = new ArrayList<>();
+        Set<String> protocolIds = configManager.getProtocolIds();
+        protocolIds.forEach(id -> {
+            if (tmpProtocols.stream().noneMatch(prot -> prot.getId().equals(id))) {
+                tmpProtocols.add(configManager.getProtocol(id).orElseGet(() -> {
+                    ProtocolConfig protocolConfig = new ProtocolConfig();
+                    protocolConfig.setId(id);
+                    protocolConfig.refresh();
+                    return protocolConfig;
+                }));
+            }
+        });
+
+        configManager.addProtocols(tmpProtocols);
+    }
+
+
+    /**
+     * Initialize {@link MetadataService} from {@link WritableMetadataService}'s extension
+     */
+    private void initMetadataService() {
+//        startMetadataCenter();
+        this.metadataService = getDefaultExtension();
+        this.metadataServiceExporter = new ConfigurableMetadataServiceExporter(metadataService);
+    }
+
+    /**
+     * Initialize {@link EventListener}
+     */
+    private void initEventListener() {
+        // Add current instance into listeners
+        addEventListener(this);
+    }
+
+    /**
+     * Start the bootstrap
+     */
+    public DubboServer start() {
+        if (started.compareAndSet(false, true)) {
+            startup.set(false);
+            initialize();
+            if (logger.isInfoEnabled()) {
+                logger.info(NAME + " is starting...");
+            }
+
+            //initializer the services and
+            configManager.getServices().forEach(serviceConfigBase -> {
+                if (serviceConfigBase instanceof ServiceConfig) {
+                    ((ServiceConfig) ((ServiceConfig<?>) serviceConfigBase)).exportByDubboServer();
+                }
+            });
+
+            configManager.getReferences().forEach(referenceConfigBase -> {
+                if (referenceConfigBase instanceof ReferenceConfig) {
+                    ((ReferenceConfig) ((ReferenceConfig<?>) referenceConfigBase)).initByDubboServer();
+                }
+            });
+
+            // 1. export Dubbo Services
+            exportServices();
+
+            // Not only provider register
+            if (!isOnlyRegisterProvider() || hasExportedServices()) {
+                // 2. export MetadataService
+                exportMetadataService();
+                //3. Register the local ServiceInstance if required
+                registerServiceInstance();
+            }
+
+            referServices();
+            if (asyncExportingFutures.size() > 0) {
+                new Thread(() -> {
+                    try {
+                        this.awaitFinish();
+                    } catch (Exception e) {
+                        logger.warn(NAME + " exportAsync occurred an exception.");
+                    }
+                    startup.set(true);
+                    if (logger.isInfoEnabled()) {
+                        logger.info(NAME + " is ready.");
+                    }
+                }).start();
+            } else {
+                startup.set(true);
+                if (logger.isInfoEnabled()) {
+                    logger.info(NAME + " is ready.");
+                }
+            }
+            if (logger.isInfoEnabled()) {
+                logger.info(NAME + " has started.");
+            }
+        }
+        return this;
+    }
+
+    private boolean hasExportedServices() {
+        return CollectionUtils.isNotEmpty(configManager.getServices());
+    }
+
+    /**
+     * Block current thread to be await.
+     *
+     * @return {@link DubboServer}
+     */
+    public DubboServer await() {
+        // if has been waited, no need to wait again, return immediately
+        if (!awaited.get()) {
+            if (!executorService.isShutdown()) {
+                executeMutually(() -> {
+                    while (!awaited.get()) {
+                        if (logger.isInfoEnabled()) {
+                            logger.info(NAME + " awaiting ...");
+                        }
+                        try {
+                            condition.await();
+                        } catch (InterruptedException e) {
+                            Thread.currentThread().interrupt();
+                        }
+                    }
+                });
+            }
+        }
+        return this;
+    }
+
+    public DubboServer awaitFinish() throws Exception {
+        logger.info(NAME + " waiting services exporting / referring ...");
+        if (exportAsync && asyncExportingFutures.size() > 0) {
+            CompletableFuture future = CompletableFuture.allOf(asyncExportingFutures.toArray(new CompletableFuture[0]));
+            future.get();
+        }
+        if (referAsync && asyncReferringFutures.size() > 0) {
+            CompletableFuture future = CompletableFuture.allOf(asyncReferringFutures.toArray(new CompletableFuture[0]));
+            future.get();
+        }
+
+        logger.info("Service export / refer finished.");
+        return this;
+    }
+
+    public boolean isInitialized() {
+        return initialized.get();
+    }
+
+    public boolean isStarted() {
+        return started.get();
+    }
+
+    public boolean isStartup() {
+        return startup.get();
+    }
+
+    public boolean isShutdown() {
+        return shutdown.get();
+    }
+
+    public DubboServer stop() throws IllegalStateException {
+        destroy();
+        return this;
+    }
+    /* serve for builder apis, begin */
+
+    private ApplicationBuilder createApplicationBuilder(String name) {
+        return new ApplicationBuilder().name(name);
+    }
+
+    private RegistryBuilder createRegistryBuilder(String id) {
+        return new RegistryBuilder().id(id);
+    }
+
+    private ProtocolBuilder createProtocolBuilder(String id) {
+        return new ProtocolBuilder().id(id);
+    }
+
+    private ServiceBuilder createServiceBuilder(String id) {
+        return new ServiceBuilder().id(id);
+    }
+
+    private ReferenceBuilder createReferenceBuilder(String id) {
+        return new ReferenceBuilder().id(id);
+    }
+
+    private ProviderBuilder createProviderBuilder(String id) {
+        return new ProviderBuilder().id(id);
+    }
+
+    private ConsumerBuilder createConsumerBuilder(String id) {
+        return new ConsumerBuilder().id(id);
+    }
+    /* serve for builder apis, end */
+
+    private DynamicConfiguration prepareEnvironment(ConfigCenterConfig configCenter) {
+        if (configCenter.isValid()) {
+            if (!configCenter.checkOrUpdateInited()) {
+                return null;
+            }
+            DynamicConfiguration dynamicConfiguration = getDynamicConfiguration(configCenter.toUrl());
+            String configContent = dynamicConfiguration.getProperties(configCenter.getConfigFile(), configCenter.getGroup());
+
+            String appGroup = getApplication().getName();
+            String appConfigContent = null;
+            if (isNotEmpty(appGroup)) {
+                appConfigContent = dynamicConfiguration.getProperties
+                        (isNotEmpty(configCenter.getAppConfigFile()) ? configCenter.getAppConfigFile() : configCenter.getConfigFile(),
+                                appGroup
+                        );
+            }
+            try {
+                environment.setConfigCenterFirst(configCenter.isHighestPriority());
+                environment.updateExternalConfigurationMap(parseProperties(configContent));
+                environment.updateAppExternalConfigurationMap(parseProperties(appConfigContent));
+            } catch (IOException e) {
+                throw new IllegalStateException("Failed to parse configurations from Config Center.", e);
+            }
+            return dynamicConfiguration;
+        }
+        return null;
+    }
+
+    /**
+     * Add an instance of {@link EventListener}
+     *
+     * @param listener {@link EventListener}
+     * @return {@link DubboServer}
+     */
+    public DubboServer addEventListener(EventListener<?> listener) {
+        eventDispatcher.addEventListener(listener);
+        return this;
+    }
+
+    /**
+     * export {@link MetadataService}
+     */
+    private void exportMetadataService() {
+        metadataServiceExporter.export();
+    }
+
+    private void unexportMetadataService() {
+        if (metadataServiceExporter != null && metadataServiceExporter.isExported()) {
+            metadataServiceExporter.unexport();
+        }
+    }
+
+    public DubboServer exportAsync() {
+        this.exportAsync = true;
+        return this;
+    }
+
+    public DubboServer referAsync() {
+        this.referAsync = true;
+        return this;
+    }
+
+
+    public DubboServer export(ServiceConfigBase serviceConfigBase) {
+        if (serviceConfigBase != null) {
+            exportService(serviceConfigBase);
+        }
+        return this;
+    }
+
+    public DubboServer exportAll() {
+        exportServices();
+        return this;
+    }
+
+    public DubboServer refer(ReferenceConfigBase referenceConfigBase) {
+        if (referenceConfigBase != null) {
+            referService(referenceConfigBase);
+        }
+        return this;
+    }
+
+    public DubboServer referAll() {
+        referServices();
+        return this;
+    }
+
+    public DubboServer unexport(ServiceConfigBase serviceConfigBase) {
+        if (serviceConfigBase != null) {
+            unexportService(serviceConfigBase);
+        }
+        return this;
+    }
+
+    public DubboServer unexportAll() {
+        unexportServices();
+        return this;
+    }
+
+    public DubboServer unrefer(ReferenceConfigBase referenceConfigBase) {
+        if (referenceConfigBase != null) {
+            unreferService(referenceConfigBase);
+        }
+
+        return this;
+    }
+
+    public DubboServer unreferAll() {
+        unreferServices();
+        return this;
+    }
+
+    private void exportServices() {
+        configManager.getServices().forEach(sc -> {
+            if (sc instanceof ServiceConfig) {
+                exportService(sc);
+            }
+        });
+    }
+
+    private void unexportServices() {
+        exportedServices.forEach(sc -> {
+            unexportService(sc);
+        });
+        asyncExportingFutures.clear();
+        exportedServices.clear();
+    }
+
+    private void referServices() {
+        configManager.getReferences().forEach(rc -> {
+            if (rc instanceof ReferenceConfig) {
+                referService(rc);
+            }
+        });
+    }
+
+    private void unreferServices() {
+        if (cache == null) {
+            cache = ReferenceConfigCache.getCache();
+        }
+
+        configManager.getReferences().stream().filter(referenceConfigBase ->
+        {
+            return referenceConfigBase instanceof ReferenceConfig;
+        }).forEach(this::unreferService);
+
+        referenceConfigBase2AsyncExportingFutures.clear();
+        asyncReferringFutures.clear();
+        cache.destroyAll();
+    }
+
+    private void exportService(ServiceConfigBase sc) {
+        if (sc instanceof ServiceConfig) {
+            if(!configManager.getServices().contains(sc)){
+                service((ServiceConfig)sc);
+            }
+            if (exportAsync) {
+                ExecutorService executor = executorRepository.getServiceExporterExecutor();
+                Future<?> future = executor.submit(() -> {
+                    sc.export();
+                    exportedServices.add(sc);
+                });
+                asyncExportingFutures.add(future);
+                serviceConfigBase2AsyncExportingFutures.put(sc, future);
+            } else {
+                sc.export();
+                exportedServices.add(sc);
+            }
+        }
+    }
+
+    private void unexportService(ServiceConfigBase sc) {
+        if (sc == null || !exportedServices.contains(sc)) {
+            return;
+        }
+        sc.unexport();
+        cancleAsyncExportingFutures(sc);
+        exportedServices.remove(sc);
+    }
+
+    private void referService(ReferenceConfigBase rc) {
+        if (cache == null) {
+            cache = ReferenceConfigCache.getCache();
+        }
+        if(!configManager.getReferences().contains(rc)){
+            reference((ReferenceConfig)rc);
+        }
+        if (rc instanceof ReferenceConfig) {
+            if (rc.shouldInit()) {
+                if (referAsync) {
+                    CompletableFuture<Object> future = ScheduledCompletableFuture.submit(
+                            executorRepository.getServiceExporterExecutor(),
+                            () -> cache.get(rc));
+                    asyncReferringFutures.add(future);
+                    referenceConfigBase2AsyncExportingFutures.put(rc, future);
+                } else {
+                    cache.get(rc);
+                }
+            }
+        }
+    }
+
+    private void unreferService(ReferenceConfigBase rc) {
+        if (rc == null) {
+            return;
+        }
+        cache.destroy(rc);
+        cancelAsyncReferringFutures(rc);
+        return;
+    }
+
+    private void cancleAsyncExportingFutures(ServiceConfigBase sc) {
+        if (exportAsync && sc != null) {
+            Future<?> future = serviceConfigBase2AsyncExportingFutures.get(sc);
+            if (future != null && !future.isDone()) {
+                future.cancel(true);
+            }
+
+            asyncExportingFutures.remove(future);
+            serviceConfigBase2AsyncExportingFutures.remove(sc);
+        }
+    }
+
+    private void cancelAsyncReferringFutures(ReferenceConfigBase referenceConfigBase) {
+        if (referenceConfigBase != null && referAsync) {
+            CompletableFuture<Object> future = referenceConfigBase2AsyncExportingFutures.get(referenceConfigBase);
+            if (!future.isDone()) {
+                future.cancel(true);
+            }
+            referenceConfigBase2AsyncExportingFutures.remove(referenceConfigBase);
+            asyncReferringFutures.remove(future);
+        }
+    }
+
+    private void registerServiceInstance() {
+        ApplicationConfig application = getApplication();
+
+        String serviceName = application.getName();
+
+        ServiceInstance serviceInstance = createServiceInstance(serviceName);
+
+        doRegisterServiceInstance(serviceInstance);
+
+        // scheduled task for updating Metadata and ServiceInstance
+        executorRepository.nextScheduledExecutor().scheduleAtFixedRate(() -> {
+            InMemoryWritableMetadataService localMetadataService = (InMemoryWritableMetadataService) WritableMetadataService.getDefaultExtension();
+            localMetadataService.blockUntilUpdated();
+            ServiceInstanceMetadataUtils.refreshMetadataAndInstance(serviceInstance);
+        }, 0, ConfigurationUtils.get(METADATA_PUBLISH_DELAY_KEY, DEFAULT_METADATA_PUBLISH_DELAY), TimeUnit.MILLISECONDS);
+    }
+
+    private void doRegisterServiceInstance(ServiceInstance serviceInstance) {
+        // register instance only when at least one service is exported.
+        if (serviceInstance.getPort() != null && serviceInstance.getPort() != -1) {
+            publishMetadataToRemote(serviceInstance);
+            logger.info("Start registering instance address to registry.");
+            getServiceDiscoveries().forEach(serviceDiscovery ->
+            {
+                calInstanceRevision(serviceDiscovery, serviceInstance);
+                if (logger.isDebugEnabled()) {
+                    logger.info("Start registering instance address to registry" + serviceDiscovery.getUrl() + ", instance " + serviceInstance);
+                }
+                // register metadata
+                serviceDiscovery.register(serviceInstance);
+            });
+        }
+    }
+
+    private void publishMetadataToRemote(ServiceInstance serviceInstance) {
+//        InMemoryWritableMetadataService localMetadataService = (InMemoryWritableMetadataService)WritableMetadataService.getDefaultExtension();
+//        localMetadataService.blockUntilUpdated();
+        if (logger.isInfoEnabled()) {
+            logger.info("Start publishing metadata to remote center, this only makes sense for applications enabled remote metadata center.");
+        }
+        RemoteMetadataServiceImpl remoteMetadataService = MetadataUtils.getRemoteMetadataService();
+        remoteMetadataService.publishMetadata(serviceInstance.getServiceName());
+    }
+
+    private void unregisterServiceInstance() {
+        if (serviceInstance != null) {
+            getServiceDiscoveries().forEach(serviceDiscovery -> {
+                serviceDiscovery.unregister(serviceInstance);
+            });
+        }
+    }
+
+    private ServiceInstance createServiceInstance(String serviceName) {
+        this.serviceInstance = new DefaultServiceInstance(serviceName);
+        setMetadataStorageType(serviceInstance, getMetadataType());
+        ServiceInstanceMetadataUtils.customizeInstance(this.serviceInstance);
+        return this.serviceInstance;
+    }
+
+    public void destroy() {
+        if (destroyLock.tryLock()
+                && shutdown.compareAndSet(false, true)) {
+            try {
+                DubboShutdownHook.destroyAll();
+
+                if (started.compareAndSet(true, false)
+                        && destroyed.compareAndSet(false, true)) {
+
+                    unregisterServiceInstance();
+                    unexportMetadataService();
+                    unexportServices();
+                    unreferServices();
+
+                    destroyRegistries();
+                    DubboShutdownHook.destroyProtocols();
+                    destroyServiceDiscoveries();
+
+                    clear();
+                    shutdown();
+                    release();
+                }
+            } finally {
+                destroyLock.unlock();
+            }
+        }
+    }
+
+    private void destroyRegistries() {
+        AbstractRegistryFactory.destroyAll();
+    }
+
+    private void destroyServiceDiscoveries() {
+        getServiceDiscoveries().forEach(serviceDiscovery -> {
+            execute(serviceDiscovery::destroy);
+        });
+        if (logger.isDebugEnabled()) {
+            logger.debug(NAME + "'s all ServiceDiscoveries have been destroyed.");
+        }
+    }
+
+    private void clear() {
+        clearConfigs();
+        clearApplicationModel();
+    }
+
+    private void clearApplicationModel() {
+
+    }
+
+    private void clearConfigs() {
+        configManager.destroy();
+        if (logger.isDebugEnabled()) {
+            logger.debug(NAME + "'s configs have been clear.");
+        }
+    }
+
+    private void release() {
+        executeMutually(() -> {
+            while (awaited.compareAndSet(false, true)) {
+                if (logger.isInfoEnabled()) {
+                    logger.info(NAME + " is about to shutdown...");
+                }
+                condition.signalAll();
+            }
+        });
+    }
+
+    private void shutdown() {
+        if (!executorService.isShutdown()) {
+            // Shutdown executorService
+            executorService.shutdown();
+        }
+    }
+
+    private void executeMutually(Runnable runnable) {
+        try {
+            lock.lock();
+
+            runnable.run();
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    public ApplicationConfig getApplication() {
+        ApplicationConfig application = configManager
+                .getApplication()
+                .orElseGet(() -> {
+                    ApplicationConfig applicationConfig = new ApplicationConfig();
+                    configManager.setApplication(applicationConfig);
+                    return applicationConfig;
+                });
+
+        if (!application.isRefreshed()) {
+            application.refresh();
+        }
+        return application;
+    }
+
+    private MonitorConfig getMonitor() {
+        MonitorConfig monitor = configManager
+                .getMonitor()
+                .orElseGet(() -> {
+                    MonitorConfig monitorConfig = new MonitorConfig();
+                    configManager.setMonitor(monitorConfig);
+                    return monitorConfig;
+                });
+
+        monitor.refresh();
+        return monitor;
+    }
+
+    private MetricsConfig getMetrics() {
+        MetricsConfig metrics = configManager
+                .getMetrics()
+                .orElseGet(() -> {
+                    MetricsConfig metricsConfig = new MetricsConfig();
+                    configManager.setMetrics(metricsConfig);
+                    return metricsConfig;
+                });
+        metrics.refresh();
+        return metrics;
+    }
+
+    private ModuleConfig getModule() {
+        ModuleConfig module = configManager
+                .getModule()
+                .orElseGet(() -> {
+                    ModuleConfig moduleConfig = new ModuleConfig();
+                    configManager.setModule(moduleConfig);
+                    return moduleConfig;
+                });
+
+        module.refresh();
+        return module;
+    }
+
+    private SslConfig getSsl() {
+        SslConfig ssl = configManager
+                .getSsl()
+                .orElseGet(() -> {
+                    SslConfig sslConfig = new SslConfig();
+                    configManager.setSsl(sslConfig);
+                    return sslConfig;
+                });
+
+        ssl.refresh();
+        return ssl;
+    }
+}

--- a/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/dubboserver/DubboServerTest.java
+++ b/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/dubboserver/DubboServerTest.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.config.dubboserver;
+
+import org.apache.dubbo.common.constants.CommonConstants;
+import org.apache.dubbo.config.ApplicationConfig;
+import org.apache.dubbo.rpc.model.ApplicationModel;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * {@link DubboServer} Test
+ *
+ * @since 2.7.5
+ */
+public class DubboServerTest {
+
+    private static File dubboProperties;
+
+    @BeforeAll
+    public static void setUp(@TempDir Path folder) {
+        ApplicationModel.reset();
+        dubboProperties = folder.resolve(CommonConstants.DUBBO_PROPERTIES_KEY).toFile();
+        System.setProperty(CommonConstants.DUBBO_PROPERTIES_KEY, dubboProperties.getAbsolutePath());
+    }
+
+    @AfterEach
+    public void tearDown() throws IOException {
+        ApplicationModel.reset();
+    }
+
+    @Test
+    public void checkApplication() {
+        System.setProperty("dubbo.application.name", "demo");
+        ApplicationConfig applicationConfig = new ApplicationConfig();
+        applicationConfig.refresh();
+        Assertions.assertEquals("demo", applicationConfig.getName());
+        System.clearProperty("dubbo.application.name");
+    }
+
+    @Test
+    public void basicConfiguration() {
+        DubboServer dubboServer = DubboServer.getInstance();
+        assertEquals(dubboServer.isStarted(), false);
+        assertEquals(dubboServer.isInitialized(), false);
+//        assertNotEquals(dubboServer.getApplication(), null);
+//        dubboServer.start();
+
+    }
+}

--- a/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/ReferenceBean.java
+++ b/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/ReferenceBean.java
@@ -65,7 +65,7 @@ public class ReferenceBean<T> extends ReferenceConfig<T> implements FactoryBean,
 
     @Override
     public Object getObject() {
-        return get();
+        return getByBean();
     }
 
     @Override

--- a/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/ReferenceBean.java
+++ b/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/ReferenceBean.java
@@ -44,7 +44,6 @@ import static org.springframework.beans.factory.BeanFactoryUtils.beansOfTypeIncl
  */
 public class ReferenceBean<T> extends ReferenceConfig<T> implements FactoryBean,
         ApplicationContextAware, InitializingBean, DisposableBean {
-
     private static final long serialVersionUID = 213195494150089726L;
 
     private transient ApplicationContext applicationContext;

--- a/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/context/DubboBootstrapApplicationListener.java
+++ b/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/context/DubboBootstrapApplicationListener.java
@@ -18,6 +18,7 @@ package org.apache.dubbo.config.spring.context;
 
 import org.apache.dubbo.config.bootstrap.DubboBootstrap;
 
+import org.apache.dubbo.config.dubboserver.DubboServer;
 import org.springframework.context.ApplicationListener;
 import org.springframework.context.event.ApplicationContextEvent;
 import org.springframework.context.event.ContextClosedEvent;
@@ -38,12 +39,12 @@ public class DubboBootstrapApplicationListener extends OneTimeExecutionApplicati
      *
      * @since 2.7.6
      */
-    public static final String BEAN_NAME = "dubboBootstrapApplicationListener";
+    public static final String BEAN_NAME = "dubboServerApplicationListener";
 
-    private final DubboBootstrap dubboBootstrap;
+    private final DubboServer dubboServer;
 
     public DubboBootstrapApplicationListener() {
-        this.dubboBootstrap = DubboBootstrap.getInstance();
+        this.dubboServer = DubboServer.getInstance();
     }
 
     @Override
@@ -56,11 +57,11 @@ public class DubboBootstrapApplicationListener extends OneTimeExecutionApplicati
     }
 
     private void onContextRefreshedEvent(ContextRefreshedEvent event) {
-        dubboBootstrap.start();
+        dubboServer.start();
     }
 
     private void onContextClosedEvent(ContextClosedEvent event) {
-        dubboBootstrap.stop();
+        dubboServer.stop();
     }
 
     @Override

--- a/dubbo-demo/dubbo-demo-api/dubbo-demo-api-provider/src/main/java/org/apache/dubbo/demo/provider/Application.java
+++ b/dubbo-demo/dubbo-demo-api/dubbo-demo-api-provider/src/main/java/org/apache/dubbo/demo/provider/Application.java
@@ -17,10 +17,14 @@
 package org.apache.dubbo.demo.provider;
 
 import org.apache.dubbo.config.ApplicationConfig;
+import org.apache.dubbo.config.ReferenceConfig;
 import org.apache.dubbo.config.RegistryConfig;
 import org.apache.dubbo.config.ServiceConfig;
 import org.apache.dubbo.config.bootstrap.DubboBootstrap;
+import org.apache.dubbo.config.dubboserver.DubboServer;
+import org.apache.dubbo.config.utils.ReferenceConfigCache;
 import org.apache.dubbo.demo.DemoService;
+import org.apache.dubbo.rpc.service.GenericService;
 
 import java.util.concurrent.CountDownLatch;
 
@@ -29,8 +33,10 @@ public class Application {
         if (isClassic(args)) {
             startWithExport();
         } else {
-            startWithBootstrap();
+//            startWithBootstrap();
+            runWithDubboServer();
         }
+
     }
 
     private static boolean isClassic(String[] args) {
@@ -61,4 +67,19 @@ public class Application {
         System.out.println("dubbo service started");
         new CountDownLatch(1).await();
     }
+
+
+    private static void runWithDubboServer() {
+        ServiceConfig<DemoServiceImpl> service = new ServiceConfig<>();
+        service.setInterface(DemoService.class);
+        service.setRef(new DemoServiceImpl());
+
+        DubboServer dubboServer = DubboServer.getInstance();
+        dubboServer.application(new ApplicationConfig("dubbo-demo-api-provider"))
+                .registry(new RegistryConfig("zookeeper://127.0.0.1:2181"))
+                .service(service)
+                .start()
+                .await();
+    }
+
 }

--- a/dubbo-metadata/dubbo-metadata-api/src/test/java/org/apache/dubbo/metadata/report/support/AbstractMetadataReportFactoryTest.java
+++ b/dubbo-metadata/dubbo-metadata-api/src/test/java/org/apache/dubbo/metadata/report/support/AbstractMetadataReportFactoryTest.java
@@ -1,135 +1,135 @@
-///*
-// * Licensed to the Apache Software Foundation (ASF) under one or more
-// * contributor license agreements.  See the NOTICE file distributed with
-// * this work for additional information regarding copyright ownership.
-// * The ASF licenses this file to You under the Apache License, Version 2.0
-// * (the "License"); you may not use this file except in compliance with
-// * the License.  You may obtain a copy of the License at
-// *
-// *     http://www.apache.org/licenses/LICENSE-2.0
-// *
-// * Unless required by applicable law or agreed to in writing, software
-// * distributed under the License is distributed on an "AS IS" BASIS,
-// * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// * See the License for the specific language governing permissions and
-// * limitations under the License.
-// */
-//package org.apache.dubbo.metadata.report.support;
-//
-//import org.apache.dubbo.common.URL;
-//import org.apache.dubbo.common.utils.NetUtils;
-//import org.apache.dubbo.metadata.definition.model.ServiceDefinition;
-//import org.apache.dubbo.metadata.report.MetadataReport;
-//import org.apache.dubbo.metadata.report.identifier.MetadataIdentifier;
-//import org.apache.dubbo.metadata.report.identifier.ServiceMetadataIdentifier;
-//import org.apache.dubbo.metadata.report.identifier.SubscriberMetadataIdentifier;
-//
-//import com.alibaba.fastjson.JSON;
-//import org.junit.jupiter.api.Assertions;
-//import org.junit.jupiter.api.Test;
-//
-//import java.util.Collection;
-//import java.util.List;
-//import java.util.Map;
-//import java.util.concurrent.ConcurrentHashMap;
-//
-///**
-// * 2018/9/14
-// */
-//public class AbstractMetadataReportFactoryTest {
-//
-//    private AbstractMetadataReportFactory metadataReportFactory = new AbstractMetadataReportFactory() {
-//        @Override
-//        protected MetadataReport createMetadataReport(URL url) {
-//            return new MetadataReport() {
-//
-//                @Override
-//                public void storeProviderMetadata(MetadataIdentifier providerMetadataIdentifier, ServiceDefinition serviceDefinition) {
-//                    store.put(providerMetadataIdentifier.getIdentifierKey(), JSON.toJSONString(serviceDefinition));
-//                }
-//
-//                @Override
-//                public void saveServiceMetadata(ServiceMetadataIdentifier metadataIdentifier, URL url) {
-//
-//                }
-//
-//                @Override
-//                public void removeServiceMetadata(ServiceMetadataIdentifier metadataIdentifier) {
-//
-//                }
-//
-//                @Override
-//                public List<String> getExportedURLs(ServiceMetadataIdentifier metadataIdentifier) {
-//                    return null;
-//                }
-//
-//                @Override
-//                public void saveSubscribedData(SubscriberMetadataIdentifier subscriberMetadataIdentifier,
-//                                               Collection<String> urls) {
-//
-//                }
-//
-//                @Override
-//                public List<String> getSubscribedURLs(SubscriberMetadataIdentifier subscriberMetadataIdentifier) {
-//                    return null;
-//                }
-//
-//                @Override
-//                public String getServiceDefinition(MetadataIdentifier consumerMetadataIdentifier) {
-//                    return null;
-//                }
-//
-//                @Override
-//                public void storeConsumerMetadata(MetadataIdentifier consumerMetadataIdentifier, Map serviceParameterMap) {
-//                    store.put(consumerMetadataIdentifier.getIdentifierKey(), JSON.toJSONString(serviceParameterMap));
-//                }
-//
-//                @Override
-//                public void close() throws Exception {
-//
-//                }
-//
-//                Map<String, String> store = new ConcurrentHashMap<>();
-//
-//
-//            };
-//        }
-//    };
-//
-//    @Test
-//    public void testGetOneMetadataReport() {
-//        URL url = URL.valueOf("zookeeper://" + NetUtils.getLocalAddress().getHostName() + ":4444/org.apache.dubbo.TestService?version=1.0.0&application=vic");
-//        MetadataReport metadataReport1 = metadataReportFactory.getMetadataReport(url);
-//        MetadataReport metadataReport2 = metadataReportFactory.getMetadataReport(url);
-//        Assertions.assertEquals(metadataReport1, metadataReport2);
-//    }
-//
-//    @Test
-//    public void testGetOneMetadataReportForIpFormat() {
-//        String hostName = NetUtils.getLocalAddress().getHostName();
-//        String ip = NetUtils.getIpByHost(hostName);
-//        URL url1 = URL.valueOf("zookeeper://" + hostName + ":4444/org.apache.dubbo.TestService?version=1.0.0&application=vic");
-//        URL url2 = URL.valueOf("zookeeper://" + ip + ":4444/org.apache.dubbo.TestService?version=1.0.0&application=vic");
-//        MetadataReport metadataReport1 = metadataReportFactory.getMetadataReport(url1);
-//        MetadataReport metadataReport2 = metadataReportFactory.getMetadataReport(url2);
-//        Assertions.assertEquals(metadataReport1, metadataReport2);
-//    }
-//
-//    @Test
-//    public void testGetForDiffService() {
-//        URL url1 = URL.valueOf("zookeeper://" + NetUtils.getLocalAddress().getHostName() + ":4444/org.apache.dubbo.TestService1?version=1.0.0&application=vic");
-//        URL url2 = URL.valueOf("zookeeper://" + NetUtils.getLocalAddress().getHostName() + ":4444/org.apache.dubbo.TestService2?version=1.0.0&application=vic");
-//        MetadataReport metadataReport1 = metadataReportFactory.getMetadataReport(url1);
-//        MetadataReport metadataReport2 = metadataReportFactory.getMetadataReport(url2);
-//        Assertions.assertEquals(metadataReport1, metadataReport2);
-//    }
-//
-//    @Test
-//    public void testGetForDiffGroup() {
-//        URL url1 = URL.valueOf("zookeeper://" + NetUtils.getLocalAddress().getHostName() + ":4444/org.apache.dubbo.TestService?version=1.0.0&application=vic&group=aaa");
-//        URL url2 = URL.valueOf("zookeeper://" + NetUtils.getLocalAddress().getHostName() + ":4444/org.apache.dubbo.TestService?version=1.0.0&application=vic&group=bbb");
-//        MetadataReport metadataReport1 = metadataReportFactory.getMetadataReport(url1);
-//        MetadataReport metadataReport2 = metadataReportFactory.getMetadataReport(url2);
-//        Assertions.assertNotEquals(metadataReport1, metadataReport2);
-//    }
-//}
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.metadata.report.support;
+
+import org.apache.dubbo.common.URL;
+import org.apache.dubbo.common.utils.NetUtils;
+import org.apache.dubbo.metadata.definition.model.ServiceDefinition;
+import org.apache.dubbo.metadata.report.MetadataReport;
+import org.apache.dubbo.metadata.report.identifier.MetadataIdentifier;
+import org.apache.dubbo.metadata.report.identifier.ServiceMetadataIdentifier;
+import org.apache.dubbo.metadata.report.identifier.SubscriberMetadataIdentifier;
+
+import com.alibaba.fastjson.JSON;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * 2018/9/14
+ */
+public class AbstractMetadataReportFactoryTest {
+
+    private AbstractMetadataReportFactory metadataReportFactory = new AbstractMetadataReportFactory() {
+        @Override
+        protected MetadataReport createMetadataReport(URL url) {
+            return new MetadataReport() {
+
+                @Override
+                public void storeProviderMetadata(MetadataIdentifier providerMetadataIdentifier, ServiceDefinition serviceDefinition) {
+                    store.put(providerMetadataIdentifier.getIdentifierKey(), JSON.toJSONString(serviceDefinition));
+                }
+
+                @Override
+                public void saveServiceMetadata(ServiceMetadataIdentifier metadataIdentifier, URL url) {
+
+                }
+
+                @Override
+                public void removeServiceMetadata(ServiceMetadataIdentifier metadataIdentifier) {
+
+                }
+
+                @Override
+                public List<String> getExportedURLs(ServiceMetadataIdentifier metadataIdentifier) {
+                    return null;
+                }
+
+                @Override
+                public void saveSubscribedData(SubscriberMetadataIdentifier subscriberMetadataIdentifier,
+                                               Collection<String> urls) {
+
+                }
+
+                @Override
+                public List<String> getSubscribedURLs(SubscriberMetadataIdentifier subscriberMetadataIdentifier) {
+                    return null;
+                }
+
+                @Override
+                public String getServiceDefinition(MetadataIdentifier consumerMetadataIdentifier) {
+                    return null;
+                }
+
+                @Override
+                public void storeConsumerMetadata(MetadataIdentifier consumerMetadataIdentifier, Map serviceParameterMap) {
+                    store.put(consumerMetadataIdentifier.getIdentifierKey(), JSON.toJSONString(serviceParameterMap));
+                }
+
+                @Override
+                public void close() throws Exception {
+
+                }
+
+                Map<String, String> store = new ConcurrentHashMap<>();
+
+
+            };
+        }
+    };
+
+    @Test
+    public void testGetOneMetadataReport() {
+        URL url = URL.valueOf("zookeeper://" + NetUtils.getLocalAddress().getHostName() + ":4444/org.apache.dubbo.TestService?version=1.0.0&application=vic");
+        MetadataReport metadataReport1 = metadataReportFactory.getMetadataReport(url);
+        MetadataReport metadataReport2 = metadataReportFactory.getMetadataReport(url);
+        Assertions.assertEquals(metadataReport1, metadataReport2);
+    }
+
+    @Test
+    public void testGetOneMetadataReportForIpFormat() {
+        String hostName = NetUtils.getLocalAddress().getHostName();
+        String ip = NetUtils.getIpByHost(hostName);
+        URL url1 = URL.valueOf("zookeeper://" + hostName + ":4444/org.apache.dubbo.TestService?version=1.0.0&application=vic");
+        URL url2 = URL.valueOf("zookeeper://" + ip + ":4444/org.apache.dubbo.TestService?version=1.0.0&application=vic");
+        MetadataReport metadataReport1 = metadataReportFactory.getMetadataReport(url1);
+        MetadataReport metadataReport2 = metadataReportFactory.getMetadataReport(url2);
+        Assertions.assertEquals(metadataReport1, metadataReport2);
+    }
+
+    @Test
+    public void testGetForDiffService() {
+        URL url1 = URL.valueOf("zookeeper://" + NetUtils.getLocalAddress().getHostName() + ":4444/org.apache.dubbo.TestService1?version=1.0.0&application=vic");
+        URL url2 = URL.valueOf("zookeeper://" + NetUtils.getLocalAddress().getHostName() + ":4444/org.apache.dubbo.TestService2?version=1.0.0&application=vic");
+        MetadataReport metadataReport1 = metadataReportFactory.getMetadataReport(url1);
+        MetadataReport metadataReport2 = metadataReportFactory.getMetadataReport(url2);
+        Assertions.assertEquals(metadataReport1, metadataReport2);
+    }
+
+    @Test
+    public void testGetForDiffGroup() {
+        URL url1 = URL.valueOf("zookeeper://" + NetUtils.getLocalAddress().getHostName() + ":4444/org.apache.dubbo.TestService?version=1.0.0&application=vic&group=aaa");
+        URL url2 = URL.valueOf("zookeeper://" + NetUtils.getLocalAddress().getHostName() + ":4444/org.apache.dubbo.TestService?version=1.0.0&application=vic&group=bbb");
+        MetadataReport metadataReport1 = metadataReportFactory.getMetadataReport(url1);
+        MetadataReport metadataReport2 = metadataReportFactory.getMetadataReport(url2);
+        Assertions.assertNotEquals(metadataReport1, metadataReport2);
+    }
+}

--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/ClientStream.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/ClientStream.java
@@ -166,6 +166,7 @@ public class ClientStream extends AbstractStream implements Stream {
 
     }
 
+    @Override
     public void halfClose() {
         final int httpCode = HttpResponseStatus.parseLine(getHeaders().status()).code();
         if (HttpResponseStatus.OK.code() != httpCode) {

--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/ServerStream.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/ServerStream.java
@@ -93,6 +93,7 @@ public class ServerStream extends AbstractStream implements Stream {
 
     }
 
+    @Override
     public void halfClose() throws Exception {
         if (getData() == null) {
             responseErr(ctx, GrpcStatus.fromCode(GrpcStatus.Code.INTERNAL)


### PR DESCRIPTION
## What is the purpose of the change

Make sure every layer only responsible for their own work.

## Brief changelog

Add the DubboServer to be the Class responsible to trigger the init/start process of the ReferenceConfig/ServiceConfig. 
Most methods of the DubboBootstrap call the methods with the same names in DubboServer.

## Verifying this change

I run Dubbo Demo in my PC. And demos based on DubboServer/DubooBootstrap/API works well.

##

The developing process is based on this link below and many unit testes can not pass before my modification.

https://github.com/apache/dubbo/issues/5666
