### PR TITLE
Add tag variables to avoid repeated calls to ExporterChangeableWrapper#unexport method

### DIFF
--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/integration/RegistryProtocol.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/integration/RegistryProtocol.java
@@ -59,6 +59,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static java.util.concurrent.Executors.newSingleThreadExecutor;
 import static org.apache.dubbo.common.constants.CommonConstants.APPLICATION_KEY;
@@ -775,7 +776,7 @@ public class RegistryProtocol implements Protocol {
         private URL subscribeUrl;
         private URL registerUrl;
 
-        private volatile boolean unexported;
+        private AtomicBoolean unexported = new AtomicBoolean(false);
 
         public ExporterChangeableWrapper(Exporter<T> exporter, Invoker<T> originInvoker) {
             this.exporter = exporter;
@@ -797,7 +798,7 @@ public class RegistryProtocol implements Protocol {
 
         @Override
         public void unexport() {
-            if (unexported) {
+            if (!unexported.compareAndSet(false,true)) {
                 return;
             }
 
@@ -833,8 +834,6 @@ public class RegistryProtocol implements Protocol {
                     LOGGER.warn(t.getMessage(), t);
                 }
             });
-
-            unexported = true;
         }
 
         public void setSubscribeUrl(URL subscribeUrl) {

--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/integration/RegistryProtocol.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/integration/RegistryProtocol.java
@@ -775,6 +775,8 @@ public class RegistryProtocol implements Protocol {
         private URL subscribeUrl;
         private URL registerUrl;
 
+        private volatile boolean unexported;
+
         public ExporterChangeableWrapper(Exporter<T> exporter, Invoker<T> originInvoker) {
             this.exporter = exporter;
             this.originInvoker = originInvoker;
@@ -795,6 +797,10 @@ public class RegistryProtocol implements Protocol {
 
         @Override
         public void unexport() {
+            if (unexported) {
+                return;
+            }
+
             String key = getCacheKey(this.originInvoker);
             bounds.remove(key);
 
@@ -827,6 +833,8 @@ public class RegistryProtocol implements Protocol {
                     LOGGER.warn(t.getMessage(), t);
                 }
             });
+
+            unexported = true;
         }
 
         public void setSubscribeUrl(URL subscribeUrl) {


### PR DESCRIPTION
When the dubbo program is destroyed, for example, start from spring's` context.stop()`. `DubboBootstrap#destroy` will be called, and the `ExporterChangeableWrapper#unexport` method will be called twice in the logic.
- The first is in `destroyProtocols()->protocol.destroy()->Registry#destroy()->exporter.unexport()->ExporterChangeableWrapper#unexport`
- the second place is in `unexportServices()->sc.unexport()->exporter.unexport()->DestroyableExporter#unexport->ExporterChangeableWrapper#unexport`

So, I add this `unexported` variable to avoid repeated `unexport`