### PR TITLE
Fix the override method "equals" will skip branches in org.apache.dubbo.common.URL#equals

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/URL.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/URL.java
@@ -1699,7 +1699,6 @@ class URL implements Serializable {
                     return false;
                 }
             }
-            return true;
         }
 
         if (!StringUtils.isEquals(password, other.password)) {

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/URLTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/URLTest.java
@@ -35,6 +35,7 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.fail;
 
 public class URLTest {
@@ -918,5 +919,65 @@ public class URLTest {
                 "dubbo-demo-api-consumer&category=consumers&check=true&dubbo=2.0.2&interface=" +
                 "org.apache.dubbo.demo.DemoService&pid=7375&side=consumer&sticky=false&timestamp=2299556506417");
         assertNotEquals(url3, url4);
+    }
+
+    @Test
+    public void testEqualsWithPassword() {
+        URL url1 = URL.valueOf("ad@min:hello@1234@10.20.130.230:20880/context/path?version=1.0.0&application=morgan");
+        URL url2 = URL.valueOf("ad@min:hello@4321@10.20.130.230:20880/context/path?version=1.0.0&application=morgan");
+        URL url3 = URL.valueOf("ad@min:hello@1234@10.20.130.230:20880/context/path?version=1.0.0&application=morgan");
+
+        boolean actual1 = url1.equals(url2);
+        boolean actual2 = url1.equals(url3);
+        assertFalse(actual1);
+        assertTrue(actual2);
+    }
+
+    @Test
+    public void testEqualsWithPath() {
+        URL url1 = URL.valueOf("ad@min:hello@1234@10.20.130.230:20880/context/path1?version=1.0.0&application=morgan");
+        URL url2 = URL.valueOf("ad@min:hello@1234@10.20.130.230:20880/context/path2?version=1.0.0&application=morgan");
+        URL url3 = URL.valueOf("ad@min:hello@1234@10.20.130.230:20880/context/path1?version=1.0.0&application=morgan");
+
+        boolean actual1 = url1.equals(url2);
+        boolean actual2 = url1.equals(url3);
+        assertFalse(actual1);
+        assertTrue(actual2);
+    }
+
+    @Test
+    public void testEqualsWithPort() {
+        URL url1 = URL.valueOf("ad@min:hello@1234@10.20.130.230:20880/context/path?version=1.0.0&application=morgan");
+        URL url2 = URL.valueOf("ad@min:hello@1234@10.20.130.230:20881/context/path?version=1.0.0&application=morgan");
+        URL url3 = URL.valueOf("ad@min:hello@1234@10.20.130.230:20880/context/path?version=1.0.0&application=morgan");
+
+        boolean actual1 = url1.equals(url2);
+        boolean actual2 = url1.equals(url3);
+        assertFalse(actual1);
+        assertTrue(actual2);
+    }
+
+    @Test
+    public void testEqualsWithProtocol() {
+        URL url1 = URL.valueOf("dubbo://ad@min:hello@1234@10.20.130.230:20880/context/path?version=1.0.0&application=morgan");
+        URL url2 = URL.valueOf("file://ad@min:hello@1234@10.20.130.230:20880/context/path?version=1.0.0&application=morgan");
+        URL url3 = URL.valueOf("dubbo://ad@min:hello@1234@10.20.130.230:20880/context/path?version=1.0.0&application=morgan");
+
+        boolean actual1 = url1.equals(url2);
+        boolean actual2 = url1.equals(url3);
+        assertFalse(actual1);
+        assertTrue(actual2);
+    }
+
+    @Test
+    public void testEqualsWithUser() {
+        URL url1 = URL.valueOf("ad@min1:hello@1234@10.20.130.230:20880/context/path?version=1.0.0&application=morgan");
+        URL url2 = URL.valueOf("ad@min2:hello@1234@10.20.130.230:20880/context/path?version=1.0.0&application=morgan");
+        URL url3 = URL.valueOf("ad@min1:hello@1234@10.20.130.230:20880/context/path?version=1.0.0&application=morgan");
+
+        boolean actual1 = url1.equals(url2);
+        boolean actual2 = url1.equals(url3);
+        assertFalse(actual1);
+        assertTrue(actual2);
     }
 }


### PR DESCRIPTION
fix org.apache.dubbo.common.URL#equals.
After comparing the parameters, the method will skip the following branches

## the purpose of the change

fix the override method "equals" will skip branches after comparing the parameters in org.apache.dubbo.common.URL#equals

## Brief changelog

1. delete the code "retuen true" in line 1702 , inorder to continue the following comparing
2. add unit test

## Verifying this change
successfully continue the following comparing
