### PR TITLE
[DUBBO-54] bug: String.format have wrong number of parameters.

### DIFF
--- a/dubbo-metadata/dubbo-metadata-api/src/main/java/org/apache/dubbo/metadata/DynamicConfigurationServiceNameMapping.java
+++ b/dubbo-metadata/dubbo-metadata-api/src/main/java/org/apache/dubbo/metadata/DynamicConfigurationServiceNameMapping.java
@@ -66,7 +66,7 @@ public class DynamicConfigurationServiceNameMapping implements ServiceNameMappin
             dynamicConfiguration.publishConfig(key, ServiceNameMapping.buildGroup(serviceInterface, group, version, protocol), content);
             if (logger.isInfoEnabled()) {
                 logger.info(String.format("Dubbo service[%s] mapped to interface name[%s].",
-                        group, serviceInterface, group));
+                        group, serviceInterface));
             }
         });
     }


### PR DESCRIPTION
## What is the purpose of the change

bug: String.format have wrong number of parameters.
