### PR TITLE
Add gitattributes to prevent file formatting

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,4 @@
-# ignore all files
+# Git will understand that all files specified are not text,
+# and it should not try to change them.
+# This will prevent file formatting (such as `crlf` endings to `lf` endings) while commit.
 * -text

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# ignore all files
+* -text


### PR DESCRIPTION
Add .gitattributes file to prevent file formatting in Windows platform