### PR TITLE
Refactoring to remove envious methods (extract methods)

### DIFF
--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/support/AccessLogData.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/support/AccessLogData.java
@@ -65,14 +65,22 @@ public final class AccessLogData {
     /**
      * Default constructor.
      */
-    private AccessLogData() {
-        RpcContext context = RpcContext.getContext();
-        data = new HashMap<>();
-        setLocalHost(context.getLocalHost());
-        setLocalPort(context.getLocalPort());
-        setRemoteHost(context.getRemoteHost());
-        setRemotePort(context.getRemotePort());
-    }
+   private AccessLogData() {
+       RpcContext context = RpcContext.getContext();
+       data = new HashMap<>();
+       setPort(context);
+       setHost(context);        
+   }
+
+   private void setPort(RpcContext context){
+       setLocalPort(context.getLocalPort());
+       setRemotePort(context.getRemotePort());
+   }
+
+   private void setHost(RpcContext context){
+       setLocalHost(context.getLocalHost());
+       setRemoteHost(context.getRemoteHost());
+   }
 
     /**
      * Get new instance of log data.


### PR DESCRIPTION
Hi everyone,

I discovered an opportunity to improve Dubbo. I observed that the AccessLogData constructor is an envious method because it calls many times the RpcContext class and it gets worse the readability of the method. Then, I extracted two methods, separating a method only to set port and set host. I expect that it improves the source code. Thanks.