### PR TITLE
introduce empty service discovery impl for redis registry

### DIFF
--- a/dubbo-metadata/dubbo-metadata-api/src/main/java/org/apache/dubbo/metadata/DynamicConfigurationServiceNameMapping.java
+++ b/dubbo-metadata/dubbo-metadata-api/src/main/java/org/apache/dubbo/metadata/DynamicConfigurationServiceNameMapping.java
@@ -20,6 +20,7 @@ import org.apache.dubbo.common.URL;
 import org.apache.dubbo.common.config.configcenter.DynamicConfiguration;
 import org.apache.dubbo.common.logger.Logger;
 import org.apache.dubbo.common.logger.LoggerFactory;
+import org.apache.dubbo.common.utils.CollectionUtils;
 
 import java.util.Collections;
 import java.util.LinkedHashSet;
@@ -83,7 +84,9 @@ public class DynamicConfigurationServiceNameMapping implements ServiceNameMappin
         execute(() -> {
             Set<String> keys = dynamicConfiguration
                     .getConfigKeys(ServiceNameMapping.buildGroup(serviceInterface, group, version, protocol));
-            serviceNames.addAll(keys);
+            if (CollectionUtils.isNotEmpty(keys)) {
+                serviceNames.addAll(keys);
+            }
         });
         return Collections.unmodifiableSet(serviceNames);
     }

--- a/dubbo-registry/dubbo-registry-redis/src/main/java/org/apache/dubbo/registry/redis/RedisServiceDiscovery.java
+++ b/dubbo-registry/dubbo-registry-redis/src/main/java/org/apache/dubbo/registry/redis/RedisServiceDiscovery.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.registry.redis;
+
+import org.apache.dubbo.common.URL;
+import org.apache.dubbo.registry.client.AbstractServiceDiscovery;
+import org.apache.dubbo.registry.client.ServiceInstance;
+
+import java.util.Collections;
+import java.util.Set;
+
+public class RedisServiceDiscovery extends AbstractServiceDiscovery {
+    private URL registryURL;
+
+    @Override
+    public void initialize(URL registryURL) throws Exception {
+        this.registryURL = registryURL;
+    }
+
+    @Override
+    public void destroy() throws Exception {
+
+    }
+
+    @Override
+    public void doRegister(ServiceInstance serviceInstance) {
+
+    }
+
+    @Override
+    public void doUpdate(ServiceInstance serviceInstance) {
+
+    }
+
+    @Override
+    public void unregister(ServiceInstance serviceInstance) throws RuntimeException {
+        this.serviceInstance = null;
+    }
+
+    @Override
+    public Set<String> getServices() {
+        return Collections.singleton("Unsupported Operation");
+    }
+
+    @Override
+    public URL getUrl() {
+        return registryURL;
+    }
+
+}

--- a/dubbo-registry/dubbo-registry-redis/src/main/java/org/apache/dubbo/registry/redis/RedisServiceDiscoveryFactory.java
+++ b/dubbo-registry/dubbo-registry-redis/src/main/java/org/apache/dubbo/registry/redis/RedisServiceDiscoveryFactory.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.registry.redis;
+
+import org.apache.dubbo.common.URL;
+import org.apache.dubbo.registry.client.AbstractServiceDiscoveryFactory;
+import org.apache.dubbo.registry.client.ServiceDiscovery;
+
+public class RedisServiceDiscoveryFactory extends AbstractServiceDiscoveryFactory {
+
+    @Override
+    protected ServiceDiscovery createDiscovery(URL registryURL) {
+        return new RedisServiceDiscovery();
+    }
+
+}

--- a/dubbo-registry/dubbo-registry-redis/src/main/resources/META-INF/dubbo/internal/org.apache.dubbo.registry.client.ServiceDiscovery
+++ b/dubbo-registry/dubbo-registry-redis/src/main/resources/META-INF/dubbo/internal/org.apache.dubbo.registry.client.ServiceDiscovery
@@ -1,0 +1,1 @@
+redis=org.apache.dubbo.registry.redis.RedisServiceDiscovery

--- a/dubbo-registry/dubbo-registry-redis/src/main/resources/META-INF/dubbo/internal/org.apache.dubbo.registry.client.ServiceDiscoveryFactory
+++ b/dubbo-registry/dubbo-registry-redis/src/main/resources/META-INF/dubbo/internal/org.apache.dubbo.registry.client.ServiceDiscoveryFactory
@@ -1,0 +1,1 @@
+redis=org.apache.dubbo.registry.redis.RedisServiceDiscoveryFactory


### PR DESCRIPTION
## What is the purpose of the change

- introduce empty service discovery impl for redis registry
- fix NPE in DynamicConfigurationServiceNameMapping

fix #7434