### PR TITLE
add ClusterRules LoadbalanceRules to dubbo common #7531

### DIFF
--- a/dubbo-common/src/main/java/com/alibaba/dubbo/config/annotation/Reference.java
+++ b/dubbo-common/src/main/java/com/alibaba/dubbo/config/annotation/Reference.java
@@ -17,6 +17,9 @@
 
 package com.alibaba.dubbo.config.annotation;
 
+import org.apache.dubbo.common.constants.ClusterRules;
+import org.apache.dubbo.common.constants.LoadbalanceRules;
+
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -61,7 +64,7 @@ public @interface Reference {
 
     String stub() default "";
 
-    String cluster() default "";
+    String cluster() default ClusterRules.EMPTY;
 
     int connections() default 0;
 
@@ -77,7 +80,7 @@ public @interface Reference {
 
     int retries() default 2;
 
-    String loadbalance() default "";
+    String loadbalance() default LoadbalanceRules.EMPTY;
 
     boolean async() default false;
 

--- a/dubbo-common/src/main/java/com/alibaba/dubbo/config/annotation/Service.java
+++ b/dubbo-common/src/main/java/com/alibaba/dubbo/config/annotation/Service.java
@@ -68,7 +68,7 @@ public @interface Service {
 
     String stub() default "";
 
-    String cluster() default ClusterRules.DEFAULT;
+    String cluster() default ClusterRules.EMPTY;
 
     String proxy() default "";
 
@@ -86,7 +86,7 @@ public @interface Service {
 
     int retries() default 0;
 
-    String loadbalance() default LoadbalanceRules.DEFAULT;
+    String loadbalance() default LoadbalanceRules.EMPTY;
 
     boolean async() default false;
 

--- a/dubbo-common/src/main/java/com/alibaba/dubbo/config/annotation/Service.java
+++ b/dubbo-common/src/main/java/com/alibaba/dubbo/config/annotation/Service.java
@@ -17,6 +17,9 @@
 
 package com.alibaba.dubbo.config.annotation;
 
+import org.apache.dubbo.common.constants.ClusterRules;
+import org.apache.dubbo.common.constants.LoadbalanceRules;
+
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Inherited;
@@ -65,7 +68,7 @@ public @interface Service {
 
     String stub() default "";
 
-    String cluster() default "";
+    String cluster() default ClusterRules.DEFAULT;
 
     String proxy() default "";
 
@@ -83,7 +86,7 @@ public @interface Service {
 
     int retries() default 0;
 
-    String loadbalance() default "";
+    String loadbalance() default LoadbalanceRules.DEFAULT;
 
     boolean async() default false;
 

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/constants/ClusterRules.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/constants/ClusterRules.java
@@ -1,8 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.dubbo.common.constants;
 
 /**
  *  constant for Cluster fault-tolerant mode
- * @author lucky-pan
  */
 public interface ClusterRules {
 

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/constants/ClusterRules.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/constants/ClusterRules.java
@@ -1,0 +1,48 @@
+package org.apache.dubbo.common.constants;
+
+/**
+ *  constant for Cluster fault-tolerant mode
+ * @author lucky-pan
+ */
+public interface ClusterRules {
+
+    /**
+     *  When invoke fails, log the initial error and retry other invokers
+     *  (retry n times, which means at most n different invokers will be invoked)
+     **/
+    String FAIL_OVER = "failover";
+
+    /**
+     *  Execute exactly once, which means this policy will throw an exception immediately in case of an invocation error.
+     **/
+    String FAIL_FAST = "failfast";
+
+    /**
+     *  When invoke fails, log the error message and ignore this error by returning an empty Result.
+     **/
+    String FAIL_SAFE = "failsafe";
+
+    /**
+     *  When fails, record failure requests and schedule for retry on a regular interval.
+     **/
+    String FAIL_BACK = "failback";
+
+    /**
+     *  Invoke a specific number of invokers concurrently, usually used for demanding real-time operations, but need to waste more service resources.
+     **/
+    String FORKING = "forking";
+
+    /**
+     *  Call all providers by broadcast, call them one by one, and report an error if any one reports an error
+     **/
+    String BROADCAST = "broadcast";
+
+
+    String AVAILABLE = "available";
+
+    String MERGEABLE = "mergeable";
+
+    String EMPTY = "";
+
+
+}

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/constants/LoadbalanceRules.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/constants/LoadbalanceRules.java
@@ -1,0 +1,36 @@
+package org.apache.dubbo.common.constants;
+
+/**
+ *  constant for Loadbalance strategy
+ * @author lucky-pan
+ */
+public interface LoadbalanceRules {
+
+    /**
+     *  This class select one provider from multiple providers randomly.
+     **/
+    String RANDOM = "random";
+
+    /**
+     *  Round robin load balance.
+     **/
+    String ROUND_ROBIN = "roundrobin";
+
+    /**
+     *  Filter the number of invokers with the least number of active calls and count the weights and quantities of these invokers.
+     **/
+    String LEAST_ACTIVE = "leastactive";
+
+    /**
+     *  Consistent Hash, requests with the same parameters are always sent to the same provider.
+     **/
+    String CONSISTENT_HASH = "consistenthash";
+
+    /**
+     *  Filter the number of invokers with the shortest response time of success calls and count the weights and quantities of these invokers.
+     **/
+    String SHORTEST_RESPONSE = "shortestresponse";
+
+    String EMPTY = "";
+
+}

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/constants/LoadbalanceRules.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/constants/LoadbalanceRules.java
@@ -1,8 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.dubbo.common.constants;
 
 /**
  *  constant for Loadbalance strategy
- * @author lucky-pan
  */
 public interface LoadbalanceRules {
 

--- a/dubbo-common/src/main/java/org/apache/dubbo/config/annotation/DubboReference.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/config/annotation/DubboReference.java
@@ -16,6 +16,8 @@
  */
 package org.apache.dubbo.config.annotation;
 
+import org.apache.dubbo.common.constants.ClusterRules;
+import org.apache.dubbo.common.constants.LoadbalanceRules;
 import org.apache.dubbo.common.constants.RegistryConstants;
 
 import java.lang.annotation.Documented;
@@ -122,9 +124,9 @@ public @interface DubboReference {
     String stub() default "";
 
     /**
-     * Cluster strategy, legal values include: failover, failfast, failsafe, failback, forking
+     * Cluster strategy, you can use {@link org.apache.dubbo.common.constants.ClusterRules#FAIL_FAST} ……
      */
-    String cluster() default "";
+    String cluster() default ClusterRules.EMPTY;
 
     /**
      * Maximum connections service provider can accept, default value is 0 - connection is shared
@@ -166,11 +168,9 @@ public @interface DubboReference {
     int retries() default 2;
 
     /**
-     * Load balance strategy, legal values include: random, roundrobin, leastactive
-     * <p>
-     * see Constants#DEFAULT_LOADBALANCE
+     * Load balance strategy, you can use {@link org.apache.dubbo.common.constants.LoadbalanceRules#RANDOM} ……
      */
-    String loadbalance() default "";
+    String loadbalance() default LoadbalanceRules.RANDOM;
 
     /**
      * Whether to enable async invocation, default value is false

--- a/dubbo-common/src/main/java/org/apache/dubbo/config/annotation/DubboReference.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/config/annotation/DubboReference.java
@@ -170,7 +170,7 @@ public @interface DubboReference {
     /**
      * Load balance strategy, you can use {@link org.apache.dubbo.common.constants.LoadbalanceRules#RANDOM} ……
      */
-    String loadbalance() default LoadbalanceRules.RANDOM;
+    String loadbalance() default LoadbalanceRules.EMPTY;
 
     /**
      * Whether to enable async invocation, default value is false

--- a/dubbo-common/src/main/java/org/apache/dubbo/config/annotation/DubboService.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/config/annotation/DubboService.java
@@ -27,7 +27,6 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-import static org.apache.dubbo.common.constants.CommonConstants.DEFAULT_LOADBALANCE;
 import static org.apache.dubbo.common.constants.CommonConstants.DEFAULT_RETRIES;
 
 /**

--- a/dubbo-common/src/main/java/org/apache/dubbo/config/annotation/DubboService.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/config/annotation/DubboService.java
@@ -17,6 +17,9 @@
 package org.apache.dubbo.config.annotation;
 
 
+import org.apache.dubbo.common.constants.ClusterRules;
+import org.apache.dubbo.common.constants.LoadbalanceRules;
+
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Inherited;
@@ -125,9 +128,9 @@ public @interface DubboService {
     String stub() default "";
 
     /**
-     * Cluster strategy, legal values include: failover, failfast, failsafe, failback, forking
+     * Cluster strategy, you can use {@link org.apache.dubbo.common.constants.ClusterRules#FAIL_FAST} ……
      */
-    String cluster() default "";
+    String cluster() default ClusterRules.EMPTY;
 
     /**
      * How the proxy is generated, legal values include: jdk, javassist
@@ -174,11 +177,9 @@ public @interface DubboService {
     int retries() default DEFAULT_RETRIES;
 
     /**
-     * Load balance strategy, legal values include: random, roundrobin, leastactive
-     *
-     * @see org.apache.dubbo.common.constants.CommonConstants#DEFAULT_LOADBALANCE
+     * Load balance strategy, you can use {@link org.apache.dubbo.common.constants.LoadbalanceRules#RANDOM} ……
      */
-    String loadbalance() default DEFAULT_LOADBALANCE;
+    String loadbalance() default LoadbalanceRules.RANDOM;
 
     /**
      * Whether to enable async invocation, default value is false

--- a/dubbo-common/src/main/java/org/apache/dubbo/config/annotation/Reference.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/config/annotation/Reference.java
@@ -16,6 +16,9 @@
  */
 package org.apache.dubbo.config.annotation;
 
+import org.apache.dubbo.common.constants.ClusterRules;
+import org.apache.dubbo.common.constants.LoadbalanceRules;
+
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -123,9 +126,9 @@ public @interface Reference {
     String stub() default "";
 
     /**
-     * Cluster strategy, legal values include: failover, failfast, failsafe, failback, forking
+     * Cluster strategy, you can use {@link org.apache.dubbo.common.constants.ClusterRules#FAIL_FAST} ……
      */
-    String cluster() default "";
+    String cluster() default ClusterRules.EMPTY;
 
     /**
      * Maximum connections service provider can accept, default value is 0 - connection is shared
@@ -167,11 +170,9 @@ public @interface Reference {
     int retries() default 2;
 
     /**
-     * Load balance strategy, legal values include: random, roundrobin, leastactive
-     * <p>
-     * see Constants#DEFAULT_LOADBALANCE
+     * Load balance strategy, you can use {@link org.apache.dubbo.common.constants.LoadbalanceRules#RANDOM} ……
      */
-    String loadbalance() default "";
+    String loadbalance() default LoadbalanceRules.RANDOM;
 
     /**
      * Whether to enable async invocation, default value is false

--- a/dubbo-common/src/main/java/org/apache/dubbo/config/annotation/Reference.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/config/annotation/Reference.java
@@ -172,7 +172,7 @@ public @interface Reference {
     /**
      * Load balance strategy, you can use {@link org.apache.dubbo.common.constants.LoadbalanceRules#RANDOM} ……
      */
-    String loadbalance() default LoadbalanceRules.RANDOM;
+    String loadbalance() default LoadbalanceRules.EMPTY;
 
     /**
      * Whether to enable async invocation, default value is false

--- a/dubbo-common/src/main/java/org/apache/dubbo/config/annotation/Service.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/config/annotation/Service.java
@@ -27,7 +27,6 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-import static org.apache.dubbo.common.constants.CommonConstants.DEFAULT_LOADBALANCE;
 import static org.apache.dubbo.common.constants.CommonConstants.DEFAULT_RETRIES;
 
 /**

--- a/dubbo-common/src/main/java/org/apache/dubbo/config/annotation/Service.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/config/annotation/Service.java
@@ -17,6 +17,9 @@
 package org.apache.dubbo.config.annotation;
 
 
+import org.apache.dubbo.common.constants.ClusterRules;
+import org.apache.dubbo.common.constants.LoadbalanceRules;
+
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Inherited;
@@ -128,9 +131,9 @@ public @interface Service {
     String stub() default "";
 
     /**
-     * Cluster strategy, legal values include: failover, failfast, failsafe, failback, forking
+     * Cluster strategy, you can use {@link org.apache.dubbo.common.constants.ClusterRules#FAIL_FAST} ……
      */
-    String cluster() default "";
+    String cluster() default ClusterRules.EMPTY;
 
     /**
      * How the proxy is generated, legal values include: jdk, javassist
@@ -177,11 +180,9 @@ public @interface Service {
     int retries() default DEFAULT_RETRIES;
 
     /**
-     * Load balance strategy, legal values include: random, roundrobin, leastactive
-     *
-     * @see org.apache.dubbo.common.constants.CommonConstants#DEFAULT_LOADBALANCE
+     * Load balance strategy, you can use {@link org.apache.dubbo.common.constants.LoadbalanceRules#RANDOM} ……
      */
-    String loadbalance() default DEFAULT_LOADBALANCE;
+    String loadbalance() default LoadbalanceRules.RANDOM;
 
     /**
      * Whether to enable async invocation, default value is false

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/constants/CommonConstantsTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/constants/CommonConstantsTest.java
@@ -16,7 +16,6 @@
  */
 package org.apache.dubbo.common.constants;
 
-import org.apache.dubbo.config.annotation.DubboReference;
 import org.junit.jupiter.api.Test;
 
 import static org.apache.dubbo.common.constants.CommonConstants.COMMA_SEPARATOR_CHAR;

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/constants/CommonConstantsTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/constants/CommonConstantsTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.dubbo.common.constants;
 
+import org.apache.dubbo.config.annotation.DubboReference;
 import org.junit.jupiter.api.Test;
 
 import static org.apache.dubbo.common.constants.CommonConstants.COMMA_SEPARATOR_CHAR;


### PR DESCRIPTION
fixed: #7531
add ClusterRules 、LoadbalanceRules for cluster and  loadbalance properties。

We can user like 
`@DubboService(loadbalance = LoadbalanceRules.RANDOM,cluster = ClusterRules.FAIL_BACK)`

It was like this before
`@DubboService(loadbalance = "random",cluster = "failback")`
