### PR TITLE
ignore non-dubbo nacos services

### DIFF
--- a/dubbo-registry/dubbo-registry-nacos/src/main/java/org/apache/dubbo/registry/nacos/NacosRegistry.java
+++ b/dubbo-registry/dubbo-registry-nacos/src/main/java/org/apache/dubbo/registry/nacos/NacosRegistry.java
@@ -49,6 +49,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
+import java.util.Collections;
 
 import static org.apache.dubbo.common.constants.CommonConstants.ANY_VALUE;
 import static org.apache.dubbo.common.constants.CommonConstants.GROUP_KEY;
@@ -64,6 +65,7 @@ import static org.apache.dubbo.common.constants.RegistryConstants.EMPTY_PROTOCOL
 import static org.apache.dubbo.common.constants.RegistryConstants.PROVIDERS_CATEGORY;
 import static org.apache.dubbo.common.constants.RegistryConstants.ROUTERS_CATEGORY;
 import static org.apache.dubbo.registry.Constants.ADMIN_PROTOCOL;
+import static org.apache.dubbo.registry.nacos.NacosServiceName.NAME_SEPARATOR;
 import static org.apache.dubbo.registry.nacos.NacosServiceName.valueOf;
 
 /**
@@ -286,19 +288,29 @@ public class NacosRegistry extends FailbackRegistry {
     private Set<String> filterServiceNames(NacosServiceName serviceName) {
         Set<String> serviceNames = new LinkedHashSet<>();
 
-        execute(namingService -> {
-
-            serviceNames.addAll(namingService.getServicesOfServer(1, Integer.MAX_VALUE,
-                    getUrl().getParameter(GROUP_KEY, Constants.DEFAULT_GROUP)).getData()
-                    .stream()
-                    .map(NacosServiceName::new)
-                    .filter(serviceName::isCompatible)
-                    .map(NacosServiceName::toString)
-                    .collect(Collectors.toList()));
-
-        });
+        execute(namingService -> serviceNames.addAll(namingService.getServicesOfServer(1, Integer.MAX_VALUE,
+                getUrl().getParameter(GROUP_KEY, Constants.DEFAULT_GROUP)).getData()
+                .stream()
+                .filter(this::isConformRules)
+                .map(NacosServiceName::new)
+                .filter(serviceName::isCompatible)
+                .map(NacosServiceName::toString)
+                .collect(Collectors.toList())));
 
         return serviceNames;
+    }
+
+    /**
+     * Verify whether it is a dubbo service
+     *
+     * @param serviceName
+     * @return
+     * @since 2.7.11
+     */
+    public boolean isConformRules(String serviceName) {
+
+        return serviceName.split(NAME_SEPARATOR, -1).length == 4;
+
     }
 
     /**
@@ -490,10 +502,9 @@ public class NacosRegistry extends FailbackRegistry {
 
 
                 if (isServiceNamesWithCompatibleMode(url)) {
-                    /**
-                     * Get all instances with corresponding serviceNames to avoid instance overwrite and but with empty instance mentioned
-                     * in https://github.com/apache/dubbo/issues/5885 and https://github.com/apache/dubbo/issues/5899
-                     */
+
+                    // Get all instances with corresponding serviceNames to avoid instance overwrite and but with empty instance mentioned
+                    // in https://github.com/apache/dubbo/issues/5885 and https://github.com/apache/dubbo/issues/5899
                     NacosInstanceManageUtil.initOrRefreshServiceInstanceList(serviceName, instances);
                     instances = NacosInstanceManageUtil.getAllCorrespondingServiceInstanceList(serviceName);
                 }
