### PR TITLE
fix #7100, Avoid memory leaking when ThreadlessExecutor.waitAnddrain(…

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/threadpool/ThreadlessExecutor.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/threadpool/ThreadlessExecutor.java
@@ -86,7 +86,13 @@ public class ThreadlessExecutor extends AbstractExecutorService {
             return;
         }
 
-        Runnable runnable = queue.take();
+        Runnable runnable;
+        try {
+            runnable = queue.take();
+        }catch (InterruptedException e){
+            waiting = false;
+            throw e;
+        }
 
         synchronized (lock) {
             waiting = false;

--- a/dubbo-remoting/dubbo-remoting-api/src/test/java/org/apache/dubbo/remoting/exchange/support/DefaultFutureTest.java
+++ b/dubbo-remoting/dubbo-remoting-api/src/test/java/org/apache/dubbo/remoting/exchange/support/DefaultFutureTest.java
@@ -17,6 +17,10 @@
 
 package org.apache.dubbo.remoting.exchange.support;
 
+import org.apache.dubbo.common.URL;
+import org.apache.dubbo.common.extension.ExtensionLoader;
+import org.apache.dubbo.common.threadpool.ThreadlessExecutor;
+import org.apache.dubbo.common.threadpool.manager.ExecutorRepository;
 import org.apache.dubbo.remoting.Channel;
 import org.apache.dubbo.remoting.TimeoutException;
 import org.apache.dubbo.remoting.exchange.Request;
@@ -28,6 +32,7 @@ import org.junit.jupiter.api.Test;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicInteger;
 
 public class DefaultFutureTest {
@@ -115,6 +120,43 @@ public class DefaultFutureTest {
             System.out.println(e.getMessage());
         }
     }
+    /**
+     * for example, it will print like this:
+     *before a future is create , time is : 2021-01-22 10:55:03
+     * null
+     * after a future is timeout , time is : 2021-01-22 10:55:05
+     */
+    @Test
+    public void interruptSend() throws Exception {
+        final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+        System.out.println("before a future is create , time is : " + LocalDateTime.now().format(formatter));
+        // timeout after 1 seconds.
+        Channel channel = new MockedChannel();
+        int channelId = 10;
+        Request request = new Request(channelId);
+        ExecutorService sharedExecutor = ExtensionLoader.getExtensionLoader(ExecutorRepository.class)
+                .getDefaultExtension().createExecutorIfAbsent(URL.valueOf("dubbo://127.0.0.1:23456"));
+        ThreadlessExecutor executor = new ThreadlessExecutor(sharedExecutor);
+        DefaultFuture f = DefaultFuture.newFuture(channel, request, 1000, executor);
+        //mark the future is sent
+        DefaultFuture.sent(channel, request);
+        // get operate will throw a interrupted exception, because the thread is interrupted.
+        try {
+            new InterruptThread(Thread.currentThread()).start();
+            executor.waitAndDrain();
+            f.get();
+        } catch (Exception e) {
+            Assertions.assertTrue(e instanceof InterruptedException, "catch exception is not interrupted exception!");
+            System.out.println(e.getMessage());
+        }
+        //waiting timeout check task finished
+        Thread.sleep(1500);
+        System.out.println("after a future is timeout , time is : " + LocalDateTime.now().format(formatter));
+
+        DefaultFuture future = DefaultFuture.getFuture(channelId);
+        //waiting future should be removed by time out check task
+        Assertions.assertNull(future);
+    }
 
     /**
      * mock a default future
@@ -124,5 +166,30 @@ public class DefaultFutureTest {
         Request request = new Request(index.getAndIncrement());
         return DefaultFuture.newFuture(channel, request, timeout, null);
     }
+
+    /**
+     * mock a thread interrupt another thread which is waiting waitAndDrain() to return.
+     */
+    static class InterruptThread extends Thread {
+        private Thread parent;
+
+        public InterruptThread(Thread parent) {
+            this.parent = parent;
+        }
+
+        @Override
+        public void run() {
+            super.run();
+            try {
+                //interrupt waiting thread before timeout
+                Thread.sleep(500);
+                parent.interrupt();
+            } catch (InterruptedException e) {
+                System.out.println(e.getMessage());
+            }
+        }
+
+    }
+
 
 }


### PR DESCRIPTION
Avoid memory leaking when ThreadlessExecutor.waitAnddrain throws InterruptionException

also see #7121 