### PR TITLE
[Dubbo-7459]Fix passing wrong parameter when calling MigrationInvoker.compareAddresses()

### DIFF
--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/support/migration/MigrationRule.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/support/migration/MigrationRule.java
@@ -24,6 +24,8 @@ import org.yaml.snakeyaml.constructor.Constructor;
 
 import java.util.Optional;
 
+import static org.apache.dubbo.common.constants.RegistryConstants.INIT;
+
 public class MigrationRule {
     private static final String DUBBO_SERVICEDISCOVERY_MIGRATION_KEY = "dubbo.application.service-discovery.migration";
     public static final String DUBBO_SERVICEDISCOVERY_MIGRATION_GROUP = "MIGRATION";
@@ -62,7 +64,7 @@ public class MigrationRule {
             return getMigrationRule(null);
         }
 
-        if (StringUtils.isBlank(rawRule) || "INIT".equals(rawRule)) {
+        if (StringUtils.isBlank(rawRule) || INIT.equals(rawRule)) {
             String step = (String)configuration.getInternalProperty(DUBBO_SERVICEDISCOVERY_MIGRATION_KEY);
             return getMigrationRule(step);
 

--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/migration/MigrationInvoker.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/migration/MigrationInvoker.java
@@ -112,10 +112,10 @@ public class MigrationInvoker<T> implements MigrationClusterInvoker<T> {
             refreshServiceDiscoveryInvoker();
             refreshInterfaceInvoker();
             setListener(invoker, () -> {
-                this.compareAddresses(invoker, serviceDiscoveryInvoker);
+                this.compareAddresses(serviceDiscoveryInvoker, invoker);
             });
             setListener(serviceDiscoveryInvoker, () -> {
-                this.compareAddresses(invoker, serviceDiscoveryInvoker);
+                this.compareAddresses(serviceDiscoveryInvoker, invoker);
             });
         } else {
             refreshServiceDiscoveryInvoker();


### PR DESCRIPTION
## What is the purpose of the change

For-[#7459](https://github.com/apache/dubbo/issues/7459)