### PR TITLE
Revert "Optimize code to remove useless objects (#7582)"

### DIFF
--- a/dubbo-compatible/src/main/java/com/alibaba/dubbo/rpc/RpcInvocation.java
+++ b/dubbo-compatible/src/main/java/com/alibaba/dubbo/rpc/RpcInvocation.java
@@ -160,16 +160,15 @@ public class RpcInvocation implements Invocation, Serializable {
             attachments.put(key, value);
         }
     }
-  
+
     public void addAttachments(Map<String, String> attachments) {
         if (attachments == null) {
             return;
         }
         if (this.attachments == null) {
-            this.attachments = attachments;
-        }else{
-            this.attachments.putAll(attachments);
+            this.attachments = new HashMap<String, String>();
         }
+        this.attachments.putAll(attachments);
     }
 
     public void addAttachmentsIfAbsent(Map<String, String> attachments) {


### PR DESCRIPTION

## What is the purpose of the change

This reverts commit d6252081

When RpcInvocation's attachemtns is null, it will share attachments.
It's indeed risk.
Thanks for your remind. @gonwan


