### PR TITLE
Fix #6833 method annotation oninvoke do not work

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/config/MethodConfig.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/config/MethodConfig.java
@@ -136,13 +136,25 @@ public class MethodConfig extends AbstractMethodConfig {
         this.setReturn(method.isReturn());
 
         if(!"".equals(method.oninvoke())){
-            this.setOninvoke(method.oninvoke());
+            int index = method.oninvoke().lastIndexOf(".");
+            String ref = method.oninvoke().substring(0, index);
+            String methodName = method.oninvoke().substring(index + 1);
+            this.setOninvoke(ref);
+            this.setOninvokeMethod(methodName);
         }
         if(!"".equals(method.onreturn())){
-            this.setOnreturn(method.onreturn());
+            int index = method.onreturn().lastIndexOf(".");
+            String ref = method.onreturn().substring(0, index);
+            String methodName = method.onreturn().substring(index + 1);
+            this.setOnreturn(ref);
+            this.setOnreturnMethod(methodName);
         }
         if(!"".equals(method.onthrow())){
-            this.setOnthrow(method.onthrow());
+            int index = method.onthrow().lastIndexOf(".");
+            String ref = method.onthrow().substring(0, index);
+            String methodName = method.onthrow().substring(index + 1);
+            this.setOnthrow(ref);
+            this.setOnthrowMethod(methodName);
         }
 
         if (method.arguments() != null && method.arguments().length != 0) {

--- a/dubbo-common/src/main/java/org/apache/dubbo/config/MethodConfig.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/config/MethodConfig.java
@@ -135,22 +135,24 @@ public class MethodConfig extends AbstractMethodConfig {
 
         this.setReturn(method.isReturn());
 
-        if(!"".equals(method.oninvoke())){
-            int index = method.oninvoke().lastIndexOf(".");
+        String split = ".";
+
+        if (!"".equals(method.oninvoke()) && method.oninvoke().lastIndexOf(split) > 0) {
+            int index = method.oninvoke().lastIndexOf(split);
             String ref = method.oninvoke().substring(0, index);
             String methodName = method.oninvoke().substring(index + 1);
             this.setOninvoke(ref);
             this.setOninvokeMethod(methodName);
         }
-        if(!"".equals(method.onreturn())){
-            int index = method.onreturn().lastIndexOf(".");
+        if (!"".equals(method.onreturn()) && method.onreturn().lastIndexOf(split) > 0) {
+            int index = method.onreturn().lastIndexOf(split);
             String ref = method.onreturn().substring(0, index);
             String methodName = method.onreturn().substring(index + 1);
             this.setOnreturn(ref);
             this.setOnreturnMethod(methodName);
         }
-        if(!"".equals(method.onthrow())){
-            int index = method.onthrow().lastIndexOf(".");
+        if (!"".equals(method.onthrow()) && method.onthrow().lastIndexOf(split) > 0) {
+            int index = method.onthrow().lastIndexOf(split);
             String ref = method.onthrow().substring(0, index);
             String methodName = method.onthrow().substring(index + 1);
             this.setOnthrow(ref);

--- a/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/MethodConfigTest.java
+++ b/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/MethodConfigTest.java
@@ -53,9 +53,15 @@ public class MethodConfigTest {
     private static final int EXECUTES = 5;
     private static final boolean DEPERECATED = true;
     private static final boolean STICKY = true;
-    private static final String ONINVOKE = "i";
-    private static final String ONTHROW = "t";
-    private static final String ONRETURN = "r";
+    private static final String ONINVOKE = "instance";
+    private static final String ONTHROW = "instance";
+    private static final String ONRETURN = "instance";
+    private static final String ONINVOKEMETHOD = "i";
+    private static final String ONTHROWMETHOD = "t";
+    private static final String ONRETURNMETHOD = "r";
+    private static final String REFERONINVOKE = "instance.i";
+    private static final String REFERONTHROW = "instance.t";
+    private static final String REFERONRETURN = "instance.r";
     private static final String CACHE = "c";
     private static final String VALIDATION = "v";
     private static final int ARGUMENTS_INDEX = 24;
@@ -63,7 +69,7 @@ public class MethodConfigTest {
     private static final String ARGUMENTS_TYPE = "sss";
 
     @Reference(methods = {@Method(name = METHOD_NAME, timeout = TIMEOUT, retries = RETRIES, loadbalance = LOADBALANCE, async = ASYNC,
-            actives = ACTIVES, executes = EXECUTES, deprecated = DEPERECATED, sticky = STICKY, oninvoke = ONINVOKE, onthrow = ONTHROW, onreturn = ONRETURN, cache = CACHE, validation = VALIDATION,
+            actives = ACTIVES, executes = EXECUTES, deprecated = DEPERECATED, sticky = STICKY, oninvoke = REFERONINVOKE, onthrow = REFERONTHROW, onreturn = REFERONRETURN, cache = CACHE, validation = VALIDATION,
             arguments = {@Argument(index = ARGUMENTS_INDEX, callback = ARGUMENTS_CALLBACK, type = ARGUMENTS_TYPE)})})
     private String testField;
 
@@ -82,9 +88,12 @@ public class MethodConfigTest {
         assertThat(EXECUTES, equalTo(methodConfig.getExecutes().intValue()));
         assertThat(DEPERECATED, equalTo(methodConfig.getDeprecated()));
         assertThat(STICKY, equalTo(methodConfig.getSticky()));
+        assertThat(ONINVOKEMETHOD, equalTo(methodConfig.getOninvokeMethod()));
+        assertThat(ONTHROWMETHOD, equalTo(methodConfig.getOnthrowMethod()));
+        assertThat(ONRETURNMETHOD, equalTo(methodConfig.getOnreturnMethod()));
         assertThat(ONINVOKE, equalTo(methodConfig.getOninvoke()));
-        assertThat(ONTHROW, equalTo(methodConfig.getOnthrow()));
-        assertThat(ONRETURN, equalTo(methodConfig.getOnreturn()));
+        assertThat(ONRETURN, equalTo(methodConfig.getOnthrow()));
+        assertThat(ONTHROW, equalTo(methodConfig.getOnreturn()));
         assertThat(CACHE, equalTo(methodConfig.getCache()));
         assertThat(VALIDATION, equalTo(methodConfig.getValidation()));
         assertThat(ARGUMENTS_INDEX, equalTo(methodConfig.getArguments().get(0).getIndex().intValue()));

--- a/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/beans/factory/annotation/ReferenceBeanBuilder.java
+++ b/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/beans/factory/annotation/ReferenceBeanBuilder.java
@@ -89,6 +89,22 @@ class ReferenceBeanBuilder extends AnnotatedInterfaceConfigBeanBuilder<Reference
     void configureMethodConfig(AnnotationAttributes attributes, ReferenceBean<?> referenceBean) {
         Method[] methods = (Method[]) attributes.get("methods");
         List<MethodConfig> methodConfigs = MethodConfig.constructMethodConfig(methods);
+
+        for (MethodConfig methodConfig : methodConfigs) {
+            if (!StringUtils.isEmpty(methodConfig.getOninvoke())) {
+                Object invokeRef = this.applicationContext.getBean((String) methodConfig.getOninvoke());
+                methodConfig.setOninvoke(invokeRef);
+            }
+            if (!StringUtils.isEmpty(methodConfig.getOnreturn())) {
+                Object returnRef = this.applicationContext.getBean((String) methodConfig.getOnreturn());
+                methodConfig.setOnreturn(returnRef);
+            }
+            if (!StringUtils.isEmpty(methodConfig.getOnthrow())) {
+                Object throwRef = this.applicationContext.getBean((String) methodConfig.getOnthrow());
+                methodConfig.setOnthrow(throwRef);
+            }
+        }
+
         if (!methodConfigs.isEmpty()) {
             referenceBean.setMethods(methodConfigs);
         }

--- a/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/api/Notify.java
+++ b/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/api/Notify.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.dubbo.config.spring.api;
+
+public interface Notify {
+    void oninvoke(String request);
+
+    void onreturn(String response, String request);
+
+    void onthrow(Throwable ex, String request);
+
+    String getOnInvoke();
+
+    String getOnReturn();
+
+    String getOnThrow();
+}

--- a/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/impl/NotifyImpl.java
+++ b/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/impl/NotifyImpl.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.dubbo.config.spring.impl;
+
+
+import org.apache.dubbo.config.spring.api.Notify;
+
+public class NotifyImpl implements Notify {
+
+    private String onInvoke;
+    private String onReturn;
+    private String onThrow;
+
+    @Override
+    public void oninvoke(String request) {
+        this.onInvoke = "dubbo invoke success";
+    }
+
+    @Override
+    public void onreturn(String response, String request) {
+        this.onReturn = "dubbo return success";
+    }
+
+    @Override
+    public void onthrow(Throwable ex, String request) {
+        this.onThrow = "dubbo throw exception";
+    }
+
+    public String getOnInvoke() {
+        return this.onInvoke;
+    }
+
+    public String getOnReturn() {
+        return this.onReturn;
+    }
+
+    public String getOnThrow() {
+        return this.onThrow;
+    }
+
+}


### PR DESCRIPTION
## What is the purpose of the change

fix #6833 the method annotation oninvoke,onreturn,onthrow do not work

## Verifying this change


<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Run `mvn clean install -DskipTests=false` & `mvn clean test-compile failsafe:integration-test` to make sure unit-test and integration-test pass.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
