### PR TITLE
[Dubbo-7434]Change migration default step to force interface

### DIFF
--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/support/migration/MigrationRule.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/support/migration/MigrationRule.java
@@ -24,6 +24,8 @@ import org.yaml.snakeyaml.constructor.Constructor;
 
 import java.util.Optional;
 
+import static org.apache.dubbo.common.constants.RegistryConstants.INIT;
+
 public class MigrationRule {
     private static final String DUBBO_SERVICEDISCOVERY_MIGRATION_KEY = "dubbo.application.service-discovery.migration";
     public static final String DUBBO_SERVICEDISCOVERY_MIGRATION_GROUP = "MIGRATION";
@@ -62,10 +64,9 @@ public class MigrationRule {
             return getMigrationRule(null);
         }
 
-        if (StringUtils.isBlank(rawRule) || "INIT".equals(rawRule)) {
+        if (StringUtils.isBlank(rawRule) || INIT.equals(rawRule)) {
             String step = (String)configuration.getInternalProperty(DUBBO_SERVICEDISCOVERY_MIGRATION_KEY);
             return getMigrationRule(step);
-
         }
 
         Constructor constructor = new Constructor(MigrationRule.class);
@@ -82,9 +83,9 @@ public class MigrationRule {
         return parse(rawRule);
     }
 
-    private  static MigrationRule getMigrationRule(String step) {
+    private static MigrationRule getMigrationRule(String step) {
         MigrationRule rule = new MigrationRule();
-        rule.setStep(Enum.valueOf(MigrationStep.class, StringUtils.isBlank(step) ? MigrationStep.APPLICATION_FIRST.name() : step));
+        rule.setStep(Enum.valueOf(MigrationStep.class, StringUtils.isBlank(step) ? MigrationStep.FORCE_INTERFACE.name() : step));
         return rule;
     }
 }

--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/support/migration/MigrationRule.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/support/migration/MigrationRule.java
@@ -19,12 +19,11 @@ package org.apache.dubbo.rpc.cluster.support.migration;
 import org.apache.dubbo.common.config.configcenter.DynamicConfiguration;
 import org.apache.dubbo.common.utils.StringUtils;
 import org.apache.dubbo.rpc.model.ApplicationModel;
+
 import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.constructor.Constructor;
 
 import java.util.Optional;
-
-import static org.apache.dubbo.common.constants.RegistryConstants.INIT;
 
 public class MigrationRule {
     private static final String DUBBO_SERVICEDISCOVERY_MIGRATION_KEY = "dubbo.application.service-discovery.migration";
@@ -64,7 +63,7 @@ public class MigrationRule {
             return getMigrationRule(null);
         }
 
-        if (StringUtils.isBlank(rawRule) || INIT.equals(rawRule)) {
+        if (StringUtils.isBlank(rawRule) || "INIT".equals(rawRule)) {
             String step = (String)configuration.getInternalProperty(DUBBO_SERVICEDISCOVERY_MIGRATION_KEY);
             return getMigrationRule(step);
         }

--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/migration/MigrationInvoker.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/migration/MigrationInvoker.java
@@ -112,10 +112,10 @@ public class MigrationInvoker<T> implements MigrationClusterInvoker<T> {
             refreshServiceDiscoveryInvoker();
             refreshInterfaceInvoker();
             setListener(invoker, () -> {
-                this.compareAddresses(invoker, serviceDiscoveryInvoker);
+                this.compareAddresses(serviceDiscoveryInvoker, invoker);
             });
             setListener(serviceDiscoveryInvoker, () -> {
-                this.compareAddresses(invoker, serviceDiscoveryInvoker);
+                this.compareAddresses(serviceDiscoveryInvoker, invoker);
             });
         } else {
             refreshServiceDiscoveryInvoker();

--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/migration/MigrationInvoker.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/migration/MigrationInvoker.java
@@ -112,10 +112,10 @@ public class MigrationInvoker<T> implements MigrationClusterInvoker<T> {
             refreshServiceDiscoveryInvoker();
             refreshInterfaceInvoker();
             setListener(invoker, () -> {
-                this.compareAddresses(serviceDiscoveryInvoker, invoker);
+                this.compareAddresses(invoker, serviceDiscoveryInvoker);
             });
             setListener(serviceDiscoveryInvoker, () -> {
-                this.compareAddresses(serviceDiscoveryInvoker, invoker);
+                this.compareAddresses(invoker, serviceDiscoveryInvoker);
             });
         } else {
             refreshServiceDiscoveryInvoker();


### PR DESCRIPTION
## What is the purpose of the change

For-[#7434](https://github.com/apache/dubbo/issues/7434)
We should use interface invoker as default in 2.7.x