### PR TITLE
[3.0] Optimization about memory performance

### DIFF
--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/router/condition/config/ListenableRouter.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/router/condition/config/ListenableRouter.java
@@ -57,8 +57,8 @@ public abstract class ListenableRouter extends AbstractRouter implements Configu
 
     @Override
     public synchronized void process(ConfigChangedEvent event) {
-        if (logger.isInfoEnabled()) {
-            logger.info("Notification of condition rule, change type is: " + event.getChangeType() +
+        if (logger.isDebugEnabled()) {
+            logger.debug("Notification of condition rule, change type is: " + event.getChangeType() +
                     ", raw rule is:\n " + event.getContent());
         }
 

--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/router/mesh/route/MeshAppRuleListener.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/router/mesh/route/MeshAppRuleListener.java
@@ -25,6 +25,7 @@ import org.apache.dubbo.rpc.cluster.router.mesh.rule.VsDestinationGroup;
 import org.apache.dubbo.rpc.cluster.router.mesh.rule.destination.DestinationRule;
 import org.apache.dubbo.rpc.cluster.router.mesh.rule.virtualservice.VirtualServiceRule;
 import org.apache.dubbo.rpc.cluster.router.mesh.util.VsDestinationGroupRuleDispatcher;
+
 import org.yaml.snakeyaml.Yaml;
 
 import java.text.MessageFormat;
@@ -46,8 +47,10 @@ public class MeshAppRuleListener implements ConfigurationListener {
     }
 
     public void receiveConfigInfo(String configInfo) {
-        logger.info(MessageFormat.format("[MeshAppRule] Received rule for app [{0}]: {1}.",
-                appName, configInfo));
+        if(logger.isDebugEnabled()) {
+            logger.debug(MessageFormat.format("[MeshAppRule] Received rule for app [{0}]: {1}.",
+                    appName, configInfo));
+        }
         try {
 
             VsDestinationGroup vsDestinationGroup = new VsDestinationGroup();

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/BaseServiceMetadata.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/BaseServiceMetadata.java
@@ -30,7 +30,11 @@ public class BaseServiceMetadata {
     protected volatile String group;
 
     public static String buildServiceKey(String path, String group, String version) {
-        StringBuilder buf = new StringBuilder();
+        int length = path.length();
+        length += group == null ? 0 : group.length();
+        length += version == null ? 0 : version.length();
+        length += 3;
+        StringBuilder buf = new StringBuilder(length);
         if (group != null && group.length() > 0) {
             buf.append(group).append("/");
         }

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/URL.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/URL.java
@@ -469,10 +469,6 @@ class URL implements Serializable {
         return Collections.unmodifiableMap(selectedParameters);
     }
 
-    public Map<String, Map<String, String>> getMethodParameters() {
-        return urlParam.getMethodParameters();
-    }
-
     public String getParameterAndDecoded(String key) {
         return getParameterAndDecoded(key, null);
     }
@@ -732,24 +728,11 @@ class URL implements Serializable {
     }
 
     public String getMethodParameter(String method, String key) {
-        Map<String, String> keyMap = getMethodParameters().get(method);
-        String value = null;
-        if (keyMap != null) {
-            value = keyMap.get(key);
-        }
-        if (StringUtils.isEmpty(value)) {
-            value = urlParam.getParameter(key);
-        }
-        return value;
+        return urlParam.getMethodParameter(method, key);
     }
 
     public String getMethodParameterStrict(String method, String key) {
-        Map<String, String> keyMap = getMethodParameters().get(method);
-        String value = null;
-        if (keyMap != null) {
-            value = keyMap.get(key);
-        }
-        return value;
+        return urlParam.getMethodParameterStrict(method, key);
     }
 
     public String getMethodParameter(String method, String key, String defaultValue) {
@@ -936,20 +919,11 @@ class URL implements Serializable {
     }
 
     public String getAnyMethodParameter(String key) {
-        String suffix = "." + key;
-        for (String fullKey : getParameters().keySet()) {
-            if (fullKey.endsWith(suffix)) {
-                return getParameter(fullKey);
-            }
-        }
-        return null;
+        return urlParam.getAnyMethodParameter(key);
     }
 
     public boolean hasMethodParameter(String method) {
-        if (method == null) {
-            return false;
-        }
-        return getMethodParameters().containsKey(method);
+        return urlParam.hasMethodParameter(method);
     }
 
     public boolean isLocalHost() {

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/url/component/URLParam.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/url/component/URLParam.java
@@ -813,14 +813,19 @@ public class URLParam implements Serializable {
                 && Objects.equals(EXTRA_PARAMS, urlParam.EXTRA_PARAMS);
     }
 
-    private int extraParamsHashCodeCache = -1;
+    private int hashCodeCache = -1;
 
     @Override
     public int hashCode() {
-        if (extraParamsHashCodeCache == -1) {
-            extraParamsHashCodeCache = EXTRA_PARAMS.hashCode();
+        if (hashCodeCache == -1) {
+            hashCodeCache = EXTRA_PARAMS.hashCode();
+            for (Integer value : VALUE) {
+                hashCodeCache = hashCodeCache * 31 + value;
+            }
+            hashCodeCache = hashCodeCache * 31 + ((KEY == null) ? 0 : KEY.hashCode());
+            hashCodeCache = hashCodeCache * 31 + ((DEFAULT_KEY == null) ? 0 : DEFAULT_KEY.hashCode());
         }
-        return Objects.hash(KEY, DEFAULT_KEY, Arrays.hashCode(VALUE)) + extraParamsHashCodeCache;
+        return hashCodeCache;
     }
 
     @Override

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/url/component/URLParam.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/url/component/URLParam.java
@@ -28,7 +28,8 @@ import java.util.BitSet;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -80,18 +81,18 @@ public class URLParam implements Serializable {
     /**
      * a compressed (those key not exist or value is default value are bring removed in this array) array which contains value-offset
      */
-    private final int[] VALUE;
+    private final Integer[] VALUE;
 
     /**
      * store extra parameters which key not match in {@link DynamicParamTable}
      */
     private final Map<String, String> EXTRA_PARAMS;
 
-    //cache
-    private transient Map<String, Map<String, String>> methodParameters;
+    private final Map<String, Map<String, String>> METHOD_PARAMETERS;
+
     private transient long timestamp;
 
-    private final static URLParam EMPTY_PARAM = new URLParam(new BitSet(0), Collections.emptyMap(), Collections.emptyMap(), "");
+    private final static URLParam EMPTY_PARAM = new URLParam(new BitSet(0), Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap(), "");
 
     private URLParam() {
         this.rawParam = null;
@@ -99,12 +100,13 @@ public class URLParam implements Serializable {
         this.DEFAULT_KEY = null;
         this.VALUE = null;
         this.EXTRA_PARAMS = null;
+        this.METHOD_PARAMETERS = null;
     }
 
-    private URLParam(BitSet key, Map<Integer, Integer> value, Map<String, String> extraParams, String rawParam) {
+    private URLParam(BitSet key, Map<Integer, Integer> value, Map<String, String> extraParams, Map<String, Map<String, String>> methodParameters, String rawParam) {
         this.KEY = key;
         this.DEFAULT_KEY = new BitSet(KEY.size());
-        this.VALUE = new int[value.size()];
+        this.VALUE = new Integer[value.size()];
 
         // compress VALUE
         for (int i = key.nextSetBit(0), offset = 0; i >= 0; i = key.nextSetBit(i + 1)) {
@@ -116,29 +118,56 @@ public class URLParam implements Serializable {
         }
 
         this.EXTRA_PARAMS = Collections.unmodifiableMap((extraParams == null ? new HashMap<>() : new HashMap<>(extraParams)));
+        this.METHOD_PARAMETERS = Collections.unmodifiableMap((methodParameters == null) ? Collections.emptyMap() : new LinkedHashMap<>(methodParameters));
         this.rawParam = rawParam;
 
         this.timestamp = System.currentTimeMillis();
     }
 
-    private URLParam(BitSet key, BitSet defaultKey, int[] value, Map<String, String> extraParams, String rawParam) {
+    private URLParam(BitSet key, BitSet defaultKey, Integer[] value, Map<String, String> extraParams, Map<String, Map<String, String>> methodParameters, String rawParam) {
         this.KEY = key;
         this.DEFAULT_KEY = defaultKey;
 
         this.VALUE = value;
 
         this.EXTRA_PARAMS = Collections.unmodifiableMap((extraParams == null ? new HashMap<>() : new HashMap<>(extraParams)));
+        this.METHOD_PARAMETERS = Collections.unmodifiableMap((methodParameters == null) ? Collections.emptyMap() : new LinkedHashMap<>(methodParameters));
         this.rawParam = rawParam;
 
         this.timestamp = System.currentTimeMillis();
     }
 
-    public Map<String, Map<String, String>> getMethodParameters() {
-        // TODO: delete it
-        if (methodParameters == null) {
-            methodParameters = Collections.unmodifiableMap(initMethodParameters(getParameters()));
+    public boolean hasMethodParameter(String method) {
+        if (method == null) {
+            return false;
         }
-        return methodParameters;
+        for (Map.Entry<String, Map<String, String>> methods : METHOD_PARAMETERS.entrySet()) {
+            if(methods.getValue().containsKey(method)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public String getMethodParameter(String method, String key) {
+        String strictResult = getMethodParameterStrict(method, key);
+        return StringUtils.isNotEmpty(strictResult) ? strictResult : getParameter(key);
+    }
+
+    public String getMethodParameterStrict(String method, String key) {
+        String methodsString = getParameter(METHODS_KEY);
+        if (StringUtils.isNotEmpty(methodsString)) {
+            if (!methodsString.contains(method)) {
+                return null;
+            }
+        }
+
+        Map<String, String> methodMap = METHOD_PARAMETERS.get(key);
+        if (CollectionUtils.isNotEmptyMap(methodMap)) {
+            return methodMap.get(method);
+        } else {
+            return null;
+        }
     }
 
     public static Map<String, Map<String, String>> initMethodParameters(Map<String, String> parameters) {
@@ -292,7 +321,7 @@ public class URLParam implements Serializable {
 
         @Override
         public Set<String> keySet() {
-            Set<String> set = new HashSet<>((int) ((urlParam.VALUE.length + urlParam.EXTRA_PARAMS.size()) / 0.75) + 1);
+            Set<String> set = new LinkedHashSet<>((int) ((urlParam.VALUE.length + urlParam.EXTRA_PARAMS.size()) / 0.75) + 1);
             for (int i = urlParam.KEY.nextSetBit(0); i >= 0; i = urlParam.KEY.nextSetBit(i + 1)) {
                 set.add(DynamicParamTable.getKey(i));
             }
@@ -304,13 +333,13 @@ public class URLParam implements Serializable {
 
         @Override
         public Collection<String> values() {
-            Set<String> set = new HashSet<>((int) ((urlParam.VALUE.length + urlParam.EXTRA_PARAMS.size()) / 0.75) + 1);
+            Set<String> set = new LinkedHashSet<>((int) ((urlParam.VALUE.length + urlParam.EXTRA_PARAMS.size()) / 0.75) + 1);
             for (int i = urlParam.KEY.nextSetBit(0); i >= 0; i = urlParam.KEY.nextSetBit(i + 1)) {
                 String value;
                 if (urlParam.DEFAULT_KEY.get(i)) {
                     value = DynamicParamTable.getDefaultValue(i);
                 } else {
-                    int offset = urlParam.keyIndexToOffset(i);
+                    Integer offset = urlParam.keyIndexToOffset(i);
                     value = DynamicParamTable.getValue(i, offset);
                 }
                 set.add(value);
@@ -324,13 +353,13 @@ public class URLParam implements Serializable {
 
         @Override
         public Set<Entry<String, String>> entrySet() {
-            Set<Entry<String, String>> set = new HashSet<>((int) ((urlParam.KEY.cardinality() + urlParam.EXTRA_PARAMS.size()) / 0.75) + 1);
+            Set<Entry<String, String>> set = new LinkedHashSet<>((int) ((urlParam.KEY.cardinality() + urlParam.EXTRA_PARAMS.size()) / 0.75) + 1);
             for (int i = urlParam.KEY.nextSetBit(0); i >= 0; i = urlParam.KEY.nextSetBit(i + 1)) {
                 String value;
                 if (urlParam.DEFAULT_KEY.get(i)) {
                     value = DynamicParamTable.getDefaultValue(i);
                 } else {
-                    int offset = urlParam.keyIndexToOffset(i);
+                    Integer offset = urlParam.keyIndexToOffset(i);
                     value = DynamicParamTable.getValue(i, offset);
                 }
                 set.add(new Node(DynamicParamTable.getKey(i), value));
@@ -371,6 +400,24 @@ public class URLParam implements Serializable {
      */
     public Map<String, String> getParameters() {
         return new URLParamMap(this);
+    }
+
+    public String getAnyMethodParameter(String key) {
+        Map<String, String> methodMap = METHOD_PARAMETERS.get(key);
+        if (CollectionUtils.isNotEmptyMap(methodMap)) {
+            String methods = getParameter(METHODS_KEY);
+            if (StringUtils.isNotEmpty(methods)) {
+                for (String method : methods.split(",")) {
+                    String value = methodMap.get(method);
+                    if (StringUtils.isNotEmpty(value)) {
+                        return value;
+                    }
+                }
+            } else {
+                return methodMap.values().iterator().next();
+            }
+        }
+        return null;
     }
 
     /**
@@ -457,9 +504,10 @@ public class URLParam implements Serializable {
         // lazy init, null if no modify
         BitSet newKey = null;
         BitSet defaultKey = null;
-        int[] newValueArray = null;
+        Integer[] newValueArray = null;
         Map<Integer, Integer> newValueMap = null;
         Map<String, String> newExtraParams = null;
+        Map<String, Map<String, String>> newMethodParams = null;
         for (Map.Entry<String, String> entry : parameters.entrySet()) {
             if (skipIfPresent && hasParameter(entry.getKey())) {
                 continue;
@@ -471,6 +519,14 @@ public class URLParam implements Serializable {
                     newExtraParams = new HashMap<>(EXTRA_PARAMS);
                 }
                 newExtraParams.put(entry.getKey(), entry.getValue());
+                String[] methodSplit = entry.getKey().split("\\.");
+                if (methodSplit.length == 2) {
+                    if (newMethodParams == null) {
+                        newMethodParams = new HashMap<>(METHOD_PARAMETERS);
+                    }
+                    Map<String, String> methodMap = newMethodParams.computeIfAbsent(methodSplit[1], (k) -> new HashMap<>());
+                    methodMap.put(methodSplit[0], entry.getValue());
+                }
             } else {
                 if (newKey == null) {
                     newKey = (BitSet) KEY.clone();
@@ -484,8 +540,8 @@ public class URLParam implements Serializable {
                     }
                     newValueMap.put(keyIndex, DynamicParamTable.getValueIndex(entry.getKey(), entry.getValue()));
                 } else if (!DynamicParamTable.isDefaultValue(entry.getKey(), entry.getValue())) {
-                    // add parameter by moving array
-                    newValueArray = addByMove(VALUE, KEY.get(0, keyIndex).cardinality(), DynamicParamTable.getValueIndex(entry.getKey(), entry.getValue()));
+                    // add parameter by moving array, only support for adding once
+                    newValueArray = addByMove(VALUE, keyIndexToCompressIndex(newKey, DEFAULT_KEY, keyIndex), DynamicParamTable.getValueIndex(entry.getKey(), entry.getValue()));
                 } else {
                     // value is default value, add to defaultKey directly
                     if (defaultKey == null) {
@@ -507,10 +563,13 @@ public class URLParam implements Serializable {
         if (newExtraParams == null) {
             newExtraParams = EXTRA_PARAMS;
         }
+        if (newMethodParams == null) {
+            newMethodParams = METHOD_PARAMETERS;
+        }
         if (newValueMap == null) {
-            return new URLParam(newKey, defaultKey, newValueArray, newExtraParams, null);
+            return new URLParam(newKey, defaultKey, newValueArray, newExtraParams, newMethodParams, null);
         } else {
-            return new URLParam(newKey, newValueMap, newExtraParams, null);
+            return new URLParam(newKey, newValueMap, newExtraParams, newMethodParams, null);
         }
     }
 
@@ -524,12 +583,12 @@ public class URLParam implements Serializable {
         return map;
     }
 
-    private int[] addByMove(int[] array, int index, int value) {
+    private Integer[] addByMove(Integer[] array, int index, Integer value) {
         if (index < 0 || index > array.length) {
             throw new IllegalArgumentException();
         }
         // copy-on-write
-        int[] result = new int[array.length + 1];
+        Integer[] result = new Integer[array.length + 1];
 
         System.arraycopy(array, 0, result, 0, index);
         result[index] = value;
@@ -551,8 +610,9 @@ public class URLParam implements Serializable {
         // lazy init, null if no modify
         BitSet newKey = null;
         BitSet defaultKey = null;
-        int[] newValueArray = null;
+        Integer[] newValueArray = null;
         Map<String, String> newExtraParams = null;
+        Map<String, Map<String, String>> newMethodParams = null;
         for (String key : keys) {
             Integer keyIndex = DynamicParamTable.getKeyIndex(key);
             if (keyIndex != null && KEY.get(keyIndex)) {
@@ -569,11 +629,11 @@ public class URLParam implements Serializable {
                 } else {
                     // which offset is in VALUE array, set value as -1, compress in the end
                     if (newValueArray == null) {
-                        newValueArray = new int[VALUE.length];
+                        newValueArray = new Integer[VALUE.length];
                         System.arraycopy(VALUE, 0, newValueArray, 0, VALUE.length);
                     }
                     // KEY is immutable
-                    newValueArray[KEY.get(0, keyIndex).cardinality()] = -1;
+                    newValueArray[keyIndexToCompressIndex(KEY, DEFAULT_KEY, keyIndex)] = -1;
                 }
             }
             if (EXTRA_PARAMS.containsKey(key)) {
@@ -581,6 +641,17 @@ public class URLParam implements Serializable {
                     newExtraParams = new HashMap<>(EXTRA_PARAMS);
                 }
                 newExtraParams.remove(key);
+
+                String[] methodSplit = key.split("\\.");
+                if (methodSplit.length == 2) {
+                    if (newMethodParams == null) {
+                        newMethodParams = new HashMap<>(METHOD_PARAMETERS);
+                    }
+                    Map<String, String> methodMap = newMethodParams.get(methodSplit[1]);
+                    if (CollectionUtils.isNotEmptyMap(methodMap)) {
+                        methodMap.remove(methodSplit[0]);
+                    }
+                }
             }
             // ignore if key is absent
         }
@@ -599,15 +670,18 @@ public class URLParam implements Serializable {
         if (newExtraParams == null) {
             newExtraParams = EXTRA_PARAMS;
         }
+        if (newMethodParams == null) {
+            newMethodParams = METHOD_PARAMETERS;
+        }
         if (newKey.cardinality() + newExtraParams.size() == 0) {
             // empty, directly return cache
             return EMPTY_PARAM;
         } else {
-            return new URLParam(newKey, defaultKey, newValueArray, newExtraParams, null);
+            return new URLParam(newKey, defaultKey, newValueArray, newExtraParams, newMethodParams, null);
         }
     }
 
-    private int[] compressArray(int[] array) {
+    private Integer[] compressArray(Integer[] array) {
         int total = 0;
         for (int i : array) {
             if (i > -1) {
@@ -615,10 +689,10 @@ public class URLParam implements Serializable {
             }
         }
         if (total == 0) {
-            return new int[0];
+            return new Integer[0];
         }
 
-        int[] result = new int[total];
+        Integer[] result = new Integer[total];
         for (int i = 0, offset = 0; i < array.length; i++) {
             // skip if value if less than 0
             if (array[i] > -1) {
@@ -670,7 +744,7 @@ public class URLParam implements Serializable {
             if (DEFAULT_KEY.get(keyIndex)) {
                 value = DynamicParamTable.getDefaultValue(keyIndex);
             } else {
-                int offset = keyIndexToOffset(keyIndex);
+                Integer offset = keyIndexToOffset(keyIndex);
                 value = DynamicParamTable.getValue(keyIndex, offset);
             }
             if (StringUtils.isEmpty(value)) {
@@ -684,8 +758,21 @@ public class URLParam implements Serializable {
         return null;
     }
 
-    private int keyIndexToOffset(int keyIndex) {
-        int arrayOffset = KEY.get(0, keyIndex).cardinality();
+
+    private int keyIndexToCompressIndex(BitSet key, BitSet defaultKey, int keyIndex) {
+        int index = 0;
+        for (int i = 0; i < keyIndex; i++) {
+            if (key.get(i)) {
+                if (!defaultKey.get(i)) {
+                    index++;
+                }
+            }
+        }
+        return index;
+    }
+
+    private Integer keyIndexToOffset(int keyIndex) {
+        int arrayOffset = keyIndexToCompressIndex(KEY, DEFAULT_KEY, keyIndex);
         return VALUE[arrayOffset];
     }
 
@@ -726,9 +813,14 @@ public class URLParam implements Serializable {
                 && Objects.equals(EXTRA_PARAMS, urlParam.EXTRA_PARAMS);
     }
 
+    private int extraParamsHashCodeCache = -1;
+
     @Override
     public int hashCode() {
-        return Objects.hash(KEY, DEFAULT_KEY, Arrays.hashCode(VALUE), EXTRA_PARAMS);
+        if (extraParamsHashCodeCache == -1) {
+            extraParamsHashCodeCache = EXTRA_PARAMS.hashCode();
+        }
+        return Objects.hash(KEY, DEFAULT_KEY, Arrays.hashCode(VALUE)) + extraParamsHashCodeCache;
     }
 
     @Override
@@ -774,8 +866,8 @@ public class URLParam implements Serializable {
      * Parse URLParam
      * Init URLParam by constructor is not allowed
      *
-     * @param rawParam original rawParam string
-     * @param encoded if parameters are URL encoded
+     * @param rawParam        original rawParam string
+     * @param encoded         if parameters are URL encoded
      * @param extraParameters extra parameters to add into URLParam
      * @return a new URLParam
      */
@@ -800,6 +892,7 @@ public class URLParam implements Serializable {
         BitSet keyBit = new BitSet((int) (parts.length / .75f) + 1);
         Map<Integer, Integer> valueMap = new HashMap<>((int) (parts.length / .75f) + 1);
         Map<String, String> extraParam = new HashMap<>((int) (parts.length / .75f) + 1);
+        Map<String, Map<String, String>> methodParameters = new HashMap<>((int) (parts.length / .75f) + 1);
 
         for (String part : parts) {
             part = part.trim();
@@ -808,24 +901,24 @@ public class URLParam implements Serializable {
                 if (j >= 0) {
                     String key = part.substring(0, j);
                     String value = part.substring(j + 1);
-                    addParameter(keyBit, valueMap, extraParam, key, value, false);
+                    addParameter(keyBit, valueMap, extraParam, methodParameters, key, value, false);
                     // compatible with lower versions registering "default." keys
                     if (key.startsWith(DEFAULT_KEY_PREFIX)) {
-                        addParameter(keyBit, valueMap, extraParam, key.substring(DEFAULT_KEY_PREFIX.length()), value, true);
+                        addParameter(keyBit, valueMap, extraParam, methodParameters, key.substring(DEFAULT_KEY_PREFIX.length()), value, true);
                     }
                 } else {
-                    addParameter(keyBit, valueMap, extraParam, part, part, false);
+                    addParameter(keyBit, valueMap, extraParam, methodParameters, part, part, false);
                 }
             }
         }
-        return new URLParam(keyBit, valueMap, extraParam, rawParam);
+        return new URLParam(keyBit, valueMap, extraParam, methodParameters, rawParam);
     }
 
     /**
      * Parse URLParam
      * Init URLParam by constructor is not allowed
      *
-     * @param params params map added into URLParam
+     * @param params   params map added into URLParam
      * @param rawParam original rawParam string, directly add to rawParam field,
      *                 will not effect real key-pairs store in URLParam.
      *                 Please make sure it can correspond with params or will
@@ -839,18 +932,19 @@ public class URLParam implements Serializable {
             BitSet keyBit = new BitSet((int) (params.size() / .75f) + 1);
             Map<Integer, Integer> valueMap = new HashMap<>((int) (params.size() / .75f) + 1);
             Map<String, String> extraParam = new HashMap<>((int) (params.size() / .75f) + 1);
+            Map<String, Map<String, String>> methodParameters = new HashMap<>((int) (params.size() / .75f) + 1);
 
             for (Map.Entry<String, String> entry : params.entrySet()) {
-                addParameter(keyBit, valueMap, extraParam, entry.getKey(), entry.getValue(), false);
+                addParameter(keyBit, valueMap, extraParam, methodParameters, entry.getKey(), entry.getValue(), false);
             }
-            return new URLParam(keyBit, valueMap, extraParam, rawParam);
+            return new URLParam(keyBit, valueMap, extraParam, methodParameters, rawParam);
         } else {
             return EMPTY_PARAM;
         }
     }
 
     private static void addParameter(BitSet keyBit, Map<Integer, Integer> valueMap, Map<String, String> extraParam,
-                                     String key, String value, boolean skipIfPresent) {
+                                     Map<String, Map<String, String>> methodParameters, String key, String value, boolean skipIfPresent) {
         Integer keyIndex = DynamicParamTable.getKeyIndex(key);
         if (skipIfPresent) {
             if (keyIndex == null) {
@@ -866,6 +960,11 @@ public class URLParam implements Serializable {
 
         if (keyIndex == null) {
             extraParam.put(key, value);
+            String[] methodSplit = key.split("\\.");
+            if (methodSplit.length == 2) {
+                Map<String, String> methodMap = methodParameters.computeIfAbsent(methodSplit[1], (k) -> new HashMap<>());
+                methodMap.put(methodSplit[0], value);
+            }
         } else {
             if (!DynamicParamTable.isDefaultValue(key, value)) {
                 valueMap.put(keyIndex, DynamicParamTable.getValueIndex(key, value));

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/url/component/URLParam.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/url/component/URLParam.java
@@ -960,7 +960,7 @@ public class URLParam implements Serializable {
 
         if (keyIndex == null) {
             extraParam.put(key, value);
-            String[] methodSplit = key.split("\\.");
+            String[] methodSplit = key.split("\\.",2);
             if (methodSplit.length == 2) {
                 Map<String, String> methodMap = methodParameters.computeIfAbsent(methodSplit[1], (k) -> new HashMap<>());
                 methodMap.put(methodSplit[0], value);

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/url/component/param/DynamicParamSource.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/url/component/param/DynamicParamSource.java
@@ -19,10 +19,8 @@ package org.apache.dubbo.common.url.component.param;
 import org.apache.dubbo.common.extension.SPI;
 
 import java.util.List;
-import java.util.Map;
-
 @SPI
 public interface DynamicParamSource {
 
-    void init(List<String> KEYS, List<ParamValue> VALUES, Map<String, Integer> KEY2INDEX);
+    void init(List<String> KEYS, List<ParamValue> VALUES);
 }

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/url/component/param/DynamicParamSource.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/url/component/param/DynamicParamSource.java
@@ -16,28 +16,13 @@
  */
 package org.apache.dubbo.common.url.component.param;
 
-public interface ParamValue {
-    /**
-     * get value at the specified index.
-     *
-     * @param n the nth value
-     * @return the value stored at index = n
-     */
-    String getN(Integer n);
+import org.apache.dubbo.common.extension.SPI;
 
+import java.util.List;
+import java.util.Map;
 
-    /**
-     * max index is 2^31 - 1
-     *
-     * @param value the stored value
-     * @return the index of value
-     */
-    Integer getIndex(String value);
+@SPI
+public interface DynamicParamSource {
 
-    /**
-     * get default value
-     *
-     * @return the default value stored at index = 0
-     */
-    String defaultVal();
+    void init(List<String> KEYS, List<ParamValue> VALUES, Map<String, Integer> KEY2INDEX);
 }

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/url/component/param/DynamicParamTable.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/url/component/param/DynamicParamTable.java
@@ -16,6 +16,8 @@
  */
 package org.apache.dubbo.common.url.component.param;
 
+import org.apache.dubbo.common.extension.ExtensionLoader;
+
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -25,6 +27,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
 
 /**
  * Global Param Cache Table
+ * Not support method parameters
  */
 public final class DynamicParamTable {
     private static final List<String> KEYS = new CopyOnWriteArrayList<>();
@@ -43,7 +46,7 @@ public final class DynamicParamTable {
         return KEY2INDEX.get(key);
     }
 
-    public static int getValueIndex(String key, String value) {
+    public static Integer getValueIndex(String key, String value) {
         Integer idx = getKeyIndex(key);
         if (idx == null) {
             throw new IllegalArgumentException("Cannot found key in url param:" + key);
@@ -60,7 +63,7 @@ public final class DynamicParamTable {
         return Objects.equals(value, VALUES.get(getKeyIndex(key)).defaultVal());
     }
 
-    public static String getValue(int vi, int offset) {
+    public static String getValue(int vi, Integer offset) {
         return VALUES.get(vi).getN(offset);
     }
 
@@ -80,7 +83,8 @@ public final class DynamicParamTable {
         values.add(new DynamicValues(null));
 
         keys.add("side");
-        values.add(new FixedParamValue("consumer","provider"));
+        values.add(new FixedParamValue("consumer", "provider"));
+
 
         for (int i = 0; i < keys.size(); i++) {
             if (!keys.get(i).isEmpty()) {
@@ -91,5 +95,8 @@ public final class DynamicParamTable {
         KEYS.addAll(keys);
         VALUES.addAll(values);
         KEY2INDEX.putAll(key2Index);
+
+        ExtensionLoader.getExtensionLoader(DynamicParamSource.class)
+                .getSupportedExtensionInstances().forEach(source -> source.init(KEYS, VALUES, KEY2INDEX));
     }
 }

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/url/component/param/DynamicParamTable.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/url/component/param/DynamicParamTable.java
@@ -85,18 +85,17 @@ public final class DynamicParamTable {
         keys.add("side");
         values.add(new FixedParamValue("consumer", "provider"));
 
-
-        for (int i = 0; i < keys.size(); i++) {
-            if (!keys.get(i).isEmpty()) {
-                key2Index.put(keys.get(i), i);
-            }
-        }
-
         KEYS.addAll(keys);
         VALUES.addAll(values);
-        KEY2INDEX.putAll(key2Index);
 
         ExtensionLoader.getExtensionLoader(DynamicParamSource.class)
-                .getSupportedExtensionInstances().forEach(source -> source.init(KEYS, VALUES, KEY2INDEX));
+                .getSupportedExtensionInstances().forEach(source -> source.init(KEYS, VALUES));
+
+        for (int i = 0; i < KEYS.size(); i++) {
+            if (!KEYS.get(i).isEmpty()) {
+                key2Index.put(KEYS.get(i), i);
+            }
+        }
+        KEY2INDEX.putAll(key2Index);
     }
 }

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/url/component/param/DynamicValues.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/url/component/param/DynamicValues.java
@@ -50,12 +50,12 @@ public class DynamicValues implements ParamValue {
     }
 
     @Override
-    public String getN(int n) {
+    public String getN(Integer n) {
         return index2Value.get(n);
     }
 
     @Override
-    public int getIndex(String value) {
+    public Integer getIndex(String value) {
         Integer index = value2Index.get(value);
         if (index == null) {
             return add(value);

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/url/component/param/FixedParamValue.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/url/component/param/FixedParamValue.java
@@ -45,14 +45,15 @@ public class FixedParamValue implements ParamValue {
 
     /**
      * DEFAULT value will be returned if n = 0
+     * @param n
      */
     @Override
-    public String getN(int n) {
+    public String getN(Integer n) {
         return values[n];
     }
 
     @Override
-    public int getIndex(String value) {
+    public Integer getIndex(String value) {
         Integer offset = val2Index.get(value.toLowerCase(Locale.ROOT));
         if (offset == null) {
             throw new IllegalArgumentException("unrecognized value " + value

--- a/dubbo-common/src/main/java/org/apache/dubbo/rpc/model/MethodDescriptor.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/rpc/model/MethodDescriptor.java
@@ -23,7 +23,6 @@ import org.apache.dubbo.common.utils.ReflectUtils;
 import java.lang.reflect.Method;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
-import java.util.Arrays;
 import java.util.stream.Stream;
 
 import static org.apache.dubbo.common.constants.CommonConstants.$ECHO;

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/url/URLParamTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/url/URLParamTest.java
@@ -258,4 +258,16 @@ public class URLParamTest {
         set.add(urlParam4.getParameters());
         Assertions.assertEquals(2,set.size());
     }
+
+    @Test
+    public void testMethodParameters() {
+        URLParam urlParam1 = URLParam.parse("aaa.method1=aaa&bbb.method2=bbb");
+        Assertions.assertEquals("aaa",urlParam1.getAnyMethodParameter("method1"));
+        Assertions.assertEquals("bbb",urlParam1.getAnyMethodParameter("method2"));
+
+
+        URLParam urlParam2 = URLParam.parse("methods=aaa&aaa.method1=aaa&bbb.method2=bbb");
+        Assertions.assertEquals("aaa",urlParam2.getAnyMethodParameter("method1"));
+        Assertions.assertNull(urlParam2.getAnyMethodParameter("method2"));
+    }
 }

--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/ServiceConfig.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/ServiceConfig.java
@@ -581,7 +581,9 @@ public class ServiceConfig<T> extends ServiceConfigBase<T> {
             if (isInvalidLocalHost(hostToBind)) {
                 anyhost = true;
                 try {
-                    logger.info("No valid ip found from environment, try to find valid host from DNS.");
+                    if(logger.isDebugEnabled()) {
+                        logger.info("No valid ip found from environment, try to find valid host from DNS.");
+                    }
                     hostToBind = InetAddress.getLocalHost().getHostAddress();
                 } catch (UnknownHostException e) {
                     logger.warn(e.getMessage(), e);

--- a/dubbo-metadata/dubbo-metadata-api/src/main/java/org/apache/dubbo/metadata/DynamicConfigurationServiceNameMapping.java
+++ b/dubbo-metadata/dubbo-metadata-api/src/main/java/org/apache/dubbo/metadata/DynamicConfigurationServiceNameMapping.java
@@ -69,7 +69,7 @@ public class DynamicConfigurationServiceNameMapping implements ServiceNameMappin
 
         execute(() -> {
             dynamicConfiguration.publishConfig(key, ServiceNameMapping.buildGroup(serviceInterface, group, version, protocol), content);
-            if (logger.isInfoEnabled()) {
+            if (logger.isDebugEnabled()) {
                 logger.info(String.format("Dubbo service[%s] mapped to interface name[%s].",
                         group, serviceInterface, group));
             }

--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/SelfHostMetaServiceDiscovery.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/SelfHostMetaServiceDiscovery.java
@@ -137,7 +137,6 @@ public abstract class SelfHostMetaServiceDiscovery implements ServiceDiscovery {
 
         // check if metadata updated
         if (!metadataRevision.equalsIgnoreCase(lastMetadataRevision)) {
-            logger.info("Update Service Instance Metadata of DNS registry. Newer metadata: " + metadataString);
             if (logger.isDebugEnabled()) {
                 logger.debug("Update Service Instance Metadata of DNS registry. Newer metadata: " + metadataString);
             }
@@ -221,7 +220,9 @@ public abstract class SelfHostMetaServiceDiscovery implements ServiceDiscovery {
             String consumerId = ApplicationModel.getName() + NetUtils.getLocalHost();
             String metadata = metadataService.getAndListenInstanceMetadata(
                     consumerId, metadataString -> {
-                        logger.info("Receive callback: " + metadataString + serviceInstance);
+                        if(logger.isDebugEnabled()) {
+                            logger.debug("Receive callback: " + metadataString + serviceInstance);
+                        }
                         if (StringUtils.isEmpty(metadataString)) {
                             // provider is shutdown
                             metadataMap.remove(hostId);

--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/event/listener/ServiceInstancesChangedListener.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/event/listener/ServiceInstancesChangedListener.java
@@ -120,7 +120,9 @@ public class ServiceInstancesChangedListener implements ConditionalEventListener
             for (ServiceInstance instance : instances) {
                 String revision = getExportedServicesRevision(instance);
                 if (EMPTY_REVISION.equals(revision)) {
-                    logger.info("Find instance without valid service metadata: " + instance.getAddress());
+                    if(logger.isDebugEnabled()) {
+                        logger.debug("Find instance without valid service metadata: " + instance.getAddress());
+                    }
                     continue;
                 }
                 List<ServiceInstance> subInstances = revisionToInstances.computeIfAbsent(revision, r -> new LinkedList<>());
@@ -134,7 +136,9 @@ public class ServiceInstancesChangedListener implements ConditionalEventListener
             }
         }
 
-        logger.info(newRevisionToMetadata.size() + " unique revisions: " + newRevisionToMetadata.keySet());
+        if(logger.isDebugEnabled()) {
+            logger.debug(newRevisionToMetadata.size() + " unique revisions: " + newRevisionToMetadata.keySet());
+        }
 
         if (hasEmptyMetadata(newRevisionToMetadata)) {// retry every 10 seconds
             if (retryPermission.tryAcquire()) {
@@ -262,9 +266,16 @@ public class ServiceInstancesChangedListener implements ConditionalEventListener
     protected MetadataInfo getRemoteMetadata(ServiceInstance instance, String revision, Map<ServiceInfo, Set<String>> localServiceToRevisions, List<ServiceInstance> subInstances) {
         MetadataInfo metadata = revisionToMetadata.get(revision);
 
+        if (metadata != null && metadata != MetadataInfo.EMPTY) {
+            if (logger.isDebugEnabled()) {
+                logger.debug("MetadataInfo for instance " + instance.getAddress() + "?revision=" + revision + "&cluster=" + instance.getRegistryCluster() + ", " + metadata);
+            }
+        }
+
         if (metadata == null
                 || (metadata == MetadataInfo.EMPTY && (failureCounter.get() < 3 || (System.currentTimeMillis() - lastFailureTime > 10000)))) {
             metadata = getMetadataInfo(instance);
+
             if (metadata != MetadataInfo.EMPTY) {
                 failureCounter.set(0);
                 revisionToMetadata.putIfAbsent(revision, metadata);
@@ -301,7 +312,7 @@ public class ServiceInstancesChangedListener implements ConditionalEventListener
         MetadataInfo metadataInfo;
         try {
             if (logger.isDebugEnabled()) {
-                logger.info("Instance " + instance.getAddress() + " is using metadata type " + metadataType);
+                logger.debug("Instance " + instance.getAddress() + " is using metadata type " + metadataType);
             }
             if (REMOTE_METADATA_STORAGE_TYPE.equals(metadataType)) {
                 RemoteMetadataServiceImpl remoteMetadataService = MetadataUtils.getRemoteMetadataService();
@@ -310,7 +321,6 @@ public class ServiceInstancesChangedListener implements ConditionalEventListener
                 MetadataService metadataServiceProxy = MetadataUtils.getMetadataServiceProxy(instance, serviceDiscovery);
                 metadataInfo = metadataServiceProxy.getMetadataInfo(ServiceInstanceMetadataUtils.getExportedServicesRevision(instance));
             }
-            logger.info("Metadata " + metadataInfo);
         } catch (Exception e) {
             logger.error("Failed to load service metadata, meta type is " + metadataType, e);
             metadataInfo = null;

--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/migration/MigrationRuleListener.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/migration/MigrationRuleListener.java
@@ -211,7 +211,9 @@ public class MigrationRuleListener implements RegistryProtocolListener, Configur
 
         @Override
         public void onEvent(MappingChangedEvent event) {
-            logger.info("Received mapping notification from meta server, " +  event);
+            if(logger.isDebugEnabled()) {
+                logger.debug("Received mapping notification from meta server, " + event);
+            }
             Set<String> newApps = event.getApps();
             Set<String> tempOldApps = oldApps;
             oldApps = newApps;

--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/support/CacheableFailbackRegistry.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/support/CacheableFailbackRegistry.java
@@ -81,8 +81,8 @@ public abstract class CacheableFailbackRegistry extends FailbackRegistry {
     static {
         ExecutorRepository executorRepository = ExtensionLoader.getExtensionLoader(ExecutorRepository.class).getDefaultExtension();
         cacheRemovalScheduler = executorRepository.nextScheduledExecutor();
-        cacheRemovalTaskIntervalInMillis = getIntConfig(CACHE_CLEAR_TASK_INTERVAL, 10 * 60 * 1000);
-        cacheClearWaitingThresholdInMillis = getIntConfig(CACHE_CLEAR_WAITING_THRESHOLD, 30 * 60 * 1000);
+        cacheRemovalTaskIntervalInMillis = getIntConfig(CACHE_CLEAR_TASK_INTERVAL, 2 * 60 * 1000);
+        cacheClearWaitingThresholdInMillis = getIntConfig(CACHE_CLEAR_WAITING_THRESHOLD, 5 * 60 * 1000);
     }
 
     public CacheableFailbackRegistry(URL url) {


### PR DESCRIPTION
- Introduce init size for StringBuilder in BaseServiceMetadata
- Make timeout smaller in CacheableFailbackRegistry
- Simplify log
- Introduce DynamicParamSource to add constant param
- Reduce unnecessary boxing
- Reduce unnecessary iterator node creation of HashMap and HashSet
- Cache activateGroup and activateValue in ExtensionLoader
- Make URLParam support method parameters natively, reduce unnecessary map creation