### PR TITLE
[Dubbo-7514]Ignore "dubbo" namespace when using nacos registry and metadata center

### DIFF
--- a/dubbo-configcenter/dubbo-configcenter-nacos/src/main/java/org/apache/dubbo/configcenter/support/nacos/NacosDynamicConfigurationFactory.java
+++ b/dubbo-configcenter/dubbo-configcenter-nacos/src/main/java/org/apache/dubbo/configcenter/support/nacos/NacosDynamicConfigurationFactory.java
@@ -22,7 +22,7 @@ import org.apache.dubbo.common.config.configcenter.AbstractDynamicConfigurationF
 import org.apache.dubbo.common.config.configcenter.DynamicConfiguration;
 import org.apache.dubbo.common.constants.CommonConstants;
 
-import com.alibaba.nacos.api.PropertyKeyConst;
+import static org.apache.dubbo.common.constants.CommonConstants.CONFIG_NAMESPACE_KEY;
 
 /**
  * The nacos implementation of {@link AbstractDynamicConfigurationFactory}
@@ -32,9 +32,9 @@ public class NacosDynamicConfigurationFactory extends AbstractDynamicConfigurati
     @Override
     protected DynamicConfiguration createDynamicConfiguration(URL url) {
         URL nacosURL = url;
-        if (CommonConstants.DUBBO.equals(url.getParameter(PropertyKeyConst.NAMESPACE))) {
+        if (CommonConstants.DUBBO.equals(url.getParameter(CONFIG_NAMESPACE_KEY))) {
             // Nacos use empty string as default name space, replace default namespace "dubbo" to ""
-            nacosURL = url.removeParameter(PropertyKeyConst.NAMESPACE);
+            nacosURL = url.removeParameter(CONFIG_NAMESPACE_KEY);
         }
         return new NacosDynamicConfiguration(nacosURL);
     }

--- a/dubbo-metadata/dubbo-metadata-report-nacos/src/main/java/org/apache/dubbo/metadata/store/nacos/NacosMetadataReportFactory.java
+++ b/dubbo-metadata/dubbo-metadata-report-nacos/src/main/java/org/apache/dubbo/metadata/store/nacos/NacosMetadataReportFactory.java
@@ -18,8 +18,11 @@
 package org.apache.dubbo.metadata.store.nacos;
 
 import org.apache.dubbo.common.URL;
+import org.apache.dubbo.common.constants.CommonConstants;
 import org.apache.dubbo.metadata.report.MetadataReport;
 import org.apache.dubbo.metadata.report.support.AbstractMetadataReportFactory;
+
+import static org.apache.dubbo.common.constants.CommonConstants.CONFIG_NAMESPACE_KEY;
 
 /**
  * metadata report factory impl for nacos
@@ -27,6 +30,11 @@ import org.apache.dubbo.metadata.report.support.AbstractMetadataReportFactory;
 public class NacosMetadataReportFactory extends AbstractMetadataReportFactory {
     @Override
     protected MetadataReport createMetadataReport(URL url) {
-        return new NacosMetadataReport(url);
+        URL nacosURL = url;
+        if (CommonConstants.DUBBO.equals(url.getParameter(CONFIG_NAMESPACE_KEY))) {
+            // ignore "dubbo" namespace, make the behavior equivalent to configcenter
+            nacosURL = url.removeParameter(CONFIG_NAMESPACE_KEY);
+        }
+        return new NacosMetadataReport(nacosURL);
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

fix #7514 