### PR TITLE
Improved conditional test execution

### DIFF
--- a/dubbo-common/src/test/java/org/apache/dubbo/common/utils/NetUtilsTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/utils/NetUtilsTest.java
@@ -35,6 +35,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -193,11 +194,15 @@ public class NetUtilsTest {
     public void testIsValidV6Address() {
         String saved = System.getProperty("java.net.preferIPv6Addresses", "false");
         System.setProperty("java.net.preferIPv6Addresses", "true");
+
         InetAddress address = NetUtils.getLocalAddress();
-        if (address instanceof Inet6Address) {
-            assertThat(NetUtils.isPreferIPV6Address(), equalTo(true));
-        }
+        boolean isPreferIPV6Address = NetUtils.isPreferIPV6Address();
+
+        // Restore system property to previous value before executing test
         System.setProperty("java.net.preferIPv6Addresses", saved);
+
+        assumeTrue(address instanceof Inet6Address);
+        assertThat(isPreferIPV6Address, equalTo(true));
     }
 
     /**


### PR DESCRIPTION
**Problem:**
Conditions within a test method may produce a false test outcome. Once a condition is not met, and the code block inside the condition is not executed, a false 'passed' outcome can be produced without the test ever being executed.

**Solution:**
Instead of using a conditional to control the test execution, we propose using JUnit Assumptions — a failed assumption results in a test being aborted. Assumptions are typically used whenever it does not make sense to continue executing a given test method.

**Result:**
_Before:_
```
if (address instanceof Inet6Address) {
    assertThat(NetUtils.isPreferIPV6Address(), equalTo(true));
}
```

_After:_
```
assumeTrue(address instanceof Inet6Address);
assertThat(isPreferIPV6Address, equalTo(true));
```
