### PR TITLE
Fix method annotation callback do not work problem

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/config/MethodConfig.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/config/MethodConfig.java
@@ -136,13 +136,25 @@ public class MethodConfig extends AbstractMethodConfig {
         this.setReturn(method.isReturn());
 
         if(!"".equals(method.oninvoke())){
-            this.setOninvoke(method.oninvoke());
+            int index = method.oninvoke().lastIndexOf(".");
+            String ref = method.oninvoke().substring(0, index);
+            String methodName = method.oninvoke().substring(index + 1);
+            this.setOninvoke(ref);
+            this.setOninvokeMethod(methodName);
         }
         if(!"".equals(method.onreturn())){
-            this.setOnreturn(method.onreturn());
+            int index = method.onreturn().lastIndexOf(".");
+            String ref = method.onreturn().substring(0, index);
+            String methodName = method.onreturn().substring(index + 1);
+            this.setOnreturn(ref);
+            this.setOnreturnMethod(methodName);
         }
         if(!"".equals(method.onthrow())){
-            this.setOnthrow(method.onthrow());
+            int index = method.onthrow().lastIndexOf(".");
+            String ref = method.onthrow().substring(0, index);
+            String methodName = method.onthrow().substring(index + 1);
+            this.setOnthrow(ref);
+            this.setOnthrowMethod(methodName);
         }
 
         if (method.arguments() != null && method.arguments().length != 0) {

--- a/dubbo-common/src/main/java/org/apache/dubbo/config/MethodConfig.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/config/MethodConfig.java
@@ -135,22 +135,24 @@ public class MethodConfig extends AbstractMethodConfig {
 
         this.setReturn(method.isReturn());
 
-        if(!"".equals(method.oninvoke())){
-            int index = method.oninvoke().lastIndexOf(".");
+        String split = ".";
+
+        if (!"".equals(method.oninvoke()) && method.oninvoke().lastIndexOf(split) > 0) {
+            int index = method.oninvoke().lastIndexOf(split);
             String ref = method.oninvoke().substring(0, index);
             String methodName = method.oninvoke().substring(index + 1);
             this.setOninvoke(ref);
             this.setOninvokeMethod(methodName);
         }
-        if(!"".equals(method.onreturn())){
-            int index = method.onreturn().lastIndexOf(".");
+        if (!"".equals(method.onreturn()) && method.onreturn().lastIndexOf(split) > 0) {
+            int index = method.onreturn().lastIndexOf(split);
             String ref = method.onreturn().substring(0, index);
             String methodName = method.onreturn().substring(index + 1);
             this.setOnreturn(ref);
             this.setOnreturnMethod(methodName);
         }
-        if(!"".equals(method.onthrow())){
-            int index = method.onthrow().lastIndexOf(".");
+        if (!"".equals(method.onthrow()) && method.onthrow().lastIndexOf(split) > 0) {
+            int index = method.onthrow().lastIndexOf(split);
             String ref = method.onthrow().substring(0, index);
             String methodName = method.onthrow().substring(index + 1);
             this.setOnthrow(ref);

--- a/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/MethodConfigTest.java
+++ b/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/MethodConfigTest.java
@@ -53,9 +53,12 @@ public class MethodConfigTest {
     private static final int EXECUTES = 5;
     private static final boolean DEPERECATED = true;
     private static final boolean STICKY = true;
-    private static final String ONINVOKE = "i";
-    private static final String ONTHROW = "t";
-    private static final String ONRETURN = "r";
+    private static final String ONINVOKE = "instance.i";
+    private static final String ONTHROW = "instance.t";
+    private static final String ONRETURN = "instance.r";
+    private static final String ONINVOKEMETHOD = "i";
+    private static final String ONTHROWMETHOD = "t";
+    private static final String ONRETURNMETHOD = "r";
     private static final String CACHE = "c";
     private static final String VALIDATION = "v";
     private static final int ARGUMENTS_INDEX = 24;
@@ -82,9 +85,9 @@ public class MethodConfigTest {
         assertThat(EXECUTES, equalTo(methodConfig.getExecutes().intValue()));
         assertThat(DEPERECATED, equalTo(methodConfig.getDeprecated()));
         assertThat(STICKY, equalTo(methodConfig.getSticky()));
-        assertThat(ONINVOKE, equalTo(methodConfig.getOninvoke()));
-        assertThat(ONTHROW, equalTo(methodConfig.getOnthrow()));
-        assertThat(ONRETURN, equalTo(methodConfig.getOnreturn()));
+        assertThat(ONINVOKEMETHOD, equalTo(methodConfig.getOninvokeMethod()));
+        assertThat(ONTHROWMETHOD, equalTo(methodConfig.getOnthrowMethod()));
+        assertThat(ONRETURNMETHOD, equalTo(methodConfig.getOnreturnMethod()));
         assertThat(CACHE, equalTo(methodConfig.getCache()));
         assertThat(VALIDATION, equalTo(methodConfig.getValidation()));
         assertThat(ARGUMENTS_INDEX, equalTo(methodConfig.getArguments().get(0).getIndex().intValue()));

--- a/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/ReferenceConfigTest.java
+++ b/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/ReferenceConfigTest.java
@@ -159,15 +159,15 @@ public class ReferenceConfigTest {
         Assertions.assertEquals(3, (int) ((MethodConfig) referenceConfig.getMethods().get(0)).getActives());
         Assertions.assertEquals(5, (int) ((MethodConfig) referenceConfig.getMethods().get(0)).getExecutes());
         Assertions.assertTrue(((MethodConfig) referenceConfig.getMethods().get(0)).isAsync());
-        Assertions.assertEquals(((MethodConfig) referenceConfig.getMethods().get(0)).getOninvoke(), "i");
-        Assertions.assertEquals(((MethodConfig) referenceConfig.getMethods().get(0)).getOnreturn(), "r");
-        Assertions.assertEquals(((MethodConfig) referenceConfig.getMethods().get(0)).getOnthrow(), "t");
+        Assertions.assertEquals(((MethodConfig) referenceConfig.getMethods().get(0)).getOninvokeMethod(), "i");
+        Assertions.assertEquals(((MethodConfig) referenceConfig.getMethods().get(0)).getOnreturnMethod(), "r");
+        Assertions.assertEquals(((MethodConfig) referenceConfig.getMethods().get(0)).getOnthrowMethod(), "t");
         Assertions.assertEquals(((MethodConfig) referenceConfig.getMethods().get(0)).getCache(), "c");
     }
 
 
     @Reference(methods = {@Method(name = "sayHello", timeout = 1300, retries = 4, loadbalance = "random", async = true,
-            actives = 3, executes = 5, deprecated = true, sticky = true, oninvoke = "i", onthrow = "t", onreturn = "r", cache = "c", validation = "v",
+            actives = 3, executes = 5, deprecated = true, sticky = true, oninvoke = "instance.i", onthrow = "instance.t", onreturn = "instance.r", cache = "c", validation = "v",
             arguments = {@Argument(index = 24, callback = true, type = "sss")})})
     private InnerTest innerTest;
 

--- a/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/beans/factory/annotation/ReferenceBeanBuilder.java
+++ b/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/beans/factory/annotation/ReferenceBeanBuilder.java
@@ -89,6 +89,22 @@ class ReferenceBeanBuilder extends AnnotatedInterfaceConfigBeanBuilder<Reference
     void configureMethodConfig(AnnotationAttributes attributes, ReferenceBean<?> referenceBean) {
         Method[] methods = (Method[]) attributes.get("methods");
         List<MethodConfig> methodConfigs = MethodConfig.constructMethodConfig(methods);
+
+        for (MethodConfig methodConfig : methodConfigs) {
+            if (!StringUtils.isEmpty(methodConfig.getOninvoke())) {
+                Object invokeRef = this.applicationContext.getBean((String) methodConfig.getOninvoke());
+                methodConfig.setOninvoke(invokeRef);
+            }
+            if (!StringUtils.isEmpty(methodConfig.getOnreturn())) {
+                Object returnRef = this.applicationContext.getBean((String) methodConfig.getOnreturn());
+                methodConfig.setOnreturn(returnRef);
+            }
+            if (!StringUtils.isEmpty(methodConfig.getOnthrow())) {
+                Object throwRef = this.applicationContext.getBean((String) methodConfig.getOnthrow());
+                methodConfig.setOnthrow(throwRef);
+            }
+        }
+
         if (!methodConfigs.isEmpty()) {
             referenceBean.setMethods(methodConfigs);
         }

--- a/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/api/MethodCallback.java
+++ b/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/api/MethodCallback.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.config.spring.api;
+
+public interface MethodCallback {
+    void oninvoke(String request);
+
+    void onreturn(String response, String request);
+
+    void onthrow(Throwable ex, String request);
+
+    String getOnInvoke();
+
+    String getOnReturn();
+
+    String getOnThrow();
+}

--- a/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/beans/factory/annotation/MethodConfigCallbackTest.java
+++ b/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/beans/factory/annotation/MethodConfigCallbackTest.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.config.spring.beans.factory.annotation;
+
+import org.apache.dubbo.config.annotation.DubboReference;
+import org.apache.dubbo.config.annotation.Method;
+import org.apache.dubbo.config.bootstrap.DubboBootstrap;
+import org.apache.dubbo.config.spring.api.HelloService;
+import org.apache.dubbo.config.spring.api.MethodCallback;
+import org.apache.dubbo.config.spring.impl.MethodCallbackImpl;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.EnableAspectJAutoProxy;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.event.annotation.AfterTestMethod;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static org.apache.dubbo.config.spring.beans.factory.annotation.ReferenceAnnotationBeanPostProcessor.BEAN_NAME;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(
+        classes = {
+                ServiceAnnotationTestConfiguration.class,
+                MethodConfigCallbackTest.class,
+        })
+@TestPropertySource(properties = {
+        "packagesToScan = org.apache.dubbo.config.spring.context.annotation.provider",
+        "consumer.version = ${demo.service.version}",
+        "consumer.url = dubbo://127.0.0.1:12345?version=2.5.7",
+})
+@EnableAspectJAutoProxy(proxyTargetClass = true, exposeProxy = true)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+public class MethodConfigCallbackTest {
+
+    @AfterTestMethod
+    public void setUp() {
+        DubboBootstrap.reset();
+    }
+
+    @Bean(BEAN_NAME)
+    public ReferenceAnnotationBeanPostProcessor referenceAnnotationBeanPostProcessor() {
+        return new ReferenceAnnotationBeanPostProcessor();
+    }
+
+    @Autowired
+    private ConfigurableApplicationContext context;
+
+    @Bean("methodCallback")
+    public MethodCallback methodCallback() {
+        return new MethodCallbackImpl();
+    }
+
+    @DubboReference(check = false,methods = {@Method(name = "sayHello",oninvoke = "methodCallback.oninvoke",onreturn = "methodCallback.onreturn",onthrow = "methodCallback.onthrow")})
+    private HelloService helloServiceMethodCallBack;
+
+    @Test
+    public void testMethodAnnotationCallBack() {
+        helloServiceMethodCallBack.sayHello("dubbo");
+        MethodCallback notify = (MethodCallback) context.getBean("methodCallback");
+        Assertions.assertEquals("dubbo invoke success", notify.getOnInvoke());
+        Assertions.assertEquals("dubbo return success", notify.getOnReturn());
+    }
+}

--- a/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/beans/factory/annotation/MethodConfigCallbackTest.java
+++ b/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/beans/factory/annotation/MethodConfigCallbackTest.java
@@ -35,8 +35,6 @@ import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.event.annotation.AfterTestMethod;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-import static org.apache.dubbo.config.spring.beans.factory.annotation.ReferenceAnnotationBeanPostProcessor.BEAN_NAME;
-
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration(
         classes = {
@@ -57,7 +55,7 @@ public class MethodConfigCallbackTest {
         DubboBootstrap.reset();
     }
 
-    @Bean(BEAN_NAME)
+    @Bean("referenceAnnotationBeanPostProcessor")
     public ReferenceAnnotationBeanPostProcessor referenceAnnotationBeanPostProcessor() {
         return new ReferenceAnnotationBeanPostProcessor();
     }

--- a/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/impl/MethodCallbackImpl.java
+++ b/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/impl/MethodCallbackImpl.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.config.spring.impl;
+
+import org.apache.dubbo.config.spring.api.MethodCallback;
+
+public class MethodCallbackImpl implements MethodCallback {
+    private String onInvoke;
+    private String onReturn;
+    private String onThrow;
+
+    @Override
+    public void oninvoke(String request) {
+        this.onInvoke = "dubbo invoke success";
+    }
+
+    @Override
+    public void onreturn(String response, String request) {
+        this.onReturn = "dubbo return success";
+    }
+
+    @Override
+    public void onthrow(Throwable ex, String request) {
+        this.onThrow = "dubbo throw exception";
+    }
+
+    public String getOnInvoke() {
+        return this.onInvoke;
+    }
+
+    public String getOnReturn() {
+        return this.onReturn;
+    }
+
+    public String getOnThrow() {
+        return this.onThrow;
+    }
+}

--- a/dubbo-rpc/dubbo-rpc-api/custom-access.log.20210512
+++ b/dubbo-rpc/dubbo-rpc-api/custom-access.log.20210512
@@ -1,1 +1,0 @@
-[2021-05-12 18:57:59] null:0 -> 10.234.211.84:0 - org.apache.dubbo.rpc.support.DemoService echo(java.lang.String) ["aa"]

--- a/dubbo-rpc/dubbo-rpc-api/custom-access.log.20210512
+++ b/dubbo-rpc/dubbo-rpc-api/custom-access.log.20210512
@@ -1,0 +1,1 @@
+[2021-05-12 18:57:59] null:0 -> 10.234.211.84:0 - org.apache.dubbo.rpc.support.DemoService echo(java.lang.String) ["aa"]


### PR DESCRIPTION
## What is the purpose of the change

fix #6833 when use method annotation like below，callback method dose not work

    @DubboReference(check = false,methods = {@Method(name = "sayHello",oninvoke = "methodCallback.oninvoke",onreturn = "methodCallback.onreturn",onthrow = "methodCallback.onthrow")})
    private HelloService helloServiceMethodCallBack;

## Brief changelog


## Verifying this change


<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Run `mvn clean install -DskipTests=false` & `mvn clean test-compile failsafe:integration-test` to make sure unit-test and integration-test pass.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
