### PR TITLE
fix_early_postprocessor_bug

### DIFF
--- a/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/util/DubboBeanUtils.java
+++ b/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/util/DubboBeanUtils.java
@@ -21,7 +21,7 @@ import org.apache.dubbo.common.logger.LoggerFactory;
 import org.apache.dubbo.config.spring.beans.factory.annotation.DubboConfigAliasPostProcessor;
 import org.apache.dubbo.config.spring.beans.factory.annotation.ReferenceAnnotationBeanPostProcessor;
 import org.apache.dubbo.config.spring.beans.factory.config.DubboConfigDefaultPropertyValueBeanPostProcessor;
-import org.apache.dubbo.config.spring.beans.factory.config.DubboConfigEarlyInitializationPostProcessor;
+import org.apache.dubbo.config.spring.beans.factory.config.DubboEarlyApplicationContext;
 import org.apache.dubbo.config.spring.context.DubboApplicationListenerRegistrar;
 import org.apache.dubbo.config.spring.context.DubboBootstrapApplicationListener;
 import org.apache.dubbo.config.spring.context.DubboLifecycleComponentApplicationListener;
@@ -89,9 +89,9 @@ public abstract class DubboBeanUtils {
         registerInfrastructureBean(registry, DubboConfigDefaultPropertyValueBeanPostProcessor.BEAN_NAME,
                 DubboConfigDefaultPropertyValueBeanPostProcessor.class);
 
-        // Since 2.7.9 Register DubboConfigEarlyInitializationPostProcessor as an infrastructure Bean
-        registerInfrastructureBean(registry, DubboConfigEarlyInitializationPostProcessor.BEAN_NAME,
-                DubboConfigEarlyInitializationPostProcessor.class);
+        // Since 2.7.9 Register early PostProcessor applicationcontext
+        registerInfrastructureBean(registry, DubboEarlyApplicationContext.BEAN_NAME,
+                DubboEarlyApplicationContext.class);
     }
 
     /**

--- a/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/issues/Issue7752Test.java
+++ b/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/issues/Issue7752Test.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.config.spring.issues;
+
+import org.apache.dubbo.config.spring.context.annotation.EnableDubboConfig;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.beans.factory.config.BeanPostProcessor;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.beans.factory.support.AbstractBeanFactory;
+import org.springframework.beans.factory.support.RootBeanDefinition;
+import org.springframework.context.annotation.*;
+import org.springframework.context.support.AbstractApplicationContext;
+import org.springframework.lang.Nullable;
+import org.springframework.test.annotation.DirtiesContext;
+
+/**
+ * The test-case for https://github.com/apache/dubbo/issues/7752
+ *
+ * @since 2.7.8
+ */
+@Configuration
+@EnableDubboConfig
+@PropertySource("classpath:/META-INF/issue-7752-test.properties")
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+public class Issue7752Test {
+
+    private static final class Issue7752TestBeanPostProcessorChecker implements BeanPostProcessor{
+
+        private ConfigurableListableBeanFactory beanFactory;
+
+        private int beanPostProcessorTargetCount;
+
+        public void setParam(ConfigurableListableBeanFactory beanFactory, int beanPostProcessorTargetCount){
+            this.beanFactory = beanFactory;
+            this.beanPostProcessorTargetCount = beanPostProcessorTargetCount;
+        }
+
+        @Override
+        public Object postProcessBeforeInitialization(Object bean, String beanName) {
+            return bean;
+        }
+
+        @Override
+        public Object postProcessAfterInitialization(Object bean, String beanName) {
+            if (!(bean instanceof BeanPostProcessor) && !isInfrastructureBean(beanName) &&
+                    //need + 1 self
+                    this.beanFactory.getBeanPostProcessorCount() < this.beanPostProcessorTargetCount + 1) {
+                Assertions.assertFalse(true);
+            }
+            return bean;
+        }
+
+        private boolean isInfrastructureBean(@Nullable String beanName) {
+            if (beanName != null && this.beanFactory.containsBeanDefinition(beanName)) {
+                BeanDefinition bd = this.beanFactory.getBeanDefinition(beanName);
+                return (bd.getRole() == RootBeanDefinition.ROLE_INFRASTRUCTURE);
+            }
+            return false;
+        }
+    }
+
+    @Test
+    public void test() throws Exception {
+        Class<?> aClass = Class.forName("org.springframework.context.support.PostProcessorRegistrationDelegate");
+
+        Issue7752TestBeanPostProcessorChecker issue7752TestBeanPostProcessorChecker = new Issue7752TestBeanPostProcessorChecker();
+        Mockito.mockStatic(aClass, new Answer() {
+            @Override
+            public Object answer(InvocationOnMock invocation) throws Throwable {
+                if(invocation.getMethod().getName().equals("registerBeanPostProcessors") && (invocation.getArgument(1) instanceof AbstractApplicationContext)){
+                    ConfigurableListableBeanFactory beanFactory = invocation.getArgument(0);
+
+                    String[] postProcessorNames = beanFactory.getBeanNamesForType(BeanPostProcessor.class, true, false);
+
+                    // Register BeanPostProcessorChecker that logs an info message when
+                    // a bean is created during BeanPostProcessor instantiation, i.e. when
+                    // a bean is not eligible for getting processed by all BeanPostProcessors.
+                    int beanProcessorTargetCount = beanFactory.getBeanPostProcessorCount() + 1 + postProcessorNames.length;
+
+                    issue7752TestBeanPostProcessorChecker.setParam(beanFactory, beanProcessorTargetCount);
+                    beanFactory.addBeanPostProcessor(issue7752TestBeanPostProcessorChecker);
+                    Object o = invocation.callRealMethod();
+                    //((AbstractBeanFactory)beanFactory).getBeanPostProcessors().remove(issue7752TestBeanPostProcessorChecker);
+                    return o;
+                }
+                return invocation.callRealMethod();
+            }
+        });
+        AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(Issue7752Test.class);
+        context.close();
+    }
+
+}

