### PR TITLE
Support sending generic requests in JSON format

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/constants/CommonConstants.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/constants/CommonConstants.java
@@ -306,6 +306,8 @@ public interface CommonConstants {
 
     String GENERIC_SERIALIZATION_NATIVE_JAVA = "nativejava";
 
+    String GENERIC_SERIALIZATION_GSON = "gson";
+
     String GENERIC_SERIALIZATION_DEFAULT = "true";
 
     String GENERIC_SERIALIZATION_BEAN = "bean";

--- a/dubbo-common/src/main/java/org/apache/dubbo/rpc/support/ProtocolUtils.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/rpc/support/ProtocolUtils.java
@@ -26,6 +26,7 @@ import static org.apache.dubbo.common.constants.CommonConstants.GENERIC_RAW_RETU
 import static org.apache.dubbo.common.constants.CommonConstants.GENERIC_SERIALIZATION_BEAN;
 import static org.apache.dubbo.common.constants.CommonConstants.GENERIC_SERIALIZATION_DEFAULT;
 import static org.apache.dubbo.common.constants.CommonConstants.GENERIC_SERIALIZATION_NATIVE_JAVA;
+import static org.apache.dubbo.common.constants.CommonConstants.GENERIC_SERIALIZATION_GSON;
 import static org.apache.dubbo.common.constants.CommonConstants.GENERIC_SERIALIZATION_PROTOBUF;
 import static org.apache.dubbo.common.constants.CommonConstants.GROUP_KEY;
 import static org.apache.dubbo.common.constants.CommonConstants.VERSION_KEY;
@@ -58,6 +59,7 @@ public class ProtocolUtils {
                 || GENERIC_SERIALIZATION_NATIVE_JAVA.equalsIgnoreCase(generic) /* Streaming generalization call supporting jdk serialization */
                 || GENERIC_SERIALIZATION_BEAN.equalsIgnoreCase(generic)
                 || GENERIC_SERIALIZATION_PROTOBUF.equalsIgnoreCase(generic)
+                || GENERIC_SERIALIZATION_GSON.equalsIgnoreCase(generic)
                 || GENERIC_RAW_RETURN.equalsIgnoreCase(generic));
 
     }
