### PR TITLE
Refactored use of embedded-redis

### DIFF
--- a/dubbo-metadata/dubbo-metadata-report-redis/src/test/java/org/apache/dubbo/metadata/store/redis/RedisMetadataReportTest.java
+++ b/dubbo-metadata/dubbo-metadata-report-redis/src/test/java/org/apache/dubbo/metadata/store/redis/RedisMetadataReportTest.java
@@ -16,7 +16,6 @@
  */
 package org.apache.dubbo.metadata.store.redis;
 
-import org.apache.commons.lang3.SystemUtils;
 import org.apache.dubbo.common.URL;
 import org.apache.dubbo.common.utils.NetUtils;
 import org.apache.dubbo.metadata.definition.ServiceDefinitionBuilder;
@@ -35,52 +34,51 @@ import redis.clients.jedis.Jedis;
 import redis.clients.jedis.exceptions.JedisConnectionException;
 import redis.clients.jedis.exceptions.JedisDataException;
 import redis.embedded.RedisServer;
-import redis.embedded.core.RedisServerBuilder;
 
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.apache.commons.lang3.SystemUtils.IS_OS_WINDOWS;
 import static org.apache.dubbo.common.constants.CommonConstants.CONSUMER_SIDE;
 import static org.apache.dubbo.common.constants.CommonConstants.PROVIDER_SIDE;
-import static org.apache.dubbo.metadata.report.support.Constants.SYNC_REPORT_KEY;
+import static redis.embedded.RedisServer.newRedisServer;
 
