### PR TITLE
Optimize the logic of obtaining the mock parameter value in the MockInvoker#invoke method

### DIFF
--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/support/MockInvoker.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/support/MockInvoker.java
@@ -99,13 +99,8 @@ final public class MockInvoker<T> implements Invoker<T> {
         if (invocation instanceof RpcInvocation) {
             ((RpcInvocation) invocation).setInvoker(this);
         }
-        String mock = null;
-        if (getUrl().hasMethodParameter(invocation.getMethodName())) {
-            mock = getUrl().getParameter(invocation.getMethodName() + "." + MOCK_KEY);
-        }
-        if (StringUtils.isBlank(mock)) {
-            mock = getUrl().getParameter(MOCK_KEY);
-        }
+
+        String mock = getUrl().getMethodParameter(invocation.getMethodName(),MOCK_KEY);
 
         if (StringUtils.isBlank(mock)) {
             throw new RpcException(new IllegalAccessException("mock can not be null. url :" + url));


### PR DESCRIPTION
The logic of the original code can be replaced with the `getMethodParameter `method. The logic of the `getMethodParameter `method is as follows:
For example, `URL url = "test://1.1.1.1/path?test.mock=xx&mock=yy"`, `url.getMethodParameter("test","mock") `will first get the parameter value of` test.mock`,if it does not exist,, then Get the `mock `parameter value directly