### PR TITLE
annotation cannt be serializable,so change to String

### DIFF
--- a/dubbo-metadata/dubbo-metadata-api/src/main/java/org/apache/dubbo/metadata/definition/ServiceDefinitionBuilder.java
+++ b/dubbo-metadata/dubbo-metadata-api/src/main/java/org/apache/dubbo/metadata/definition/ServiceDefinitionBuilder.java
@@ -27,6 +27,7 @@ import com.google.gson.Gson;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.lang.reflect.Type;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -65,7 +66,7 @@ public final class ServiceDefinitionBuilder {
         sd.setCanonicalName(interfaceClass.getCanonicalName());
         sd.setCodeSource(ClassUtils.getCodeSource(interfaceClass));
         Annotation[] classAnnotations = interfaceClass.getAnnotations();
-        sd.setAnnotations(classAnnotations == null ? Collections.emptyList() : Arrays.asList(classAnnotations));
+        sd.setAnnotations(annotationToStringList(classAnnotations));
 
         TypeDefinitionBuilder builder = new TypeDefinitionBuilder();
         List<Method> methods = ClassUtils.getPublicNonStaticMethods(interfaceClass);
@@ -74,7 +75,7 @@ public final class ServiceDefinitionBuilder {
             md.setName(method.getName());
 
             Annotation[] methodAnnotations = method.getAnnotations();
-            md.setAnnotations(methodAnnotations == null ? Collections.emptyList() : Arrays.asList(methodAnnotations));
+            md.setAnnotations(annotationToStringList(methodAnnotations));
 
             // Process parameter types.
             Class<?>[] paramTypes = method.getParameterTypes();
@@ -95,6 +96,17 @@ public final class ServiceDefinitionBuilder {
         }
 
         sd.setTypes(builder.getTypeDefinitions());
+    }
+
+    private static List<String> annotationToStringList(Annotation[] annotations) {
+        List<String> list = new ArrayList<>();
+        if (annotations == null) {
+            return list;
+        }
+        for (Annotation annotation : annotations) {
+            list.add(annotation.toString());
+        }
+        return list;
     }
 
     /**

--- a/dubbo-metadata/dubbo-metadata-api/src/main/java/org/apache/dubbo/metadata/definition/ServiceDefinitionBuilder.java
+++ b/dubbo-metadata/dubbo-metadata-api/src/main/java/org/apache/dubbo/metadata/definition/ServiceDefinitionBuilder.java
@@ -16,20 +16,17 @@
  */
 package org.apache.dubbo.metadata.definition;
 
+import com.google.gson.Gson;
 import org.apache.dubbo.metadata.definition.model.FullServiceDefinition;
 import org.apache.dubbo.metadata.definition.model.MethodDefinition;
 import org.apache.dubbo.metadata.definition.model.ServiceDefinition;
 import org.apache.dubbo.metadata.definition.model.TypeDefinition;
 import org.apache.dubbo.metadata.definition.util.ClassUtils;
 
-import com.google.gson.Gson;
-
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 

--- a/dubbo-metadata/dubbo-metadata-api/src/main/java/org/apache/dubbo/metadata/definition/model/MethodDefinition.java
+++ b/dubbo-metadata/dubbo-metadata-api/src/main/java/org/apache/dubbo/metadata/definition/model/MethodDefinition.java
@@ -17,7 +17,6 @@
 package org.apache.dubbo.metadata.definition.model;
 
 import java.io.Serializable;
-import java.lang.annotation.Annotation;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;

--- a/dubbo-metadata/dubbo-metadata-api/src/main/java/org/apache/dubbo/metadata/definition/model/MethodDefinition.java
+++ b/dubbo-metadata/dubbo-metadata-api/src/main/java/org/apache/dubbo/metadata/definition/model/MethodDefinition.java
@@ -16,15 +16,15 @@
  */
 package org.apache.dubbo.metadata.definition.model;
 
+import static org.apache.dubbo.metadata.definition.model.TypeDefinition.formatType;
+import static org.apache.dubbo.metadata.definition.model.TypeDefinition.formatTypes;
+
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
-
-import static org.apache.dubbo.metadata.definition.model.TypeDefinition.formatType;
-import static org.apache.dubbo.metadata.definition.model.TypeDefinition.formatTypes;
 
 /**
  * 2015/1/27.

--- a/dubbo-metadata/dubbo-metadata-api/src/main/java/org/apache/dubbo/metadata/definition/model/MethodDefinition.java
+++ b/dubbo-metadata/dubbo-metadata-api/src/main/java/org/apache/dubbo/metadata/definition/model/MethodDefinition.java
@@ -36,8 +36,8 @@ public class MethodDefinition implements Serializable {
     private String[] parameterTypes;
     private String returnType;
     private List<TypeDefinition> parameters;
-    private List<Annotation> annotations;
-    
+    private List<String> annotations;
+
     public String getName() {
         return name;
     }
@@ -73,14 +73,14 @@ public class MethodDefinition implements Serializable {
         this.returnType = formatType(returnType);
     }
 
-    public List<Annotation> getAnnotations() {
+    public List<String> getAnnotations() {
         if (annotations == null) {
             annotations = Collections.emptyList();
         }
         return annotations;
     }
 
-    public void setAnnotations(List<Annotation> annotations) {
+    public void setAnnotations(List<String> annotations) {
         this.annotations = annotations;
     }
 

--- a/dubbo-metadata/dubbo-metadata-api/src/main/java/org/apache/dubbo/metadata/definition/model/ServiceDefinition.java
+++ b/dubbo-metadata/dubbo-metadata-api/src/main/java/org/apache/dubbo/metadata/definition/model/ServiceDefinition.java
@@ -32,7 +32,7 @@ public class ServiceDefinition implements Serializable {
     private String codeSource;
     private List<MethodDefinition> methods;
     private List<TypeDefinition> types;
-    private List<Annotation> annotations;
+    private List<String> annotations;
 
     public String getCanonicalName() {
         return canonicalName;
@@ -56,7 +56,7 @@ public class ServiceDefinition implements Serializable {
         return types;
     }
 
-    public List<Annotation> getAnnotations() {
+    public List<String> getAnnotations() {
         if (annotations == null) {
             annotations = Collections.emptyList();
         }
@@ -83,7 +83,7 @@ public class ServiceDefinition implements Serializable {
         this.types = types;
     }
 
-    public void setAnnotations(List<Annotation> annotations) {
+    public void setAnnotations(List<String> annotations) {
         this.annotations = annotations;
     }
 

--- a/dubbo-metadata/dubbo-metadata-api/src/main/java/org/apache/dubbo/metadata/definition/model/ServiceDefinition.java
+++ b/dubbo-metadata/dubbo-metadata-api/src/main/java/org/apache/dubbo/metadata/definition/model/ServiceDefinition.java
@@ -17,7 +17,6 @@
 package org.apache.dubbo.metadata.definition.model;
 
 import java.io.Serializable;
-import java.lang.annotation.Annotation;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;


### PR DESCRIPTION
## What is the purpose of the change
https://github.com/apache/dubbo/issues/7907


## Brief changelog
修改MethodDefinition、ServiceDefinition中annotation序列化存储类型为String的字符串（FastJson在序列化List<Annotation>的时候存储的元数据就是[]，所以这里直接修改数据类型为List<String> ）


## Verifying this change


<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [x] Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [x] GitHub Actions works fine on your own branch.
- [x] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
