### PR TITLE
Replace the toString() method with a public parameter

### DIFF
--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/ServiceConfig.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/ServiceConfig.java
@@ -276,7 +276,7 @@ public class ServiceConfig<T> extends ServiceConfigBase<T> {
         if (ref instanceof GenericService) {
             interfaceClass = GenericService.class;
             if (StringUtils.isEmpty(generic)) {
-                generic = Boolean.TRUE.toString();
+                generic = TRUE_VALUE;
             }
         } else {
             try {
@@ -287,7 +287,7 @@ public class ServiceConfig<T> extends ServiceConfigBase<T> {
             }
             checkInterfaceAndMethods(interfaceClass, getMethods());
             checkRef();
-            generic = Boolean.FALSE.toString();
+            generic = FALSE_VALUE;
         }
         if (local != null) {
             if (TRUE_VALUE.equals(local)) {


### PR DESCRIPTION
## What is the purpose of the change
Replace the toString() method with a public parameter to improve readability



