### PR TITLE
Improve reference bean definition and prepare logic

### DIFF
--- a/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/DubboConfigInitializationPostProcessor.java
+++ b/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/DubboConfigInitializationPostProcessor.java
@@ -30,7 +30,6 @@ import org.springframework.beans.BeansException;
 import org.springframework.beans.FatalBeanException;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.BeanFactoryAware;
-import org.springframework.beans.factory.BeanInitializationException;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.beans.factory.config.BeanPostProcessor;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
@@ -76,14 +75,14 @@ public class DubboConfigInitializationPostProcessor implements BeanPostProcessor
 
     @Override
     public Object postProcessAfterInitialization(Object bean, String beanName) throws BeansException {
-        try {
-            if (bean instanceof ReferenceBean) {
-                ReferenceBean referenceBean = (ReferenceBean) bean;
-                referenceBeanManager.addReference(referenceBean);
-            }
-        } catch (Exception e) {
-            throw new BeanInitializationException("Initialization reference bean failed", e);
-        }
+//        try {
+//            if (bean instanceof ReferenceBean) {
+//                ReferenceBean referenceBean = (ReferenceBean) bean;
+//                referenceBeanManager.addReference(referenceBean);
+//            }
+//        } catch (Exception e) {
+//            throw new BeanInitializationException("Initialization reference bean failed", e);
+//        }
         return bean;
     }
 

--- a/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/ReferenceBean.java
+++ b/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/ReferenceBean.java
@@ -107,7 +107,7 @@ public class ReferenceBean<T> implements FactoryBean,
         if (referenceProps == null) {
             Assert.notEmptyString(getId(), "The id of ReferenceBean cannot be empty");
             ConfigurableListableBeanFactory beanFactory = getBeanFactory();
-            BeanDefinition beanDefinition = beanFactory.getMergedBeanDefinition(getId());
+            BeanDefinition beanDefinition = beanFactory.getBeanDefinition(getId());
             propertyValues = beanDefinition.getPropertyValues();
         }
     }
@@ -187,7 +187,7 @@ public class ReferenceBean<T> implements FactoryBean,
                 String consumer = (String) referenceProps.get("consumer");
                 if (StringUtils.isBlank(generic) && consumer != null) {
                     // get generic from consumerConfig
-                    BeanDefinition consumerBeanDefinition = getBeanFactory().getMergedBeanDefinition(consumer);
+                    BeanDefinition consumerBeanDefinition = getBeanFactory().getBeanDefinition(consumer);
                     if (consumerBeanDefinition != null) {
                         generic = (String) consumerBeanDefinition.getPropertyValues().get("generic");
                     }

--- a/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/ReferenceBeanManager.java
+++ b/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/ReferenceBeanManager.java
@@ -80,16 +80,6 @@ public class ReferenceBeanManager implements ApplicationContextAware {
         return configMap.get(id);
     }
 
-//    public ReferenceBean getOrCreateReference(Map<String, String> referenceProps) {
-//        Integer key = referenceProps.hashCode();
-//        return configMap.computeIfAbsent(key, k -> {
-//            ReferenceBean referenceBean = new ReferenceBean();
-//            referenceBean.setReferenceProps(referenceProps);
-//            //referenceBean.setId();
-//            return referenceBean;
-//        });
-//    }
-
     public Collection<ReferenceBean> getReferences() {
         return configMap.values();
     }
@@ -104,10 +94,16 @@ public class ReferenceBeanManager implements ApplicationContextAware {
      * @throws Exception
      */
     public void prepareReferenceBeans() throws Exception {
-        initialized = true;
         for (ReferenceBean referenceBean : getReferences()) {
             initReferenceBean(referenceBean);
         }
+
+        // prepare all reference beans
+        Map<String, ReferenceBean> referenceBeanMap = applicationContext.getBeansOfType(ReferenceBean.class, true, false);
+        for (ReferenceBean referenceBean : referenceBeanMap.values()) {
+            initReferenceBean(referenceBean);
+        }
+        initialized = true;
     }
 
     /**

--- a/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/beans/factory/annotation/ReferenceAnnotationBeanPostProcessor.java
+++ b/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/beans/factory/annotation/ReferenceAnnotationBeanPostProcessor.java
@@ -114,7 +114,7 @@ public class ReferenceAnnotationBeanPostProcessor extends AbstractAnnotationBean
         for (String beanName : beanNames) {
             Class<?> beanType;
             if (beanFactory.isFactoryBean(beanName)){
-                BeanDefinition beanDefinition = beanFactory.getMergedBeanDefinition(beanName);
+                BeanDefinition beanDefinition = beanFactory.getBeanDefinition(beanName);
                 if (isReferenceBean(beanDefinition)) {
                     continue;
                 }
@@ -253,7 +253,7 @@ public class ReferenceAnnotationBeanPostProcessor extends AbstractAnnotationBean
                 beanDefinitionRegistry.registerBeanDefinition(referenceBeanName, beanDefinition);
                 getBeanFactory().registerSingleton(referenceBeanName, referenceBean);
 
-                referenceBeanManager.addReference(referenceBean);
+                //referenceBeanManager.addReference(referenceBean);
             } catch (Exception e) {
                 throw new Exception("Create dubbo reference bean failed", e);
             }

--- a/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/schema/DubboBeanDefinitionParser.java
+++ b/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/schema/DubboBeanDefinitionParser.java
@@ -53,6 +53,7 @@ import java.lang.reflect.Modifier;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.regex.Pattern;
@@ -258,6 +259,12 @@ public class DubboBeanDefinitionParser implements BeanDefinitionParser {
         targetDefinition.setBeanClass(interfaceClass);
         String id = (String) beanDefinition.getPropertyValues().get("id");
         beanDefinition.setDecoratedDefinition(new BeanDefinitionHolder(targetDefinition, id+"_decorated"));
+
+        //mark property value as optional
+        List<PropertyValue> propertyValues = beanDefinition.getPropertyValues().getPropertyValueList();
+        for (PropertyValue propertyValue : propertyValues) {
+            propertyValue.setOptional(true);
+        }
     }
 
     private static void getPropertyMap(Class<?> beanClass, Map<String, Class> beanPropsMap) {


### PR DESCRIPTION

## What is the purpose of the change

Improve reference bean definition and prepare logic, fix injection problems of PropertyPlaceholderConfigurer

## Brief changelog

* Set bean definition property value as optional
* use `getBeanDefinition` instead of `getMergedBeanDefinition`, fix injection problems of PropertyPlaceholderConfigurer
* Prepare all reference beans in spring context, avoid missing instances initialized earlier (before `DubboConfigInitializationPostProcessor` is loaded)

## Verifying this change

Run dubbo-demo-property-configurer  (may be added to samples in the future)

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a [GITHUB_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Run `mvn clean install -DskipTests=false` & `mvn clean test-compile failsafe:integration-test` to make sure unit-test and integration-test pass.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
