### PR TITLE
When making a generic dubbo service request, setting check to true co…

### DIFF
--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/directory/AbstractDirectory.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/directory/AbstractDirectory.java
@@ -86,6 +86,10 @@ public abstract class AbstractDirectory<T> implements Directory<T> {
         setRouterChain(routerChain);
     }
 
+    public URL getSubscribeConsumerurl() {
+        return this.consumerUrl;
+    }
+
     @Override
     public List<Invoker<T>> list(Invocation invocation) throws RpcException {
         if (destroyed) {

--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/integration/DynamicDirectory.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/integration/DynamicDirectory.java
@@ -234,8 +234,8 @@ public abstract class DynamicDirectory<T> extends AbstractDirectory<T> implement
         }
         // unsubscribe.
         try {
-            if (getConsumerUrl() != null && registry != null && registry.isAvailable()) {
-                registry.unsubscribe(getConsumerUrl(), this);
+            if (getSubscribeConsumerurl() != null && registry != null && registry.isAvailable()) {
+                registry.unsubscribe(getSubscribeConsumerurl(), this);
             }
         } catch (Throwable t) {
             logger.warn("unexpected error when unsubscribe service " + serviceKey + "from registry" + registry.getUrl(), t);


### PR DESCRIPTION
当多次泛化调用一个上游接口的时候,当你填写的check=true并且此时上游调用不通(服务下线,或者你的代码是网关,并没有填对group或者version),就会触发内存泄露.内存泄露的同时还会触发大量的notify(有的时候这个更可怕一些)
测试代码
<img width="1069" alt="test" src="https://user-images.githubusercontent.com/869986/115560573-4db84880-a2e7-11eb-9c3b-57a532af9dd7.png">
<img width="1186" alt="error1" src="https://user-images.githubusercontent.com/869986/115560609-56a91a00-a2e7-11eb-8e10-3ab41b4c8841.png">
<img width="681" alt="error2" src="https://user-images.githubusercontent.com/869986/115560644-60cb1880-a2e7-11eb-95e5-c4706b57668c.png">
修改代码后
<img width="1146" alt="ok" src="https://user-images.githubusercontent.com/869986/115560690-69235380-a2e7-11eb-9bbd-c9d63cb6e397.png">


<img width="1013" alt="info" src="https://user-images.githubusercontent.com/869986/115561514-3d549d80-a2e8-11eb-8aa6-0bae9e8481bc.png">
