### PR TITLE
Fix remoteMap may be null to avoid NullPointerException being thrown(#7653)

### DIFF
--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/support/ClusterUtils.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/support/ClusterUtils.java
@@ -103,20 +103,22 @@ public class ClusterUtils {
 
             map.putAll(copyOfLocalMap);
 
-            map.put(REMOTE_APPLICATION_KEY, remoteMap.get(APPLICATION_KEY));
+            if (remoteMap != null) {
+                map.put(REMOTE_APPLICATION_KEY, remoteMap.get(APPLICATION_KEY));
 
-            // Combine filters and listeners on Provider and Consumer
-            String remoteFilter = remoteMap.get(REFERENCE_FILTER_KEY);
-            String localFilter = copyOfLocalMap.get(REFERENCE_FILTER_KEY);
-            if (remoteFilter != null && remoteFilter.length() > 0
-                    && localFilter != null && localFilter.length() > 0) {
-                map.put(REFERENCE_FILTER_KEY, remoteFilter + "," + localFilter);
-            }
-            String remoteListener = remoteMap.get(INVOKER_LISTENER_KEY);
-            String localListener = copyOfLocalMap.get(INVOKER_LISTENER_KEY);
-            if (remoteListener != null && remoteListener.length() > 0
-                    && localListener != null && localListener.length() > 0) {
-                map.put(INVOKER_LISTENER_KEY, remoteListener + "," + localListener);
+                // Combine filters and listeners on Provider and Consumer
+                String remoteFilter = remoteMap.get(REFERENCE_FILTER_KEY);
+                String localFilter = copyOfLocalMap.get(REFERENCE_FILTER_KEY);
+                if (remoteFilter != null && remoteFilter.length() > 0
+                        && localFilter != null && localFilter.length() > 0) {
+                    map.put(REFERENCE_FILTER_KEY, remoteFilter + "," + localFilter);
+                }
+                String remoteListener = remoteMap.get(INVOKER_LISTENER_KEY);
+                String localListener = copyOfLocalMap.get(INVOKER_LISTENER_KEY);
+                if (remoteListener != null && remoteListener.length() > 0
+                        && localListener != null && localListener.length() > 0) {
+                    map.put(INVOKER_LISTENER_KEY, remoteListener + "," + localListener);
+                }
             }
         }
 


### PR DESCRIPTION
## What is the purpose of the change
In this issue(https://github.com/apache/dubbo/issues/7653 ) RemoteMap may be null, NullPointerException will be thrown in ClusterUtils, this pr is to fix this issue, to avoid throwing NullPointerException in ClusterUtils, thanks


## Brief changelog


## Verifying this change


<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Run `mvn clean install -DskipTests=false` & `mvn clean test-compile failsafe:integration-test` to make sure unit-test and integration-test pass.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
