### PR TITLE
Filter Order was disrupted when user application extends the SPI of org.apache.dubbo.rpc.Filter

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/extension/support/ActivateComparator.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/extension/support/ActivateComparator.java
@@ -74,9 +74,20 @@ public class ActivateComparator implements Comparator<Class> {
                     return -1;
                 }
             }
+
+            return a1.order > a2.order ? 1 : -1;
         }
-        // never return 0 even if n1 equals n2, otherwise, o1 and o2 will override each other in collection like HashSet
-        return a1.order > a2.order ? 1 : -1;
+
+        // In order to avoid the problem of inconsistency between the loading order of two filters
+        // in different loading scenarios without specifying the order attribute of the filter,
+        // when the order is the same, compare its filterName
+        if (a1.order > a2.order) {
+            return 1;
+        } else if (a1.order == a2.order) {
+            return o1.getSimpleName().compareTo(o2.getSimpleName());
+        } else {
+            return -1;
+        }
     }
 
     private Class<?> findSpi(Class clazz) {

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/extension/support/ActivateComparatorTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/extension/support/ActivateComparatorTest.java
@@ -47,4 +47,30 @@ public class ActivateComparatorTest {
         Assertions.assertEquals(f2.getClass(), filters.get(3));
         Assertions.assertEquals(f1.getClass(), filters.get(4));
     }
+
+    @Test
+    public void testFilterOrder() {
+        Order0Filter1 order0Filter1 = new Order0Filter1();
+        Order0Filter2 order0Filter2 = new Order0Filter2();
+
+        List<Class> filters = null;
+
+        {
+            filters = new ArrayList<>();
+            filters.add(order0Filter1.getClass());
+            filters.add(order0Filter2.getClass());
+            Collections.sort(filters, ActivateComparator.COMPARATOR);
+            Assertions.assertEquals(order0Filter1.getClass(), filters.get(0));
+            Assertions.assertEquals(order0Filter2.getClass(), filters.get(1));
+        }
+
+        {
+            filters = new ArrayList<>();
+            filters.add(order0Filter2.getClass());
+            filters.add(order0Filter1.getClass());
+            Collections.sort(filters, ActivateComparator.COMPARATOR);
+            Assertions.assertEquals(order0Filter1.getClass(), filters.get(0));
+            Assertions.assertEquals(order0Filter2.getClass(), filters.get(1));
+        }
+    }
 }

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/extension/support/Order0Filter0.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/extension/support/Order0Filter0.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.dubbo.common.extension.support;
+
+import org.apache.dubbo.common.extension.SPI;
+
+@SPI
+public interface Order0Filter0 {
+}

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/extension/support/Order0Filter1.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/extension/support/Order0Filter1.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.dubbo.common.extension.support;
+
+import org.apache.dubbo.common.extension.Activate;
+
+@Activate
+public class Order0Filter1 implements Order0Filter0 {
+}

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/extension/support/Order0Filter2.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/extension/support/Order0Filter2.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.dubbo.common.extension.support;
+
+import org.apache.dubbo.common.extension.Activate;
+
+@Activate
+public class Order0Filter2 implements Order0Filter0 {
+}


### PR DESCRIPTION

## What is the purpose of the change

Filter Order was disrupted when user application extends the SPI of org.apache.dubbo.rpc.Filter

see more detail from #7757 

## Brief changelog


## Verifying this change


<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Run `mvn clean install -DskipTests=false` & `mvn clean test-compile failsafe:integration-test` to make sure unit-test and integration-test pass.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
