### PR TITLE
Revert "Fix consumer side call DefaultExecutorRepository#getExecutor method cannot hit the cache when use the service discovery pattern "

### DIFF
--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/InstanceAddressURL.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/InstanceAddressURL.java
@@ -29,8 +29,6 @@ import static org.apache.dubbo.common.constants.CommonConstants.GROUP_KEY;
 import static org.apache.dubbo.common.constants.CommonConstants.INTERFACE_KEY;
 import static org.apache.dubbo.common.constants.CommonConstants.REMOTE_APPLICATION_KEY;
 import static org.apache.dubbo.common.constants.CommonConstants.VERSION_KEY;
-import static org.apache.dubbo.common.constants.CommonConstants.SIDE_KEY;
-import static org.apache.dubbo.common.constants.CommonConstants.CONSUMER_SIDE;
 
 public class InstanceAddressURL extends URL {
     private ServiceInstance instance;
@@ -110,8 +108,6 @@ public class InstanceAddressURL extends URL {
             return getServiceInterface();
         } else if (REMOTE_APPLICATION_KEY.equals(key)) {
             return instance.getServiceName();
-        } else if (SIDE_KEY.equals(key)) {
-            return CONSUMER_SIDE;
         }
 
         String protocolServiceKey = getProtocolServiceKey();


### PR DESCRIPTION
I'm sorry, There was a problem with #7717 PR before. There are some gaps in my understanding.

In consumer side,`DefaultExecutorRepository#getExecutor` in acquiring `side` parameter value is `null` because not RPC calls, but some of the other events, such as `channelActive` (use SHARED_EXECUTOR).

If an RPC call is made, `InvokerInvocationHandler#invoke` calls `RpcContext.setRpcContext(invoker.getUrl());` So `DefaultExecutorRepository#getExecutor` ->`InstanceAddressURL#getParameter `will get the `side` parameter and its value is `consumer`

So the cached Executor can only be used if the consumer initiates the RPC call, and SHARED_EXECUTOR is used for other network events

// ====================================================================
Here is the screenshot

In consumer side, `channelActive` event use SHARED_EXECUTOR:
![image](https://user-images.githubusercontent.com/43363120/117760088-9795ae00-b257-11eb-9c13-4ec59a3461c0.png)


In consumer side, RPC call use previous cached executor:
![image](https://user-images.githubusercontent.com/43363120/117760126-ac724180-b257-11eb-8e6a-74362ffd7019.png)

