### PR TITLE
[DUBBO-57] use ByteArrayOutputStream.toString()

### DIFF
--- a/dubbo-common/src/test/java/org/apache/dubbo/common/utils/IOUtilsTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/utils/IOUtilsTest.java
@@ -108,7 +108,7 @@ public class IOUtilsTest {
     public void testWriteLines() throws Exception {
         IOUtils.writeLines(os, new String[]{TEXT});
         ByteArrayOutputStream bos = (ByteArrayOutputStream) os;
-        assertThat(new String(bos.toByteArray()), equalTo(TEXT + System.lineSeparator()));
+        assertThat(bos.toString(), equalTo(TEXT + System.lineSeparator()));
     }
 
     @Test


### PR DESCRIPTION
## What is the purpose of the change

use ByteArrayOutputStream.toString()
