### PR TITLE
modules‘ dependency fix & optimize

### DIFF
--- a/dubbo-all/pom.xml
+++ b/dubbo-all/pom.xml
@@ -138,6 +138,13 @@
         </dependency>
         <dependency>
             <groupId>org.apache.dubbo</groupId>
+            <artifactId>dubbo-remoting-zookeeper</artifactId>
+            <version>${project.version}</version>
+            <scope>compile</scope>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.dubbo</groupId>
             <artifactId>dubbo-rpc-api</artifactId>
             <version>${project.version}</version>
             <scope>compile</scope>
@@ -694,8 +701,6 @@
                                     <include>org.apache.dubbo:dubbo-serialization-gson</include>
                                     <include>org.apache.dubbo:dubbo-serialization-msgpack</include>
                                     <include>org.apache.dubbo:dubbo-serialization-protobuf</include>
-                                    <include>org.apache.dubbo:dubbo-configcenter-api</include>
-                                    <include>org.apache.dubbo:dubbo-configcenter-definition</include>
                                     <include>org.apache.dubbo:dubbo-configcenter-apollo</include>
                                     <include>org.apache.dubbo:dubbo-configcenter-zookeeper</include>
                                     <include>org.apache.dubbo:dubbo-configcenter-consul</include>

--- a/dubbo-all/pom.xml
+++ b/dubbo-all/pom.xml
@@ -344,6 +344,13 @@
         </dependency>
         <dependency>
             <groupId>org.apache.dubbo</groupId>
+            <artifactId>dubbo-container-api</artifactId>
+            <version>${project.version}</version>
+            <scope>compile</scope>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.dubbo</groupId>
             <artifactId>dubbo-container-spring</artifactId>
             <version>${project.version}</version>
             <scope>compile</scope>

--- a/dubbo-all/pom.xml
+++ b/dubbo-all/pom.xml
@@ -124,6 +124,13 @@
         </dependency>
         <dependency>
             <groupId>org.apache.dubbo</groupId>
+            <artifactId>dubbo-remoting-redis</artifactId>
+            <version>${project.version}</version>
+            <scope>compile</scope>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.dubbo</groupId>
             <artifactId>dubbo-remoting-http</artifactId>
             <version>${project.version}</version>
             <scope>compile</scope>
@@ -638,6 +645,7 @@
                                     <include>org.apache.dubbo:dubbo-remoting-mina</include>
                                     <include>org.apache.dubbo:dubbo-remoting-grizzly</include>
                                     <include>org.apache.dubbo:dubbo-remoting-p2p</include>
+                                    <include>org.apache.dubbo:dubbo-remoting-redis</include>
                                     <include>org.apache.dubbo:dubbo-remoting-http</include>
                                     <include>org.apache.dubbo:dubbo-remoting-zookeeper</include>
                                     <include>org.apache.dubbo:dubbo-rpc-api</include>

--- a/dubbo-bom/pom.xml
+++ b/dubbo-bom/pom.xml
@@ -165,6 +165,16 @@
             </dependency>
             <dependency>
                 <groupId>org.apache.dubbo</groupId>
+                <artifactId>dubbo-remoting-redis</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.dubbo</groupId>
+                <artifactId>dubbo-remoting-zookeeper</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.dubbo</groupId>
                 <artifactId>dubbo-rpc-api</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/dubbo-bom/pom.xml
+++ b/dubbo-bom/pom.xml
@@ -310,6 +310,11 @@
             </dependency>
             <dependency>
                 <groupId>org.apache.dubbo</groupId>
+                <artifactId>dubbo-container-api</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.dubbo</groupId>
                 <artifactId>dubbo-container-spring</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/dubbo-bom/pom.xml
+++ b/dubbo-bom/pom.xml
@@ -270,6 +270,11 @@
             </dependency>
             <dependency>
                 <groupId>org.apache.dubbo</groupId>
+                <artifactId>dubbo-registry-eureka</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.dubbo</groupId>
                 <artifactId>dubbo-registry-consul</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/dubbo-compatible/pom.xml
+++ b/dubbo-compatible/pom.xml
@@ -30,7 +30,27 @@
     <dependencies>
         <dependency>
             <groupId>org.apache.dubbo</groupId>
+            <artifactId>dubbo-container-api</artifactId>
+            <version>${project.parent.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.eclipse.jetty</groupId>
+                    <artifactId>jetty-server</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.eclipse.jetty</groupId>
+                    <artifactId>jetty-servlet</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.dubbo</groupId>
             <artifactId>dubbo-filter-cache</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.dubbo</groupId>
+            <artifactId>dubbo-filter-validation</artifactId>
             <version>${project.parent.version}</version>
         </dependency>
         <dependency>

--- a/dubbo-config/dubbo-config-api/pom.xml
+++ b/dubbo-config/dubbo-config-api/pom.xml
@@ -59,11 +59,13 @@
             <groupId>org.apache.dubbo</groupId>
             <artifactId>dubbo-filter-validation</artifactId>
             <version>${project.parent.version}</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.dubbo</groupId>
             <artifactId>dubbo-filter-cache</artifactId>
             <version>${project.parent.version}</version>
+            <scope>test</scope>
         </dependency>
 
         <!-- FIXME, we shouldn't rely on these modules, even in test scope -->

--- a/dubbo-registry/dubbo-registry-api/pom.xml
+++ b/dubbo-registry/dubbo-registry-api/pom.xml
@@ -43,21 +43,6 @@
             <artifactId>dubbo-cluster</artifactId>
             <version>${project.parent.version}</version>
         </dependency>
-        <dependency>
-            <groupId>org.apache.dubbo</groupId>
-            <artifactId>dubbo-container-api</artifactId>
-            <version>${project.parent.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.eclipse.jetty</groupId>
-                    <artifactId>jetty-server</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.eclipse.jetty</groupId>
-                    <artifactId>jetty-servlet</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
 
         <dependency>
             <groupId>org.apache.dubbo</groupId>


### PR DESCRIPTION
几处module未配置
dubbo-all/pom.xml 缺少依赖dubbo-remoting-redis、dubbo-remoting-zookeeper、dubbo-container-api
dubbo-all/pom.xml 遗漏打包org.apache.dubbo:dubbo-remoting-redis
dubbo-all/pom.xml 打包的org.apache.dubbo:dubbo-configcenter-api、org.apache.dubbo:dubbo-configcenter-definition不再存在
dubbo-bom/pom.xml 缺少dubbo-remoting-redis、dubbo-remoting-zookeeper、dubbo-registry-eureka、dubbo-container-api

2处依赖不合理
dubbo-config/dubbo-config-api/pom.xml 依赖的dubbo-filter-validation、dubbo-filter-cache的scope应该是test
dubbo-registry/dubbo-registry-api/pom.xml 不需要直接依赖dubbo-container-api
以上依赖调整后，改到dubbo-compatible/pom.xml