### PR TITLE
Fix DubboProtocol is not directly used externally

### DIFF
--- a/dubbo-monitor/dubbo-monitor-default/src/test/java/org/apache/dubbo/monitor/dubbo/DubboMonitorFactoryTest.java
+++ b/dubbo-monitor/dubbo-monitor-default/src/test/java/org/apache/dubbo/monitor/dubbo/DubboMonitorFactoryTest.java
@@ -45,7 +45,7 @@ public class DubboMonitorFactoryTest {
     public void setUp() throws Exception {
         initMocks(this);
         this.dubboMonitorFactory = new DubboMonitorFactory();
-        this.dubboMonitorFactory.setProtocol(new DubboProtocol());
+        this.dubboMonitorFactory.setProtocol(DubboProtocol.getDubboProtocol());
         this.dubboMonitorFactory.setProxyFactory(proxyFactory);
     }
 

--- a/dubbo-monitor/dubbo-monitor-default/src/test/java/org/apache/dubbo/monitor/dubbo/DubboMonitorFactoryTest.java
+++ b/dubbo-monitor/dubbo-monitor-default/src/test/java/org/apache/dubbo/monitor/dubbo/DubboMonitorFactoryTest.java
@@ -54,7 +54,7 @@ public class DubboMonitorFactoryTest {
     }
 
     @AfterEach
-    public static void tearDownAfterClass() {
+    public void tearDownAfterClass() {
         DubboProtocol.getDubboProtocol().destroy();
         List<ProtocolServer> servers = DubboProtocol.getDubboProtocol().getServers();
         for (ProtocolServer server : servers) {

--- a/dubbo-monitor/dubbo-monitor-default/src/test/java/org/apache/dubbo/monitor/dubbo/DubboMonitorFactoryTest.java
+++ b/dubbo-monitor/dubbo-monitor-default/src/test/java/org/apache/dubbo/monitor/dubbo/DubboMonitorFactoryTest.java
@@ -19,13 +19,17 @@ package org.apache.dubbo.monitor.dubbo;
 import org.apache.dubbo.common.URL;
 import org.apache.dubbo.monitor.Monitor;
 import org.apache.dubbo.rpc.Invoker;
+import org.apache.dubbo.rpc.ProtocolServer;
 import org.apache.dubbo.rpc.ProxyFactory;
-import org.apache.dubbo.rpc.protocol.dubbo.DubboProtocol;
 
+import org.apache.dubbo.rpc.protocol.dubbo.DubboProtocol;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
+
+import java.util.List;
 
 import static org.apache.dubbo.common.constants.CommonConstants.REFERENCE_FILTER_KEY;
 import static org.hamcrest.CoreMatchers.containsString;
@@ -47,6 +51,15 @@ public class DubboMonitorFactoryTest {
         this.dubboMonitorFactory = new DubboMonitorFactory();
         this.dubboMonitorFactory.setProtocol(DubboProtocol.getDubboProtocol());
         this.dubboMonitorFactory.setProxyFactory(proxyFactory);
+    }
+
+    @AfterEach
+    public static void tearDownAfterClass() {
+        DubboProtocol.getDubboProtocol().destroy();
+        List<ProtocolServer> servers = DubboProtocol.getDubboProtocol().getServers();
+        for (ProtocolServer server : servers) {
+            server.close();
+        }
     }
 
     @Test

--- a/dubbo-monitor/dubbo-monitor-default/src/test/java/org/apache/dubbo/monitor/dubbo/MetricsFilterTest.java
+++ b/dubbo-monitor/dubbo-monitor-default/src/test/java/org/apache/dubbo/monitor/dubbo/MetricsFilterTest.java
@@ -266,7 +266,7 @@ public class MetricsFilterTest {
                 //ignore
             }
         }
-        Protocol protocol = new DubboProtocol();
+        Protocol protocol = DubboProtocol.getDubboProtocol();
         URL metricUrl = URL.valueOf("dubbo://" + url.getHost() + ":" + url.getPort() + "/" + MetricsService.class.getName() + "?" + METRICS_PORT + "=" + port);
         Invoker<MetricsService> invoker = protocol.refer(MetricsService.class, metricUrl);
         invocation = new RpcInvocation("getMetricsByGroup", DemoService.class.getName(), "", new Class<?>[]{String.class}, new Object[]{DUBBO_GROUP});
@@ -320,7 +320,7 @@ public class MetricsFilterTest {
             }
         }
 
-        Protocol protocol = new DubboProtocol();
+        Protocol protocol = DubboProtocol.getDubboProtocol();
         URL metricUrl = URL.valueOf("dubbo://" + url.getHost() + ":" + url.getPort() + "/" + MetricsService.class.getName() + "?" + METRICS_PORT + "=" + port);
         Invoker<MetricsService> invoker = protocol.refer(MetricsService.class, metricUrl);
         Invocation invocation = new RpcInvocation("getMetricsByGroup", DemoService.class.getName(), "", new Class<?>[]{String.class}, new Object[]{DUBBO_GROUP});

--- a/dubbo-monitor/dubbo-monitor-default/src/test/java/org/apache/dubbo/monitor/dubbo/MetricsFilterTest.java
+++ b/dubbo-monitor/dubbo-monitor-default/src/test/java/org/apache/dubbo/monitor/dubbo/MetricsFilterTest.java
@@ -291,6 +291,8 @@ public class MetricsFilterTest {
         Assertions.assertEquals(100.0, metricMap.get("bucket_count"));
         Assertions.assertEquals(100.0 / 5, metricMap.get("qps"));
         Assertions.assertEquals(50.0 / 100.0, metricMap.get("success_rate"));
+
+        invoker.destroy();
     }
 
     public void testInvokeMetricsMethodService() {
@@ -365,5 +367,7 @@ public class MetricsFilterTest {
                 methodMetricMap.get("org.apache.dubbo.monitor.dubbo.service.DemoService.void sayName()").get("success_rate"));
         Assertions.assertEquals(50.0 / 100.0,
                 methodMetricMap.get("org.apache.dubbo.monitor.dubbo.service.DemoService.void echo(Integer)").get("success_rate"));
+
+        invoker.destroy();
     }
 }

--- a/dubbo-rpc/dubbo-rpc-dubbo/src/test/java/org/apache/dubbo/rpc/protocol/dubbo/DubboInvokerAvailableTest.java
+++ b/dubbo-rpc/dubbo-rpc-dubbo/src/test/java/org/apache/dubbo/rpc/protocol/dubbo/DubboInvokerAvailableTest.java
@@ -53,7 +53,7 @@ public class DubboInvokerAvailableTest {
 
     @BeforeEach
     public void setUp() throws Exception {
-        protocol = new DubboProtocol();
+        protocol = DubboProtocol.getDubboProtocol();
     }
 
     @AfterAll


### PR DESCRIPTION
## What is the purpose of the change

Fix DubboProtocol is not directly used externally

see more detail from #7923 

## Brief changelog


## Verifying this change


<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [ ] GitHub Actions works fine on your own branch.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