-/**
- * 2018/10/9
- */
 public class RedisMetadataReportTest {
+
+    private static final String
+            REDIS_URL_TEMPLATE = "redis://%slocalhost:%d",
+            REDIS_PASSWORD = "チェリー",
+            REDIS_URL_AUTH_SECTION = "username:" + REDIS_PASSWORD + "@";
+
     RedisMetadataReport redisMetadataReport;
     RedisMetadataReport syncRedisMetadataReport;
     RedisServer redisServer;
     URL registryUrl;
 
     @BeforeEach
-    public void constructor(TestInfo testInfo) throws IOException {
-        int redisPort = NetUtils.getAvailablePort();
-        String methodName = testInfo.getTestMethod().get().getName();
-        if ("testAuthRedisMetadata".equals(methodName) || ("testWrongAuthRedisMetadata".equals(methodName))) {
-            String password = "チェリー";
-            RedisServerBuilder builder = RedisServer.newRedisServer().port(redisPort).setting("requirepass " + password);
-            if (SystemUtils.IS_OS_WINDOWS) {
-                // set maxheap to fix Windows error 0x70 while starting redis
-                builder.setting("maxheap 128mb");
-            }
-            redisServer = builder.build();
-            registryUrl = URL.valueOf("redis://username:" + password + "@localhost:" + redisPort);
-        } else {
-            RedisServerBuilder builder = RedisServer.newRedisServer().port(redisPort);
-            if (SystemUtils.IS_OS_WINDOWS) {
-                // set maxheap to fix Windows error 0x70 while starting redis
-                builder.setting("maxheap 128mb");
-            }
-            redisServer = builder.build();
-            registryUrl = URL.valueOf("redis://localhost:" + redisPort);
-        }
+    public void constructor(final TestInfo testInfo) throws IOException {
+        final int redisPort = NetUtils.getAvailablePort();
+        final boolean usesAuthentication = usesAuthentication(testInfo);
 
-        this.redisServer.start();
+        redisServer = newRedisServer()
+            .port(redisPort)
+            .settingIf(usesAuthentication, "requirepass " + REDIS_PASSWORD)
+            .settingIf(IS_OS_WINDOWS, "maxheap 128mb")
+            .build();
+        redisServer.start();
+        registryUrl = newRedisUrl(usesAuthentication, redisPort);
         redisMetadataReport = (RedisMetadataReport) new RedisMetadataReportFactory().createMetadataReport(registryUrl);
-        URL asyncRegistryUrl = URL.valueOf("redis://localhost:" + redisPort + "?" + SYNC_REPORT_KEY + "=true");
         syncRedisMetadataReport = (RedisMetadataReport) new RedisMetadataReportFactory().createMetadataReport(registryUrl);
+    }
+
+    private static boolean usesAuthentication(final TestInfo testInfo) {
+        final String methodName = testInfo.getTestMethod().get().getName();
+        return "testAuthRedisMetadata".equals(methodName) || "testWrongAuthRedisMetadata".equals(methodName);
+    }
+    private static URL newRedisUrl(final boolean usesAuthentication, final int redisPort) {
+        final String urlAuthSection = usesAuthentication ? REDIS_URL_AUTH_SECTION : "";
+        return URL.valueOf(String.format(REDIS_URL_TEMPLATE, urlAuthSection, redisPort));
     }
 
     @AfterEach

--- a/dubbo-registry/dubbo-registry-multiple/src/test/java/org/apache/dubbo/registry/multiple/MultipleRegistry2S2RTest.java
+++ b/dubbo-registry/dubbo-registry-multiple/src/test/java/org/apache/dubbo/registry/multiple/MultipleRegistry2S2RTest.java
@@ -16,7 +16,6 @@
  */
 package org.apache.dubbo.registry.multiple;
 
-import org.apache.commons.lang3.SystemUtils;
 import org.apache.dubbo.common.URL;
 import org.apache.dubbo.common.utils.NetUtils;
 import org.apache.dubbo.registry.NotifyListener;
@@ -32,10 +31,12 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import redis.embedded.RedisServer;
-import redis.embedded.core.RedisServerBuilder;
 
 import java.util.ArrayList;
 import java.util.List;
+
+import static org.apache.commons.lang3.SystemUtils.IS_OS_WINDOWS;
+import static redis.embedded.RedisServer.newRedisServer;
 
 /**
  * 2019-04-30
@@ -68,15 +69,13 @@ public class MultipleRegistry2S2RTest {
         zookeeperRegistryURLStr = "zookeeper://127.0.0.1:" + zkServerPort;
 
         redisServerPort = NetUtils.getAvailablePort();
-        RedisServerBuilder builder = RedisServer.newRedisServer().port(redisServerPort);
-        if (SystemUtils.IS_OS_WINDOWS) {
-            // set maxheap to fix Windows error 0x70 while starting redis
-            builder.setting("maxheap 128mb");
-        }
-        redisServer = builder.build();
+        redisServer = newRedisServer()
+                .port(redisServerPort)
+                // set maxheap to fix Windows error 0x70 while starting redis
+                .settingIf(IS_OS_WINDOWS, "maxheap 128mb")
+                .build();
         redisServer.start();
         redisRegistryURLStr = "redis://127.0.0.1:" + redisServerPort;
-
 
         URL url = URL.valueOf("multiple://127.0.0.1?application=vic&" +
                 MultipleRegistry.REGISTRY_FOR_SERVICE + "=" + zookeeperRegistryURLStr + "," + redisRegistryURLStr + "&"

--- a/dubbo-registry/dubbo-registry-redis/src/test/java/org/apache/dubbo/registry/redis/RedisRegistryTest.java
+++ b/dubbo-registry/dubbo-registry-redis/src/test/java/org/apache/dubbo/registry/redis/RedisRegistryTest.java
@@ -27,7 +27,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import redis.clients.jedis.exceptions.JedisConnectionException;
 import redis.embedded.RedisServer;
-import redis.embedded.core.RedisServerBuilder;
 
 import java.util.List;
 import java.util.Map;
@@ -37,26 +36,28 @@ import static org.apache.dubbo.common.constants.RemotingConstants.BACKUP_KEY;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static redis.embedded.RedisServer.newRedisServer;
 
 public class RedisRegistryTest {
 
-    private String service = "org.apache.dubbo.test.injvmServie";
-    private URL serviceUrl = URL.valueOf("redis://redis/" + service + "?notify=false&methods=test1,test2");
+    private static final String SERVICE = "org.apache.dubbo.test.injvmServie";
+    private static final URL SERVICE_URL = URL.valueOf("redis://redis/" + SERVICE + "?notify=false&methods=test1,test2");
+
     private RedisServer redisServer;
     private RedisRegistry redisRegistry;
     private URL registryUrl;
 
     @BeforeEach
     public void setUp() throws Exception {
-        int redisPort = NetUtils.getAvailablePort();
-        RedisServerBuilder builder = RedisServer.newRedisServer().port(redisPort);
-        if (SystemUtils.IS_OS_WINDOWS) {
+        final int redisPort = NetUtils.getAvailablePort();
+
+        redisServer = newRedisServer()
+            .port(redisPort)
             // set maxheap to fix Windows error 0x70 while starting redis
-            builder.setting("maxheap 128mb");
-        }
-        this.redisServer = builder.build();
-        this.redisServer.start();
-        this.registryUrl = URL.valueOf("redis://localhost:" + redisPort);
+            .settingIf(SystemUtils.IS_OS_WINDOWS, "maxheap 128mb")
+            .build();
+        redisServer.start();
+        registryUrl = URL.valueOf("redis://localhost:" + redisPort);
         redisRegistry = (RedisRegistry) new RedisRegistryFactory().createRegistry(registryUrl);
     }
 
@@ -70,9 +71,9 @@ public class RedisRegistryTest {
         Set<URL> registered = null;
 
         for (int i = 0; i < 2; i++) {
-            redisRegistry.register(serviceUrl);
+            redisRegistry.register(SERVICE_URL);
             registered = redisRegistry.getRegistered();
-            assertThat(registered.contains(serviceUrl), is(true));
+            assertThat(registered.contains(SERVICE_URL), is(true));
         }
 
         registered = redisRegistry.getRegistered();
@@ -96,20 +97,20 @@ public class RedisRegistryTest {
 
             }
         };
-        redisRegistry.subscribe(serviceUrl, listener);
+        redisRegistry.subscribe(SERVICE_URL, listener);
 
         Map<URL, Set<NotifyListener>> subscribed = redisRegistry.getSubscribed();
         assertThat(subscribed.size(), is(1));
-        assertThat(subscribed.get(serviceUrl).size(), is(1));
+        assertThat(subscribed.get(SERVICE_URL).size(), is(1));
 
-        redisRegistry.unsubscribe(serviceUrl, listener);
+        redisRegistry.unsubscribe(SERVICE_URL, listener);
         subscribed = redisRegistry.getSubscribed();
-        assertThat(subscribed.get(serviceUrl).size(), is(0));
+        assertThat(subscribed.get(SERVICE_URL).size(), is(0));
     }
 
     @Test
     public void testAvailable() {
-        redisRegistry.register(serviceUrl);
+        redisRegistry.register(SERVICE_URL);
         assertThat(redisRegistry.isAvailable(), is(true));
 
         redisRegistry.destroy();

--- a/dubbo-rpc/dubbo-rpc-redis/src/test/java/org/apache/dubbo/rpc/protocol/redis/RedisProtocolTest.java
+++ b/dubbo-rpc/dubbo-rpc-redis/src/test/java/org/apache/dubbo/rpc/protocol/redis/RedisProtocolTest.java
@@ -16,7 +16,6 @@
  */
 package org.apache.dubbo.rpc.protocol.redis;
 
-import org.apache.commons.lang3.SystemUtils;
 import org.apache.dubbo.common.URL;
 import org.apache.dubbo.common.extension.ExtensionLoader;
 import org.apache.dubbo.common.serialize.ObjectInput;
@@ -39,44 +38,52 @@ import redis.clients.jedis.JedisPool;
 import redis.clients.jedis.exceptions.JedisConnectionException;
 import redis.clients.jedis.exceptions.JedisDataException;
 import redis.embedded.RedisServer;
-import redis.embedded.core.RedisServerBuilder;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 
+import static org.apache.commons.lang3.SystemUtils.IS_OS_WINDOWS;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static redis.embedded.RedisServer.newRedisServer;
 
 public class RedisProtocolTest {
-    private Protocol protocol = ExtensionLoader.getExtensionLoader(Protocol.class).getAdaptiveExtension();
-    private ProxyFactory proxy = ExtensionLoader.getExtensionLoader(ProxyFactory.class).getAdaptiveExtension();
+
+    private static final String
+            REDIS_URL_TEMPLATE = "redis://%slocalhost:%d",
+            REDIS_PASSWORD = "123456",
+            REDIS_URL_AUTH_SECTION = "username:" + REDIS_PASSWORD + "@";
+
+    private static final Protocol PROTOCOL = ExtensionLoader.getExtensionLoader(Protocol.class).getAdaptiveExtension();
+    private static final ProxyFactory PROXY = ExtensionLoader.getExtensionLoader(ProxyFactory.class).getAdaptiveExtension();
+
     private RedisServer redisServer;
     private URL registryUrl;
 
     @BeforeEach
-    public void setUp(TestInfo testInfo) throws IOException {
-        int redisPort = NetUtils.getAvailablePort();
-        String methodName = testInfo.getTestMethod().get().getName();
-        if ("testAuthRedis".equals(methodName) || ("testWrongAuthRedis".equals(methodName))) {
-            String password = "123456";
-            RedisServerBuilder builder = RedisServer.newRedisServer().port(redisPort).setting("requirepass " + password);
-            if (SystemUtils.IS_OS_WINDOWS) {
-                // set maxheap to fix Windows error 0x70 while starting redis
-                builder.setting("maxheap 128mb");
-            }
-            redisServer = builder.build();
-            this.registryUrl = URL.valueOf("redis://username:" + password + "@localhost:" + redisPort + "?db.index=0");
-        } else {
-            RedisServerBuilder builder = RedisServer.newRedisServer().port(redisPort);
-            if (SystemUtils.IS_OS_WINDOWS) {
-                // set maxheap to fix Windows error 0x70 while starting redis
-                builder.setting("maxheap 128mb");
-            }
-            redisServer = builder.build();
-            this.registryUrl = URL.valueOf("redis://localhost:" + redisPort);
-        }
-        this.redisServer.start();
+    public void setUp(final TestInfo testInfo) throws IOException {
+        final int redisPort = NetUtils.getAvailablePort();
+
+        final boolean usesAuthentication = usesAuthentication(testInfo);
+
+        redisServer = newRedisServer()
+            .port(redisPort)
+            .settingIf(usesAuthentication, "requirepass " + REDIS_PASSWORD)
+            .settingIf(IS_OS_WINDOWS, "maxheap 128mb")
+            .build();
+        redisServer.start();
+        registryUrl = newRedisUrl(usesAuthentication, redisPort);
+    }
+
+    private static boolean usesAuthentication(final TestInfo testInfo) {
+        final String methodName = testInfo.getTestMethod().get().getName();
+        return "testAuthRedis".equals(methodName) || "testWrongAuthRedis".equals(methodName);
+    }
+    private static URL newRedisUrl(final boolean usesAuthentication, final int redisPort) {
+        final String urlAuthSection = usesAuthentication ? REDIS_URL_AUTH_SECTION : "";
+        final String urlSuffix = usesAuthentication ? "?db.index=0" : "";
+        return URL.valueOf(String.format(REDIS_URL_TEMPLATE, urlAuthSection, redisPort) + urlSuffix);
     }
 
     @AfterEach
@@ -85,7 +92,7 @@ public class RedisProtocolTest {
     }
     @Test
     public void testReferClass() {
-        Invoker<IDemoService> refer = protocol.refer(IDemoService.class, registryUrl);
+        Invoker<IDemoService> refer = PROTOCOL.refer(IDemoService.class, registryUrl);
 
         Class<IDemoService> serviceClass = refer.getInterface();
         assertThat(serviceClass.getName(), is("org.apache.dubbo.rpc.protocol.redis.IDemoService"));
@@ -93,11 +100,11 @@ public class RedisProtocolTest {
 
     @Test
     public void testInvocation() {
-        Invoker<IDemoService> refer = protocol.refer(IDemoService.class,
+        Invoker<IDemoService> refer = PROTOCOL.refer(IDemoService.class,
                 registryUrl
                         .addParameter("max.idle", 10)
                         .addParameter("max.active", 20));
-        IDemoService demoService = this.proxy.getProxy(refer);
+        IDemoService demoService = PROXY.getProxy(refer);
 
         String value = demoService.get("key");
         assertThat(value, is(nullValue()));
@@ -116,8 +123,8 @@ public class RedisProtocolTest {
     @Test
     public void testUnsupportedMethod() {
         Assertions.assertThrows(RpcException.class, () -> {
-            Invoker<IDemoService> refer = protocol.refer(IDemoService.class, registryUrl);
-            IDemoService demoService = this.proxy.getProxy(refer);
+            Invoker<IDemoService> refer = PROTOCOL.refer(IDemoService.class, registryUrl);
+            IDemoService demoService = this.PROXY.getProxy(refer);
 
             demoService.unsupported(null);
         });
@@ -126,8 +133,8 @@ public class RedisProtocolTest {
     @Test
     public void testWrongParameters() {
         Assertions.assertThrows(RpcException.class, () -> {
-            Invoker<IDemoService> refer = protocol.refer(IDemoService.class, registryUrl);
-            IDemoService demoService = this.proxy.getProxy(refer);
+            Invoker<IDemoService> refer = PROTOCOL.refer(IDemoService.class, registryUrl);
+            IDemoService demoService = this.PROXY.getProxy(refer);
 
             demoService.set("key", "value", "wrongValue");
         });
@@ -136,8 +143,8 @@ public class RedisProtocolTest {
     @Test
     public void testWrongRedis() {
         Assertions.assertThrows(RpcException.class, () -> {
-            Invoker<IDemoService> refer = protocol.refer(IDemoService.class, URL.valueOf("redis://localhost:1"));
-            IDemoService demoService = this.proxy.getProxy(refer);
+            Invoker<IDemoService> refer = PROTOCOL.refer(IDemoService.class, URL.valueOf("redis://localhost:1"));
+            IDemoService demoService = this.PROXY.getProxy(refer);
 
             demoService.get("key");
         });
@@ -145,17 +152,17 @@ public class RedisProtocolTest {
 
     @Test
     public void testExport() {
-        Assertions.assertThrows(UnsupportedOperationException.class, () -> protocol.export(protocol.refer(IDemoService.class, registryUrl)));
+        Assertions.assertThrows(UnsupportedOperationException.class, () -> PROTOCOL.export(PROTOCOL.refer(IDemoService.class, registryUrl)));
     }
 
     @Test
     public void testAuthRedis() {
         // default db.index=0
-        Invoker<IDemoService> refer = protocol.refer(IDemoService.class,
+        Invoker<IDemoService> refer = PROTOCOL.refer(IDemoService.class,
                 registryUrl
                         .addParameter("max.idle", 10)
                         .addParameter("max.active", 20));
-        IDemoService demoService = this.proxy.getProxy(refer);
+        IDemoService demoService = this.PROXY.getProxy(refer);
 
         String value = demoService.get("key");
         assertThat(value, is(nullValue()));
@@ -174,11 +181,11 @@ public class RedisProtocolTest {
         String password = "123456";
         int database = 1;
         this.registryUrl = this.registryUrl.setPassword(password).addParameter("db.index", database);
-        refer = protocol.refer(IDemoService.class,
+        refer = PROTOCOL.refer(IDemoService.class,
                 registryUrl
                         .addParameter("max.idle", 10)
                         .addParameter("max.active", 20));
-        demoService = this.proxy.getProxy(refer);
+        demoService = this.PROXY.getProxy(refer);
 
         demoService.set("key", "newValue");
         value = demoService.get("key");
@@ -209,11 +216,11 @@ public class RedisProtocolTest {
     public void testWrongAuthRedis() {
         String password = "1234567";
         this.registryUrl = this.registryUrl.setPassword(password);
-        Invoker<IDemoService> refer = protocol.refer(IDemoService.class,
+        Invoker<IDemoService> refer = PROTOCOL.refer(IDemoService.class,
                 registryUrl
                         .addParameter("max.idle", 10)
                         .addParameter("max.active", 20));
-        IDemoService demoService = this.proxy.getProxy(refer);
+        IDemoService demoService = this.PROXY.getProxy(refer);
 
         try {
             String value = demoService.get("key");


### PR DESCRIPTION
## What is the purpose of the change

Clean up of embedded redis code.

## Brief changelog
Rewrote these classes:
- dubbo-metadata/dubbo-metadata-report-redis/src/test/java/org/apache/dubbo/metadata/store/redis/RedisMetadataReportTest.java
- dubbo-registry/dubbo-registry-multiple/src/test/java/org/apache/dubbo/registry/multiple/MultipleRegistry2S2RTest.java
- dubbo-registry/dubbo-registry-redis/src/test/java/org/apache/dubbo/registry/redis/RedisRegistryTest.java
- dubbo-rpc/dubbo-rpc-redis/src/test/java/org/apache/dubbo/rpc/protocol/redis/RedisProtocolTest.java

## Verifying this change

I couldn't run `mvn clean install`. Maven dies with this error:

[ERROR] Error executing Maven.
[ERROR] java.lang.IllegalStateException: Unable to load cache item
[ERROR] Caused by: Unable to load cache item
[ERROR] Caused by: Could not initialize class com.google.inject.internal.cglib.core.$MethodWrapper

