### PR TITLE
[Dubbo-6034] Fix the RegistyUrl mismatching to ZoneAwareClusterInvoker.PREFER_REGISTRY_KEY

### DIFF
--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/support/registry/ZoneAwareClusterInvoker.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/support/registry/ZoneAwareClusterInvoker.java
@@ -39,12 +39,12 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import static org.apache.dubbo.common.constants.CommonConstants.PREFERRED_KEY;
 import static org.apache.dubbo.common.constants.RegistryConstants.LOADBALANCE_AMONG_REGISTRIES;
 import static org.apache.dubbo.common.constants.RegistryConstants.REGISTRY_KEY;
 import static org.apache.dubbo.common.constants.RegistryConstants.REGISTRY_ZONE;
 import static org.apache.dubbo.common.constants.RegistryConstants.REGISTRY_ZONE_FORCE;
 import static org.apache.dubbo.common.constants.RegistryConstants.ZONE_KEY;
+import static org.apache.dubbo.config.RegistryConfig.PREFER_REGISTRY_KEY;
 
 /**
  * When there're more than one registry for subscription.
@@ -58,9 +58,7 @@ import static org.apache.dubbo.common.constants.RegistryConstants.ZONE_KEY;
 public class ZoneAwareClusterInvoker<T> extends AbstractClusterInvoker<T> {
 
     private static final Logger logger = LoggerFactory.getLogger(ZoneAwareClusterInvoker.class);
-
-    private static final String PREFER_REGISTRY_KEY = REGISTRY_KEY + "." + PREFERRED_KEY;
-
+    
     private static final String PREFER_REGISTRY_WITH_ZONE_KEY = REGISTRY_KEY + "." + ZONE_KEY;
 
     private final LoadBalance loadBalanceAmongRegistries = ExtensionLoader.getExtensionLoader(LoadBalance.class).getExtension(LOADBALANCE_AMONG_REGISTRIES);

--- a/dubbo-common/src/main/java/org/apache/dubbo/config/RegistryConfig.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/config/RegistryConfig.java
@@ -23,8 +23,8 @@ import org.apache.dubbo.config.support.Parameter;
 
 import java.util.Map;
 
-import static org.apache.dubbo.common.constants.CommonConstants.EXTRA_KEYS_KEY;
-import static org.apache.dubbo.common.constants.CommonConstants.SHUTDOWN_WAIT_KEY;
+import static org.apache.dubbo.common.constants.CommonConstants.*;
+import static org.apache.dubbo.common.constants.RegistryConstants.REGISTRY_KEY;
 import static org.apache.dubbo.common.constants.RemotingConstants.BACKUP_KEY;
 import static org.apache.dubbo.common.utils.PojoUtils.updatePropertyIfAbsent;
 import static org.apache.dubbo.config.Constants.REGISTRIES_SUFFIX;
@@ -486,6 +486,7 @@ public class RegistryConfig extends AbstractConfig {
         this.accepts = accepts;
     }
 
+    @Parameter(key = REGISTRY_KEY + "." + PREFERRED_KEY)
     public Boolean getPreferred() {
         return preferred;
     }

--- a/dubbo-common/src/main/java/org/apache/dubbo/config/RegistryConfig.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/config/RegistryConfig.java
@@ -23,7 +23,9 @@ import org.apache.dubbo.config.support.Parameter;
 
 import java.util.Map;
 
-import static org.apache.dubbo.common.constants.CommonConstants.*;
+import static org.apache.dubbo.common.constants.CommonConstants.EXTRA_KEYS_KEY;
+import static org.apache.dubbo.common.constants.CommonConstants.SHUTDOWN_WAIT_KEY;
+import static org.apache.dubbo.common.constants.CommonConstants.PREFERRED_KEY;
 import static org.apache.dubbo.common.constants.RegistryConstants.REGISTRY_KEY;
 import static org.apache.dubbo.common.constants.RemotingConstants.BACKUP_KEY;
 import static org.apache.dubbo.common.utils.PojoUtils.updatePropertyIfAbsent;

--- a/dubbo-common/src/main/java/org/apache/dubbo/config/RegistryConfig.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/config/RegistryConfig.java
@@ -39,6 +39,7 @@ import static org.apache.dubbo.config.Constants.REGISTRIES_SUFFIX;
 public class RegistryConfig extends AbstractConfig {
 
     public static final String NO_AVAILABLE = "N/A";
+    public static final String PREFER_REGISTRY_KEY = REGISTRY_KEY + "." + PREFERRED_KEY;
     private static final long serialVersionUID = 5508512956753757169L;
 
     /**
@@ -488,7 +489,7 @@ public class RegistryConfig extends AbstractConfig {
         this.accepts = accepts;
     }
 
-    @Parameter(key = REGISTRY_KEY + "." + PREFERRED_KEY)
+    @Parameter(key = PREFER_REGISTRY_KEY)
     public Boolean getPreferred() {
         return preferred;
     }

--- a/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/RegistryConfigTest.java
+++ b/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/RegistryConfigTest.java
@@ -17,6 +17,9 @@
 
 package org.apache.dubbo.config;
 
+import org.apache.dubbo.common.URL;
+import org.apache.dubbo.common.utils.UrlUtils;
+
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -26,6 +29,7 @@ import java.util.Map;
 
 import static org.apache.dubbo.common.constants.CommonConstants.SHUTDOWN_WAIT_KEY;
 import static org.apache.dubbo.config.Constants.SHUTDOWN_TIMEOUT_KEY;
+import static org.apache.dubbo.config.RegistryConfig.PREFER_REGISTRY_KEY;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
@@ -186,5 +190,28 @@ public class RegistryConfigTest {
         registry2.setAddress("zookeeper://127.0.0.1:2183");
         Assertions.assertNotEquals(registry1, registry2);
     }
+    
+    @Test
+    public void testPreferredWithTrueValue() {
+        RegistryConfig registry = new RegistryConfig();
+        registry.setPreferred(true);
+        Map<String, String> map = new HashMap<>();
+        // process Parameter annotation
+        AbstractConfig.appendParameters(map, registry);
+        // Simulate the check that ZoneAwareClusterInvoker#doInvoke do
+        URL url = UrlUtils.parseURL("zookeeper://127.0.0.1:2181", map);
+        Assertions.assertTrue(url.getParameter(PREFER_REGISTRY_KEY, false));
+    }
 
+    @Test
+    public void testPreferredWithFalseValue() {
+        RegistryConfig registry = new RegistryConfig();
+        registry.setPreferred(false);
+        Map<String, String> map = new HashMap<>();
+        // Process Parameter annotation
+        AbstractConfig.appendParameters(map, registry);
+        // Simulate the check that ZoneAwareClusterInvoker#doInvoke do
+        URL url = UrlUtils.parseURL("zookeeper://127.0.0.1:2181", map);
+        Assertions.assertFalse(url.getParameter(PREFER_REGISTRY_KEY, false));
+    }
 }


### PR DESCRIPTION
## What is the purpose of the change
Fixes #6034 

When I have follow setting, the final registry URL is: `nacos://127.0.0.1:8849/....?preferred=true`.
```xml
<dubbo:registry address="nacos://127.0.0.1:8849" preferred="true"/>
```

Because of `ZoneAwareClusterInvoker.PREFER_REGISTRY_KEY` is mismatching to `RegistryConfig.preferred` key, the following code can't works as expect.
```java
// method => org.apache.dubbo.rpc.cluster.support.registry.ZoneAwareClusterInvoker#doInvoke
if (clusterInvoker.isAvailable() && clusterInvoker.getRegistryUrl()
        .getParameter(PREFER_REGISTRY_KEY, false)) {
    return clusterInvoker.invoke(invocation);
}
```

## Brief changelog
* Aliasing `preferred` equal to `ZoneAwareClusterInvoker.PREFER_REGISTRY_KEY` when invoking `AbstractConfig#appendParameters` method.

## Verifying this change
* The final registry URL should be: `nacos://127.0.0.1:8849/....?registry.preferred=true`.

---

<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [x] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Run `mvn clean install -DskipTests=false` & `mvn clean test-compile failsafe:integration-test` to make sure unit-test and integration-test pass.
- [x] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
