### PR TITLE
enhance LRUCache

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/utils/LRUCache.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/utils/LRUCache.java
@@ -20,6 +20,12 @@ import java.util.LinkedHashMap;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
+/**
+ * LRU-2
+ * </p>
+ * When the data accessed for the first time, add it to history list. If the size of history list reaches max capacity, eliminate the earliest data (first in first out).
+ * When the data already exists in the history list, and be accessed for the second time, then it will be put into cache.
+ */
 public class LRUCache<K, V> extends LinkedHashMap<K, V> {
 
     private static final long serialVersionUID = -5167631809472116969L;
@@ -30,6 +36,9 @@ public class LRUCache<K, V> extends LinkedHashMap<K, V> {
     private final Lock lock = new ReentrantLock();
     private volatile int maxCapacity;
 
+    // as history list
+    private PreCache<K, Boolean> preCache;
+
     public LRUCache() {
         this(DEFAULT_MAX_CAPACITY);
     }
@@ -37,6 +46,7 @@ public class LRUCache<K, V> extends LinkedHashMap<K, V> {
     public LRUCache(int maxCapacity) {
         super(16, DEFAULT_LOAD_FACTOR, true);
         this.maxCapacity = maxCapacity;
+        this.preCache = new PreCache<>(maxCapacity);
     }
 
     @Override
@@ -68,7 +78,15 @@ public class LRUCache<K, V> extends LinkedHashMap<K, V> {
     public V put(K key, V value) {
         lock.lock();
         try {
-            return super.put(key, value);
+            if (preCache.containsKey(key)) {
+                // add it to cache
+                preCache.remove(key);
+                return super.put(key, value);
+            } else {
+                // add it to history list
+                preCache.put(key, true);
+                return value;
+            }
         } finally {
             lock.unlock();
         }
@@ -78,6 +96,7 @@ public class LRUCache<K, V> extends LinkedHashMap<K, V> {
     public V remove(Object key) {
         lock.lock();
         try {
+            preCache.remove(key);
             return super.remove(key);
         } finally {
             lock.unlock();
@@ -98,6 +117,7 @@ public class LRUCache<K, V> extends LinkedHashMap<K, V> {
     public void clear() {
         lock.lock();
         try {
+            preCache.clear();
             super.clear();
         } finally {
             lock.unlock();
@@ -109,7 +129,31 @@ public class LRUCache<K, V> extends LinkedHashMap<K, V> {
     }
 
     public void setMaxCapacity(int maxCapacity) {
+        preCache.setMaxCapacity(maxCapacity);
         this.maxCapacity = maxCapacity;
+    }
+
+    static class PreCache<K, V> extends LinkedHashMap<K, V> {
+
+        private volatile int maxCapacity;
+
+        public PreCache() {
+            this(DEFAULT_MAX_CAPACITY);
+        }
+
+        public PreCache(int maxCapacity) {
+            super(16, DEFAULT_LOAD_FACTOR, true);
+            this.maxCapacity = maxCapacity;
+        }
+
+        @Override
+        protected boolean removeEldestEntry(java.util.Map.Entry<K, V> eldest) {
+            return size() > maxCapacity;
+        }
+
+        public void setMaxCapacity(int maxCapacity) {
+            this.maxCapacity = maxCapacity;
+        }
     }
 
 }

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/utils/LRUCacheTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/utils/LRUCacheTest.java
@@ -31,10 +31,17 @@ public class LRUCacheTest {
         cache.put("one", 1);
         cache.put("two", 2);
         cache.put("three", 3);
+        assertFalse(cache.containsKey("one"));
+        assertFalse(cache.containsKey("two"));
+        assertFalse(cache.containsKey("three"));
+        cache.put("one", 1);
+        cache.put("two", 2);
+        cache.put("three", 3);
         assertThat(cache.get("one"), equalTo(1));
         assertThat(cache.get("two"), equalTo(2));
         assertThat(cache.get("three"), equalTo(3));
         assertThat(cache.size(), equalTo(3));
+        cache.put("four", 4);
         cache.put("four", 4);
         assertThat(cache.size(), equalTo(3));
         assertFalse(cache.containsKey("one"));
@@ -44,11 +51,14 @@ public class LRUCacheTest {
         cache.remove("four");
         assertThat(cache.size(), equalTo(2));
         cache.put("five", 5);
+        cache.put("five", 5);
         assertFalse(cache.containsKey("four"));
         assertTrue(cache.containsKey("five"));
         assertTrue(cache.containsKey("two"));
         assertTrue(cache.containsKey("three"));
         assertThat(cache.size(), equalTo(3));
+        cache.put("six", 6);
+        assertFalse(cache.containsKey("six"));
     }
 
     @Test

--- a/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/cache/CacheTest.java
+++ b/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/cache/CacheTest.java
@@ -83,6 +83,7 @@ public class CacheTest {
                 // verify cache, same result is returned for multiple invocations (in fact, the return value increases
                 // on every invocation on the server side)
                 String fix = null;
+                cacheService.findCache("0");
                 for (int i = 0; i < 3; i++) {
                     String result = cacheService.findCache("0");
                     assertTrue(fix == null || fix.equals(result));
@@ -94,6 +95,7 @@ public class CacheTest {
                     // default cache.size is 1000 for LRU, should have cache expired if invoke more than 1001 times
                     for (int n = 0; n < 1001; n++) {
                         String pre = null;
+                        cacheService.findCache(String.valueOf(n));
                         for (int i = 0; i < 10; i++) {
                             String result = cacheService.findCache(String.valueOf(n));
                             assertTrue(pre == null || pre.equals(result));

--- a/dubbo-filter/dubbo-filter-cache/src/test/java/org/apache/dubbo/cache/filter/CacheFilterTest.java
+++ b/dubbo-filter/dubbo-filter-cache/src/test/java/org/apache/dubbo/cache/filter/CacheFilterTest.java
@@ -86,6 +86,7 @@ public class CacheFilterTest {
         invocation.setArguments(new Object[]{});
 
         cacheFilter.invoke(invoker, invocation);
+        cacheFilter.invoke(invoker, invocation);
         Result rpcResult1 = cacheFilter.invoke(invoker1, invocation);
         Result rpcResult2 = cacheFilter.invoke(invoker2, invocation);
         Assertions.assertEquals(rpcResult1.getValue(), rpcResult2.getValue());
@@ -100,6 +101,7 @@ public class CacheFilterTest {
         invocation.setParameterTypes(new Class<?>[]{String.class});
         invocation.setArguments(new Object[]{"arg1"});
 
+        cacheFilter.invoke(invoker, invocation);
         cacheFilter.invoke(invoker, invocation);
         Result rpcResult1 = cacheFilter.invoke(invoker1, invocation);
         Result rpcResult2 = cacheFilter.invoke(invoker2, invocation);
@@ -116,6 +118,7 @@ public class CacheFilterTest {
         invocation.setArguments(new Object[]{"arg2"});
 
         cacheFilter.invoke(invoker3, invocation);
+        cacheFilter.invoke(invoker3, invocation);
         Result rpcResult = cacheFilter.invoke(invoker2, invocation);
         Assertions.assertEquals(rpcResult.getValue(), "value2");
     }
@@ -128,6 +131,7 @@ public class CacheFilterTest {
         invocation.setParameterTypes(new Class<?>[]{String.class});
         invocation.setArguments(new Object[]{"arg3"});
 
+        cacheFilter.invoke(invoker4, invocation);
         cacheFilter.invoke(invoker4, invocation);
         Result result1 = cacheFilter.invoke(invoker1, invocation);
         Result result2 = cacheFilter.invoke(invoker2, invocation);


### PR DESCRIPTION
## What is the purpose of the change

Update LRU to LRU-2

## Brief changelog

Reduce cache pollution by filtering one access data with a history list. This strategy will not occupy too much extra memory because the history list only saves the keys.

When the data accessed for the first time, add it to the history list. If the size of the history list reaches max capacity, eliminate the earliest data. When the data already exists in the history list, and be accessed for the second time, then it will be put into the real cache.

## Verifying this change

Also need to update LRUCacheTest, CacheTest, and CacheFilterTest due to the two-time verification mechanism of LRU-2, and two calls need to be performed to put the cache into LRUCache, which shows as commit. 

The performance between LRU and LRU2 refer to https://blog.csdn.net/Victorgcx/article/details/104378378.
