### PR TITLE
[2.7] Add provided-by paramater for DubboReference

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/config/annotation/DubboReference.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/config/annotation/DubboReference.java
@@ -285,7 +285,14 @@ public @interface DubboReference {
     /**
      * @return The service names that the Dubbo interface subscribed
      * @see RegistryConstants#SUBSCRIBED_SERVICE_NAMES_KEY
+     * @deprecated using {@link DubboReference#providedBy()}
      * @since 2.7.8
      */
     String[] services() default {};
+
+    /**
+     * declares which app or service this interface belongs to
+     * @see RegistryConstants#PROVIDED_BY
+     */
+    String[] providedBy() default {};
 }

--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/ReferenceConfig.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/ReferenceConfig.java
@@ -170,6 +170,7 @@ public class ReferenceConfig<T> extends ReferenceConfigBase<T> {
      * @see RegistryConstants#SUBSCRIBED_SERVICE_NAMES_KEY
      * @since 2.7.8
      */
+    @Deprecated
     @Parameter(key = SUBSCRIBED_SERVICE_NAMES_KEY)
     public String getServices() {
         return services;
@@ -181,6 +182,7 @@ public class ReferenceConfig<T> extends ReferenceConfigBase<T> {
      * @return the String {@link List} presenting the Dubbo interface subscribed
      * @since 2.7.8
      */
+    @Deprecated
     @Parameter(excluded = true)
     public Set<String> getSubscribedServices() {
         return splitToSet(getServices(), COMMA_SEPARATOR_CHAR);

--- a/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/beans/factory/annotation/ReferenceBeanBuilderTest.java
+++ b/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/beans/factory/annotation/ReferenceBeanBuilderTest.java
@@ -74,7 +74,8 @@ public class ReferenceBeanBuilderTest {
             // @since 2.7.3
             id = "reference",
             // @since 2.7.8
-            services = {"service1", "service2", "service3", "service2", "service1"}
+            services = {"service1", "service2", "service3", "service2", "service1"},
+            providedBy = {"service1", "service2", "service3"}
     )
     private static final Object TEST_FIELD = new Object();
 
@@ -128,6 +129,7 @@ public class ReferenceBeanBuilderTest {
         Assertions.assertEquals("deprecated", referenceBean.getListener());
         Assertions.assertEquals("reference", referenceBean.getId());
         Assertions.assertEquals(ofSet("service1", "service2", "service3"), referenceBean.getSubscribedServices());
+        Assertions.assertEquals("service1,service2,service3", referenceBean.getProvidedBy());
 
         // parameters
         Map<String, String> parameters = new HashMap<String, String>();


### PR DESCRIPTION
## What is the purpose of the change

- add providedBy parameter in DubboReference
- make services deprecated

Related #7190