### PR TITLE
to fix something wrong with MergeableClusterInvoker

### DIFF
--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/support/MergeableClusterInvoker.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/support/MergeableClusterInvoker.java
@@ -114,7 +114,7 @@ public class MergeableClusterInvoker<T> extends AbstractClusterInvoker<T> {
         if (resultList.isEmpty()) {
             return AsyncRpcResult.newDefaultAsyncResult(invocation);
         } else if (resultList.size() == 1) {
-            return resultList.iterator().next();
+            return AsyncRpcResult.newDefaultAsyncResult(resultList.iterator().next().getValue(), invocation);
         }
 
         if (returnType == void.class) {

--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/support/MergeableClusterInvoker.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/support/MergeableClusterInvoker.java
@@ -114,7 +114,7 @@ public class MergeableClusterInvoker<T> extends AbstractClusterInvoker<T> {
         if (resultList.isEmpty()) {
             return AsyncRpcResult.newDefaultAsyncResult(invocation);
         } else if (resultList.size() == 1) {
-            return AsyncRpcResult.newDefaultAsyncResult(resultList.iterator().next().getValue(), invocation);
+            return AsyncRpcResult.newDefaultAsyncResult(resultList.get(0).getValue(), invocation);
         }
 
         if (returnType == void.class) {


### PR DESCRIPTION
## What is the purpose of the change

to fix something wrong with MergeableClusterInvoker#7359

## Brief changelog

As MergeableClusterInvoker was used, when 'resultList.size() == 1', there would be an error msg "AppResponse represents an concrete business response, there will be no status changes, you should get internal values directly." The reason is that the resultType would be "AppResponse", in org.apache.dubbo.rpc.cluster.support.wrapper.AbstractCluster.InterceptorInvokerNode#invoke method's "return clause" the exception would be thrown. 

## Verifying this change

XXXXX

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a [GITHUB_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Run `mvn clean install -DskipTests=false` & `mvn clean test-compile failsafe:integration-test` to make sure unit-test and integration-test pass.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
