### PR TITLE
The dubbo2.7.x version is based on the registry-type to confirm whether to use applicant_first or force_interface.

### DIFF
--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/support/registry/ZoneAwareClusterInvoker.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/support/registry/ZoneAwareClusterInvoker.java
@@ -63,7 +63,8 @@ public class ZoneAwareClusterInvoker<T> extends AbstractClusterInvoker<T> {
 
     private static final String PREFER_REGISTRY_WITH_ZONE_KEY = REGISTRY_KEY + "." + ZONE_KEY;
 
-    private final LoadBalance loadBalanceAmongRegistries = ExtensionLoader.getExtensionLoader(LoadBalance.class).getExtension(LOADBALANCE_AMONG_REGISTRIES);
+    private final LoadBalance loadBalanceAmongRegistries =
+            ExtensionLoader.getExtensionLoader(LoadBalance.class).getExtension(LOADBALANCE_AMONG_REGISTRIES);
 
     public ZoneAwareClusterInvoker(Directory<T> directory) {
         super(directory);
@@ -86,7 +87,8 @@ public class ZoneAwareClusterInvoker<T> extends AbstractClusterInvoker<T> {
         if (StringUtils.isNotEmpty(zone)) {
             for (Invoker<T> invoker : invokers) {
                 ClusterInvoker<T> clusterInvoker = (ClusterInvoker<T>) invoker;
-                if (clusterInvoker.isAvailable() && zone.equals(clusterInvoker.getRegistryUrl().getParameter(PREFER_REGISTRY_WITH_ZONE_KEY))) {
+                if (clusterInvoker.isAvailable() &&
+                        zone.equals(clusterInvoker.getRegistryUrl().getParameter(PREFER_REGISTRY_WITH_ZONE_KEY))) {
                     return clusterInvoker.invoke(invocation);
                 }
             }
@@ -94,7 +96,8 @@ public class ZoneAwareClusterInvoker<T> extends AbstractClusterInvoker<T> {
             if (StringUtils.isNotEmpty(force) && "true".equalsIgnoreCase(force)) {
                 throw new IllegalStateException("No registry instance in zone or no available providers in the registry, zone: "
                         + zone
-                        + ", registries: " + invokers.stream().map(invoker -> ((MockClusterInvoker<T>) invoker).getRegistryUrl().toString()).collect(Collectors.joining(",")));
+                        + ", registries: " + invokers.stream().map(invoker -> ((MockClusterInvoker<T>) invoker).getRegistryUrl().toString())
+                        .collect(Collectors.joining(",")));
             }
         }
 
@@ -156,7 +159,8 @@ public class ZoneAwareClusterInvoker<T> extends AbstractClusterInvoker<T> {
 
             // inconsistency rule
             if (!rule.equals(migrationClusterInvoker.getMigrationRule())) {
-                rule = MigrationRule.queryRule();
+                String defaultStep = MigrationRule.getDefaultStep(migrationClusterInvoker.getRegistryUrl());
+                rule = MigrationRule.queryRule(defaultStep);
                 break;
             }
         }
@@ -187,7 +191,8 @@ public class ZoneAwareClusterInvoker<T> extends AbstractClusterInvoker<T> {
                 }
 
                 if (logger.isDebugEnabled()) {
-                    logger.debug("step is APPLICATION_FIRST " + (serviceInvokers.isEmpty() ? "serviceInvokers is empty" : "shouldMigrate false") + " get interfaceInvokers");
+                    logger.debug("step is APPLICATION_FIRST " +
+                            (serviceInvokers.isEmpty() ? "serviceInvokers is empty" : "shouldMigrate false") + " get interfaceInvokers");
                 }
 
                 return interfaceInvokers;
@@ -208,7 +213,8 @@ public class ZoneAwareClusterInvoker<T> extends AbstractClusterInvoker<T> {
 
 
     private boolean shouldMigrate(boolean addressChanged, List<Invoker<T>> serviceInvokers, List<Invoker<T>> interfaceInvokers) {
-        Set<MigrationClusterComparator> detectors = ExtensionLoader.getExtensionLoader(MigrationClusterComparator.class).getSupportedExtensionInstances();
+        Set<MigrationClusterComparator> detectors =
+                ExtensionLoader.getExtensionLoader(MigrationClusterComparator.class).getSupportedExtensionInstances();
         if (detectors != null && !detectors.isEmpty()) {
             return detectors.stream().allMatch(s -> s.shouldMigrate(interfaceInvokers, serviceInvokers));
         }

--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/migration/MigrationRuleHandler.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/migration/MigrationRuleHandler.java
@@ -35,7 +35,9 @@ public class MigrationRuleHandler<T> {
     private MigrationStep currentStep;
 
     public void doMigrate(String rawRule) {
-        MigrationRule rule = MigrationRule.parse(rawRule);
+        String defaultStep = MigrationRule.getDefaultStep(migrationInvoker.getRegistryUrl());
+
+        MigrationRule rule = MigrationRule.parse(rawRule, defaultStep);
 
         if (null != currentStep && currentStep.equals(rule.getStep())) {
             if (logger.isInfoEnabled()) {


### PR DESCRIPTION
## What is the purpose of the change

The dubbo2.7.x version is based on the registry-type to confirm whether to use applicant_first or force_interface.

see more detail from #7703 

## Brief changelog


## Verifying this change


<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Run `mvn clean install -DskipTests=false` & `mvn clean test-compile failsafe:integration-test` to make sure unit-test and integration-test pass.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