--- a/dubbo-config/dubbo-config-spring/src/test/resources/META-INF/issue-7752-test.properties
+++ b/dubbo-config/dubbo-config-spring/src/test/resources/META-INF/issue-7752-test.properties
@@ -1,6 +1,0 @@
-dubbo.application.name=demo-zk
-dubbo.application.qos-enable=false
-dubbo.protocol.name=dubbo
-dubbo.protocol.port=-1
-dubbo.scan.basePackages=com.example.demo
-dubbo.consumer.check=false

--- a/dubbo-config/dubbo-config-spring/src/test/resources/META-INF/issue-7752-test.properties
+++ b/dubbo-config/dubbo-config-spring/src/test/resources/META-INF/issue-7752-test.properties
@@ -1,0 +1,6 @@
+dubbo.application.name=demo-zk
+dubbo.application.qos-enable=false
+dubbo.protocol.name=dubbo
+dubbo.protocol.port=-1
+dubbo.scan.basePackages=com.example.demo
+dubbo.consumer.check=false

--- a/pom.xml
+++ b/pom.xml
@@ -192,6 +192,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-inline</artifactId>
+            <version>${mockito_version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>cglib</groupId>
             <artifactId>cglib-nodep</artifactId>
             <version>${cglib_version}</version>


### PR DESCRIPTION
## What is the purpose of the change
fix bug 
early post processor must not Registry beanDefinition
BeanPostProcessorChecker check error, because it think the beanprocess size is less than create. so must have some beanprocess not deal with the bean
see spring error:
same 
https://github.com/apache/dubbo-spring-boot-project/issues/786



## Brief changelog


## Verifying this change


<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Run `mvn clean install -DskipTests=false` & `mvn clean test-compile failsafe:integration-test` to make sure unit-test and integration-test pass.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
