### PR TITLE
[ISSUE-#7363] Support a way to ignore check some key in parameters.

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/config/Constants.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/config/Constants.java
@@ -115,4 +115,6 @@ public interface Constants {
     String ZOOKEEPER_PROTOCOL = "zookeeper";
 
     String REGISTER_KEY = "register";
+
+    String IGNORE_CHECK_KEYS = "ignoreCheckKeys";
 }

--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/utils/ConfigValidationUtils.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/utils/ConfigValidationUtils.java
@@ -65,6 +65,7 @@ import org.apache.dubbo.rpc.support.MockInvoker;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -102,6 +103,7 @@ import static org.apache.dubbo.config.Constants.ARCHITECTURE;
 import static org.apache.dubbo.config.Constants.CONTEXTPATH_KEY;
 import static org.apache.dubbo.config.Constants.DUBBO_IP_TO_REGISTRY;
 import static org.apache.dubbo.config.Constants.ENVIRONMENT;
+import static org.apache.dubbo.config.Constants.IGNORE_CHECK_KEYS;
 import static org.apache.dubbo.config.Constants.LAYER_KEY;
 import static org.apache.dubbo.config.Constants.NAME;
 import static org.apache.dubbo.config.Constants.ORGANIZATION;
@@ -624,8 +626,14 @@ public class ConfigValidationUtils {
         if (CollectionUtils.isEmptyMap(parameters)) {
             return;
         }
+        List<String> ignoreCheckKeys = new ArrayList<>();
+        ignoreCheckKeys.add(BACKUP_KEY);
+        String ignoreCheckKeysStr = parameters.get(IGNORE_CHECK_KEYS);
+        if (!StringUtils.isBlank(ignoreCheckKeysStr)) {
+            ignoreCheckKeys.addAll(Arrays.asList(ignoreCheckKeysStr.split(",")));
+        }
         for (Map.Entry<String, String> entry : parameters.entrySet()) {
-            if (!entry.getKey().equals(BACKUP_KEY)) {
+            if (!ignoreCheckKeys.contains(entry.getKey())) {
                 checkNameHasSymbol(entry.getKey(), entry.getValue());
             }
         }


### PR DESCRIPTION
## What is the purpose of the change
For-#7363.

If someone need ignore check someKey.
Just add param `ignoreCheckKeys`:`secretKey `.
```
    <dubbo:registry id="registry1" address="nacos://127.0.0.1:8848">
        <dubbo:parameter key="username" value="nacos"/>
        <dubbo:parameter key="secretKey" value="++++"/>
        <dubbo:parameter key="ignoreCheckKeys" value="secretKey"/>
    </dubbo:registry>
```