### PR TITLE
When there's multiple ProtocolConfig settings, having port number set…

### DIFF
--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/ServiceConfig.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/ServiceConfig.java
@@ -63,6 +63,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -140,6 +141,8 @@ public class ServiceConfig<T> extends ServiceConfigBase<T> {
      * The exported services
      */
     private final List<Exporter<?>> exporters = new ArrayList<Exporter<?>>();
+
+    private static final ConcurrentHashMap<Integer, Integer> randomPortSet = new ConcurrentHashMap<>();
 
     public ServiceConfig() {
     }
@@ -642,10 +645,9 @@ public class ServiceConfig<T> extends ServiceConfigBase<T> {
                 portToBind = defaultPort;
             }
             if (portToBind <= 0) {
-                portToBind = getRandomPort(name);
+                portToBind = getRandomPort(protocolConfig.getId());
                 if (portToBind == null || portToBind < 0) {
-                    portToBind = getAvailablePort(defaultPort);
-                    putRandomPort(name, portToBind);
+                    portToBind = getAndSaveAvailablePort(protocolConfig.getId(), 20880);
                 }
             }
         }
@@ -661,6 +663,16 @@ public class ServiceConfig<T> extends ServiceConfigBase<T> {
         }
 
         return portToRegistry;
+    }
+
+
+    private int getAndSaveAvailablePort(String id, int port) {
+        int portToBind = 0;
+        do {
+            portToBind = getAvailablePort(port++);
+        } while (null == randomPortSet.putIfAbsent(portToBind, portToBind));
+        putRandomPort(id, portToBind);
+        return portToBind;
     }
 
     private Integer parsePort(String configPort) {


### PR DESCRIPTION
When there's multiple ProtocolConfig settings, having port number set as -1 may possibly lead to port conflicts.

多协议配置的时候,如果端口号都交由程序计算,那么计算的端口可能是冲突的.原因是那个计算其实是尝试打开tcp的端口如果能
打开则使用这个端口,但问题是你不知道下次开始计算开始这个端口到底被占用了没有.(几率问题 同时之前还有一个问题,他们用的是name,但这个玩意并不是用来区分Protocol的,应当用id)

一个容易产生碰撞的例子

<img width="1006" alt="8" src="https://user-images.githubusercontent.com/869986/116524032-7bb21400-a909-11eb-8f2e-41603b408948.png">