### PR TITLE
[Optimization] generic releaize and generalize. (#6189)

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/utils/CompatibleTypeUtils.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/utils/CompatibleTypeUtils.java
@@ -206,19 +206,19 @@ public class CompatibleTypeUtils {
             }
         }
         if (value.getClass().isArray() && Collection.class.isAssignableFrom(type)) {
+            int length = Array.getLength(value);
             Collection collection;
             if (!type.isInterface()) {
                 try {
                     collection = (Collection) type.newInstance();
                 } catch (Throwable e) {
-                    collection = new ArrayList<Object>();
+                    collection = new ArrayList<Object>(length);
                 }
             } else if (type == Set.class) {
-                collection = new HashSet<Object>();
+                collection = new HashSet<Object>(Math.max((int) (length/.75f) + 1, 16));
             } else {
-                collection = new ArrayList<Object>();
+                collection = new ArrayList<Object>(length);
             }
-            int length = Array.getLength(value);
             for (int i = 0; i < length; i++) {
                 collection.add(Array.get(value, i));
             }

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/utils/PojoUtils.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/utils/PojoUtils.java
@@ -256,7 +256,7 @@ public class PojoUtils {
             return new ArrayList<Object>(len);
         }
         if (type.isAssignableFrom(HashSet.class)) {
-            return new HashSet<Object>(len);
+            return new HashSet<Object>(Math.max((int) (len/.75f) + 1, 16));
         }
         if (!type.isInterface() && !Modifier.isAbstract(type.getModifiers())) {
             try {
@@ -265,18 +265,19 @@ public class PojoUtils {
                 // ignore
             }
         }
-        return new ArrayList<Object>();
+        return new ArrayList<Object>(len);
     }
 
     private static Map createMap(Map src) {
         Class<? extends Map> cl = src.getClass();
+        int size = src.size();
         Map result = null;
         if (HashMap.class == cl) {
-            result = new HashMap();
+            result = new HashMap(Math.max((int) (size/.75f) + 1, 16));
         } else if (Hashtable.class == cl) {
-            result = new Hashtable();
+            result = new Hashtable(Math.max((int) (size/.75f) + 1, 16));
         } else if (IdentityHashMap.class == cl) {
-            result = new IdentityHashMap();
+            result = new IdentityHashMap((int)(1 + size * 1.1));
         } else if (LinkedHashMap.class == cl) {
             result = new LinkedHashMap();
         } else if (Properties.class == cl) {
@@ -284,9 +285,9 @@ public class PojoUtils {
         } else if (TreeMap.class == cl) {
             result = new TreeMap();
         } else if (WeakHashMap.class == cl) {
-            return new WeakHashMap();
+            return new WeakHashMap(Math.max((int) (size/.75f) + 1, 16));
         } else if (ConcurrentHashMap.class == cl) {
-            result = new ConcurrentHashMap();
+            result = new ConcurrentHashMap(Math.max((int) (size/.75f) + 1, 16));
         } else if (ConcurrentSkipListMap.class == cl) {
             result = new ConcurrentSkipListMap();
         } else {
@@ -303,7 +304,7 @@ public class PojoUtils {
         }
 
         if (result == null) {
-            result = new HashMap<Object, Object>();
+            result = new HashMap<Object, Object>(Math.max((int) (size/.75f) + 1, 16));
         }
 
         return result;
@@ -393,11 +394,15 @@ public class PojoUtils {
         }
 
         if (pojo instanceof Map<?, ?> && type != null) {
+            Map<Object, Object> map = (Map<Object, Object>) pojo;
             Object className = ((Map<Object, Object>) pojo).get("class");
             if (className instanceof String) {
                 SerializeClassChecker.getInstance().validateClass((String) className);
                 try {
                     type = ClassUtils.forName((String) className);
+                    if (GENERIC_WITH_CLZ) {
+                        map.remove("class");
+                    }
                 } catch (ClassNotFoundException e) {
                     // ignore
                 }
@@ -409,23 +414,6 @@ public class PojoUtils {
                 if (name != null) {
                     return Enum.valueOf((Class<Enum>) type, name.toString());
                 }
-            }
-            Map<Object, Object> map;
-            // when return type is not the subclass of return type from the signature and not an interface
-            if (!type.isInterface() && !type.isAssignableFrom(pojo.getClass())) {
-                try {
-                    map = (Map<Object, Object>) type.newInstance();
-                    Map<Object, Object> mapPojo = (Map<Object, Object>) pojo;
-                    map.putAll(mapPojo);
-                    if (GENERIC_WITH_CLZ) {
-                        map.remove("class");
-                    }
-                } catch (Exception e) {
-                    //ignore error
-                    map = (Map<Object, Object>) pojo;
-                }
-            } else {
-                map = (Map<Object, Object>) pojo;
             }
 
             if (Map.class.isAssignableFrom(type) || type == Object.class) {
@@ -482,9 +470,7 @@ public class PojoUtils {
                         Object value = entry.getValue();
                         if (value != null) {
                             Method method = getSetterMethod(dest.getClass(), name, value.getClass());
-                            Field field = getField(dest.getClass(), name);
                             if (method != null) {
-                                ReflectUtils.makeAccessible(method);
                                 Type ptype = method.getGenericParameterTypes()[0];
                                 value = realize0(value, method.getParameterTypes()[0], ptype, history);
                                 try {
@@ -495,12 +481,16 @@ public class PojoUtils {
                                     logger.error(exceptionDescription, e);
                                     throw new RuntimeException(exceptionDescription, e);
                                 }
-                            } else if (field != null) {
-                                value = realize0(value, field.getType(), field.getGenericType(), history);
-                                try {
-                                    field.set(dest, value);
-                                } catch (IllegalAccessException e) {
-                                    throw new RuntimeException("Failed to set field " + name + " of pojo " + dest.getClass().getName() + " : " + e.getMessage(), e);
+                            } else {
+                                Field field = getField(dest.getClass(), name);
+                                if (field != null) {
+                                    value = realize0(value, field.getType(), field.getGenericType(), history);
+                                    try {
+                                        field.set(dest, value);
+                                    } catch (IllegalAccessException e) {
+                                        String exceptionDescription = "Failed to set field " + name + " of pojo " + dest.getClass().getName() + " : " + e.getMessage();
+                                        throw new RuntimeException(exceptionDescription, e);
+                                    }
                                 }
                             }
                         }
@@ -636,6 +626,7 @@ public class PojoUtils {
                 }
             }
             if (method != null) {
+                ReflectUtils.makeAccessible(method);
                 NAME_METHODS_CACHE.put(cls.getName() + "." + name + "(" + valueCls.getName() + ")", method);
             }
         }


### PR DESCRIPTION
- [ ] I have searched the [issues](https://github.com/apache/dubbo/issues) of this repository and believe that this is not a duplicate.
- [ ] I have checked the [FAQ](https://github.com/apache/dubbo/blob/master/FAQ.md) of this repository and believe that this is not a duplicate.

1，创建map或者list时传入原始数据的长度，避免数据量大时进行扩容
例如
` 
result = new HashMap(Math.max((int) (size/.75f) + 1, 16));
`

2，避免无意义的方法调用
例如：
~~~
            Map<Object, Object> map;
            // when return type is not the subclass of return type from the signature and not an interface
            if (!type.isInterface() && !type.isAssignableFrom(pojo.getClass())) {
                try {
                    map = (Map<Object, Object>) type.newInstance();
                    Map<Object, Object> mapPojo = (Map<Object, Object>) pojo;
                    map.putAll(mapPojo);
                    if (GENERIC_WITH_CLZ) {
                        map.remove("class");
                    }
                } catch (Exception e) {
                    //ignore error
                    map = (Map<Object, Object>) pojo;
                }
            } else {
                map = (Map<Object, Object>) pojo;
            }

~~~
根据逻辑，pojo本身是一个map，又创建了一个新map来存放，无存在意义

3，其他一些优化
例如某个pojo的method取到之后，不需要再取filed，没有实际意义。


