### PR TITLE
Using Gson serialization can cause Exception messages to be lost

### DIFF
--- a/dubbo-serialization/dubbo-serialization-gson/src/main/java/org/apache/dubbo/common/serialize/gson/ExceptionWrapper.java
+++ b/dubbo-serialization/dubbo-serialization-gson/src/main/java/org/apache/dubbo/common/serialize/gson/ExceptionWrapper.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.dubbo.common.serialize.gson;
+
+public class ExceptionWrapper {
+
+
+    private final Object exception;
+
+    private final String clazz;
+
+
+    public ExceptionWrapper(Object exception, String clazz) {
+        this.exception = exception;
+        this.clazz = clazz;
+    }
+
+    public Object getException() {
+        return exception;
+    }
+
+
+    public String getClazz() {
+        return clazz;
+    }
+
+}

--- a/dubbo-serialization/dubbo-serialization-gson/src/main/java/org/apache/dubbo/common/serialize/gson/GsonJsonObjectInput.java
+++ b/dubbo-serialization/dubbo-serialization-gson/src/main/java/org/apache/dubbo/common/serialize/gson/GsonJsonObjectInput.java
@@ -118,4 +118,10 @@ public class GsonJsonObjectInput implements ObjectInput {
         String json = readLine();
         return gson.fromJson(json, cls);
     }
+
+    @Override
+    public Throwable readThrowable() throws IOException, ClassNotFoundException {
+        ExceptionWrapper obj = readObject(ExceptionWrapper.class);
+        return gson.fromJson(obj.getException().toString(), (Type) Class.forName(obj.getClazz()));
+    }
 }

--- a/dubbo-serialization/dubbo-serialization-gson/src/main/java/org/apache/dubbo/common/serialize/gson/GsonJsonObjectOutput.java
+++ b/dubbo-serialization/dubbo-serialization-gson/src/main/java/org/apache/dubbo/common/serialize/gson/GsonJsonObjectOutput.java
@@ -100,6 +100,14 @@ public class GsonJsonObjectOutput implements ObjectOutput {
         json = null;
     }
 
+
+    @Override
+    public void writeThrowable(Object obj) throws IOException {
+        String clazz = obj.getClass().getName();
+        ExceptionWrapper bo = new ExceptionWrapper(obj, clazz);
+        this.writeObject(bo);
+    }
+
     @Override
     public void flushBuffer() throws IOException {
         writer.flush();

--- a/dubbo-serialization/dubbo-serialization-gson/src/test/java/org/apache/dubbo/common/serialize/gson/GsonJsonObjectOutputTest.java
+++ b/dubbo-serialization/dubbo-serialization-gson/src/test/java/org/apache/dubbo/common/serialize/gson/GsonJsonObjectOutputTest.java
@@ -135,6 +135,26 @@ public class GsonJsonObjectOutputTest {
         assertThat(readObjectForImage, is(image));
     }
 
+    public class BizException extends RuntimeException {
+
+        public BizException(String message) {
+            super(message);
+        }
+
+    }
+
+
+    @Test
+    public void testWriteThrowable() throws IOException, ClassNotFoundException {
+        BizException exception = new BizException("biz_exception");
+        this.gsonJsonObjectOutput.writeThrowable(exception);
+        this.flushToInput();
+        Throwable ex = this.gsonJsonObjectInput.readThrowable();
+        assertThat(ex.getMessage(), is("biz_exception"));
+        assertThat(ex.getClass(), is(BizException.class));
+
+    }
+
     private void flushToInput() throws IOException {
         this.gsonJsonObjectOutput.flushBuffer();
         this.byteArrayInputStream = new ByteArrayInputStream(byteArrayOutputStream.toByteArray());


### PR DESCRIPTION
Using Gson serialization can cause Exception messages to be lost
当选用gson作为序列化协议后,如果provider返回异常,则异常信息会全部丢掉
原因:gson的反序列化协议哪里写的有点问题,默认传入Object.class后,会拿到Map.
![1](https://user-images.githubusercontent.com/869986/117237621-ead5be00-ae5d-11eb-8fe2-122ddd31bec2.png)
![2](https://user-images.githubusercontent.com/869986/117237724-1a84c600-ae5e-11eb-9612-34f9ab779d70.png)
这里有一个挺有意思的点,就是为啥fastjson没有此问题
![3](https://user-images.githubusercontent.com/869986/117237776-38522b00-ae5e-11eb-92f2-545fa6042aba.png)

