### PR TITLE
[3.0] Address URL fault tolerance on getParameter usage

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/url/component/ServiceAddressURL.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/url/component/ServiceAddressURL.java
@@ -25,7 +25,9 @@ import java.util.Map;
 import static org.apache.dubbo.common.constants.CommonConstants.APPLICATION_KEY;
 import static org.apache.dubbo.common.constants.CommonConstants.CONSUMER_SIDE;
 import static org.apache.dubbo.common.constants.CommonConstants.GROUP_KEY;
+import static org.apache.dubbo.common.constants.CommonConstants.SIDE_KEY;
 import static org.apache.dubbo.common.constants.CommonConstants.VERSION_KEY;
+import static org.apache.dubbo.common.constants.RegistryConstants.CATEGORY_KEY;
 import static org.apache.dubbo.common.constants.RegistryConstants.PROVIDERS_CATEGORY;
 
 public abstract class ServiceAddressURL extends URL {
@@ -111,8 +113,17 @@ public abstract class ServiceAddressURL extends URL {
 
     @Override
     public String getParameter(String key) {
+        // call corresponding methods directly, then we can remove the following if branches.
         if (GROUP_KEY.equals(key)) {
             return getGroup();
+        } else if (VERSION_KEY.equals(key)) {
+            return getVersion();
+        } else if (APPLICATION_KEY.equals(key)) {
+            return getRemoteApplication();
+        } else if (SIDE_KEY.equals(key)) {
+            return getSide();
+        } else if (CATEGORY_KEY.equals(key)) {
+            return getCategory();
         }
         String value = null;
         if (consumerURL != null) {

--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/migration/MigrationInvoker.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/migration/MigrationInvoker.java
@@ -471,4 +471,8 @@ public class MigrationInvoker<T> implements MigrationClusterInvoker<T> {
     public boolean checkInvokerAvailable(ClusterInvoker<T> invoker) {
         return invoker != null && !invoker.isDestroyed() && invoker.isAvailable();
     }
+
+    public ClusterInvoker<T> getCurrentAvailableInvoker() {
+        return currentAvailableInvoker;
+    }
 }


### PR DESCRIPTION
```java'
 @Override
    public String getParameter(String key) {
        // call corresponding methods directly, then we can remove the following if branches.
        if (GROUP_KEY.equals(key)) {
            return getGroup();
        } else if (VERSION_KEY.equals(key)) {
            return getVersion();
        } else if (APPLICATION_KEY.equals(key)) {
            return getRemoteApplication();
        } else if (SIDE_KEY.equals(key)) {
            return getSide();
        } else if (CATEGORY_KEY.equals(key)) {
            return getCategory();
        }
        String value = null;
        if (consumerURL != null) {
            value = consumerURL.getParameter(key);
        }
        if (StringUtils.isEmpty(value)) {
            value = super.getParameter(key);
        }
        return value;
    }
```