### PR TITLE
Fix EtcdServiceDiscovery not overriding the getUrl method, causing subscribe to throw an exception

### DIFF
--- a/dubbo-registry/dubbo-registry-etcd3/src/main/java/org/apache/dubbo/registry/etcd/EtcdServiceDiscovery.java
+++ b/dubbo-registry/dubbo-registry-etcd3/src/main/java/org/apache/dubbo/registry/etcd/EtcdServiceDiscovery.java
@@ -62,6 +62,8 @@ public class EtcdServiceDiscovery extends AbstractServiceDiscovery implements Ev
     EtcdClient etcdClient;
     EventDispatcher dispatcher;
 
+    private URL registryURL;
+
     @Override
     public void onEvent(ServiceInstancesChangedEvent event) {
         registerServiceWatcher(event.getServiceName());
@@ -90,6 +92,7 @@ public class EtcdServiceDiscovery extends AbstractServiceDiscovery implements Ev
 
         this.dispatcher = EventDispatcher.getDefaultExtension();
         this.dispatcher.addEventListener(this);
+        this.registryURL = registryURL;
     }
 
     @Override
@@ -202,5 +205,10 @@ public class EtcdServiceDiscovery extends AbstractServiceDiscovery implements Ev
             }
             register(serviceInstance);
         }
+    }
+
+    @Override
+    public URL getUrl() {
+        return registryURL;
     }
 }


### PR DESCRIPTION

## What is the purpose of the change

Fix EtcdServiceDiscovery not overriding the getUrl method, causing subscribe to throw an exception

see more detail from #7636

## Brief changelog


## Verifying this change


<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Run `mvn clean install -DskipTests=false` & `mvn clean test-compile failsafe:integration-test` to make sure unit-test and integration-test pass.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
