### PR TITLE
Injvm protocol support async invoke

### DIFF
--- a/dubbo-rpc/dubbo-rpc-injvm/src/main/java/org/apache/dubbo/rpc/protocol/injvm/InjvmInvoker.java
+++ b/dubbo-rpc/dubbo-rpc-injvm/src/main/java/org/apache/dubbo/rpc/protocol/injvm/InjvmInvoker.java
@@ -31,7 +31,6 @@ import org.apache.dubbo.rpc.RpcContext;
 import org.apache.dubbo.rpc.RpcException;
 import org.apache.dubbo.rpc.RpcInvocation;
 import org.apache.dubbo.rpc.protocol.AbstractInvoker;
-import org.apache.dubbo.rpc.support.RpcUtils;
 
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;

--- a/dubbo-rpc/dubbo-rpc-injvm/src/main/java/org/apache/dubbo/rpc/protocol/injvm/InjvmInvoker.java
+++ b/dubbo-rpc/dubbo-rpc-injvm/src/main/java/org/apache/dubbo/rpc/protocol/injvm/InjvmInvoker.java
@@ -83,10 +83,7 @@ class InjvmInvoker<T> extends AbstractInvoker<T> {
         if (isAsync(exporter.getInvoker().getUrl(), getUrl())) {
             ((RpcInvocation) invocation).setInvokeMode(InvokeMode.ASYNC);
             // use consumer executor
-            ExecutorService executor = executorRepository.getExecutor(getUrl());
-            if (executor == null) {
-                executor = executorRepository.createExecutorIfAbsent(getUrl());
-            }
+            ExecutorService executor = executorRepository.createExecutorIfAbsent(getUrl());
             CompletableFuture<AppResponse> appResponseFuture = CompletableFuture.supplyAsync(() -> {
                 Result result = exporter.getInvoker().invoke(invocation);
                 if (result.hasException()) {

--- a/dubbo-rpc/dubbo-rpc-injvm/src/main/java/org/apache/dubbo/rpc/protocol/injvm/InjvmInvoker.java
+++ b/dubbo-rpc/dubbo-rpc-injvm/src/main/java/org/apache/dubbo/rpc/protocol/injvm/InjvmInvoker.java
@@ -85,6 +85,9 @@ class InjvmInvoker<T> extends AbstractInvoker<T> {
             ((RpcInvocation) invocation).setInvokeMode(InvokeMode.ASYNC);
             // use consumer executor
             ExecutorService executor = executorRepository.getExecutor(getUrl());
+            if (executor == null) {
+                executor = executorRepository.createExecutorIfAbsent(getUrl());
+            }
             CompletableFuture<AppResponse> appResponseFuture = CompletableFuture.supplyAsync(() -> {
                 Result result = exporter.getInvoker().invoke(invocation);
                 if (result.hasException()) {

--- a/dubbo-rpc/dubbo-rpc-injvm/src/test/java/org/apache/dubbo/rpc/protocol/injvm/DemoService.java
+++ b/dubbo-rpc/dubbo-rpc-injvm/src/test/java/org/apache/dubbo/rpc/protocol/injvm/DemoService.java
@@ -39,6 +39,7 @@ public interface DemoService {
 
     Type enumlength(Type... types);
 
-
     String getRemoteApplicationName();
+
+    String getAsyncResult();
 }

--- a/dubbo-rpc/dubbo-rpc-injvm/src/test/java/org/apache/dubbo/rpc/protocol/injvm/DemoServiceImpl.java
+++ b/dubbo-rpc/dubbo-rpc-injvm/src/test/java/org/apache/dubbo/rpc/protocol/injvm/DemoServiceImpl.java
@@ -80,7 +80,7 @@ public class DemoServiceImpl implements DemoService {
         try {
             Thread.sleep(1000);
         } catch (InterruptedException e) {
-            // do nothing
+            System.out.println("getAsyncResult() Interrupted");
         }
         return "DONE";
     }

--- a/dubbo-rpc/dubbo-rpc-injvm/src/test/java/org/apache/dubbo/rpc/protocol/injvm/DemoServiceImpl.java
+++ b/dubbo-rpc/dubbo-rpc-injvm/src/test/java/org/apache/dubbo/rpc/protocol/injvm/DemoServiceImpl.java
@@ -70,9 +70,19 @@ public class DemoServiceImpl implements DemoService {
         return str.length();
     }
 
-
     @Override
     public String getRemoteApplicationName() {
         return RpcContext.getContext().getRemoteApplicationName();
     }
+
+    @Override
+    public String getAsyncResult() {
+        try {
+            Thread.sleep(1000);
+        } catch (InterruptedException e) {
+            // do nothing
+        }
+        return "DONE";
+    }
+
 }

--- a/dubbo-rpc/dubbo-rpc-injvm/src/test/java/org/apache/dubbo/rpc/protocol/injvm/InjvmProtocolTest.java
+++ b/dubbo-rpc/dubbo-rpc-injvm/src/test/java/org/apache/dubbo/rpc/protocol/injvm/InjvmProtocolTest.java
@@ -42,6 +42,7 @@ import static org.apache.dubbo.rpc.Constants.SCOPE_LOCAL;
 import static org.apache.dubbo.rpc.Constants.SCOPE_REMOTE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -148,6 +149,6 @@ public class InjvmProtocolTest {
         Exporter<?> exporter = protocol.export(invoker);
         exporters.add(exporter);
         service = proxy.getProxy(protocol.refer(DemoService.class, url));
-        assertEquals(service.getAsyncResult(), null);
+        assertNull(service.getAsyncResult());
     }
 }

--- a/dubbo-rpc/dubbo-rpc-injvm/src/test/java/org/apache/dubbo/rpc/protocol/injvm/InjvmProtocolTest.java
+++ b/dubbo-rpc/dubbo-rpc-injvm/src/test/java/org/apache/dubbo/rpc/protocol/injvm/InjvmProtocolTest.java
@@ -34,11 +34,12 @@ import java.util.List;
 import static org.apache.dubbo.common.constants.CommonConstants.GROUP_KEY;
 import static org.apache.dubbo.common.constants.CommonConstants.INTERFACE_KEY;
 import static org.apache.dubbo.common.constants.CommonConstants.VERSION_KEY;
+import static org.apache.dubbo.rpc.Constants.ASYNC_KEY;
+import static org.apache.dubbo.rpc.Constants.GENERIC_KEY;
+import static org.apache.dubbo.rpc.Constants.LOCAL_PROTOCOL;
 import static org.apache.dubbo.rpc.Constants.SCOPE_KEY;
 import static org.apache.dubbo.rpc.Constants.SCOPE_LOCAL;
 import static org.apache.dubbo.rpc.Constants.SCOPE_REMOTE;
-import static org.apache.dubbo.rpc.Constants.GENERIC_KEY;
-import static org.apache.dubbo.rpc.Constants.LOCAL_PROTOCOL;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -136,4 +137,17 @@ public class InjvmProtocolTest {
         assertEquals(service.getRemoteApplicationName(), "consumer");
     }
 
+    @Test
+    public void testLocalProtocolAsync() throws Exception {
+        DemoService service = new DemoServiceImpl();
+        URL url = URL.valueOf("injvm://127.0.0.1/TestService")
+                .addParameter(ASYNC_KEY, true)
+                .addParameter(INTERFACE_KEY, DemoService.class.getName()).addParameter("application", "consumer");
+        Invoker<?> invoker = proxy.getInvoker(service, DemoService.class, url);
+        assertTrue(invoker.isAvailable());
+        Exporter<?> exporter = protocol.export(invoker);
+        exporters.add(exporter);
+        service = proxy.getProxy(protocol.refer(DemoService.class, url));
+        assertEquals(service.getAsyncResult(), null);
+    }
 }


### PR DESCRIPTION
## What is the purpose of the change

当提供者和消费者部署在一起时，dubbo:service上的async参数无法生效，服务调用只执行同步调用。

从用户角度看，服务是同步调用/异步调用应该只与配置参数有关，而与部署方式无关。

issue-demo: https://github.com/70-cloud-lab/dubbo-issues/tree/main/210413-injvm-async

## Brief changelog

在InjvmInvoker.doInvoke时，如果async=true，则使用CompletableFuture+AsyncRpcResult返回result。async=false则保持原有逻辑。

<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

- [ ] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Run `mvn clean install -DskipTests=false` & `mvn clean test-compile failsafe:integration-test` to make sure unit-test and integration-test pass.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
