### PR TITLE
fix: Address already in use in ConfigTest#testDubboProtocolPortOverride (#7695)

### DIFF
--- a/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/ConfigTest.java
+++ b/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/ConfigTest.java
@@ -993,7 +993,7 @@ public class ConfigTest {
 
     @Test
     public void testDubboProtocolPortOverride() throws Exception {
-        int port = 55555;
+        int port = NetUtils.getAvailablePort();
         System.setProperty("dubbo.protocol.dubbo.port", String.valueOf(port));
         ServiceConfig<DemoService> service = null;
         DubboBootstrap bootstrap = null;


### PR DESCRIPTION
Solve the problem of Address already in use in ConfigTest#testDubboProtocolPortOverride

## What is the purpose of the change

Fix the bug in ConfigTest#testDubboProtocolPortOverride, see #7695

## Brief changelog

Make the port available

## Verifying this change


<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [X] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [X] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [X] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [X] Run `mvn clean install -DskipTests=false` & `mvn clean test-compile failsafe:integration-test` to make sure unit-test and integration-test pass.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
