### PR TITLE
Limit the maximum number of lines for the clear command

### DIFF
--- a/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/telnet/support/command/ClearTelnetHandler.java
+++ b/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/telnet/support/command/ClearTelnetHandler.java
@@ -29,6 +29,8 @@ import org.apache.dubbo.remoting.telnet.support.Help;
 @Help(parameter = "[lines]", summary = "Clear screen.", detail = "Clear screen.")
 public class ClearTelnetHandler implements TelnetHandler {
 
+    private static final int MAX_LINES = 1000;
+
     @Override
     public String telnet(Channel channel, String message) {
         int lines = 100;
@@ -36,7 +38,7 @@ public class ClearTelnetHandler implements TelnetHandler {
             if (!StringUtils.isInteger(message)) {
                 return "Illegal lines " + message + ", must be integer.";
             }
-            lines = Integer.parseInt(message);
+            lines = Math.min(MAX_LINES,Integer.parseInt(message));
         }
         StringBuilder buf = new StringBuilder();
         for (int i = 0; i < lines; i++) {


### PR DESCRIPTION
## What is the purpose of the change

If it is not limited, if the user specifies a very large value (such as 999999999), it will cause a large number of data packets to be sent, and the java heap size is prompted under the mac, and the cmd window directly under my win is forced to close
dang

mac:
![image](https://user-images.githubusercontent.com/43363120/120061069-f9df1300-c08d-11eb-9d53-5501ae55dab4.png)
