### PR TITLE
Fix the problem that the AbstractInterfaceConfig#setRegistry method does not fill the RegistryConfig to the ConfigManager

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/config/AbstractInterfaceConfig.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/config/AbstractInterfaceConfig.java
@@ -526,10 +526,8 @@ public abstract class AbstractInterfaceConfig extends AbstractMethodConfig {
         registries.add(registry);
         setRegistries(registries);
 
-        if (CollectionUtils.isNotEmpty(registries)) {
-            ConfigManager configManager = ApplicationModel.getConfigManager();
-            configManager.addRegistries(registries);
-        }
+        ConfigManager configManager = ApplicationModel.getConfigManager();
+        configManager.addRegistries(registries);
     }
 
     public List<RegistryConfig> getRegistries() {

--- a/dubbo-common/src/main/java/org/apache/dubbo/config/AbstractInterfaceConfig.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/config/AbstractInterfaceConfig.java
@@ -525,6 +525,11 @@ public abstract class AbstractInterfaceConfig extends AbstractMethodConfig {
         List<RegistryConfig> registries = new ArrayList<RegistryConfig>(1);
         registries.add(registry);
         setRegistries(registries);
+
+        if (CollectionUtils.isNotEmpty(registries)) {
+            ConfigManager configManager = ApplicationModel.getConfigManager();
+            configManager.addRegistries(registries);
+        }
     }
 
     public List<RegistryConfig> getRegistries() {


### PR DESCRIPTION
When I use the` dubbo-samples-api` test program of the `dubbo-samples` project, the provider manually calls `ServiceConfig#setRegistry`. This method does not fill the `RegistryConfig `into the `ConfigManager`

This will cause some problems, such as the inability to rely on `RegistryConfig` to build the corresponding `ConfigCenterConfig `when calling the `DubboBootstap#startConfigCenter` method