### PR TITLE
Move ContextFilter to lowest order

### DIFF
--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/filter/ContextFilter.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/filter/ContextFilter.java
@@ -55,7 +55,7 @@ import static org.apache.dubbo.rpc.Constants.TOKEN_KEY;
  *
  * @see RpcContext
  */
-@Activate(group = PROVIDER, order = -10000)
+@Activate(group = PROVIDER, order = Integer.MIN_VALUE)
 public class ContextFilter implements Filter, Filter.Listener {
 
     private static final String TAG_KEY = "dubbo.tag";


### PR DESCRIPTION
## What is the purpose of the change

Fix #5842

Move ContextFilter's order to the lowest, avoid RpcContext be cleared