### PR TITLE
fix incorrect handling of the urlBuilder caused the wrong URL to be generated

### DIFF
--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/configurator/parser/ConfigParser.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/configurator/parser/ConfigParser.java
@@ -96,7 +96,10 @@ public class ConfigParser {
 
             List<String> apps = item.getApplications();
             if (CollectionUtils.isNotEmpty(apps)) {
-                apps.forEach(app -> urls.add(URL.valueOf(urlBuilder.append("&application=").append(app).toString())));
+                apps.forEach(app -> {
+                    StringBuilder tmpUrlBuilder = new StringBuilder(urlBuilder);
+                    urls.add(URL.valueOf(tmpUrlBuilder.append("&application=").append(app).toString()));
+                });
             } else {
                 urls.add(URL.valueOf(urlBuilder.toString()));
             }
@@ -119,17 +122,18 @@ public class ConfigParser {
                 services.add("*");
             }
             for (String s : services) {
-                urlBuilder.append(appendService(s));
-                urlBuilder.append(toParameterString(item));
+                StringBuilder tmpUrlBuilder = new StringBuilder(urlBuilder);
+                tmpUrlBuilder.append(appendService(s));
+                tmpUrlBuilder.append(toParameterString(item));
 
-                urlBuilder.append("&application=").append(config.getKey());
+                tmpUrlBuilder.append("&application=").append(config.getKey());
 
-                parseEnabled(item, config, urlBuilder);
+                parseEnabled(item, config, tmpUrlBuilder);
 
-                urlBuilder.append("&category=").append(APP_DYNAMIC_CONFIGURATORS_CATEGORY);
-                urlBuilder.append("&configVersion=").append(config.getConfigVersion());
+                tmpUrlBuilder.append("&category=").append(APP_DYNAMIC_CONFIGURATORS_CATEGORY);
+                tmpUrlBuilder.append("&configVersion=").append(config.getConfigVersion());
 
-                urls.add(URL.valueOf(urlBuilder.toString()));
+                urls.add(URL.valueOf(tmpUrlBuilder.toString()));
             }
         }
         return urls;


### PR DESCRIPTION
## What is the purpose of the change

fix incorrect handling of the URLBuilder caused the wrong URL to be generated

## Brief changelog


在appItemToUrls方法中，对services进行遍历的时候，因为复用同一个URLBuilder，没有使用深拷贝，导致所有的值都追加在了一起。

serviceItemToUrls方法中，对apps遍历的时候，也是这个问题。不过因为是追加参数到url，所以后者会覆盖前者，这个并不影响功能，我只是在这个上面和appItemToUrls保持统一。

## Verifying this change

下面两张图分别是修改后和修改前的，测试程序为 ConfigParserTest#parseConfiguratorsAppMultiServicesTest
![image](https://user-images.githubusercontent.com/43363120/113375767-b3797a80-93a2-11eb-88c3-f702b3c6c6db.png)
![image](https://user-images.githubusercontent.com/43363120/113375770-b5dbd480-93a2-11eb-8bad-3d5c00ca7db1.png)

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a [GITHUB_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Run `mvn clean install -DskipTests=false` & `mvn clean test-compile failsafe:integration-test` to make sure unit-test and integration-test pass.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).


