### PR TITLE
fix #7201 The client-side and server-side payload parameters are inconsistent, and the server-side response data packet length exceeds the client-side payload

### DIFF
--- a/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/exchange/codec/ExchangeCodec.java
+++ b/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/exchange/codec/ExchangeCodec.java
@@ -110,6 +110,14 @@ public class ExchangeCodec extends TelnetCodec {
 
         // get data length.
         int len = Bytes.bytes2int(header, 12);
+
+        // When receiving response, how to exceed the length, then directly construct a response to the client.
+        // see more detail from https://github.com/apache/dubbo/issues/7021.
+        Object obj = finishRespWhenOverPayload(channel, len, header);
+        if (null != obj) {
+            return obj;
+        }
+
         checkPayload(channel, len);
 
         int tt = len + HEADER_LENGTH;
@@ -474,5 +482,26 @@ public class ExchangeCodec extends TelnetCodec {
         encodeResponseData(out, data);
     }
 
-
+    private Object finishRespWhenOverPayload(Channel channel, long size, byte[] header) {
+        int payload = getPayload(channel);
+        boolean overPayload = isOverPayload(payload, size);
+        if (overPayload) {
+            long reqId = Bytes.bytes2long(header, 4);
+            byte flag = header[2];
+            if ((flag & FLAG_REQUEST) == 0) {
+                Response res = new Response(reqId);
+                if ((flag & FLAG_EVENT) != 0) {
+                    res.setEvent(true);
+                }
+                // get status.
+                byte status = header[3];
+                res.setStatus(Response.CLIENT_ERROR);
+                String errorMsg = "Data length too large: " + size + ", max payload: " + payload + ", channel: " + channel;
+                logger.error(errorMsg);
+                res.setErrorMessage(errorMsg);
+                return res;
+            }
+        }
+        return null;
+    }
 }

--- a/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/transport/AbstractCodec.java
+++ b/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/transport/AbstractCodec.java
@@ -44,16 +44,29 @@ public abstract class AbstractCodec implements Codec2 {
     private static final String SERVER_SIDE = "server";
 
     protected static void checkPayload(Channel channel, long size) throws IOException {
-        int payload = Constants.DEFAULT_PAYLOAD;
-        if (channel != null && channel.getUrl() != null) {
-            payload = channel.getUrl().getParameter(Constants.PAYLOAD_KEY, Constants.DEFAULT_PAYLOAD);
-        }
-        if (payload > 0 && size > payload) {
+        int payload = getPayload(channel);
+        boolean overPayload = isOverPayload(payload, size);
+        if (overPayload) {
             ExceedPayloadLimitException e = new ExceedPayloadLimitException(
                     "Data length too large: " + size + ", max payload: " + payload + ", channel: " + channel);
             logger.error(e);
             throw e;
         }
+    }
+
+    protected static int getPayload(Channel channel) {
+        int payload = Constants.DEFAULT_PAYLOAD;
+        if (channel != null && channel.getUrl() != null) {
+            payload = channel.getUrl().getParameter(Constants.PAYLOAD_KEY, Constants.DEFAULT_PAYLOAD);
+        }
+        return payload;
+    }
+
+    protected static boolean isOverPayload(int payload, long size) {
+        if (payload > 0 && size > payload) {
+            return true;
+        }
+        return false;
     }
 
     protected Serialization getSerialization(Channel channel, Request req) {

--- a/dubbo-rpc/dubbo-rpc-dubbo/src/test/java/org/apache/dubbo/rpc/protocol/dubbo/DubboProtocolTest.java
+++ b/dubbo-rpc/dubbo-rpc-dubbo/src/test/java/org/apache/dubbo/rpc/protocol/dubbo/DubboProtocolTest.java
@@ -231,4 +231,22 @@ public class DubboProtocolTest {
         service = proxy.getProxy(protocol.refer(DemoService.class, url));
         assertEquals(service.getRemoteApplicationName(), "consumer");
     }
+
+    @Test
+    public void testPayloadOverException() throws Exception {
+        DemoService service = new DemoServiceImpl();
+        int port = NetUtils.getAvailablePort();
+        protocol.export(proxy.getInvoker(service, DemoService.class,
+                URL.valueOf("dubbo://127.0.0.1:" + port + "/" + DemoService.class.getName()).addParameter("payload", 10 * 1024)));
+        service = proxy.getProxy(protocol.refer(DemoService.class,
+                URL.valueOf("dubbo://127.0.0.1:" + port + "/" + DemoService.class.getName()).addParameter("timeout",
+                        6000L).addParameter("payload", 160)));
+        try {
+            service.download(300);
+            Assertions.fail();
+        } catch (Exception expected) {
+            Assertions.assertTrue(expected.getMessage().contains("Data length too large"));
+        }
+
+    }
 }

--- a/dubbo-rpc/dubbo-rpc-dubbo/src/test/java/org/apache/dubbo/rpc/protocol/dubbo/support/DemoService.java
+++ b/dubbo-rpc/dubbo-rpc-dubbo/src/test/java/org/apache/dubbo/rpc/protocol/dubbo/support/DemoService.java
@@ -66,4 +66,6 @@ public interface DemoService {
     String getPerson(Man man);
 
     String getRemoteApplicationName();
+
+    byte[] download(int size);
 }

--- a/dubbo-rpc/dubbo-rpc-dubbo/src/test/java/org/apache/dubbo/rpc/protocol/dubbo/support/DemoServiceImpl.java
+++ b/dubbo-rpc/dubbo-rpc-dubbo/src/test/java/org/apache/dubbo/rpc/protocol/dubbo/support/DemoServiceImpl.java
@@ -18,6 +18,7 @@ package org.apache.dubbo.rpc.protocol.dubbo.support;
 
 import org.apache.dubbo.rpc.RpcContext;
 
+import java.util.Arrays;
 import java.util.Map;
 import java.util.Set;
 
@@ -125,5 +126,12 @@ public class DemoServiceImpl implements DemoService {
     @Override
     public String getRemoteApplicationName() {
         return RpcContext.getContext().getRemoteApplicationName();
+    }
+
+    @Override
+    public byte[] download(int size) {
+        byte[] bytes = new byte[size];
+        Arrays.fill(bytes, (byte) 0);
+        return bytes;
     }
 }


### PR DESCRIPTION

## What is the purpose of the change

The client-side and server-side payload parameters are inconsistent, and the server-side response data packet length exceeds the client-side payload

## Brief changelog

XXXXX

## Verifying this change

XXXXX

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a [GITHUB_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Run `mvn clean install -DskipTests=false` & `mvn clean test-compile failsafe:integration-test` to make sure unit-test and integration-test pass.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
