### PR TITLE
Fix some bugs in publishMetadata command

### DIFF
--- a/dubbo-plugin/dubbo-qos/src/main/java/org/apache/dubbo/qos/command/DefaultCommandExecutor.java
+++ b/dubbo-plugin/dubbo-qos/src/main/java/org/apache/dubbo/qos/command/DefaultCommandExecutor.java
@@ -17,13 +17,17 @@
 package org.apache.dubbo.qos.command;
 
 import org.apache.dubbo.common.extension.ExtensionLoader;
+import org.apache.dubbo.common.utils.StringUtils;
+
+import static org.apache.dubbo.common.constants.CommonConstants.PROPERTIES_CHAR_SEPARATOR;
 
 public class DefaultCommandExecutor implements CommandExecutor {
     @Override
     public String execute(CommandContext commandContext) throws NoSuchCommandException {
         BaseCommand command = null;
         try {
-            command = ExtensionLoader.getExtensionLoader(BaseCommand.class).getExtension(commandContext.getCommandName());
+            String extName = StringUtils.camelToSplitName(commandContext.getCommandName(), PROPERTIES_CHAR_SEPARATOR);
+            command = ExtensionLoader.getExtensionLoader(BaseCommand.class).getExtension(extName);
         } catch (Throwable throwable) {
                 //can't find command
         }

--- a/dubbo-plugin/dubbo-qos/src/main/java/org/apache/dubbo/qos/command/impl/PublishMetadata.java
+++ b/dubbo-plugin/dubbo-qos/src/main/java/org/apache/dubbo/qos/command/impl/PublishMetadata.java
@@ -51,7 +51,7 @@ public class PublishMetadata implements BaseCommand {
             int delay = Integer.parseInt(args[0]);
             if (future == null || future.isDone() || future.isCancelled()) {
                 future = executorRepository.nextScheduledExecutor()
-                        .scheduleWithFixedDelay(ServiceInstanceMetadataUtils::refreshMetadataAndInstance, 0, delay, TimeUnit.MILLISECONDS);
+                        .schedule(ServiceInstanceMetadataUtils::refreshMetadataAndInstance,  delay, TimeUnit.SECONDS);
             }
         } catch (NumberFormatException e) {
             logger.error("Wrong delay param", e);


### PR DESCRIPTION
## What is the purpose of the change
1.Fix the bug that publishMetadata cmd does not work
2.Delay scheduling should be used instead of scheduled scheduling
3.The delay unit should be seconds, not milliseconds
