### PR TITLE
RpcInvocation adds returnType assignment in initParameterDesc

### DIFF
--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/RpcInvocation.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/RpcInvocation.java
@@ -125,7 +125,6 @@ public class RpcInvocation implements Invocation, Serializable {
 
     public RpcInvocation(Method method, String serviceName, String protocolServiceKey, Object[] arguments, Map<String, Object> attachment, Map<Object, Object> attributes) {
         this(method.getName(), serviceName, protocolServiceKey, method.getParameterTypes(), arguments, attachment, null, attributes);
-        this.returnType = method.getReturnType();
     }
 
     public RpcInvocation(String methodName, String serviceName, String protocolServiceKey, Class<?>[] parameterTypes, Object[] arguments) {
@@ -181,10 +180,12 @@ public class RpcInvocation implements Invocation, Serializable {
         this.invoker = invoker;
     }
 
+    @Override
     public Object put(Object key, Object value) {
         return attributes.put(key, value);
     }
 
+    @Override
     public Object get(Object key) {
         return attributes.get(key);
     }
@@ -243,6 +244,7 @@ public class RpcInvocation implements Invocation, Serializable {
         this.parameterTypesDesc = parameterTypesDesc;
     }
 
+    @Override
     public String[] getCompatibleParamSignatures() {
         return compatibleParamSignatures;
     }
@@ -287,6 +289,7 @@ public class RpcInvocation implements Invocation, Serializable {
         this.attachments = attachments == null ? new HashMap<>() : attachments;
     }
 
+    @Override
     public void setAttachment(String key, Object value) {
        setObjectAttachment(key, value);
     }
@@ -304,6 +307,7 @@ public class RpcInvocation implements Invocation, Serializable {
         setObjectAttachmentIfAbsent(key, value);
     }
 
+    @Override
     public void setAttachmentIfAbsent(String key, Object value) {
         setObjectAttachmentIfAbsent(key, value);
     }
@@ -398,6 +402,7 @@ public class RpcInvocation implements Invocation, Serializable {
     }
 
     @Deprecated
+    @Override
     public Object getObjectAttachment(String key, Object defaultValue) {
         if (attachments == null) {
             return defaultValue;

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/RpcInvocation.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/RpcInvocation.java
@@ -159,6 +159,7 @@ public class RpcInvocation implements Invocation, Serializable {
                     this.parameterTypesDesc = methodDescriptor.getParamDesc();
                     this.compatibleParamSignatures = methodDescriptor.getCompatibleParamSignatures();
                     this.returnTypes = methodDescriptor.getReturnTypes();
+                    this.returnType = methodDescriptor.getReturnClass();
                 }
             }
         }
@@ -167,6 +168,7 @@ public class RpcInvocation implements Invocation, Serializable {
             this.parameterTypesDesc = ReflectUtils.getDesc(this.getParameterTypes());
             this.compatibleParamSignatures = Stream.of(this.parameterTypes).map(Class::getName).toArray(String[]::new);
             this.returnTypes = RpcUtils.getReturnTypes(this);
+            this.returnType = RpcUtils.getReturnType(this);
         }
     }
 

--- a/dubbo-rpc/dubbo-rpc-api/src/test/java/org/apache/dubbo/rpc/support/RpcUtilsTest.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/test/java/org/apache/dubbo/rpc/support/RpcUtilsTest.java
@@ -21,6 +21,8 @@ import org.apache.dubbo.rpc.Invocation;
 import org.apache.dubbo.rpc.Invoker;
 import org.apache.dubbo.rpc.RpcInvocation;
 
+import org.apache.dubbo.rpc.model.ApplicationModel;
+import org.apache.dubbo.rpc.model.ServiceRepository;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -51,7 +53,7 @@ public class RpcUtilsTest {
         URL url = URL.valueOf("dubbo://localhost/?test.async=true");
         Map<String, Object> attachments = new HashMap<>();
         attachments.put("aa", "bb");
-        Invocation inv = new RpcInvocation("test", "DemoService", "", new Class[]{}, new String[]{}, attachments);
+        Invocation inv = new RpcInvocation("test", "DemoService", "", new Class[] {}, new String[] {}, attachments);
         RpcUtils.attachInvocationIdIfAsync(url, inv);
         long id1 = RpcUtils.getInvocationId(inv);
         RpcUtils.attachInvocationIdIfAsync(url, inv);
@@ -68,7 +70,7 @@ public class RpcUtilsTest {
     @Test
     public void testAttachInvocationIdIfAsync_sync() {
         URL url = URL.valueOf("dubbo://localhost/");
-        Invocation inv = new RpcInvocation("test", "DemoService", "", new Class[]{}, new String[]{});
+        Invocation inv = new RpcInvocation("test", "DemoService", "", new Class[] {}, new String[] {});
         RpcUtils.attachInvocationIdIfAsync(url, inv);
         assertNull(RpcUtils.getInvocationId(inv));
     }
@@ -80,7 +82,7 @@ public class RpcUtilsTest {
     @Test
     public void testAttachInvocationIdIfAsync_nullAttachments() {
         URL url = URL.valueOf("dubbo://localhost/?test.async=true");
-        Invocation inv = new RpcInvocation("test", "DemoService", "", new Class[]{}, new String[]{});
+        Invocation inv = new RpcInvocation("test", "DemoService", "", new Class[] {}, new String[] {});
         RpcUtils.attachInvocationIdIfAsync(url, inv);
         assertTrue(RpcUtils.getInvocationId(inv) >= 0L);
     }
@@ -92,7 +94,7 @@ public class RpcUtilsTest {
     @Test
     public void testAttachInvocationIdIfAsync_forceNotAttache() {
         URL url = URL.valueOf("dubbo://localhost/?test.async=true&" + AUTO_ATTACH_INVOCATIONID_KEY + "=false");
-        Invocation inv = new RpcInvocation("test", "DemoService", "", new Class[]{}, new String[]{});
+        Invocation inv = new RpcInvocation("test", "DemoService", "", new Class[] {}, new String[] {});
         RpcUtils.attachInvocationIdIfAsync(url, inv);
         assertNull(RpcUtils.getInvocationId(inv));
     }
@@ -104,7 +106,7 @@ public class RpcUtilsTest {
     @Test
     public void testAttachInvocationIdIfAsync_forceAttache() {
         URL url = URL.valueOf("dubbo://localhost/?" + AUTO_ATTACH_INVOCATIONID_KEY + "=true");
-        Invocation inv = new RpcInvocation("test", "DemoService", "", new Class[]{}, new String[]{});
+        Invocation inv = new RpcInvocation("test", "DemoService", "", new Class[] {}, new String[] {});
         RpcUtils.attachInvocationIdIfAsync(url, inv);
         assertNotNull(RpcUtils.getInvocationId(inv));
     }
@@ -114,33 +116,35 @@ public class RpcUtilsTest {
         Class<?> demoServiceClass = DemoService.class;
         String serviceName = demoServiceClass.getName();
         Invoker invoker = mock(Invoker.class);
-        given(invoker.getUrl()).willReturn(URL.valueOf("test://127.0.0.1:1/org.apache.dubbo.rpc.support.DemoService?interface=org.apache.dubbo.rpc.support.DemoService"));
+        given(invoker.getUrl()).willReturn(URL.valueOf(
+                "test://127.0.0.1:1/org.apache.dubbo.rpc.support.DemoService?interface=org.apache.dubbo.rpc.support.DemoService"));
 
         // void sayHello(String name);
-        RpcInvocation inv = new RpcInvocation("sayHello", serviceName, "", new Class<?>[]{String.class}, null, null, invoker, null);
+        RpcInvocation inv = new RpcInvocation("sayHello", serviceName, "", new Class<?>[] {String.class}, null, null, invoker, null);
         Class<?> returnType = RpcUtils.getReturnType(inv);
         Assertions.assertNull(returnType);
 
         //String echo(String text);
-        RpcInvocation inv1 = new RpcInvocation("echo", serviceName, "", new Class<?>[]{String.class}, null, null, invoker, null);
+        RpcInvocation inv1 = new RpcInvocation("echo", serviceName, "", new Class<?>[] {String.class}, null, null, invoker, null);
         Class<?> returnType1 = RpcUtils.getReturnType(inv1);
         Assertions.assertNotNull(returnType1);
         Assertions.assertEquals(String.class, returnType1);
 
         //int getSize(String[] strs);
-        RpcInvocation inv2 = new RpcInvocation("getSize", serviceName, "", new Class<?>[]{String[].class}, null, null, invoker, null);
+        RpcInvocation inv2 = new RpcInvocation("getSize", serviceName, "", new Class<?>[] {String[].class}, null, null, invoker, null);
         Class<?> returnType2 = RpcUtils.getReturnType(inv2);
         Assertions.assertNotNull(returnType2);
         Assertions.assertEquals(int.class, returnType2);
 
         //Person getPerson(Person person);
-        RpcInvocation inv3 = new RpcInvocation("getPerson", serviceName, "", new Class<?>[]{Person.class}, null, null, invoker, null);
+        RpcInvocation inv3 = new RpcInvocation("getPerson", serviceName, "", new Class<?>[] {Person.class}, null, null, invoker, null);
         Class<?> returnType3 = RpcUtils.getReturnType(inv3);
         Assertions.assertNotNull(returnType3);
         Assertions.assertEquals(Person.class, returnType3);
 
         //List<String> testReturnType1(String str);
-        RpcInvocation inv4 = new RpcInvocation("testReturnType1", serviceName, "", new Class<?>[]{String.class}, null, null, invoker, null);
+        RpcInvocation inv4 =
+                new RpcInvocation("testReturnType1", serviceName, "", new Class<?>[] {String.class}, null, null, invoker, null);
         Class<?> returnType4 = RpcUtils.getReturnType(inv4);
         Assertions.assertNotNull(returnType4);
         Assertions.assertEquals(List.class, returnType4);
@@ -152,9 +156,10 @@ public class RpcUtilsTest {
         Class<?> demoServiceClass = DemoService.class;
         String serviceName = demoServiceClass.getName();
         Invoker invoker = mock(Invoker.class);
-        given(invoker.getUrl()).willReturn(URL.valueOf("test://127.0.0.1:1/org.apache.dubbo.rpc.support.DemoService?interface=org.apache.dubbo.rpc.support.DemoService"));
+        given(invoker.getUrl()).willReturn(URL.valueOf(
+                "test://127.0.0.1:1/org.apache.dubbo.rpc.support.DemoService?interface=org.apache.dubbo.rpc.support.DemoService"));
 
-        RpcInvocation inv = new RpcInvocation("testReturnType", serviceName, "", new Class<?>[]{String.class}, null, null, invoker, null);
+        RpcInvocation inv = new RpcInvocation("testReturnType", serviceName, "", new Class<?>[] {String.class}, null, null, invoker, null);
         Type[] types = RpcUtils.getReturnTypes(inv);
         Assertions.assertNotNull(types);
         Assertions.assertEquals(2, types.length);
@@ -162,7 +167,8 @@ public class RpcUtilsTest {
         Assertions.assertEquals(String.class, types[1]);
         Assertions.assertArrayEquals(types, inv.getReturnTypes());
 
-        RpcInvocation inv1 = new RpcInvocation("testReturnType1", serviceName, "", new Class<?>[]{String.class}, null, null, invoker, null);
+        RpcInvocation inv1 =
+                new RpcInvocation("testReturnType1", serviceName, "", new Class<?>[] {String.class}, null, null, invoker, null);
         java.lang.reflect.Type[] types1 = RpcUtils.getReturnTypes(inv1);
         Assertions.assertNotNull(types1);
         Assertions.assertEquals(2, types1.length);
@@ -170,7 +176,8 @@ public class RpcUtilsTest {
         Assertions.assertEquals(demoServiceClass.getMethod("testReturnType1", String.class).getGenericReturnType(), types1[1]);
         Assertions.assertArrayEquals(types1, inv1.getReturnTypes());
 
-        RpcInvocation inv2 = new RpcInvocation("testReturnType2", serviceName, "", new Class<?>[]{String.class}, null, null, invoker, null);
+        RpcInvocation inv2 =
+                new RpcInvocation("testReturnType2", serviceName, "", new Class<?>[] {String.class}, null, null, invoker, null);
         java.lang.reflect.Type[] types2 = RpcUtils.getReturnTypes(inv2);
         Assertions.assertNotNull(types2);
         Assertions.assertEquals(2, types2.length);
@@ -178,7 +185,8 @@ public class RpcUtilsTest {
         Assertions.assertEquals(String.class, types2[1]);
         Assertions.assertArrayEquals(types2, inv2.getReturnTypes());
 
-        RpcInvocation inv3 = new RpcInvocation("testReturnType3", serviceName, "", new Class<?>[]{String.class}, null, null, invoker, null);
+        RpcInvocation inv3 =
+                new RpcInvocation("testReturnType3", serviceName, "", new Class<?>[] {String.class}, null, null, invoker, null);
         java.lang.reflect.Type[] types3 = RpcUtils.getReturnTypes(inv3);
         Assertions.assertNotNull(types3);
         Assertions.assertEquals(2, types3.length);
@@ -187,7 +195,8 @@ public class RpcUtilsTest {
         Assertions.assertEquals(((ParameterizedType) genericReturnType3).getActualTypeArguments()[0], types3[1]);
         Assertions.assertArrayEquals(types3, inv3.getReturnTypes());
 
-        RpcInvocation inv4 = new RpcInvocation("testReturnType4", serviceName, "", new Class<?>[]{String.class}, null, null, invoker, null);
+        RpcInvocation inv4 =
+                new RpcInvocation("testReturnType4", serviceName, "", new Class<?>[] {String.class}, null, null, invoker, null);
         java.lang.reflect.Type[] types4 = RpcUtils.getReturnTypes(inv4);
         Assertions.assertNotNull(types4);
         Assertions.assertEquals(2, types4.length);
@@ -195,7 +204,8 @@ public class RpcUtilsTest {
         Assertions.assertNull(types4[1]);
         Assertions.assertArrayEquals(types4, inv4.getReturnTypes());
 
-        RpcInvocation inv5 = new RpcInvocation("testReturnType5", serviceName, "", new Class<?>[]{String.class}, null, null, invoker, null);
+        RpcInvocation inv5 =
+                new RpcInvocation("testReturnType5", serviceName, "", new Class<?>[] {String.class}, null, null, invoker, null);
         java.lang.reflect.Type[] types5 = RpcUtils.getReturnTypes(inv5);
         Assertions.assertNotNull(types5);
         Assertions.assertEquals(2, types5.length);
@@ -213,7 +223,7 @@ public class RpcUtilsTest {
 
         // void sayHello(String name);
         RpcInvocation inv1 = new RpcInvocation("sayHello", serviceName, "",
-                new Class<?>[]{String.class}, null, null, invoker, null);
+                new Class<?>[] {String.class}, null, null, invoker, null);
         Class<?>[] parameterTypes1 = RpcUtils.getParameterTypes(inv1);
         Assertions.assertNotNull(parameterTypes1);
         Assertions.assertEquals(1, parameterTypes1.length);
@@ -226,7 +236,7 @@ public class RpcUtilsTest {
 
         //Type enumlength(Type... types);
         RpcInvocation inv3 = new RpcInvocation("enumlength", serviceName, "",
-                new Class<?>[]{Type.class, Type.class}, null, null, invoker, null);
+                new Class<?>[] {Type.class, Type.class}, null, null, invoker, null);
         Class<?>[] parameterTypes3 = RpcUtils.getParameterTypes(inv3);
         Assertions.assertNotNull(parameterTypes3);
         Assertions.assertEquals(2, parameterTypes3.length);
@@ -235,7 +245,7 @@ public class RpcUtilsTest {
 
         //byte getbyte(byte arg);
         RpcInvocation inv4 = new RpcInvocation("getbyte", serviceName, "",
-                new Class<?>[]{byte.class}, null, null, invoker, null);
+                new Class<?>[] {byte.class}, null, null, invoker, null);
         Class<?>[] parameterTypes4 = RpcUtils.getParameterTypes(inv4);
         Assertions.assertNotNull(parameterTypes4);
         Assertions.assertEquals(1, parameterTypes4.length);
@@ -243,8 +253,8 @@ public class RpcUtilsTest {
 
         //void $invoke(String s1, String s2);
         RpcInvocation inv5 = new RpcInvocation("$invoke", serviceName, "",
-                new Class<?>[]{String.class, String[].class},
-                new Object[]{"method", new String[]{"java.lang.String", "void", "java.lang.Object"}},
+                new Class<?>[] {String.class, String[].class},
+                new Object[] {"method", new String[] {"java.lang.String", "void", "java.lang.Object"}},
                 null, invoker, null);
         Class<?>[] parameterTypes5 = RpcUtils.getParameterTypes(inv5);
         Assertions.assertNotNull(parameterTypes5);
@@ -266,7 +276,7 @@ public class RpcUtilsTest {
         Invoker invoker = mock(Invoker.class);
 
         RpcInvocation inv1 = new RpcInvocation(methodName, serviceName, "",
-                new Class<?>[]{String.class}, null, null, invoker, null);
+                new Class<?>[] {String.class}, null, null, invoker, null);
         String actual = RpcUtils.getMethodName(inv1);
         Assertions.assertNotNull(actual);
         Assertions.assertEquals(methodName, actual);
@@ -284,8 +294,8 @@ public class RpcUtilsTest {
         Invoker invoker = mock(Invoker.class);
 
         RpcInvocation inv = new RpcInvocation("$invoke", serviceName, "",
-                new Class<?>[]{String.class, String[].class},
-                new Object[]{method, new String[]{"java.lang.String", "void", "java.lang.Object"}},
+                new Class<?>[] {String.class, String[].class},
+                new Object[] {method, new String[] {"java.lang.String", "void", "java.lang.Object"}},
                 null, invoker, null);
         String actual = RpcUtils.getMethodName(inv);
         Assertions.assertNotNull(actual);
@@ -295,14 +305,14 @@ public class RpcUtilsTest {
 
     @Test
     public void testGet_$invoke_Arguments() {
-        Object[] args = new Object[]{"hello", "dubbo", 520};
+        Object[] args = new Object[] {"hello", "dubbo", 520};
         Class<?> demoServiceClass = DemoService.class;
         String serviceName = demoServiceClass.getName();
         Invoker invoker = mock(Invoker.class);
 
         RpcInvocation inv = new RpcInvocation("$invoke", serviceName, "",
-                new Class<?>[]{String.class, String[].class, Object[].class},
-                new Object[]{"method", new String[]{}, args},
+                new Class<?>[] {String.class, String[].class, Object[].class},
+                new Object[] {"method", new String[] {}, args},
                 null, invoker, null);
 
         Object[] arguments = RpcUtils.getArguments(inv);
@@ -311,6 +321,24 @@ public class RpcUtilsTest {
             Assertions.assertEquals(args[i].getClass().getName(), arguments[i].getClass().getName());
             Assertions.assertEquals(args[i], arguments[i]);
         }
+    }
+
+    @Test
+    public void testIsReturnTypeFuture() {
+        Class<?> demoServiceClass = DemoService.class;
+        String serviceName = demoServiceClass.getName();
+        Invoker invoker = mock(Invoker.class);
+        given(invoker.getUrl()).willReturn(URL.valueOf(
+                "test://127.0.0.1:1/org.apache.dubbo.rpc.support.DemoService?interface=org.apache.dubbo.rpc.support.DemoService"));
+
+        RpcInvocation inv = new RpcInvocation("testReturnType", serviceName, "", new Class<?>[] {String.class}, null, null, invoker, null);
+        Assertions.assertFalse(RpcUtils.isReturnTypeFuture(inv));
+
+        ServiceRepository repository = ApplicationModel.getServiceRepository();
+        repository.registerService(demoServiceClass);
+
+        inv = new RpcInvocation("testReturnType4", serviceName, "", new Class<?>[] {String.class}, null, null, invoker, null);
+        Assertions.assertTrue(RpcUtils.isReturnTypeFuture(inv));
     }
 
 }


### PR DESCRIPTION
## What is the purpose of the change

RpcInvocation adds returnType assignment in initParameterDesc

see more detail from #7745 

## Brief changelog


## Verifying this change


<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Run `mvn clean install -DskipTests=false` & `mvn clean test-compile failsafe:integration-test` to make sure unit-test and integration-test pass.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