@@ -75,6 +77,11 @@ public class ProtocolUtils {
     public static boolean isJavaGenericSerialization(String generic) {
         return isGeneric(generic)
                 && GENERIC_SERIALIZATION_NATIVE_JAVA.equalsIgnoreCase(generic);
+    }
+
+    public static boolean isGsonGenericSerialization(String generic) {
+        return isGeneric(generic)
+                && GENERIC_SERIALIZATION_GSON.equalsIgnoreCase(generic);
     }
 
     public static boolean isBeanGenericSerialization(String generic) {

--- a/dubbo-rpc/dubbo-rpc-api/pom.xml
+++ b/dubbo-rpc/dubbo-rpc-api/pom.xml
@@ -50,5 +50,11 @@
             <artifactId>hessian-lite</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+        </dependency>
+
     </dependencies>
 </project>

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/filter/GenericFilter.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/filter/GenericFilter.java
@@ -16,6 +16,10 @@
  */
 package org.apache.dubbo.rpc.filter;
 
+import com.google.gson.Gson;
+import com.google.gson.JsonSyntaxException;
+import com.google.gson.reflect.TypeToken;
+
 import org.apache.dubbo.common.beanutil.JavaBeanAccessor;
 import org.apache.dubbo.common.beanutil.JavaBeanDescriptor;
 import org.apache.dubbo.common.beanutil.JavaBeanSerializeUtil;
@@ -45,10 +49,13 @@ import org.apache.dubbo.rpc.support.ProtocolUtils;
 
 import java.io.IOException;
 import java.lang.reflect.Method;
+import java.lang.reflect.Type;
+import java.util.stream.IntStream;
 
 import static org.apache.dubbo.common.constants.CommonConstants.$INVOKE;
 import static org.apache.dubbo.common.constants.CommonConstants.$INVOKE_ASYNC;
 import static org.apache.dubbo.common.constants.CommonConstants.GENERIC_SERIALIZATION_BEAN;
+import static org.apache.dubbo.common.constants.CommonConstants.GENERIC_SERIALIZATION_GSON;
 import static org.apache.dubbo.common.constants.CommonConstants.GENERIC_SERIALIZATION_NATIVE_JAVA;
 import static org.apache.dubbo.common.constants.CommonConstants.GENERIC_SERIALIZATION_PROTOBUF;
 import static org.apache.dubbo.rpc.Constants.GENERIC_KEY;
@@ -93,7 +100,13 @@ public class GenericFilter implements Filter, Filter.Listener {
                 if (StringUtils.isEmpty(generic)
                         || ProtocolUtils.isDefaultGenericSerialization(generic)
                         || ProtocolUtils.isGenericReturnRawResult(generic)) {
-                    args = PojoUtils.realize(args, params, method.getGenericParameterTypes());
+                    try {
+                        args = PojoUtils.realize(args, params, method.getGenericParameterTypes());
+                    } catch (IllegalArgumentException e) {
+                        throw new RpcException(e);
+                    }
+                } else if (ProtocolUtils.isGsonGenericSerialization(generic)) {
+                    args = getGsonGenericArgs(args, method.getGenericParameterTypes());
                 } else if (ProtocolUtils.isJavaGenericSerialization(generic)) {
                     Configuration configuration = ApplicationModel.getEnvironment().getConfiguration();
                     if (!configuration.getBoolean(CommonConstants.ENABLE_NATIVE_JAVA_GENERIC_SERIALIZE, false)) {
@@ -162,7 +175,9 @@ public class GenericFilter implements Filter, Filter.Listener {
                     }
                 }
 
-                RpcInvocation rpcInvocation = new RpcInvocation(method, invoker.getInterface().getName(), invoker.getUrl().getProtocolServiceKey(), args, inv.getObjectAttachments(), inv.getAttributes());
+                RpcInvocation rpcInvocation =
+                        new RpcInvocation(method, invoker.getInterface().getName(), invoker.getUrl().getProtocolServiceKey(), args,
+                                inv.getObjectAttachments(), inv.getAttributes());
                 rpcInvocation.setInvoker(inv.getInvoker());
                 rpcInvocation.setTargetServiceUniqueName(inv.getTargetServiceUniqueName());
 
@@ -172,6 +187,19 @@ public class GenericFilter implements Filter, Filter.Listener {
             }
         }
         return invoker.invoke(inv);
+    }
+
+    private Object[] getGsonGenericArgs(final Object[] args, Type[] types) {
+        Gson gson = new Gson();
+        return IntStream.range(0, args.length).mapToObj(i -> {
+            String str = args[i].toString();
+            Type type = TypeToken.get(types[i]).getType();
+            try {
+                return gson.fromJson(str, type);
+            } catch (JsonSyntaxException ex) {
+                throw new RpcException(String.format("Generic serialization [%s] Json syntax exception thrown when parsing (message:%s type:%s) error:%s", GENERIC_SERIALIZATION_GSON, str, type.toString(), ex.getMessage()));
+            }
+        }).toArray();
     }
 
     @Override
@@ -200,7 +228,8 @@ public class GenericFilter implements Filter, Filter.Listener {
             if (ProtocolUtils.isJavaGenericSerialization(generic)) {
                 try {
                     UnsafeByteArrayOutputStream os = new UnsafeByteArrayOutputStream(512);
-                    ExtensionLoader.getExtensionLoader(Serialization.class).getExtension(GENERIC_SERIALIZATION_NATIVE_JAVA).serialize(null, os).writeObject(appResponse.getValue());
+                    ExtensionLoader.getExtensionLoader(Serialization.class).getExtension(GENERIC_SERIALIZATION_NATIVE_JAVA)
+                            .serialize(null, os).writeObject(appResponse.getValue());
                     appResponse.setValue(os.toByteArray());
                 } catch (IOException e) {
                     throw new RpcException(


### PR DESCRIPTION
Invoking a dubbo service via calling from api gateway or running dynamic scripts like groovy by simply passing string values instead of using maps or updating jar files.
<img width="1283" alt="zzz" src="https://user-images.githubusercontent.com/869986/116065508-a9088300-a6b9-11eb-9904-ab9de0e29cf2.png">


像网关和groovy动态脚本这样的调用,可以直接通过传递字符串完成一次rpc调用(不必自己再组装Map之类,或者更新jar包).变的更简单.(golang 夸语言的泛化调用也会大幅度降低难度,毕竟字符串更好产出出来,相较于struct)