### PR TITLE
[ISSUE-#7299] Logic optmization about zookeeperServiceDiscoveryChangeWatcher.

### DIFF
--- a/dubbo-registry/dubbo-registry-zookeeper/src/main/java/org/apache/dubbo/registry/zookeeper/ZookeeperServiceDiscovery.java
+++ b/dubbo-registry/dubbo-registry-zookeeper/src/main/java/org/apache/dubbo/registry/zookeeper/ZookeeperServiceDiscovery.java
@@ -192,7 +192,7 @@ public class ZookeeperServiceDiscovery extends AbstractServiceDiscovery {
         }
 
         CuratorWatcher watcher = watcherCaches.computeIfAbsent(path, key ->
-                new ZookeeperServiceDiscoveryChangeWatcher(this, serviceName, listener));
+                new ZookeeperServiceDiscoveryChangeWatcher(this, serviceName, path, listener));
         try {
             curatorFramework.getChildren().usingWatcher(watcher).forPath(path);
         } catch (KeeperException.NoNodeException e) {
@@ -207,5 +207,9 @@ public class ZookeeperServiceDiscovery extends AbstractServiceDiscovery {
 
     private String buildServicePath(String serviceName) {
         return rootPath + "/" + serviceName;
+    }
+
+    public CuratorFramework getCuratorFramework() {
+        return curatorFramework;
     }
 }


### PR DESCRIPTION
## What is the purpose of the change
For-#7299
1.use same instances to notify listener.onEvent and dispatchServiceInstancesChangedEvent.
2.modify the re watcher machine mechanism, re watcher by ZookeeperServiceDiscoveryChangeWatcher self.