### PR TITLE
Fix the bug that calling the unregisterServiceInstance method in the DubboBootstrap#destroy method does not work

### DIFF
--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/bootstrap/DubboBootstrap.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/bootstrap/DubboBootstrap.java
@@ -1244,8 +1244,6 @@ public class DubboBootstrap {
     public void destroy() {
         if (destroyLock.tryLock()) {
             try {
-                DubboShutdownHook.destroyAll();
-
                 if (started.compareAndSet(true, false)
                         && destroyed.compareAndSet(false, true)) {
 
@@ -1264,6 +1262,8 @@ public class DubboBootstrap {
                     ExtensionLoader<DubboBootstrapStartStopListener> exts = getExtensionLoader(DubboBootstrapStartStopListener.class);
                     exts.getSupportedExtensionInstances().forEach(ext -> ext.onStop(this));
                 }
+
+                DubboShutdownHook.destroyAll();
             } finally {
                 destroyLock.unlock();
             }


### PR DESCRIPTION
for issue #7960