### PR TITLE
fix: ExtensionLoader only collect exceptions but do not throws when loadResource #3575

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/extension/ExtensionLoader.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/extension/ExtensionLoader.java
@@ -109,6 +109,11 @@ public class ExtensionLoader<T> {
 
     private Map<String, IllegalStateException> exceptions = new ConcurrentHashMap<>();
 
+    /**
+     * Record all unacceptable exceptions when using SPI
+     */
+    private Set<String> unacceptableExceptions = new ConcurrentHashSet<>();
+
     private static volatile LoadingStrategy[] strategies = loadLoadingStrategies();
 
     public static void setLoadingStrategies(LoadingStrategy... strategies) {
@@ -633,7 +638,7 @@ public class ExtensionLoader<T> {
     @SuppressWarnings("unchecked")
     private T createExtension(String name, boolean wrap) {
         Class<?> clazz = getExtensionClasses().get(name);
-        if (clazz == null) {
+        if (clazz == null || unacceptableExceptions.contains(name)) {
             throw findException(name);
         }
         try {
@@ -946,6 +951,8 @@ public class ExtensionLoader<T> {
         if (c == null || overridden) {
             extensionClasses.put(name, clazz);
         } else if (c != clazz) {
+            // duplicate implementation is unacceptable
+            unacceptableExceptions.add(name);
             String duplicateMsg = "Duplicate extension " + type.getName() + " name " + name + " on " + c.getName() + " and " + clazz.getName();
             logger.error(duplicateMsg);
             throw new IllegalStateException(duplicateMsg);

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/extension/ExtensionLoaderTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/extension/ExtensionLoaderTest.java
@@ -27,12 +27,14 @@ import org.apache.dubbo.common.extension.activate.impl.ActivateExt1Impl1;
 import org.apache.dubbo.common.extension.activate.impl.GroupActivateExtImpl;
 import org.apache.dubbo.common.extension.activate.impl.OldActivateExt1Impl2;
 import org.apache.dubbo.common.extension.activate.impl.OldActivateExt1Impl3;
+import org.apache.dubbo.common.extension.activate.impl.ValueActivateExtImpl;
 import org.apache.dubbo.common.extension.activate.impl.OrderActivateExtImpl1;
 import org.apache.dubbo.common.extension.activate.impl.OrderActivateExtImpl2;
-import org.apache.dubbo.common.extension.activate.impl.ValueActivateExtImpl;
 import org.apache.dubbo.common.extension.convert.String2BooleanConverter;
 import org.apache.dubbo.common.extension.convert.String2DoubleConverter;
 import org.apache.dubbo.common.extension.convert.String2IntegerConverter;
+import org.apache.dubbo.common.extension.duplicated.DuplicatedOverriddenExt;
+import org.apache.dubbo.common.extension.duplicated.DuplicatedWithoutOverriddenExt;
 import org.apache.dubbo.common.extension.ext1.SimpleExt;
 import org.apache.dubbo.common.extension.ext1.impl.SimpleExtImpl1;
 import org.apache.dubbo.common.extension.ext1.impl.SimpleExtImpl2;
@@ -46,11 +48,11 @@ import org.apache.dubbo.common.extension.ext8_add.AddExt1;
 import org.apache.dubbo.common.extension.ext8_add.AddExt2;
 import org.apache.dubbo.common.extension.ext8_add.AddExt3;
 import org.apache.dubbo.common.extension.ext8_add.AddExt4;
-import org.apache.dubbo.common.extension.ext8_add.impl.AddExt1Impl1;
-import org.apache.dubbo.common.extension.ext8_add.impl.AddExt1_ManualAdaptive;
 import org.apache.dubbo.common.extension.ext8_add.impl.AddExt1_ManualAdd1;
 import org.apache.dubbo.common.extension.ext8_add.impl.AddExt1_ManualAdd2;
+import org.apache.dubbo.common.extension.ext8_add.impl.AddExt1Impl1;
 import org.apache.dubbo.common.extension.ext8_add.impl.AddExt2_ManualAdaptive;
+import org.apache.dubbo.common.extension.ext8_add.impl.AddExt1_ManualAdaptive;
 import org.apache.dubbo.common.extension.ext8_add.impl.AddExt3_ManualAdaptive;
 import org.apache.dubbo.common.extension.ext8_add.impl.AddExt4_ManualAdaptive;
 import org.apache.dubbo.common.extension.ext9_empty.Ext9Empty;
@@ -58,7 +60,6 @@ import org.apache.dubbo.common.extension.ext9_empty.impl.Ext9EmptyImpl;
 import org.apache.dubbo.common.extension.injection.InjectExt;
 import org.apache.dubbo.common.extension.injection.impl.InjectExtImpl;
 import org.apache.dubbo.common.lang.Prioritized;
-
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -70,17 +71,16 @@ import java.util.Set;
 import static org.apache.dubbo.common.constants.CommonConstants.GROUP_KEY;
 import static org.apache.dubbo.common.extension.ExtensionLoader.getExtensionLoader;
 import static org.apache.dubbo.common.extension.ExtensionLoader.getLoadingStrategies;
-import static org.apache.dubbo.common.extension.ExtensionLoader.resetExtensionLoader;
-import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.CoreMatchers.anyOf;
+import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 public class ExtensionLoaderTest {
     @Test
@@ -397,21 +397,21 @@ public class ExtensionLoaderTest {
         URL url = URL.valueOf("test://localhost/test");
         List<ActivateExt1> list = getExtensionLoader(ActivateExt1.class)
                 .getActivateExtension(url, new String[]{}, "default_group");
-        Assertions.assertEquals(1, list.size());
+        assertEquals(1, list.size());
         Assertions.assertSame(list.get(0).getClass(), ActivateExt1Impl1.class);
 
         // test group
         url = url.addParameter(GROUP_KEY, "group1");
         list = getExtensionLoader(ActivateExt1.class)
                 .getActivateExtension(url, new String[]{}, "group1");
-        Assertions.assertEquals(1, list.size());
+        assertEquals(1, list.size());
         Assertions.assertSame(list.get(0).getClass(), GroupActivateExtImpl.class);
 
         // test old @Activate group
         url = url.addParameter(GROUP_KEY, "old_group");
         list = getExtensionLoader(ActivateExt1.class)
                 .getActivateExtension(url, new String[]{}, "old_group");
-        Assertions.assertEquals(2, list.size());
+        assertEquals(2, list.size());
         Assertions.assertTrue(list.get(0).getClass() == OldActivateExt1Impl2.class
                 || list.get(0).getClass() == OldActivateExt1Impl3.class);
 
@@ -421,7 +421,7 @@ public class ExtensionLoaderTest {
         url = url.addParameter("value", "value");
         list = getExtensionLoader(ActivateExt1.class)
                 .getActivateExtension(url, new String[]{}, "value");
-        Assertions.assertEquals(1, list.size());
+        assertEquals(1, list.size());
         Assertions.assertSame(list.get(0).getClass(), ValueActivateExtImpl.class);
 
         // test order
@@ -429,7 +429,7 @@ public class ExtensionLoaderTest {
         url = url.addParameter(GROUP_KEY, "order");
         list = getExtensionLoader(ActivateExt1.class)
                 .getActivateExtension(url, new String[]{}, "order");
-        Assertions.assertEquals(2, list.size());
+        assertEquals(2, list.size());
         Assertions.assertSame(list.get(0).getClass(), OrderActivateExtImpl1.class);
         Assertions.assertSame(list.get(1).getClass(), OrderActivateExtImpl2.class);
     }
@@ -440,14 +440,14 @@ public class ExtensionLoaderTest {
         URL url = URL.valueOf("test://localhost/test?ext=order1,default");
         List<ActivateExt1> list = getExtensionLoader(ActivateExt1.class)
                 .getActivateExtension(url, "ext", "default_group");
-        Assertions.assertEquals(2, list.size());
+        assertEquals(2, list.size());
         Assertions.assertSame(list.get(0).getClass(), OrderActivateExtImpl1.class);
         Assertions.assertSame(list.get(1).getClass(), ActivateExt1Impl1.class);
 
         url = URL.valueOf("test://localhost/test?ext=default,order1");
         list = getExtensionLoader(ActivateExt1.class)
                 .getActivateExtension(url, "ext", "default_group");
-        Assertions.assertEquals(2, list.size());
+        assertEquals(2, list.size());
         Assertions.assertSame(list.get(0).getClass(), ActivateExt1Impl1.class);
         Assertions.assertSame(list.get(1).getClass(), OrderActivateExtImpl1.class);
     }
@@ -542,5 +542,94 @@ public class ExtensionLoaderTest {
         loadingStrategy = strategies.get(i++);
         assertEquals(ServicesLoadingStrategy.class, loadingStrategy.getClass());
         assertEquals(Prioritized.MIN_PRIORITY, loadingStrategy.getPriority());
+    }
+
+    /**
+     * see issue: https://github.com/apache/dubbo/issues/3575
+     */
+    @Test
+    public void testDuplicatedImplWithoutOverriddenStrategy() {
+        List<LoadingStrategy> loadingStrategies = ExtensionLoader.getLoadingStrategies();
+        ExtensionLoader.setLoadingStrategies(new DubboExternalLoadingStrategyTest(false),
+                new DubboInternalLoadingStrategyTest(false));
+        ExtensionLoader<DuplicatedWithoutOverriddenExt> extensionLoader = ExtensionLoader.getExtensionLoader(DuplicatedWithoutOverriddenExt.class);
+        try {
+            extensionLoader.getExtension("duplicated");
+            fail();
+        } catch (IllegalStateException expected) {
+            assertThat(expected.getMessage(), containsString("Failed to load extension class (interface: interface org.apache.dubbo.common.extension.duplicated.DuplicatedWithoutOverriddenExt"));
+            assertThat(expected.getMessage(), containsString("cause: Duplicate extension org.apache.dubbo.common.extension.duplicated.DuplicatedWithoutOverriddenExt name duplicated"));
+        }finally {
+            //recover the loading strategies
+            ExtensionLoader.setLoadingStrategies(loadingStrategies.toArray(new LoadingStrategy[loadingStrategies.size()]));
+        }
+    }
+
+    @Test
+    public void testDuplicatedImplWithOverriddenStrategy() {
+        List<LoadingStrategy> loadingStrategies = ExtensionLoader.getLoadingStrategies();
+        ExtensionLoader.setLoadingStrategies(new DubboExternalLoadingStrategyTest(true),
+                new DubboInternalLoadingStrategyTest(true));
+        ExtensionLoader<DuplicatedOverriddenExt> extensionLoader = ExtensionLoader.getExtensionLoader(DuplicatedOverriddenExt.class);
+        DuplicatedOverriddenExt duplicatedOverriddenExt = extensionLoader.getExtension("duplicated");
+        assertEquals("DuplicatedOverriddenExt1", duplicatedOverriddenExt.echo());
+        //recover the loading strategies
+        ExtensionLoader.setLoadingStrategies(loadingStrategies.toArray(new LoadingStrategy[loadingStrategies.size()]));
+    }
+
+    /**
+     * The external {@link LoadingStrategy}, which can set if it support overridden
+     * see issue: https://github.com/apache/dubbo/issues/3575
+     */
+    private static class DubboExternalLoadingStrategyTest implements LoadingStrategy {
+
+        public DubboExternalLoadingStrategyTest(boolean overridden) {
+            this.overridden = overridden;
+        }
+
+        private boolean overridden;
+
+        @Override
+        public String directory() {
+            return "META-INF/dubbo/external/";
+        }
+
+        @Override
+        public boolean overridden() {
+            return this.overridden;
+        }
+
+        @Override
+        public int getPriority() {
+            return MAX_PRIORITY + 1;
+        }
+    }
+
+    /**
+     * The internal {@link LoadingStrategy}, which can set if it support overridden
+     * see issue: https://github.com/apache/dubbo/issues/3575
+     */
+    private static class DubboInternalLoadingStrategyTest implements LoadingStrategy {
+
+        public DubboInternalLoadingStrategyTest(boolean overridden) {
+            this.overridden = overridden;
+        }
+
+        private boolean overridden;
+
+        @Override
+        public String directory() {
+            return "META-INF/dubbo/internal/";
+        }
+
+        @Override
+        public boolean overridden() {
+            return this.overridden;
+        }
+
+        @Override
+        public int getPriority() {
+            return MAX_PRIORITY;
+        }
     }
 }

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/extension/duplicated/DuplicatedOverriddenExt.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/extension/duplicated/DuplicatedOverriddenExt.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.common.extension.duplicated;
+
+import org.apache.dubbo.common.extension.SPI;
+
+/**
+ * This is an interface for testing duplicated extension
+ */
+@SPI
+public interface DuplicatedOverriddenExt {
+
+    String echo();
+}

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/extension/duplicated/DuplicatedWithoutOverriddenExt.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/extension/duplicated/DuplicatedWithoutOverriddenExt.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.common.extension.duplicated;
+
+import org.apache.dubbo.common.extension.SPI;
+
+/**
+ * This is an interface for testing duplicated extension
+ * see issue: https://github.com/apache/dubbo/issues/3575
+ */
+@SPI
+public interface DuplicatedWithoutOverriddenExt {
+
+    String echo();
+}

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/extension/duplicated/impl/DuplicatedOverriddenExt1.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/extension/duplicated/impl/DuplicatedOverriddenExt1.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.common.extension.duplicated.impl;
+
+import org.apache.dubbo.common.extension.duplicated.DuplicatedOverriddenExt;
+
+public class DuplicatedOverriddenExt1 implements DuplicatedOverriddenExt {
+
+    @Override
+    public String echo() {
+        return "DuplicatedOverriddenExt1";
+    }
+}

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/extension/duplicated/impl/DuplicatedOverriddenExt2.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/extension/duplicated/impl/DuplicatedOverriddenExt2.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.common.extension.duplicated.impl;
+
+import org.apache.dubbo.common.extension.duplicated.DuplicatedOverriddenExt;
+
+public class DuplicatedOverriddenExt2 implements DuplicatedOverriddenExt {
+
+    @Override
+    public String echo() {
+        return "DuplicatedOverriddenExt2";
+    }
+}

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/extension/duplicated/impl/DuplicatedWithoutOverriddenExt1.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/extension/duplicated/impl/DuplicatedWithoutOverriddenExt1.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.common.extension.duplicated.impl;
+
+import org.apache.dubbo.common.extension.duplicated.DuplicatedWithoutOverriddenExt;
+
+public class DuplicatedWithoutOverriddenExt1 implements DuplicatedWithoutOverriddenExt {
+
+    @Override
+    public String echo() {
+        return "DuplicatedWithoutOverriddenExt1";
+    }
+}

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/extension/duplicated/impl/DuplicatedWithoutOverriddenExt2.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/extension/duplicated/impl/DuplicatedWithoutOverriddenExt2.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.common.extension.duplicated.impl;
+
+import org.apache.dubbo.common.extension.duplicated.DuplicatedWithoutOverriddenExt;
+
+public class DuplicatedWithoutOverriddenExt2 implements DuplicatedWithoutOverriddenExt {
+
+    @Override
+    public String echo() {
+        return "DuplicatedWithoutOverriddenExt2";
+    }
+}

--- a/dubbo-common/src/test/resources/META-INF/dubbo/external/org.apache.dubbo.common.extension.duplicated.DuplicatedOverriddenExt
+++ b/dubbo-common/src/test/resources/META-INF/dubbo/external/org.apache.dubbo.common.extension.duplicated.DuplicatedOverriddenExt
@@ -1,0 +1,1 @@
+duplicated=org.apache.dubbo.common.extension.duplicated.impl.DuplicatedOverriddenExt2

--- a/dubbo-common/src/test/resources/META-INF/dubbo/external/org.apache.dubbo.common.extension.duplicated.DuplicatedWithoutOverriddenExt
+++ b/dubbo-common/src/test/resources/META-INF/dubbo/external/org.apache.dubbo.common.extension.duplicated.DuplicatedWithoutOverriddenExt
@@ -1,0 +1,1 @@
+duplicated=org.apache.dubbo.common.extension.duplicated.impl.DuplicatedWithoutOverriddenExt2

--- a/dubbo-common/src/test/resources/META-INF/dubbo/internal/org.apache.dubbo.common.extension.duplicated.DuplicatedOverriddenExt
+++ b/dubbo-common/src/test/resources/META-INF/dubbo/internal/org.apache.dubbo.common.extension.duplicated.DuplicatedOverriddenExt
@@ -1,0 +1,1 @@
+duplicated=org.apache.dubbo.common.extension.duplicated.impl.DuplicatedOverriddenExt1

--- a/dubbo-common/src/test/resources/META-INF/dubbo/internal/org.apache.dubbo.common.extension.duplicated.DuplicatedWithoutOverriddenExt
+++ b/dubbo-common/src/test/resources/META-INF/dubbo/internal/org.apache.dubbo.common.extension.duplicated.DuplicatedWithoutOverriddenExt
@@ -1,0 +1,1 @@
+duplicated=org.apache.dubbo.common.extension.duplicated.impl.DuplicatedWithoutOverriddenExt1


### PR DESCRIPTION
## What is the purpose of the change

see #3575 

## Brief changelog

+ fix the bug on duplicated implementation by using SPI
+ add testcases

## Verifying this change


<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [x] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Run `mvn clean install -DskipTests=false` & `mvn clean test-compile failsafe:integration-test` to make sure unit-test and integration-test pass.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
