### PR TITLE
Add a new Router class for making requests targeted at specified ip …

### DIFF
--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/router/address/Address.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/router/address/Address.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.dubbo.rpc.cluster.router.address;
+
+import java.io.Serializable;
+
+public class Address implements Serializable {
+
+    private final String ip;
+
+    private final int port;
+
+    public Address(String ip, int port) {
+        this.ip = ip;
+        this.port = port;
+    }
+
+    public String getIp() {
+        return ip;
+    }
+
+    public int getPort() {
+        return port;
+    }
+
+}

--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/router/address/AddressInvokersSelector.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/router/address/AddressInvokersSelector.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.rpc.cluster.router.address;
+
+import org.apache.dubbo.common.URL;
+import org.apache.dubbo.common.utils.CollectionUtils;
+import org.apache.dubbo.rpc.Invocation;
+import org.apache.dubbo.rpc.Invoker;
+import org.apache.dubbo.rpc.RpcException;
+import org.apache.dubbo.rpc.cluster.router.AbstractRouter;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+public class AddressInvokersSelector extends AbstractRouter {
+
+    public static final String NAME = "ADDRESS_ROUTER";
+
+    private static final int ADDRESS_INVOKERS_DEFAULT_PRIORITY = 180;
+
+    public AddressInvokersSelector() {
+        this.priority = ADDRESS_INVOKERS_DEFAULT_PRIORITY;
+    }
+
+    @Override
+    public <T> List<Invoker<T>> route(final List<Invoker<T>> invokers,
+                                      URL url, final Invocation invocation) throws RpcException {
+        if (CollectionUtils.isEmpty(invokers)) {
+            return invokers;
+        }
+
+        if (invocation.getObjectAttachments() != null) {
+            Address address = Address.class.cast(invocation.getObjectAttachment(AddressRouterFactory.NAME));
+            if (Optional.ofNullable(address).isPresent()) {
+                invocation.getObjectAttachments().remove(AddressRouterFactory.NAME);
+                return invokers.stream().filter(it -> it.getUrl().getIp().equals(address.getIp()) && (it.getUrl().getPort() == address.getPort()) && it.isAvailable()).collect(Collectors.toList());
+            }
+        }
+        return invokers;
+    }
+
+
+}

--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/router/address/AddressRouterFactory.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/router/address/AddressRouterFactory.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.rpc.cluster.router.address;
+
+import org.apache.dubbo.common.URL;
+import org.apache.dubbo.common.extension.Activate;
+import org.apache.dubbo.rpc.cluster.Router;
+import org.apache.dubbo.rpc.cluster.RouterFactory;
+
+/**
+ * AddressRouterFactory
+ */
+@Activate(value = AddressRouterFactory.NAME)
+public class AddressRouterFactory implements RouterFactory {
+
+    public static final String NAME = "address";
+
+    @Override
+    public Router getRouter(URL url) {
+        return new AddressInvokersSelector();
+    }
+
+}

--- a/dubbo-cluster/src/main/resources/META-INF/dubbo/internal/org.apache.dubbo.rpc.cluster.RouterFactory
+++ b/dubbo-cluster/src/main/resources/META-INF/dubbo/internal/org.apache.dubbo.rpc.cluster.RouterFactory
@@ -4,3 +4,4 @@ service=org.apache.dubbo.rpc.cluster.router.condition.config.ServiceRouterFactor
 app=org.apache.dubbo.rpc.cluster.router.condition.config.AppRouterFactory
 tag=org.apache.dubbo.rpc.cluster.router.tag.TagRouterFactory
 mock=org.apache.dubbo.rpc.cluster.router.mock.MockRouterFactory
+address=org.apache.dubbo.rpc.cluster.router.address.AddressRouterFactory

--- a/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/router/MockInvoker.java
+++ b/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/router/MockInvoker.java
@@ -38,6 +38,12 @@ public class MockInvoker<T> implements Invoker<T> {
         this.available = available;
     }
 
+    public MockInvoker(URL url, boolean available) {
+        super();
+        this.url = url;
+        this.available = available;
+    }
+
     @Override
     public Class<T> getInterface() {
         return null;

--- a/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/router/address/AddressRouterTest.java
+++ b/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/router/address/AddressRouterTest.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.dubbo.rpc.cluster.router.address;
+
+import org.apache.dubbo.common.URL;
+import org.apache.dubbo.rpc.Invocation;
+import org.apache.dubbo.rpc.Invoker;
+import org.apache.dubbo.rpc.RpcInvocation;
+import org.apache.dubbo.rpc.cluster.Router;
+import org.apache.dubbo.rpc.cluster.router.MockInvoker;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+
+public class AddressRouterTest {
+
+
+    @Test
+    public void testAddressRouteSelector() {
+        Router router = new AddressRouterFactory().getRouter(URL.valueOf("url"));
+        List<Invoker<String>> invokers = new ArrayList<Invoker<String>>();
+        invokers.add(new MockInvoker<>(new URL("dubbo", "129.34.56.7", 8809), true));
+        invokers.add(new MockInvoker<>(new URL("dubbo", "129.34.56.8", 8809), true));
+        invokers.add(new MockInvoker<>(new URL("dubbo", "129.34.56.9", 8809), true));
+        Invocation invocation = new RpcInvocation();
+        Address address = new Address("129.34.56.9", 8809);
+        invocation.setObjectAttachment("address", address);
+        List<Invoker<String>> list = router.route(invokers, URL.valueOf("url"), invocation);
+        Assertions.assertEquals(address.getIp(), list.get(0).getUrl().getHost());
+    }
+}


### PR DESCRIPTION
Add a new Router class for making requests targeted at specified ip and port
有时候调用需要指定ip和port,而且每次可能发生变化,比如测试调用线上指定服务器的provider
这种方式好处是比url里设定更动态一点.每次调用我都可以指定新的,并且provider不用打任何tag
<img width="1049" alt="vvv" src="https://user-images.githubusercontent.com/869986/118116467-e50f4800-b41c-11eb-98de-16e7e98bf138.png">

