### PR TITLE
DUBBO-7349 Fix the build on Linux ARM64 CPU architecture

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,30 @@
+sudo: false # faster builds
+os: linux
+dist: focal
+arch: arm64-graviton2
+virt: lxd
+group: edge
+
+language: java
+jdk: openjdk11
+
+cache:
+  directories:
+    - $HOME/.m2
+
+install: true
+
+branches:
+  only:
+    - master
+
+before_script:
+  - rm -rf $HOME/.m2/repository/org/glassfish/javax.el/3.0.1-b08
+
+script: if [[ "${TRAVIS_EVENT_TYPE}" == "cron" ]]; then travis_wait 60 ./mvnw --batch-mode -U -e --no-transfer-progress clean test -Dmaven.wagon.httpconnectionManager.ttlSeconds=120 -Dmaven.wagon.http.retryHandler.count=5 -DskipTests=false -DskipIntegrationTests=false -Dcheckstyle.skip=false -Drat.skip=false -Dmaven.javadoc.skip=true;  fi
+
+after_success:
+  - bash <(curl -s https://codecov.io/bash)
+
+after_failure:
+  - echo "build failed!"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,6 +60,23 @@ git push origin your_awesome_patch
 
 Thanks for contributing!
 
+### Debugging issues on Linux ARM64
+
+Apache Dubbo officially supports ARM64 CPU architecture!
+The project uses TravisCI to run the build and tests every night.
+
+If one needs to debug a problem on ARM64 and has no access to such hardware then the following setup with Docker and QEMU could be used on a 
+x86_64 machine:
+
+    (dev-machine) $ docker run -it --rm --privileged multiarch/qemu-user-static --credential yes --persistent yes
+    (dev-machine) $ docker run -it --rm -v /path/to/dubbo:/dubbo arm64v8/ubuntu:focal bash
+    (docker) # apt install ... # jdk, ...
+    (docker) # cd /dubbo
+    (docker) # ./mvnw clean test
+
+More information about the Docker+QEMU setup could be found [here](https://martin-grigorov.medium.
+com/building-linux-packages-for-different-cpu-architectures-with-docker-and-qemu-d29e4ebc9fa5). 
+
 ### Code style
 
 We provide a template file [dubbo_codestyle_for_idea.xml](https://github.com/apache/dubbo/tree/master/codestyle/dubbo_codestyle_for_idea.xml) for IntelliJ idea that you can import it to your workplace. 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Apache Dubbo Project
 
 [![Build Status](https://github.com/apache/dubbo/workflows/Build%20and%20Test/badge.svg?branch=master)](https://github.com/apache/dubbo/actions/workflows/build-and-test.yml?query=branch%3Amaster+)
+[![Build Status](https://api.travis-ci.com/apache/dubbo.svg?branch=master)](https://travis-ci.com/github/apache/dubbo)
 [![Codecov](https://codecov.io/gh/apache/dubbo/branch/master/graph/badge.svg)](https://codecov.io/gh/apache/dubbo)
 ![Maven](https://img.shields.io/maven-central/v/org.apache.dubbo/dubbo.svg)
 ![License](https://img.shields.io/github/license/alibaba/dubbo.svg)

--- a/dubbo-configcenter/dubbo-configcenter-consul/pom.xml
+++ b/dubbo-configcenter/dubbo-configcenter-consul/pom.xml
@@ -40,6 +40,7 @@
         <dependency>
             <groupId>com.pszymczyk.consul</groupId>
             <artifactId>embedded-consul</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/dubbo-dependencies-bom/pom.xml
+++ b/dubbo-dependencies-bom/pom.xml
@@ -103,7 +103,7 @@
         <curator_test_version>2.12.0</curator_test_version>
         <jedis_version>3.3.0</jedis_version>
         <consul_version>1.4.2</consul_version>
-        <consul_process_version>2.0.0</consul_process_version>
+        <consul_process_version>2.2.0</consul_process_version>
         <consul_client_version>1.3.7</consul_client_version>
         <xmemcached_version>1.3.6</xmemcached_version>
         <cxf_version>3.1.15</cxf_version>
@@ -132,6 +132,7 @@
         <jetcd_version>0.5.3</jetcd_version>
         <nacos_version>1.3.1</nacos_version>
         <grpc.version>1.31.1</grpc.version>
+        <groovy.version>2.5.13</groovy.version>
         <!-- Log libs -->
         <slf4j_version>1.7.25</slf4j_version>
         <jcl_version>1.2</jcl_version>
@@ -140,7 +141,7 @@
         <log4j2_version>2.11.1</log4j2_version>
         <commons_io_version>2.6</commons_io_version>
 
-        <embedded_redis_version>0.6</embedded_redis_version>
+        <embedded_redis_version>0.9.0</embedded_redis_version>
 
         <!-- Eureka -->
         <eureka.version>1.9.12</eureka.version>
@@ -621,7 +622,7 @@
                 <scope>test</scope>
             </dependency>
             <dependency>
-                <groupId>com.github.kstyrc</groupId>
+                <groupId>com.github.codemonstur</groupId>
                 <artifactId>embedded-redis</artifactId>
                 <version>${embedded_redis_version}</version>
                 <scope>test</scope>
@@ -700,6 +701,15 @@
                 <artifactId>grpc-grpclb</artifactId>
                 <version>${grpc.version}</version>
             </dependency>
+            <!-- Groovy, for Embedded Consul. Could be removed once embedded-consul:2.2.1 is released
+             See https://github.com/pszymczyk/embedded-consul/pull/114
+             -->
+            <dependency>
+                <groupId>org.codehaus.groovy</groupId>
+                <artifactId>groovy-xml</artifactId>
+                <version>${groovy.version}</version>
+            </dependency>
+
             <dependency>
                 <groupId>io.fabric8</groupId>
                 <artifactId>kubernetes-client</artifactId>

--- a/dubbo-dependencies-bom/pom.xml
+++ b/dubbo-dependencies-bom/pom.xml
@@ -132,7 +132,6 @@
         <jetcd_version>0.5.3</jetcd_version>
         <nacos_version>1.3.1</nacos_version>
         <grpc.version>1.31.1</grpc.version>
-        <groovy.version>2.5.13</groovy.version>
         <!-- Log libs -->
         <slf4j_version>1.7.25</slf4j_version>
         <jcl_version>1.2</jcl_version>
@@ -707,7 +706,8 @@
             <dependency>
                 <groupId>org.codehaus.groovy</groupId>
                 <artifactId>groovy-xml</artifactId>
-                <version>${groovy.version}</version>
+                <version>2.5.13</version>
+                <scope>test</scope>
             </dependency>
 
             <dependency>

--- a/dubbo-dependencies-bom/pom.xml
+++ b/dubbo-dependencies-bom/pom.xml
@@ -140,7 +140,7 @@
         <log4j2_version>2.11.1</log4j2_version>
         <commons_io_version>2.6</commons_io_version>
 
-        <embedded_redis_version>0.9.0</embedded_redis_version>
+        <embedded_redis_version>0.10.0</embedded_redis_version>
 
         <!-- Eureka -->
         <eureka.version>1.9.12</eureka.version>

--- a/dubbo-dependencies-bom/pom.xml
+++ b/dubbo-dependencies-bom/pom.xml
@@ -103,7 +103,7 @@
         <curator_test_version>2.12.0</curator_test_version>
         <jedis_version>3.3.0</jedis_version>
         <consul_version>1.4.2</consul_version>
-        <consul_process_version>2.2.0</consul_process_version>
+        <consul_process_version>2.2.1</consul_process_version>
         <consul_client_version>1.3.7</consul_client_version>
         <xmemcached_version>1.3.6</xmemcached_version>
         <cxf_version>3.1.15</cxf_version>
@@ -700,16 +700,6 @@
                 <artifactId>grpc-grpclb</artifactId>
                 <version>${grpc.version}</version>
             </dependency>
-            <!-- Groovy, for Embedded Consul. Could be removed once embedded-consul:2.2.1 is released
-             See https://github.com/pszymczyk/embedded-consul/pull/114
-             -->
-            <dependency>
-                <groupId>org.codehaus.groovy</groupId>
-                <artifactId>groovy-xml</artifactId>
-                <version>2.5.13</version>
-                <scope>test</scope>
-            </dependency>
-
             <dependency>
                 <groupId>io.fabric8</groupId>
                 <artifactId>kubernetes-client</artifactId>

--- a/dubbo-metadata/dubbo-metadata-report-redis/pom.xml
+++ b/dubbo-metadata/dubbo-metadata-report-redis/pom.xml
@@ -41,9 +41,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.github.kstyrc</groupId>
+            <groupId>com.github.codemonstur</groupId>
             <artifactId>embedded-redis</artifactId>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/dubbo-metadata/dubbo-metadata-report-redis/pom.xml
+++ b/dubbo-metadata/dubbo-metadata-report-redis/pom.xml
@@ -43,6 +43,7 @@
         <dependency>
             <groupId>com.github.codemonstur</groupId>
             <artifactId>embedded-redis</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/dubbo-metadata/dubbo-metadata-report-redis/src/test/java/org/apache/dubbo/metadata/store/redis/RedisMetadataReportTest.java
+++ b/dubbo-metadata/dubbo-metadata-report-redis/src/test/java/org/apache/dubbo/metadata/store/redis/RedisMetadataReportTest.java
@@ -35,7 +35,7 @@ import redis.clients.jedis.Jedis;
 import redis.clients.jedis.exceptions.JedisConnectionException;
 import redis.clients.jedis.exceptions.JedisDataException;
 import redis.embedded.RedisServer;
-import redis.embedded.RedisServerBuilder;
+import redis.embedded.core.RedisServerBuilder;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -60,7 +60,7 @@ public class RedisMetadataReportTest {
         String methodName = testInfo.getTestMethod().get().getName();
         if ("testAuthRedisMetadata".equals(methodName) || ("testWrongAuthRedisMetadata".equals(methodName))) {
             String password = "チェリー";
-            RedisServerBuilder builder = RedisServer.builder().port(redisPort).setting("requirepass " + password);
+            RedisServerBuilder builder = RedisServer.newRedisServer().port(redisPort).setting("requirepass " + password);
             if (SystemUtils.IS_OS_WINDOWS) {
                 // set maxheap to fix Windows error 0x70 while starting redis
                 builder.setting("maxheap 128mb");
@@ -68,7 +68,7 @@ public class RedisMetadataReportTest {
             redisServer = builder.build();
             registryUrl = URL.valueOf("redis://username:" + password + "@localhost:" + redisPort);
         } else {
-            RedisServerBuilder builder = RedisServer.builder().port(redisPort);
+            RedisServerBuilder builder = RedisServer.newRedisServer().port(redisPort);
             if (SystemUtils.IS_OS_WINDOWS) {
                 // set maxheap to fix Windows error 0x70 while starting redis
                 builder.setting("maxheap 128mb");

--- a/dubbo-registry/dubbo-registry-consul/pom.xml
+++ b/dubbo-registry/dubbo-registry-consul/pom.xml
@@ -46,6 +46,14 @@
             <artifactId>embedded-consul</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <!-- Could be removed once embedded-consul:2.2.1 is released
+             See https://github.com/pszymczyk/embedded-consul/pull/114
+             -->
+            <groupId>org.codehaus.groovy</groupId>
+            <artifactId>groovy-xml</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/dubbo-registry/dubbo-registry-consul/pom.xml
+++ b/dubbo-registry/dubbo-registry-consul/pom.xml
@@ -46,13 +46,6 @@
             <artifactId>embedded-consul</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <!-- Could be removed once embedded-consul:2.2.1 is released
-             See https://github.com/pszymczyk/embedded-consul/pull/114
-             -->
-            <groupId>org.codehaus.groovy</groupId>
-            <artifactId>groovy-xml</artifactId>
-        </dependency>
     </dependencies>
 
     <build>

--- a/dubbo-registry/dubbo-registry-consul/pom.xml
+++ b/dubbo-registry/dubbo-registry-consul/pom.xml
@@ -52,7 +52,6 @@
              -->
             <groupId>org.codehaus.groovy</groupId>
             <artifactId>groovy-xml</artifactId>
-            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/dubbo-registry/dubbo-registry-consul/src/main/java/org/apache/dubbo/registry/consul/ConsulServiceDiscovery.java
+++ b/dubbo-registry/dubbo-registry-consul/src/main/java/org/apache/dubbo/registry/consul/ConsulServiceDiscovery.java
@@ -77,8 +77,6 @@ import static org.apache.dubbo.registry.consul.ConsulParameter.TAGS;
  */
 public class ConsulServiceDiscovery extends AbstractServiceDiscovery implements EventListener<ServiceInstancesChangedEvent> {
 
-    private static final Logger logger = LoggerFactory.getLogger(ConsulServiceDiscovery.class);
-
     private static final String QUERY_TAG = "consul_query_tag";
     private static final String REGISTER_TAG = "consul_register_tag";
 

--- a/dubbo-registry/dubbo-registry-multiple/pom.xml
+++ b/dubbo-registry/dubbo-registry-multiple/pom.xml
@@ -53,9 +53,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.github.kstyrc</groupId>
+            <groupId>com.github.codemonstur</groupId>
             <artifactId>embedded-redis</artifactId>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/dubbo-registry/dubbo-registry-multiple/pom.xml
+++ b/dubbo-registry/dubbo-registry-multiple/pom.xml
@@ -55,6 +55,7 @@
         <dependency>
             <groupId>com.github.codemonstur</groupId>
             <artifactId>embedded-redis</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/dubbo-registry/dubbo-registry-multiple/src/test/java/org/apache/dubbo/registry/multiple/MultipleRegistry2S2RTest.java
+++ b/dubbo-registry/dubbo-registry-multiple/src/test/java/org/apache/dubbo/registry/multiple/MultipleRegistry2S2RTest.java
@@ -32,7 +32,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import redis.embedded.RedisServer;
-import redis.embedded.RedisServerBuilder;
+import redis.embedded.core.RedisServerBuilder;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -68,7 +68,7 @@ public class MultipleRegistry2S2RTest {
         zookeeperRegistryURLStr = "zookeeper://127.0.0.1:" + zkServerPort;
 
         redisServerPort = NetUtils.getAvailablePort();
-        RedisServerBuilder builder = RedisServer.builder().port(redisServerPort);
+        RedisServerBuilder builder = RedisServer.newRedisServer().port(redisServerPort);
         if (SystemUtils.IS_OS_WINDOWS) {
             // set maxheap to fix Windows error 0x70 while starting redis
             builder.setting("maxheap 128mb");

--- a/dubbo-registry/dubbo-registry-redis/pom.xml
+++ b/dubbo-registry/dubbo-registry-redis/pom.xml
@@ -45,9 +45,8 @@
             <artifactId>jedis</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.github.kstyrc</groupId>
+            <groupId>com.github.codemonstur</groupId>
             <artifactId>embedded-redis</artifactId>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/dubbo-registry/dubbo-registry-redis/pom.xml
+++ b/dubbo-registry/dubbo-registry-redis/pom.xml
@@ -47,6 +47,7 @@
         <dependency>
             <groupId>com.github.codemonstur</groupId>
             <artifactId>embedded-redis</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/dubbo-registry/dubbo-registry-redis/src/test/java/org/apache/dubbo/registry/redis/RedisRegistryTest.java
+++ b/dubbo-registry/dubbo-registry-redis/src/test/java/org/apache/dubbo/registry/redis/RedisRegistryTest.java
@@ -23,12 +23,11 @@ import org.apache.dubbo.registry.NotifyListener;
 import org.apache.dubbo.registry.Registry;
 
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import redis.clients.jedis.exceptions.JedisConnectionException;
 import redis.embedded.RedisServer;
-import redis.embedded.RedisServerBuilder;
+import redis.embedded.core.RedisServerBuilder;
 
 import java.util.List;
 import java.util.Map;
@@ -50,7 +49,7 @@ public class RedisRegistryTest {
     @BeforeEach
     public void setUp() throws Exception {
         int redisPort = NetUtils.getAvailablePort();
-        RedisServerBuilder builder = RedisServer.builder().port(redisPort);
+        RedisServerBuilder builder = RedisServer.newRedisServer().port(redisPort);
         if (SystemUtils.IS_OS_WINDOWS) {
             // set maxheap to fix Windows error 0x70 while starting redis
             builder.setting("maxheap 128mb");

--- a/dubbo-rpc/dubbo-rpc-redis/pom.xml
+++ b/dubbo-rpc/dubbo-rpc-redis/pom.xml
@@ -40,9 +40,8 @@
             <artifactId>jedis</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.github.kstyrc</groupId>
+            <groupId>com.github.codemonstur</groupId>
             <artifactId>embedded-redis</artifactId>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.dubbo</groupId>

--- a/dubbo-rpc/dubbo-rpc-redis/pom.xml
+++ b/dubbo-rpc/dubbo-rpc-redis/pom.xml
@@ -42,6 +42,7 @@
         <dependency>
             <groupId>com.github.codemonstur</groupId>
             <artifactId>embedded-redis</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.dubbo</groupId>

--- a/dubbo-rpc/dubbo-rpc-redis/src/test/java/org/apache/dubbo/rpc/protocol/redis/RedisProtocolTest.java
+++ b/dubbo-rpc/dubbo-rpc-redis/src/test/java/org/apache/dubbo/rpc/protocol/redis/RedisProtocolTest.java
@@ -39,9 +39,10 @@ import redis.clients.jedis.JedisPool;
 import redis.clients.jedis.exceptions.JedisConnectionException;
 import redis.clients.jedis.exceptions.JedisDataException;
 import redis.embedded.RedisServer;
-import redis.embedded.RedisServerBuilder;
+import redis.embedded.core.RedisServerBuilder;
 
 import java.io.ByteArrayInputStream;
+import java.io.IOException;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
@@ -54,12 +55,12 @@ public class RedisProtocolTest {
     private URL registryUrl;
 
     @BeforeEach
-    public void setUp(TestInfo testInfo) {
+    public void setUp(TestInfo testInfo) throws IOException {
         int redisPort = NetUtils.getAvailablePort();
         String methodName = testInfo.getTestMethod().get().getName();
         if ("testAuthRedis".equals(methodName) || ("testWrongAuthRedis".equals(methodName))) {
             String password = "123456";
-            RedisServerBuilder builder = RedisServer.builder().port(redisPort).setting("requirepass " + password);
+            RedisServerBuilder builder = RedisServer.newRedisServer().port(redisPort).setting("requirepass " + password);
             if (SystemUtils.IS_OS_WINDOWS) {
                 // set maxheap to fix Windows error 0x70 while starting redis
                 builder.setting("maxheap 128mb");
@@ -67,7 +68,7 @@ public class RedisProtocolTest {
             redisServer = builder.build();
             this.registryUrl = URL.valueOf("redis://username:" + password + "@localhost:" + redisPort + "?db.index=0");
         } else {
-            RedisServerBuilder builder = RedisServer.builder().port(redisPort);
+            RedisServerBuilder builder = RedisServer.newRedisServer().port(redisPort);
             if (SystemUtils.IS_OS_WINDOWS) {
                 // set maxheap to fix Windows error 0x70 while starting redis
                 builder.setting("maxheap 128mb");
@@ -79,7 +80,7 @@ public class RedisProtocolTest {
     }
 
     @AfterEach
-    public void tearDown() {
+    public void tearDown() throws IOException {
         this.redisServer.stop();
     }
     @Test


### PR DESCRIPTION
## What is the purpose of the change

Apache Dubbo is a Java application and thus should work fine on any architecture supported by the Java Virtual Machine.
But Dubbo depends on some libraries which use native binaries that do not have aarch64 version, for example embedded-redis and embedded-consul.
This PR updates those dependencies with newer versions which added support for ARM64 architecture!

## Verifying this change

The PR re-introduces TravisCI as a build tool to build and tests `master` branch every night.
This has been discussed at https://lists.apache.org/thread.html/r2742c51066b55787571417ed74843cd9607ba8202566ddd807f9bdab%40%3Cdev.dubbo.apache.org%3E
Someone from Dubbo team will have to setup the Cron job at TravisCI UI !
