### PR TITLE
fix duplicate generation of referenceBeanName

### DIFF
--- a/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/beans/factory/annotation/ReferenceAnnotationBeanPostProcessor.java
+++ b/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/beans/factory/annotation/ReferenceAnnotationBeanPostProcessor.java
@@ -137,7 +137,7 @@ public class ReferenceAnnotationBeanPostProcessor extends AbstractAnnotationBean
 
         prepareReferenceBean(referencedBeanName, referenceBean, localServiceBean);
 
-        registerReferenceBean(referencedBeanName, referenceBean, attributes, localServiceBean, injectedType);
+        registerReferenceBean(referencedBeanName, referenceBeanName, localServiceBean);
 
         cacheInjectedReferenceBean(referenceBean, injectedElement);
 
@@ -148,19 +148,15 @@ public class ReferenceAnnotationBeanPostProcessor extends AbstractAnnotationBean
      * Register an instance of {@link ReferenceBean} as a Spring Bean
      *
      * @param referencedBeanName The name of bean that annotated Dubbo's {@link Service @Service} in the Spring {@link ApplicationContext}
-     * @param referenceBean      the instance of {@link ReferenceBean} is about to register into the Spring {@link ApplicationContext}
-     * @param attributes         the {@link AnnotationAttributes attributes} of {@link Reference @Reference}
+     * @param referenceBeanName  The name of bean that annotated Dubbo's {@link Reference @Reference} in the Spring {@link ApplicationContext}
      * @param localServiceBean   Is Local Service bean or not
-     * @param interfaceClass     the {@link Class class} of Service interface
      * @since 2.7.3
      */
-    private void registerReferenceBean(String referencedBeanName, ReferenceBean referenceBean,
-                                       AnnotationAttributes attributes,
-                                       boolean localServiceBean, Class<?> interfaceClass) {
+    private void registerReferenceBean(String referencedBeanName, String referenceBeanName, boolean localServiceBean) {
 
         ConfigurableListableBeanFactory beanFactory = getBeanFactory();
 
-        String beanName = getReferenceBeanName(attributes, interfaceClass);
+        ReferenceBean referenceBean = referenceBeanCache.get(referenceBeanName);
 
         if (localServiceBean) {  // If @Service bean is local one
             /**
@@ -172,10 +168,10 @@ public class ReferenceAnnotationBeanPostProcessor extends AbstractAnnotationBean
             // The name of bean annotated @Service
             String serviceBeanName = runtimeBeanReference.getBeanName();
             // register Alias rather than a new bean name, in order to reduce duplicated beans
-            beanFactory.registerAlias(serviceBeanName, beanName);
+            beanFactory.registerAlias(serviceBeanName, referenceBeanName);
         } else { // Remote @Service Bean
-            if (!beanFactory.containsBean(beanName)) {
-                beanFactory.registerSingleton(beanName, referenceBean);
+            if (!beanFactory.containsBean(referenceBeanName)) {
+                beanFactory.registerSingleton(referenceBeanName, referenceBean);
             }
         }
     }


### PR DESCRIPTION
## What is the purpose of the change

In the ReferenceAnnotationBeanPostProcessor#doGetInjectedBean() method, the getReferenceBeanName() method has already been called, and there is no need to call the getReferenceBeanName() method again to calculate the beanName when the registerReferenceBean() method is called. If there are many parameters, it will lead to redundant calculations and waste of resources.
## Brief changelog

XXXXX

## Verifying this change

XXXXX

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a [GITHUB_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Run `mvn clean install -DskipTests=false` & `mvn clean test-compile failsafe:integration-test` to make sure unit-test and integration-test pass.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
