### PR TITLE
[LFUCache]Add frequency of key and delete the empty cache queue

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/extension/ExtensionLoader.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/extension/ExtensionLoader.java
@@ -270,7 +270,7 @@ public class ExtensionLoader<T> {
         List<T> activateExtensions = new ArrayList<>();
         // solve the bug of using @SPI's wrapper method to report a null pointer exception.
         TreeMap<Class, T> activateExtensionsMap = new TreeMap<>(ActivateComparator.COMPARATOR);
-        List<String> names = values == null ? new ArrayList<>(0) : asList(values);
+        Set<String> names = CollectionUtils.ofSet(values);
         if (!names.contains(REMOVE_VALUE_PREFIX + DEFAULT_KEY)) {
             getExtensionClasses();
             for (Map.Entry<String, Object> entry : cachedActivates.entrySet()) {
@@ -300,8 +300,7 @@ public class ExtensionLoader<T> {
             }
         }
         List<T> loadedExtensions = new ArrayList<>();
-        for (int i = 0; i < names.size(); i++) {
-            String name = names.get(i);
+        for (String name : names) {
             if (!name.startsWith(REMOVE_VALUE_PREFIX)
                     && !names.contains(REMOVE_VALUE_PREFIX + name)) {
                 if (DEFAULT_KEY.equals(name)) {
@@ -405,17 +404,6 @@ public class ExtensionLoader<T> {
     public Object getLoadedAdaptiveExtensionInstances() {
         return cachedAdaptiveInstance.get();
     }
-
-//    public T getPrioritizedExtensionInstance() {
-//        Set<String> supported = getSupportedExtensions();
-//
-//        Set<T> instances = new HashSet<>();
-//        Set<T> prioritized = new HashSet<>();
-//        for (String s : supported) {
-//
-//        }
-//
-//    }
 
     /**
      * Find the extension with the given name. If the specified name is not found, then {@link IllegalStateException}

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/utils/LFUCache.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/utils/LFUCache.java
@@ -18,14 +18,12 @@ package org.apache.dubbo.common.utils;
 
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.concurrent.locks.ReentrantLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 public class LFUCache<K, V> {

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/utils/LFUCacheTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/utils/LFUCacheTest.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class LFUCacheTest {
 
@@ -71,6 +72,37 @@ public class LFUCacheTest {
     public void testDefaultCapacity() throws Exception {
         LFUCache<String, Integer> cache = new LFUCache<>();
         assertThat(cache.getCapacity(), equalTo(1000));
+    }
+
+    @Test
+    public void testGetFreq() throws Exception {
+        LFUCache<String, Integer> cache = new LFUCache<>();
+        cache.put("one", 1);
+        cache.put("two", 2);
+        cache.put("two", 2);
+        assertThat(cache.getFreq("one"), equalTo(1L));
+        assertThat(cache.getFreq("two"), equalTo(2L));
+    }
+
+    @Test
+    public void testRemoveEmptyCacheQueue() throws Exception {
+        LFUCache<String, Integer> cache = new LFUCache<>(2, 0.5f, 1000);
+        cache.put("one", 1);
+        cache.put("two", 2);
+        assertThat(cache.getFreqTableSize(), equalTo(1));
+        cache.put("two", 2);
+        long begin = System.currentTimeMillis();
+        assertThat(cache.getFreqTableSize(), equalTo(2));
+        cache.remove("two");
+        cache.put("three",3);
+        cache.put("four", 4);
+        assertThat(cache.getSize(), equalTo(1));
+        assertThat(cache.getFreqTableSize(), equalTo(2));
+        Thread.sleep(1000);
+        cache.put("five",5);
+        cache.put("six", 6);
+        assertThat(cache.getSize(), equalTo(1));
+        assertThat(cache.getFreqTableSize(), equalTo(1));
     }
 
     @Test

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/utils/LFUCacheTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/utils/LFUCacheTest.java
@@ -91,7 +91,6 @@ public class LFUCacheTest {
         cache.put("two", 2);
         assertThat(cache.getFreqTableSize(), equalTo(1));
         cache.put("two", 2);
-        long begin = System.currentTimeMillis();
         assertThat(cache.getFreqTableSize(), equalTo(2));
         cache.remove("two");
         cache.put("three",3);

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/utils/LFUCacheTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/utils/LFUCacheTest.java
@@ -23,7 +23,6 @@ import java.io.IOException;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class LFUCacheTest {
 


### PR DESCRIPTION
## What is the purpose of the change
You can not get frequency of the key or delete the empty cache queue before.

## Brief changelog
1.Change the freqTable from Array to TreeMap
2.Add a timeout field to determine if an empty queue can be deleted
3.Add a method to get frequency of the key
## Verifying this change
![image](https://user-images.githubusercontent.com/14951786/120629553-8592de00-c498-11eb-859e-210900277b24.png)


<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [ ] GitHub Actions works fine on your own branch.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
