### PR TITLE
Clear the container at the end of the DefaultExecutorRepository#destroyAll method

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/threadpool/manager/DefaultExecutorRepository.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/threadpool/manager/DefaultExecutorRepository.java
@@ -166,6 +166,8 @@ public class DefaultExecutorRepository implements ExecutorRepository {
                 });
             }
         });
+
+        data.clear();
     }
 
     private ExecutorService createExecutor(URL url) {

--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/support/AbstractRegistry.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/support/AbstractRegistry.java
@@ -470,7 +470,7 @@ public abstract class AbstractRegistry implements Registry {
         }
         Set<URL> destroyRegistered = new HashSet<>(getRegistered());
         if (!destroyRegistered.isEmpty()) {
-            for (URL url : new HashSet<>(getRegistered())) {
+            for (URL url : new HashSet<>(destroyRegistered)) {
                 if (url.getParameter(DYNAMIC_KEY, true)) {
                     try {
                         unregister(url);


### PR DESCRIPTION
Clear the container at the end of the DefaultExecutorRepository#destroyAll method

Reuse destroyRegistered variable