### PR TITLE
Fix the problem of ProtocolConfig requiring a name parameter in new v…

### DIFF
--- a/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/beans/factory/config/DubboConfigDefaultPropertyValueBeanPostProcessor.java
+++ b/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/beans/factory/config/DubboConfigDefaultPropertyValueBeanPostProcessor.java
@@ -16,7 +16,9 @@
  */
 package org.apache.dubbo.config.spring.beans.factory.config;
 
+import org.apache.dubbo.common.utils.StringUtils;
 import org.apache.dubbo.config.AbstractConfig;
+import org.apache.dubbo.config.ProtocolConfig;
 
 import com.alibaba.spring.beans.factory.config.GenericBeanPostProcessorAdapter;
 import org.springframework.beans.BeansException;
@@ -54,7 +56,14 @@ public class DubboConfigDefaultPropertyValueBeanPostProcessor extends GenericBea
     protected void processBeforeInitialization(AbstractConfig dubboConfigBean, String beanName) throws BeansException {
         // [Feature] https://github.com/apache/dubbo/issues/5721
         setBeanNameAsDefaultValue(dubboConfigBean, "id", beanName);
-        setBeanNameAsDefaultValue(dubboConfigBean, "name", beanName);
+        if (dubboConfigBean instanceof ProtocolConfig) {
+            ProtocolConfig config = (ProtocolConfig) dubboConfigBean;
+            if (StringUtils.isEmpty(config.getName())) {
+                config.setName("dubbo");
+            }
+        } else {
+            setBeanNameAsDefaultValue(dubboConfigBean, "name", beanName);
+        }
     }
 
     @Override


### PR DESCRIPTION
https://github.com/apache/dubbo/issues/6565
2.7 低版本代码向2.7高版本迁移的时候,如果你发现你还像之前protocolConfig不指定name,你会发现你的程序根本拉不起来.会说你找不到某个扩展(扩展名字取决于你ProtocolConfig 定义方法的名字).你检查代码会发现如果你不指定name会使用dubbo这个默认值.问题的原因是咱们实现了一个DubboConfigDefaultPropertyValueBeanPostProcessor  这个对config类中的name有操作.
造成原有代码逻辑被跳过.
影响范围:高版本必须修改ProtocolConfig,并手动指定name

<img width="801" alt="-2" src="https://user-images.githubusercontent.com/869986/115986543-42189a80-a5e3-11eb-953d-8e87e603559e.png">
<img width="703" alt="-1" src="https://user-images.githubusercontent.com/869986/115986548-45ac2180-a5e3-11eb-9ec1-94fda5c0fc13.png">
<img width="1232" alt="1" src="https://user-images.githubusercontent.com/869986/115986552-493fa880-a5e3-11eb-8c40-001be2f03137.png">
<img width="1013" alt="2" src="https://user-images.githubusercontent.com/869986/115986558-4cd32f80-a5e3-11eb-9c8c-4d07479c03f9.png">
