### PR TITLE
[3.0] Kubernetes Client dependency upgrade

### DIFF
--- a/dubbo-dependencies-bom/pom.xml
+++ b/dubbo-dependencies-bom/pom.xml
@@ -148,7 +148,7 @@
         <eureka.version>1.9.12</eureka.version>
 
         <!-- Fabric8 for Kubernetes -->
-        <fabric8_kubernetes_version>4.10.3</fabric8_kubernetes_version>
+        <fabric8_kubernetes_version>5.3.0</fabric8_kubernetes_version>
 
         <!-- Alibaba -->
         <alibaba_spring_context_support_version>1.0.8</alibaba_spring_context_support_version>

--- a/dubbo-registry/dubbo-registry-kubernetes/pom.xml
+++ b/dubbo-registry/dubbo-registry-kubernetes/pom.xml
@@ -51,12 +51,6 @@
 
         <dependency>
             <groupId>io.fabric8</groupId>
-            <artifactId>kubernetes-server-mock</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>io.fabric8</groupId>
             <artifactId>mockwebserver</artifactId>
             <version>0.1.8</version>
             <scope>test</scope>

--- a/dubbo-registry/dubbo-registry-kubernetes/pom.xml
+++ b/dubbo-registry/dubbo-registry-kubernetes/pom.xml
@@ -56,6 +56,13 @@
         </dependency>
 
         <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>mockwebserver</artifactId>
+            <version>0.1.8</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <version>3.4.6</version>

--- a/dubbo-registry/dubbo-registry-kubernetes/pom.xml
+++ b/dubbo-registry/dubbo-registry-kubernetes/pom.xml
@@ -51,8 +51,7 @@
 
         <dependency>
             <groupId>io.fabric8</groupId>
-            <artifactId>mockwebserver</artifactId>
-            <version>0.1.8</version>
+            <artifactId>kubernetes-server-mock</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/dubbo-registry/dubbo-registry-kubernetes/src/main/java/org/apache/dubbo/registry/kubernetes/KubernetesServiceDiscovery.java
+++ b/dubbo-registry/dubbo-registry-kubernetes/src/main/java/org/apache/dubbo/registry/kubernetes/KubernetesServiceDiscovery.java
@@ -34,13 +34,14 @@ import io.fabric8.kubernetes.api.model.EndpointPort;
 import io.fabric8.kubernetes.api.model.EndpointSubset;
 import io.fabric8.kubernetes.api.model.Endpoints;
 import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodBuilder;
 import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.client.Config;
 import io.fabric8.kubernetes.client.DefaultKubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClient;
-import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.Watch;
 import io.fabric8.kubernetes.client.Watcher;
+import io.fabric8.kubernetes.client.WatcherException;
 
 import java.util.HashSet;
 import java.util.LinkedList;
@@ -123,11 +124,12 @@ public class KubernetesServiceDiscovery implements ServiceDiscovery {
                     .pods()
                     .inNamespace(namespace)
                     .withName(currentHostname)
-                    .edit()
-                    .editOrNewMetadata()
-                    .addToAnnotations(KUBERNETES_PROPERTIES_KEY, JSONObject.toJSONString(serviceInstance.getMetadata()))
-                    .endMetadata()
-                    .done();
+                    .edit(pod->
+                            new PodBuilder(pod)
+                                    .editOrNewMetadata()
+                                    .addToAnnotations(KUBERNETES_PROPERTIES_KEY, JSONObject.toJSONString(serviceInstance.getMetadata()))
+                                    .endMetadata()
+                                    .build());
             if (logger.isInfoEnabled()) {
                 logger.info("Write Current Service Instance Metadata to Kubernetes pod. " +
                         "Current pod name: " + currentHostname);
@@ -149,11 +151,12 @@ public class KubernetesServiceDiscovery implements ServiceDiscovery {
                     .pods()
                     .inNamespace(namespace)
                     .withName(currentHostname)
-                    .edit()
-                    .editOrNewMetadata()
-                    .removeFromAnnotations(KUBERNETES_PROPERTIES_KEY)
-                    .endMetadata()
-                    .done();
+                    .edit(pod ->
+                            new PodBuilder(pod)
+                                    .editOrNewMetadata()
+                                    .removeFromAnnotations(KUBERNETES_PROPERTIES_KEY)
+                                    .endMetadata()
+                                    .build());
             if (logger.isInfoEnabled()) {
                 logger.info("Remove Current Service Instance from Kubernetes pod. Current pod name: " + currentHostname);
             }
@@ -222,7 +225,7 @@ public class KubernetesServiceDiscovery implements ServiceDiscovery {
                     }
 
                     @Override
-                    public void onClose(KubernetesClientException cause) {
+                    public void onClose(WatcherException cause) {
                         // ignore
                     }
                 });
@@ -253,7 +256,7 @@ public class KubernetesServiceDiscovery implements ServiceDiscovery {
                     }
 
                     @Override
-                    public void onClose(KubernetesClientException cause) {
+                    public void onClose(WatcherException cause) {
                         // ignore
                     }
                 });
@@ -284,7 +287,7 @@ public class KubernetesServiceDiscovery implements ServiceDiscovery {
                     }
 
                     @Override
-                    public void onClose(KubernetesClientException cause) {
+                    public void onClose(WatcherException cause) {
                         // ignore
                     }
                 });


### PR DESCRIPTION
## What is the purpose of the change

- upgrade `io.fabric8` version
- use http protocol instead in ut