### PR TITLE
ConfigCenterConfig add constructor with address param 

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/config/ConfigCenterConfig.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/config/ConfigCenterConfig.java
@@ -91,6 +91,10 @@ public class ConfigCenterConfig extends AbstractConfig {
     public ConfigCenterConfig() {
     }
 
+    public ConfigCenterConfig(String address) {
+        setAddress(address);
+    }
+
     public URL toUrl() {
         Map<String, String> map = new HashMap<>();
         appendParameters(map, this);


### PR DESCRIPTION
## What is the purpose of the change
RegistryConfig and MetadataReportConfig both has constructor with address param.

ConfigCenterConfig also support it.