### PR TITLE
Replace some orElse with orElseGet

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/config/ReferenceConfigBase.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/config/ReferenceConfigBase.java
@@ -109,7 +109,7 @@ public abstract class ReferenceConfigBase<T> extends AbstractReferenceConfig {
         if (consumer == null) {
             consumer = ApplicationModel.getConfigManager()
                     .getDefaultConsumer()
-                    .orElse(new ConsumerConfig());
+                    .orElseGet(ConsumerConfig::new);
         }
     }
 

--- a/dubbo-common/src/main/java/org/apache/dubbo/config/ServiceConfigBase.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/config/ServiceConfigBase.java
@@ -194,7 +194,7 @@ public abstract class ServiceConfigBase<T> extends AbstractServiceConfig {
         if (provider == null) {
             provider = ApplicationModel.getConfigManager()
                     .getDefaultProvider()
-                    .orElse(new ProviderConfig());
+                    .orElseGet(ProviderConfig::new);
         }
     }
 

--- a/dubbo-common/src/main/java/org/apache/dubbo/event/EventListener.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/event/EventListener.java
@@ -84,7 +84,7 @@ public interface EventListener<E extends Event> extends java.util.EventListener,
                     .map(EventListener::findEventType)
                     .filter(Objects::nonNull)
                     .findAny()
-                    .orElse((Class) findEventType(listenerClass.getSuperclass()));
+                    .orElseGet(() -> (Class) findEventType(listenerClass.getSuperclass()));
         }
 
         return eventType;


### PR DESCRIPTION
## What is the purpose of the change

According to the [document](https://www.baeldung.com/java-optional-or-else-vs-or-else-get), the statement in orElse will be executed anyway, this may cause some extra consumption, we should replace it with orElseGet.