### PR TITLE
Remove repetitive and unnecessary judgment

### DIFF
--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/bootstrap/DubboBootstrap.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/bootstrap/DubboBootstrap.java
@@ -1200,9 +1200,6 @@ public class DubboBootstrap {
 
         for (String urlValue : urlValues) {
             URL url = URL.valueOf(urlValue);
-            if (MetadataService.class.getName().equals(url.getServiceInterface())) {
-                continue;
-            }
             if ("rest".equals(url.getProtocol())) { // REST first
                 selectedURL = url;
                 break;

--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/metadata/ProtocolPortsMetadataCustomizer.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/metadata/ProtocolPortsMetadataCustomizer.java
@@ -17,7 +17,6 @@
 package org.apache.dubbo.registry.client.metadata;
 
 import org.apache.dubbo.common.URL;
-import org.apache.dubbo.metadata.MetadataService;
 import org.apache.dubbo.metadata.WritableMetadataService;
 import org.apache.dubbo.registry.client.ServiceInstance;
 import org.apache.dubbo.registry.client.ServiceInstanceCustomizer;

--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/metadata/ProtocolPortsMetadataCustomizer.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/metadata/ProtocolPortsMetadataCustomizer.java
@@ -44,7 +44,6 @@ public class ProtocolPortsMetadataCustomizer implements ServiceInstanceCustomize
         writableMetadataService.getExportedURLs()
                 .stream()
                 .map(URL::valueOf)
-                .filter(url -> !MetadataService.class.getName().equals(url.getServiceInterface()))
                 .forEach(url -> {
                     // TODO, same protocol listen on different ports will override with each other.
                     protocols.put(url.getProtocol(), url.getPort());


### PR DESCRIPTION
## What is the purpose of the change
The `metadataService.getExportedURLs()` method will be called in the `selectMetadataServiceExportedURL` method. This method has already made this judgment, so the repeated judgments here can be removed

![image](https://user-images.githubusercontent.com/43363120/119652649-f44cb780-be58-11eb-881e-0352693a4f07.png)

![image](https://user-images.githubusercontent.com/43363120/119652703-06c6f100-be59-11eb-8db8-8c7f0980dc4b.png)
