### PR TITLE
Fix the DubboReference * version is invalid issue (#6391)

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/rpc/support/GroupServiceKeyCache.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/rpc/support/GroupServiceKeyCache.java
@@ -62,7 +62,7 @@ public class GroupServiceKeyCache {
         }
 
         buf.append(serviceName);
-        if (StringUtils.isNotEmpty(serviceVersion) && !"0.0.0".equals(serviceVersion)) {
+        if (StringUtils.isNotEmpty(serviceVersion) && !"0.0.0".equals(serviceVersion) && !"*".equals(serviceVersion)) {
             buf.append(':').append(serviceVersion);
         }
         buf.append(':').append(port);


### PR DESCRIPTION
(#6391)

## What is the purpose of the change

When the version of DubboReference is *, service reference cannot be performed. Fix the problem that the version of DubboReference is *,thanks

## Brief changelog

Support DubboReference for * can be used for service reference

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a [GITHUB_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Run `mvn clean install -DskipTests=false` & `mvn clean test-compile failsafe:integration-test` to make sure unit-test and integration-test pass.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
