### PR TITLE
fix: Incompatibility due to incorrect references & nacos-client -> 2.0.0

### DIFF
--- a/dubbo-registry/dubbo-registry-nacos/pom.xml
+++ b/dubbo-registry/dubbo-registry-nacos/pom.xml
@@ -27,7 +27,7 @@
     <artifactId>dubbo-registry-nacos</artifactId>
 
     <properties>
-        <nacos.version>0.6.2</nacos.version>
+        <nacos.version>2.0.0</nacos.version>
     </properties>
 
     <dependencies>
@@ -51,6 +51,11 @@
             <artifactId>nacos-client</artifactId>
             <version>${nacos.version}</version>
             <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
         </dependency>
 
         <!-- Test Libraries -->

--- a/dubbo-registry/dubbo-registry-nacos/src/main/java/com/alibaba/dubbo/registry/nacos/NacosRegistryFactory.java
+++ b/dubbo-registry/dubbo-registry-nacos/src/main/java/com/alibaba/dubbo/registry/nacos/NacosRegistryFactory.java
@@ -23,7 +23,7 @@ import com.alibaba.dubbo.registry.support.AbstractRegistryFactory;
 import com.alibaba.nacos.api.NacosFactory;
 import com.alibaba.nacos.api.exception.NacosException;
 import com.alibaba.nacos.api.naming.NamingService;
-import com.alibaba.nacos.client.naming.utils.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;


### PR DESCRIPTION
fixed #7571

```
java.lang.ClassNotFoundException: com.alibaba.nacos.client.naming.utils.StringUtils
```
Should be:

```
import org.apache.commons.lang3.StringUtils
```
