### PR TITLE
Optimize the registryAsConfigCenter/MetadataCenter method to return directly when the id exists in configManger

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/config/context/ConfigManager.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/config/context/ConfigManager.java
@@ -165,6 +165,10 @@ public class ConfigManager extends LifecycleAdapter implements FrameworkExt {
         return getConfigs(getTagName(MetadataReportConfig.class));
     }
 
+    public MetadataReportConfig getMetadataConfig(String id) {
+        return getConfig(getTagName(MetadataReportConfig.class), id);
+    }
+
     public Collection<MetadataReportConfig> getDefaultMetadataConfigs() {
         Collection<MetadataReportConfig> defaults = getDefaultConfigs(getConfigsMap(getTagName(MetadataReportConfig.class)));
         if (CollectionUtils.isEmpty(defaults)) {

--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/bootstrap/DubboBootstrap.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/bootstrap/DubboBootstrap.java
@@ -680,6 +680,10 @@ public class DubboBootstrap {
         String protocol = registryConfig.getProtocol();
         Integer port = registryConfig.getPort();
         String id = "config-center-" + protocol + "-" + port;
+        if (configManager.getConfigCenter(id) != null) {
+            return null;
+        }
+
         ConfigCenterConfig cc = new ConfigCenterConfig();
         cc.setId(id);
         if (cc.getParameters() == null) {

--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/bootstrap/DubboBootstrap.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/bootstrap/DubboBootstrap.java
@@ -785,6 +785,10 @@ public class DubboBootstrap {
         String protocol = registryConfig.getProtocol();
         Integer port = registryConfig.getPort();
         String id = "metadata-center-" + protocol + "-" + port;
+        if (configManager.getMetadataConfig(id) != null) {
+            return null;
+        }
+
         MetadataReportConfig metadataReportConfig = new MetadataReportConfig();
         metadataReportConfig.setId(id);
         if (metadataReportConfig.getParameters() == null) {


### PR DESCRIPTION
When using multiple registries, the registryAsConfigCenter method will be called multiple times. When the address of the registry is the same, the id of the generated ConfigCenterConfig is also the same, so there is no need to follow the logic behind, because in ConfigManager#addConfig Will judge the id to be repeated and return directly.

So add a judgment here, if the id of ConfigCenterConfig already exists in ConfigManager, just return it directly.

multiple registries like this (test case is `servicediscovery-transfer-provider#Application` in `dubbo-samples` project)
```
    <dubbo:registry id="service-discovery" address="zookeeper://127.0.0.1:2181?registry-type=service"/>
    <dubbo:registry id="normal" address="zookeeper://127.0.0.1:2181"/>
```

The registryAsMetadataCenter method is the same