@@ -531,7 +542,7 @@ public class NacosRegistry extends FailbackRegistry {
      */
     private List<String> getCategories(URL url) {
         return ANY_VALUE.equals(url.getServiceInterface()) ?
-                ALL_SUPPORTED_CATEGORIES : Arrays.asList(DEFAULT_CATEGORY);
+                ALL_SUPPORTED_CATEGORIES : Collections.singletonList(DEFAULT_CATEGORY);
     }
 
     private URL buildURL(Instance instance) {

--- a/dubbo-registry/dubbo-registry-nacos/src/main/java/org/apache/dubbo/registry/nacos/NacosRegistry.java
+++ b/dubbo-registry/dubbo-registry-nacos/src/main/java/org/apache/dubbo/registry/nacos/NacosRegistry.java
@@ -305,9 +305,9 @@ public class NacosRegistry extends FailbackRegistry {
      *
      * @param serviceName
      * @return
-     * @since 2.7.11
+     * @since 2.7.12
      */
-    public boolean isConformRules(String serviceName) {
+    private boolean isConformRules(String serviceName) {
 
         return serviceName.split(NAME_SEPARATOR, -1).length == 4;
 

--- a/dubbo-registry/dubbo-registry-nacos/src/main/java/org/apache/dubbo/registry/nacos/NacosServiceName.java
+++ b/dubbo-registry/dubbo-registry-nacos/src/main/java/org/apache/dubbo/registry/nacos/NacosServiceName.java
@@ -103,7 +103,8 @@ public class NacosServiceName {
 
     public boolean isCompatible(NacosServiceName concreteServiceName) {
 
-        if (!concreteServiceName.isConcrete()) { // The argument must be the concrete NacosServiceName
+        // The argument must be the concrete NacosServiceName
+        if (!concreteServiceName.isConcrete()) {
             return false;
         }
 
@@ -160,7 +161,7 @@ public class NacosServiceName {
     }
 
     private boolean isRange(String value) {
-        return value != null && value.indexOf(VALUE_SEPARATOR) > -1 && value.split(VALUE_SEPARATOR).length > 1;
+        return value != null && value.contains(VALUE_SEPARATOR) && value.split(VALUE_SEPARATOR).length > 1;
     }
 
     public String getCategory() {
@@ -203,11 +204,10 @@ public class NacosServiceName {
     }
 
     private String toValue() {
-        return new StringBuilder(category)
-                .append(NAME_SEPARATOR).append(serviceInterface)
-                .append(NAME_SEPARATOR).append(version)
-                .append(NAME_SEPARATOR).append(group)
-                .toString();
+        return category +
+                NAME_SEPARATOR + serviceInterface +
+                NAME_SEPARATOR + version +
+                NAME_SEPARATOR + group;
     }
 
     @Override

--- a/dubbo-registry/dubbo-registry-nacos/src/test/java/org/apache/dubbo/registry/nacos/NacosRegistryTest.java
+++ b/dubbo-registry/dubbo-registry-nacos/src/test/java/org/apache/dubbo/registry/nacos/NacosRegistryTest.java
@@ -1,0 +1,327 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.registry.nacos;
+
+
+import com.alibaba.nacos.api.common.Constants;
+import com.alibaba.nacos.api.exception.NacosException;
+import com.alibaba.nacos.api.naming.NamingService;
+import com.alibaba.nacos.api.naming.pojo.Instance;
+import com.alibaba.nacos.api.naming.pojo.ListView;
+import com.alibaba.nacos.client.naming.NacosNamingService;
+import org.apache.dubbo.common.URL;
+import org.apache.dubbo.common.utils.NetUtils;
+import org.apache.dubbo.registry.NotifyListener;
+import org.apache.dubbo.registry.nacos.util.NacosNamingServiceUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+
+import java.util.HashMap;
+import java.util.Set;
+import java.util.List;
+import java.util.ArrayList;
+import java.util.Map;
+
+import static org.apache.dubbo.common.constants.CommonConstants.PATH_KEY;
+import static org.apache.dubbo.common.constants.CommonConstants.PROTOCOL_KEY;
+import static org.apache.dubbo.common.constants.CommonConstants.GROUP_KEY;
+import static org.apache.dubbo.common.constants.RegistryConstants.CATEGORY_KEY;
+import static org.apache.dubbo.common.constants.RegistryConstants.DEFAULT_CATEGORY;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.doNothing;
+
+public class NacosRegistryTest {
+
+
+    private NacosRegistryFactory nacosRegistryFactory;
+
+    private NacosRegistry nacosRegistry;
+
+    private static final String serviceInterface = "org.apache.dubbo.registry.nacos.NacosService";
+
+    private final URL serviceUrl = URL.valueOf("nacos://127.0.0.1:3333/" + serviceInterface + "?interface=" +
+            serviceInterface + "&notify=false&methods=test1,test2&category=providers&version=1.0.0&group=default");
+
+    private URL registryUrl;
+
+
+    @BeforeEach
+    public void setUp() throws Exception {
+
+        int nacosServerPort = NetUtils.getAvailablePort();
+
+        this.registryUrl = URL.valueOf("nacos://localhost:" + nacosServerPort);
+
+        this.nacosRegistryFactory = new NacosRegistryFactory();
+
+        this.nacosRegistry = (NacosRegistry) nacosRegistryFactory.createRegistry(registryUrl);
+
+    }
+
+
+    @AfterEach
+    public void tearDown() throws Exception {
+    }
+
+    @Test
+    public void testRegister() {
+        NamingService namingService = mock(NacosNamingService.class);
+        try {
+
+            String serviceName = "providers:org.apache.dubbo.registry.nacos.NacosService:1.0.0:default";
+            String category = this.serviceUrl.getParameter(CATEGORY_KEY, DEFAULT_CATEGORY);
+            URL newUrl = this.serviceUrl.addParameter(CATEGORY_KEY, category);
+            newUrl = newUrl.addParameter(PROTOCOL_KEY, this.serviceUrl.getProtocol());
+            newUrl = newUrl.addParameter(PATH_KEY, this.serviceUrl.getPath());
+            newUrl = newUrl.addParameters(NacosNamingServiceUtils.getNacosPreservedParam(this.serviceUrl));
+            String ip = newUrl.getHost();
+            int port = newUrl.getPort();
+            Instance instance = new Instance();
+            instance.setIp(ip);
+            instance.setPort(port);
+            instance.setMetadata(new HashMap<>(newUrl.getParameters()));
+            doNothing().when(namingService).registerInstance(serviceName,
+                    Constants.DEFAULT_GROUP, instance);
+        } catch (NacosException e) {
+            // ignore
+        }
+
+        NacosNamingServiceWrapper nacosNamingServiceWrapper = new
+                NacosNamingServiceWrapper(namingService);
+        nacosRegistry = new NacosRegistry(this.registryUrl, nacosNamingServiceWrapper);
+
+        Set<URL> registered;
+        for (int i = 0; i < 2; i++) {
+            nacosRegistry.register(serviceUrl);
+            registered = nacosRegistry.getRegistered();
+            assertThat(registered.contains(serviceUrl), is(true));
+        }
+
+        registered = nacosRegistry.getRegistered();
+        assertThat(registered.size(), is(1));
+
+    }
+
+    @Test
+    public void testUnRegister() {
+        NamingService namingService = mock(NacosNamingService.class);
+
+        try {
+
+            String serviceName = "providers:org.apache.dubbo.registry.nacos.NacosService:1.0.0:default";
+            String category = this.serviceUrl.getParameter(CATEGORY_KEY, DEFAULT_CATEGORY);
+            URL newUrl = this.serviceUrl.addParameter(CATEGORY_KEY, category);
+            newUrl = newUrl.addParameter(PROTOCOL_KEY, this.serviceUrl.getProtocol());
+            newUrl = newUrl.addParameter(PATH_KEY, this.serviceUrl.getPath());
+            newUrl = newUrl.addParameters(NacosNamingServiceUtils.getNacosPreservedParam(this.serviceUrl));
+            String ip = newUrl.getHost();
+            int port = newUrl.getPort();
+            Instance instance = new Instance();
+            instance.setIp(ip);
+            instance.setPort(port);
+            instance.setMetadata(new HashMap<>(newUrl.getParameters()));
+            doNothing().when(namingService).registerInstance(serviceName,
+                    Constants.DEFAULT_GROUP, instance);
+
+            doNothing().when(namingService).deregisterInstance(serviceName,
+                    Constants.DEFAULT_GROUP, ip, port);
+        } catch (NacosException e) {
+            // ignore
+        }
+
+        NacosNamingServiceWrapper nacosNamingServiceWrapper = new
+                NacosNamingServiceWrapper(namingService);
+        nacosRegistry = new NacosRegistry(this.registryUrl, nacosNamingServiceWrapper);
+
+        nacosRegistry.register(serviceUrl);
+        Set<URL> registered = nacosRegistry.getRegistered();
+
+        assertThat(registered.contains(serviceUrl), is(true));
+        assertThat(registered.size(), is(1));
+
+        nacosRegistry.unregister(serviceUrl);
+        assertThat(registered.contains(serviceUrl), is(false));
+        assertThat(registered.size(), is(0));
+
+    }
+
+    @Test
+    public void testSubscribe() {
+        NamingService namingService = mock(NacosNamingService.class);
+
+        try {
+
+            String serviceName = "providers:org.apache.dubbo.registry.nacos.NacosService:1.0.0:default";
+            String category = this.serviceUrl.getParameter(CATEGORY_KEY, DEFAULT_CATEGORY);
+            URL newUrl = this.serviceUrl.addParameter(CATEGORY_KEY, category);
+            newUrl = newUrl.addParameter(PROTOCOL_KEY, this.serviceUrl.getProtocol());
+            newUrl = newUrl.addParameter(PATH_KEY, this.serviceUrl.getPath());
+            newUrl = newUrl.addParameters(NacosNamingServiceUtils.getNacosPreservedParam(this.serviceUrl));
+            String ip = newUrl.getHost();
+            int port = newUrl.getPort();
+            Instance instance = new Instance();
+            instance.setIp(ip);
+            instance.setPort(port);
+            instance.setMetadata(new HashMap<>(newUrl.getParameters()));
+
+            List<Instance> instances = new ArrayList<>();
+            instances.add(instance);
+            when(namingService.getAllInstances(serviceName,
+                    this.registryUrl.getParameter(GROUP_KEY, Constants.DEFAULT_GROUP))).thenReturn(instances);
+        } catch (NacosException e) {
+            // ignore
+        }
+
+        NacosNamingServiceWrapper nacosNamingServiceWrapper = new
+                NacosNamingServiceWrapper(namingService);
+        nacosRegistry = new NacosRegistry(this.registryUrl, nacosNamingServiceWrapper);
+
+        NotifyListener listener = mock(NotifyListener.class);
+        nacosRegistry.subscribe(serviceUrl, listener);
+
+        Map<URL, Set<NotifyListener>> subscribed = nacosRegistry.getSubscribed();
+        assertThat(subscribed.size(), is(1));
+        assertThat(subscribed.get(serviceUrl).size(), is(1));
+
+    }
+
+    @Test
+    public void testUnSubscribe() {
+        NamingService namingService = mock(NacosNamingService.class);
+
+        try {
+
+            String serviceName = "providers:org.apache.dubbo.registry.nacos.NacosService:1.0.0:default";
+            String category = this.serviceUrl.getParameter(CATEGORY_KEY, DEFAULT_CATEGORY);
+            URL newUrl = this.serviceUrl.addParameter(CATEGORY_KEY, category);
+            newUrl = newUrl.addParameter(PROTOCOL_KEY, this.serviceUrl.getProtocol());
+            newUrl = newUrl.addParameter(PATH_KEY, this.serviceUrl.getPath());
+            newUrl = newUrl.addParameters(NacosNamingServiceUtils.getNacosPreservedParam(this.serviceUrl));
+            String ip = newUrl.getHost();
+            int port = newUrl.getPort();
+            Instance instance = new Instance();
+            instance.setIp(ip);
+            instance.setPort(port);
+            instance.setMetadata(new HashMap<>(newUrl.getParameters()));
+
+            List<Instance> instances = new ArrayList<>();
+            instances.add(instance);
+            when(namingService.getAllInstances(serviceName,
+                    this.registryUrl.getParameter(GROUP_KEY, Constants.DEFAULT_GROUP))).thenReturn(instances);
+
+        } catch (NacosException e) {
+            // ignore
+        }
+
+        NacosNamingServiceWrapper nacosNamingServiceWrapper = new
+                NacosNamingServiceWrapper(namingService);
+        nacosRegistry = new NacosRegistry(this.registryUrl, nacosNamingServiceWrapper);
+
+        NotifyListener listener = mock(NotifyListener.class);
+        nacosRegistry.subscribe(serviceUrl, listener);
+
+        Map<URL, Set<NotifyListener>> subscribed = nacosRegistry.getSubscribed();
+        assertThat(subscribed.size(), is(1));
+        assertThat(subscribed.get(serviceUrl).size(), is(1));
+
+        nacosRegistry.unsubscribe(serviceUrl, listener);
+        subscribed = nacosRegistry.getSubscribed();
+        assertThat(subscribed.size(), is(1));
+        assertThat(subscribed.get(serviceUrl).size(), is(0));
+    }
+
+
+    @Test
+    public void testIsConformRules() {
+        NamingService namingService = mock(NacosNamingService.class);
+        URL serviceUrlWithoutCategory = URL.valueOf("nacos://127.0.0.1:3333/" + serviceInterface + "?interface=" +
+                serviceInterface + "&notify=false&methods=test1,test2&version=1.0.0&group=default");
+        try {
+            String serviceName = "providers:org.apache.dubbo.registry.nacos.NacosService:1.0.0:default";
+            String category = this.serviceUrl.getParameter(CATEGORY_KEY, DEFAULT_CATEGORY);
+            URL newUrl = this.serviceUrl.addParameter(CATEGORY_KEY, category);
+            newUrl = newUrl.addParameter(PROTOCOL_KEY, this.serviceUrl.getProtocol());
+            newUrl = newUrl.addParameter(PATH_KEY, this.serviceUrl.getPath());
+            newUrl = newUrl.addParameters(NacosNamingServiceUtils.getNacosPreservedParam(this.serviceUrl));
+            String ip = newUrl.getHost();
+            int port = newUrl.getPort();
+            Instance instance = new Instance();
+            instance.setIp(ip);
+            instance.setPort(port);
+            instance.setMetadata(new HashMap<>(newUrl.getParameters()));
+
+            List<Instance> instances = new ArrayList<>();
+            instances.add(instance);
+            when(namingService.getAllInstances(serviceName,
+                    this.registryUrl.getParameter(GROUP_KEY, Constants.DEFAULT_GROUP))).thenReturn(instances);
+
+            String serviceNameWithoutVersion = "providers:org.apache.dubbo.registry.nacos.NacosService:default";
+            String serviceName1 = "providers:org.apache.dubbo.registry.nacos.NacosService:1.0.0:default";
+            List<String> serviceNames = new ArrayList<>();
+            serviceNames.add(serviceNameWithoutVersion);
+            serviceNames.add(serviceName1);
+            ListView<String> result = new ListView<>();
+            result.setData(serviceNames);
+            when(namingService.getServicesOfServer(1, Integer.MAX_VALUE,
+                    registryUrl.getParameter(GROUP_KEY, Constants.DEFAULT_GROUP))).thenReturn(result);
+        } catch (NacosException e) {
+            // ignore
+        }
+
+        NacosNamingServiceWrapper nacosNamingServiceWrapper = new
+                NacosNamingServiceWrapper(namingService);
+        nacosRegistry = new NacosRegistry(this.registryUrl, nacosNamingServiceWrapper);
+
+        Set<URL> registered;
+        nacosRegistry.register(this.serviceUrl);
+        nacosRegistry.register(serviceUrlWithoutCategory);
+        registered = nacosRegistry.getRegistered();
+        assertThat(registered.contains(serviceUrl), is(true));
+        assertThat(registered.contains(serviceUrlWithoutCategory), is(true));
+        assertThat(registered.size(), is(2));
+
+
+        URL serviceUrlWithWildcard = URL.valueOf("nacos://127.0.0.1:3333/" +
+                serviceInterface +
+                "?interface=org.apache.dubbo.registry.nacos.NacosService" +
+                "&notify=false&methods=test1,test2&category=providers&version=*&group=default");
+
+        URL serviceUrlWithOutWildcard = URL.valueOf("nacos://127.0.0.1:3333/" +
+                serviceInterface +
+                "?interface=org.apache.dubbo.registry.nacos.NacosService" +
+                "&notify=false&methods=test1,test2&category=providers&version=1.0.0&group=default");
+
+        NotifyListener listener = mock(NotifyListener.class);
+        nacosRegistry.subscribe(serviceUrlWithWildcard, listener);
+        nacosRegistry.subscribe(serviceUrlWithOutWildcard, listener);
+
+        Map<URL, Set<NotifyListener>> subscribed = nacosRegistry.getSubscribed();
+
+        assertThat(subscribed.size(), is(2));
+        assertThat(subscribed.get(serviceUrlWithOutWildcard).size(), is(1));
+
+        assertThat(subscribed.size(), is(2));
+        assertThat(subscribed.get(serviceUrlWithWildcard).size(), is(1));
+
+
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

fix Consumer aborted with ArrayIndexOutOfBoundsException when subscribing services from Nacos with '*' in group or version #6814

## Brief changelog


## Verifying this change


<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Run `mvn clean install -DskipTests=false` & `mvn clean test-compile failsafe:integration-test` to make sure unit-test and integration-test pass.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
