### PR TITLE
Fix consumer side call DefaultExecutorRepository#getExecutor method cannot hit the cache when use the service discovery pattern

### DIFF
--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/InstanceAddressURL.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/InstanceAddressURL.java
@@ -29,6 +29,8 @@ import static org.apache.dubbo.common.constants.CommonConstants.GROUP_KEY;
 import static org.apache.dubbo.common.constants.CommonConstants.INTERFACE_KEY;
 import static org.apache.dubbo.common.constants.CommonConstants.REMOTE_APPLICATION_KEY;
 import static org.apache.dubbo.common.constants.CommonConstants.VERSION_KEY;
+import static org.apache.dubbo.common.constants.CommonConstants.SIDE_KEY;
+import static org.apache.dubbo.common.constants.CommonConstants.CONSUMER_SIDE;
 
 public class InstanceAddressURL extends URL {
     private ServiceInstance instance;
@@ -108,6 +110,8 @@ public class InstanceAddressURL extends URL {
             return getServiceInterface();
         } else if (REMOTE_APPLICATION_KEY.equals(key)) {
             return instance.getServiceName();
+        } else if (SIDE_KEY.equals(key)) {
+            return CONSUMER_SIDE;
         }
 
         String protocolServiceKey = getProtocolServiceKey();


### PR DESCRIPTION
issue #7718