### PR TITLE
When using multiple protocols and having port specified, service can …

### DIFF
--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/ServiceConfig.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/ServiceConfig.java
@@ -62,6 +62,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -318,17 +319,18 @@ public class ServiceConfig<T> extends ServiceConfigBase<T> {
 
         List<URL> registryURLs = ConfigValidationUtils.loadRegistries(this, true);
 
+        int protocolConfigNum = protocols.size();
         for (ProtocolConfig protocolConfig : protocols) {
             String pathKey = URL.buildKey(getContextPath(protocolConfig)
                     .map(p -> p + "/" + path)
                     .orElse(path), group, version);
             // In case user specified path, register service one more time to map it to path.
             repository.registerService(pathKey, interfaceClass);
-            doExportUrlsFor1Protocol(protocolConfig, registryURLs);
+            doExportUrlsFor1Protocol(protocolConfig, registryURLs, protocolConfigNum);
         }
     }
 
-    private void doExportUrlsFor1Protocol(ProtocolConfig protocolConfig, List<URL> registryURLs) {
+    private void doExportUrlsFor1Protocol(ProtocolConfig protocolConfig, List<URL> registryURLs, int protocolConfigNum) {
         String name = protocolConfig.getName();
         if (StringUtils.isEmpty(name)) {
             name = DUBBO;
@@ -443,7 +445,7 @@ public class ServiceConfig<T> extends ServiceConfigBase<T> {
 
         // export service
         String host = findConfigedHosts(protocolConfig, registryURLs, map);
-        Integer port = findConfigedPorts(protocolConfig, name, map);
+        Integer port = findConfigedPorts(protocolConfig, name, map, protocolConfigNum);
         URL url = new URL(name, host, port, getContextPath(protocolConfig).map(p -> p + "/" + path).orElse(path), map);
 
         // You can customize Configurator to append extra parameters
@@ -620,11 +622,12 @@ public class ServiceConfig<T> extends ServiceConfigBase<T> {
      *
      * @param protocolConfig
      * @param name
+     * @param protocolConfigNum
      * @return
      */
     private Integer findConfigedPorts(ProtocolConfig protocolConfig,
                                       String name,
-                                      Map<String, String> map) {
+                                      Map<String, String> map, int protocolConfigNum) {
         Integer portToBind = null;
 
         // parse bind port from environment
@@ -650,17 +653,26 @@ public class ServiceConfig<T> extends ServiceConfigBase<T> {
             }
         }
 
-        // save bind port, used as url's key later
-        map.put(BIND_PORT_KEY, String.valueOf(portToBind));
-
         // registry port, not used as bind port by default
-        String portToRegistryStr = getValueFromConfig(protocolConfig, DUBBO_PORT_TO_REGISTRY);
+        String key = DUBBO_PORT_TO_REGISTRY;
+        if (protocolConfigNum > 1) {
+            key = getProtocolConfigId(protocolConfig).toUpperCase() + "_" + key;
+        }
+        String portToRegistryStr = getValueFromConfig(protocolConfig, key);
         Integer portToRegistry = parsePort(portToRegistryStr);
         if (portToRegistry == null) {
             portToRegistry = portToBind;
         }
 
+        // save bind port, used as url's key later
+        map.put(BIND_PORT_KEY, String.valueOf(portToRegistry));
+
         return portToRegistry;
+    }
+
+
+    private String getProtocolConfigId(ProtocolConfig config) {
+        return Optional.ofNullable(config.getId()).orElse("dubbo");
     }
 
     private Integer parsePort(String configPort) {


### PR DESCRIPTION
When using multiple protocols and having port specified, service can not be started.

当你使用多协议的时候,并且指定端口.你会发现后边的服务拉不起来,因为程序不可能拉起来两个端口一致的server
这在容器化中非常普遍.我需要在外围指定端口.并且我也需要多协议.很多公司面临多语言,这是文本协议就相对简单很多
<img width="1020" alt="1" src="https://user-images.githubusercontent.com/869986/116500139-7be9e980-a8e0-11eb-8f08-60be192c8d24.png">
<img width="1343" alt="2" src="https://user-images.githubusercontent.com/869986/116500167-899f6f00-a8e0-11eb-93a2-64b997dc7541.png">
<img width="774" alt="3" src="https://user-images.githubusercontent.com/869986/116500181-8efcb980-a8e0-11eb-84a0-e88cfeb6a5da.png">

After resolving
<img width="1218" alt="4" src="https://user-images.githubusercontent.com/869986/116504545-1a7b4800-a8eb-11eb-952c-5aa970e9cee0.png">
<img width="745" alt="5" src="https://user-images.githubusercontent.com/869986/116504555-20712900-a8eb-11eb-889f-512238df9e62.png">
<img width="864" alt="6" src="https://user-images.githubusercontent.com/869986/116504565-249d4680-a8eb-11eb-93dd-28a2a4fbf694.png">
