### PR TITLE
[Dubbo-7425]Upgrade javassist version to 3.23.1-GA

### DIFF
--- a/dubbo-dependencies-bom/pom.xml
+++ b/dubbo-dependencies-bom/pom.xml
@@ -90,7 +90,7 @@
     <properties>
         <!-- Common libs -->
         <spring_version>5.2.8.RELEASE</spring_version>
-        <javassist_version>3.20.0-GA</javassist_version>
+        <javassist_version>3.23.1-GA</javassist_version>
         <netty_version>3.2.5.Final</netty_version>
         <netty4_version>4.1.51.Final</netty4_version>
         <mina_version>1.1.7</mina_version>


### PR DESCRIPTION
## What is the purpose of the change

upgrade javassist version to prevent warning message in jdk11

Fix #7425