### PR TITLE
Fix unit test for ConfigUtils#loadProperties method

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/utils/ConfigUtils.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/utils/ConfigUtils.java
@@ -220,7 +220,7 @@ public class ConfigUtils {
      * </ul>
      * @throws IllegalStateException not allow multi-file, but multi-file exist on class path.
      */
-    public static Properties loadProperties(String fileName, boolean allowMultiFile, boolean optional) {
+    public static Properties loadProperties(String fileName, boolean allowMultiFile, boolean optional) throws IllegalStateException {
         Properties properties = new Properties();
         // add scene judgement in windows environment Fix 2557
         if (checkFileNameExist(fileName)) {
@@ -259,7 +259,7 @@ public class ConfigUtils {
             if (list.size() > 1) {
                 String errMsg = String.format("only 1 %s file is expected, but %d dubbo.properties files found on class path: %s",
                         fileName, list.size(), list.toString());
-                logger.warn(errMsg);
+                throw new IllegalStateException(errMsg);
             }
 
             // fall back to use method getResourceAsStream

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/utils/ConfigUtilsTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/utils/ConfigUtilsTest.java
@@ -229,14 +229,13 @@ public class ConfigUtilsTest {
     }
 
 
-    @Disabled("Not know why disabled, the original link explaining this was reachable.")
     @Test
     public void testLoadPropertiesMultiFileNotRootPathException() throws Exception {
         try {
-            ConfigUtils.loadProperties("META-INF/services/org.apache.dubbo.common.status.StatusChecker", false);
+            ConfigUtils.loadProperties("META-INF/dubbo/internal/org.apache.dubbo.common.status.StatusChecker", false);
             Assertions.fail();
         } catch (IllegalStateException expected) {
-            assertThat(expected.getMessage(), containsString("only 1 META-INF/services/org.apache.dubbo.common.status.StatusChecker file is expected, but 2 dubbo.properties files found on class path:"));
+            assertThat(expected.getMessage(), containsString("only 1 META-INF/dubbo/internal/org.apache.dubbo.common.status.StatusChecker file is expected, but 2 dubbo.properties files found on class path:"));
         }
     }
 


### PR DESCRIPTION


## What is the purpose of the change

- Fix the bug that the ConfigUtils#loadProperties method does not handle exceptions when allowMultiFile=false and multiple files are satisfied

- Fix unit test for ConfigUtils#loadProperties method

