### PR TITLE
fix: Support Lazy annotation

### DIFF
--- a/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/beans/factory/annotation/ServiceClassPostProcessor.java
+++ b/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/beans/factory/annotation/ServiceClassPostProcessor.java
@@ -50,6 +50,7 @@ import org.springframework.context.annotation.AnnotationBeanNameGenerator;
 import org.springframework.context.annotation.AnnotationConfigUtils;
 import org.springframework.context.annotation.ClassPathBeanDefinitionScanner;
 import org.springframework.context.annotation.ConfigurationClassPostProcessor;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.core.annotation.AnnotationAttributes;
 import org.springframework.core.env.Environment;
 import org.springframework.core.io.ResourceLoader;
@@ -291,7 +292,13 @@ public class ServiceClassPostProcessor implements BeanDefinitionRegistryPostProc
 
         AbstractBeanDefinition serviceBeanDefinition =
                 buildServiceBeanDefinition(service, serviceAnnotationAttributes, interfaceClass, annotatedServiceBeanName);
-
+        /**
+         * Supports {@link Lazy} annotation
+         * */
+        Lazy lazyAnnotation = beanClass.getAnnotation(Lazy.class);
+        if (lazyAnnotation != null) {
+            serviceBeanDefinition.setLazyInit(lazyAnnotation.value());
+        }
         // ServiceBean Bean name
         String beanName = generateServiceBeanName(serviceAnnotationAttributes, interfaceClass);
 

--- a/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/annotation/consumer/lazyinit/DefaultLazyInitConsumer.java
+++ b/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/annotation/consumer/lazyinit/DefaultLazyInitConsumer.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.config.spring.annotation.consumer.lazyinit;
+
+import org.apache.dubbo.config.annotation.DubboReference;
+import org.apache.dubbo.config.annotation.DubboService;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.stereotype.Component;
+
+/**
+ * Service sets Lazy
+ */
+@Lazy
+@Component("defaultLazyInitConsumer")
+public class DefaultLazyInitConsumer implements LazyInitConsumer{
+
+    @DubboReference
+    private LazyInitService lazyInitService;
+
+    @Override
+    public String say(String name) {
+        return lazyInitService.hello(name);
+    }
+}

--- a/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/annotation/consumer/lazyinit/DefaultLazyInitService.java
+++ b/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/annotation/consumer/lazyinit/DefaultLazyInitService.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.config.spring.annotation.consumer.lazyinit;
+
+import org.apache.dubbo.config.annotation.DubboService;
+import org.springframework.context.annotation.Lazy;
+
+/**
+ * Service sets Lazy
+ */
+@Lazy
+@DubboService
+public class DefaultLazyInitService implements LazyInitService{
+
+    @Override
+    public String hello(String name) {
+        return "hello " + name;
+    }
+}

--- a/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/annotation/consumer/lazyinit/DefaultNotLazyInitService.java
+++ b/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/annotation/consumer/lazyinit/DefaultNotLazyInitService.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.config.spring.annotation.consumer.lazyinit;
+
+import org.apache.dubbo.config.annotation.DubboService;
+import org.springframework.context.annotation.Lazy;
+
+/**
+ * Service doesn't set Lazy
+ */
+@DubboService
+public class DefaultNotLazyInitService implements NotLazyInitService{
+
+    @Override
+    public String hello(String name) {
+        return "hello " + name;
+    }
+}

--- a/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/annotation/consumer/lazyinit/LazyInitConsumer.java
+++ b/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/annotation/consumer/lazyinit/LazyInitConsumer.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.config.spring.annotation.consumer.lazyinit;
+/**
+ * Customer interface
+ */
+public interface LazyInitConsumer {
+
+    String say(String name);
+}

--- a/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/annotation/consumer/lazyinit/LazyInitService.java
+++ b/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/annotation/consumer/lazyinit/LazyInitService.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.config.spring.annotation.consumer.lazyinit;
+
+/**
+ * Service interface
+ */
+public interface LazyInitService {
+
+    String hello(String name);
+}

--- a/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/annotation/consumer/lazyinit/NotLazyInitService.java
+++ b/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/annotation/consumer/lazyinit/NotLazyInitService.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.config.spring.annotation.consumer.lazyinit;
+
+/**
+ * Service interface non-lazy-init
+ */
+public interface NotLazyInitService {
+
+    String hello(String name);
+}

--- a/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/api/LazyInitHelloService.java
+++ b/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/api/LazyInitHelloService.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.config.spring.api;
+
+/**
+ * Test the service with Lazy annotation.
+ */
+public interface LazyInitHelloService {
+
+    String sayHello(String name);
+}

--- a/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/beans/factory/annotation/LazyInitDubboAnnotationTest.java
+++ b/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/beans/factory/annotation/LazyInitDubboAnnotationTest.java
@@ -1,0 +1,134 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.config.spring.beans.factory.annotation;
+
+import org.apache.dubbo.common.utils.NetUtils;
+import org.apache.dubbo.config.ApplicationConfig;
+import org.apache.dubbo.config.ProtocolConfig;
+import org.apache.dubbo.config.RegistryConfig;
+import org.apache.dubbo.config.bootstrap.DubboBootstrap;
+import org.apache.dubbo.config.spring.annotation.consumer.lazyinit.DefaultLazyInitConsumer;
+import org.apache.dubbo.config.spring.annotation.consumer.lazyinit.LazyInitConsumer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(
+        classes = {
+                LazyInitDubboAnnotationTest.class,
+                DefaultLazyInitConsumer.class
+        })
+@TestPropertySource(properties = {
+        "consumer.package = org.apache.dubbo.config.spring.annotation.consumer.lazyinit",
+        "packagesToScan = ${consumer.package}",
+})
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+public class LazyInitDubboAnnotationTest {
+
+    @BeforeEach
+    public void setUp() {
+        DubboBootstrap.reset();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        DubboBootstrap.reset();
+    }
+
+    @Autowired
+    private ConfigurableListableBeanFactory beanFactory;
+
+    @Bean
+    public ServiceClassPostProcessor serviceClassPostProcessor(@Value("${packagesToScan}") String... packagesToScan) {
+        return new ServiceClassPostProcessor(packagesToScan);
+    }
+
+    /**
+     * lazy-init Application Configuration
+     *
+     * @return {@link ApplicationConfig} Bean
+     */
+    @Bean("applicationConfig")
+    public ApplicationConfig applicationConfig() {
+        ApplicationConfig applicationConfig = new ApplicationConfig();
+        applicationConfig.setName("lazy-init-annotation-application");
+        return applicationConfig;
+    }
+
+    /**
+     * lazy-init Registry Configuration
+     *
+     * @return {@link RegistryConfig} Bean
+     */
+    @Bean("registryConfig")
+    public RegistryConfig registryConfig() {
+        RegistryConfig registryConfig = new RegistryConfig();
+        registryConfig.setAddress("N/A");
+        return registryConfig;
+    }
+
+    /**
+     * lazy-init Protocol Configuration
+     *
+     * @return {@link ProtocolConfig} Bean
+     */
+    @Bean("protocolConfig")
+    public ProtocolConfig protocolConfig() {
+        ProtocolConfig protocolConfig = new ProtocolConfig();
+        protocolConfig.setName("dubbo");
+        protocolConfig.setPort(NetUtils.getAvailablePort());
+        return protocolConfig;
+    }
+
+    @Test
+    public void testLazyInitReference() {
+        // Customer has Lazy annotation
+        BeanDefinition defaultLazyInitConsumerBeanDefinition = beanFactory.getBeanDefinition("defaultLazyInitConsumer");
+        Assertions.assertEquals(defaultLazyInitConsumerBeanDefinition.isLazyInit(), true);
+
+        // Service has Lazy annotation
+        BeanDefinition defaultLazyInitServiceBeanDefinition = beanFactory.getBeanDefinition("defaultLazyInitService");
+        Assertions.assertEquals(defaultLazyInitServiceBeanDefinition.isLazyInit(), true);
+
+        // Service doesn't have Lazy annotation
+        BeanDefinition defaultNotLazyInitServiceBeanDefinition = beanFactory.getBeanDefinition("defaultNotLazyInitService");
+        Assertions.assertEquals(defaultNotLazyInitServiceBeanDefinition.isLazyInit(), false);
+
+        // Call Customer's reference and it will initialize
+        try {
+            beanFactory.getBean("defaultLazyInitConsumer", LazyInitConsumer.class);
+        } catch (Exception ex) {
+            // throw an exception because the provider need to export, but the registry config is invalid.
+            Throwable rootCause = ex.getCause();
+            Assertions.assertTrue(rootCause instanceof IllegalStateException);
+            Assertions.assertTrue(rootCause.getMessage().startsWith("No registry config found or it's not a valid config!"));
+        }
+    }
+
+}

--- a/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/beans/factory/annotation/ServiceAnnotationBeanPostProcessorTest.java
+++ b/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/beans/factory/annotation/ServiceAnnotationBeanPostProcessorTest.java
@@ -20,6 +20,7 @@ import org.apache.dubbo.config.bootstrap.DubboBootstrap;
 import org.apache.dubbo.config.spring.ServiceBean;
 import org.apache.dubbo.config.spring.api.HelloService;
 
+import org.apache.dubbo.config.spring.api.LazyInitHelloService;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -76,8 +77,10 @@ public class ServiceAnnotationBeanPostProcessorTest {
         Assertions.assertEquals(2, helloServicesMap.size());
 
         Map<String, ServiceBean> serviceBeansMap = beanFactory.getBeansOfType(ServiceBean.class);
-
-        Assertions.assertEquals(2, serviceBeansMap.size());
+        /**
+         * There are one {@link HelloService} and two {@link LazyInitHelloService} has 1
+         * */
+        Assertions.assertEquals(3, serviceBeansMap.size());
 
         Map<String, ServiceAnnotationBeanPostProcessor> beanPostProcessorsMap =
                 beanFactory.getBeansOfType(ServiceAnnotationBeanPostProcessor.class);
@@ -93,8 +96,10 @@ public class ServiceAnnotationBeanPostProcessorTest {
     public void testMethodAnnotation() {
 
         Map<String, ServiceBean> serviceBeansMap = beanFactory.getBeansOfType(ServiceBean.class);
-
-        Assertions.assertEquals(2, serviceBeansMap.size());
+        /**
+         * There are one {@link HelloService} and two {@link LazyInitHelloService} has 1
+         * */
+        Assertions.assertEquals(3, serviceBeansMap.size());
 
         ServiceBean demoServiceBean = serviceBeansMap.get("ServiceBean:org.apache.dubbo.config.spring.api.DemoService:2.5.7");
 

--- a/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/beans/factory/annotation/ServiceClassPostProcessorTest.java
+++ b/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/beans/factory/annotation/ServiceClassPostProcessorTest.java
@@ -26,12 +26,14 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.context.annotation.Bean;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.apache.dubbo.config.spring.api.LazyInitHelloService;
 
 import java.util.Map;
 
@@ -80,8 +82,10 @@ public class ServiceClassPostProcessorTest {
         Assertions.assertEquals(2, helloServicesMap.size());
 
         Map<String, ServiceBean> serviceBeansMap = beanFactory.getBeansOfType(ServiceBean.class);
-
-        Assertions.assertEquals(2, serviceBeansMap.size());
+        /**
+         * There are one {@link HelloService} and two {@link LazyInitHelloService} has 1
+         * */
+        Assertions.assertEquals(3, serviceBeansMap.size());
 
         Map<String, ServiceClassPostProcessor> beanPostProcessorsMap =
                 beanFactory.getBeansOfType(ServiceClassPostProcessor.class);
@@ -98,7 +102,10 @@ public class ServiceClassPostProcessorTest {
 
         Map<String, ServiceBean> serviceBeansMap = beanFactory.getBeansOfType(ServiceBean.class);
 
-        Assertions.assertEquals(2, serviceBeansMap.size());
+        /**
+         * There are one {@link HelloService} and two {@link LazyInitHelloService} has 1
+         * */
+        Assertions.assertEquals(3, serviceBeansMap.size());
 
         ServiceBean demoServiceBean = serviceBeansMap.get("ServiceBean:org.apache.dubbo.config.spring.api.DemoService:2.5.7");
 
@@ -106,4 +113,15 @@ public class ServiceClassPostProcessorTest {
 
     }
 
+    /**
+     * Lazy-init for Dubbo Service
+     */
+    @Test
+    public void testLazyInitDubboService(){
+        /**
+         * The class {@link org.apache.dubbo.config.spring.context.annotation.provider.DefaultLazyInitHelloService} has Lazy annotation
+         * */
+        BeanDefinition beanDefinition=beanFactory.getBeanDefinition("defaultLazyInitHelloService");
+        Assertions.assertEquals(beanDefinition.isLazyInit(),true);
+    }
 }

--- a/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/context/annotation/provider/DefaultLazyInitHelloService.java
+++ b/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/context/annotation/provider/DefaultLazyInitHelloService.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.config.spring.context.annotation.provider;
+
+import org.apache.dubbo.config.annotation.DubboService;
+import org.apache.dubbo.config.spring.api.LazyInitHelloService;
+import org.springframework.context.annotation.Lazy;
+
+/**
+ * lazy-initialized {@link org.apache.dubbo.config.annotation.DubboService}
+ */
+@Lazy
+@DubboService
+public class DefaultLazyInitHelloService implements LazyInitHelloService {
+
+    @Override
+    public String sayHello(String name) {
+        return "Greeting, " + name;
+    }
+
+}

--- a/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/impl/DemoServiceXMLLazyInitImpl1.java
+++ b/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/impl/DemoServiceXMLLazyInitImpl1.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.config.spring.impl;
+
+import org.apache.dubbo.config.spring.api.Box;
+import org.apache.dubbo.config.spring.api.DemoService;
+
+/**
+ * This demo is to test if it's lazy-initialized
+ */
+public class DemoServiceXMLLazyInitImpl1 implements DemoService {
+
+    public DemoServiceXMLLazyInitImpl1() {
+        initialized = true;
+    }
+
+    /**
+     * Checks if the instance is initialized.
+     */
+    private static boolean initialized = false;
+
+    private String prefix = "say:";
+
+    public String sayName(String name) {
+        return prefix + name;
+    }
+
+    public Box getBox() {
+        return null;
+    }
+
+    public String getPrefix() {
+        return prefix;
+    }
+
+    public void setPrefix(String prefix) {
+        this.prefix = prefix;
+    }
+
+    /**
+     * Checks if the instance is initialized.
+     */
+    public static boolean isInitialized() {
+        return initialized;
+    }
+}

--- a/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/impl/DemoServiceXMLLazyInitImpl2.java
+++ b/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/impl/DemoServiceXMLLazyInitImpl2.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.config.spring.impl;
+
+import org.apache.dubbo.config.spring.api.Box;
+import org.apache.dubbo.config.spring.api.DemoService;
+
+/**
+ * This demo is to test if it's lazy-initialized
+ */
+public class DemoServiceXMLLazyInitImpl2 implements DemoService {
+
+    public DemoServiceXMLLazyInitImpl2() {
+        initialized = true;
+    }
+
+    /**
+     * Checks if the instance is initialized.
+     */
+    private static boolean initialized = false;
+
+    private String prefix = "say:";
+
+    public String sayName(String name) {
+        return prefix + name;
+    }
+
+    public Box getBox() {
+        return null;
+    }
+
+    public String getPrefix() {
+        return prefix;
+    }
+
+    public void setPrefix(String prefix) {
+        this.prefix = prefix;
+    }
+
+    /**
+     * Checks if the instance is initialized.
+     */
+    public static boolean isInitialized() {
+        return initialized;
+    }
+}

--- a/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/impl/DemoServiceXMLNotLazyInitImpl.java
+++ b/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/impl/DemoServiceXMLNotLazyInitImpl.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.config.spring.impl;
+
+import org.apache.dubbo.config.spring.api.Box;
+import org.apache.dubbo.config.spring.api.DemoService;
+
+/**
+ * This demo is to test if it's lazy-initialized
+ */
+public class DemoServiceXMLNotLazyInitImpl implements DemoService {
+
+    public DemoServiceXMLNotLazyInitImpl() {
+        initialized = true;
+    }
+
+    /**
+     * Checks if the instance is initialized.
+     */
+    private static boolean initialized = false;
+
+    private String prefix = "say:";
+
+    public String sayName(String name) {
+        return prefix + name;
+    }
+
+    public Box getBox() {
+        return null;
+    }
+
+    public String getPrefix() {
+        return prefix;
+    }
+
+    public void setPrefix(String prefix) {
+        this.prefix = prefix;
+    }
+
+    /**
+     * Checks if the instance is initialized.
+     */
+    public static boolean isInitialized() {
+        return initialized;
+    }
+}

--- a/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/schema/DubboNamespaceHandlerTest.java
+++ b/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/schema/DubboNamespaceHandlerTest.java
@@ -26,6 +26,9 @@ import org.apache.dubbo.config.spring.ConfigTest;
 import org.apache.dubbo.config.spring.ServiceBean;
 import org.apache.dubbo.config.spring.api.DemoService;
 import org.apache.dubbo.config.spring.impl.DemoServiceImpl;
+import org.apache.dubbo.config.spring.impl.DemoServiceXMLLazyInitImpl1;
+import org.apache.dubbo.config.spring.impl.DemoServiceXMLLazyInitImpl2;
+import org.apache.dubbo.config.spring.impl.DemoServiceXMLNotLazyInitImpl;
 import org.apache.dubbo.rpc.model.ApplicationModel;
 
 import org.junit.jupiter.api.AfterEach;
@@ -233,5 +236,51 @@ public class DubboNamespaceHandlerTest {
             return;
         }
         Assertions.fail();
+    }
+
+    @Test
+    public void testLazyInitServiceBean() {
+        ClassPathXmlApplicationContext ctx = null;
+        try {
+            ctx = new ClassPathXmlApplicationContext("classpath:/org/apache/dubbo/config/spring/demo-provider-lazy-init.xml");
+            ctx.start();
+            /**
+             * {@link DemoServiceXMLLazyInitImpl1} sets lazy-init
+             * */
+            Assertions.assertEquals(DemoServiceXMLLazyInitImpl1.isInitialized(),false);
+            /**
+             * {@link DemoServiceXMLLazyInitImpl2} sets default-lazy-init
+             * */
+            Assertions.assertEquals(DemoServiceXMLLazyInitImpl2.isInitialized(),false);
+
+            /**
+             * After getBean and then {@link DemoServiceXMLLazyInitImpl1#isInitialized()} changed to {@code true}
+             * */
+            ctx.getBean("demoServiceXMLLazyInitImpl1",DemoServiceXMLLazyInitImpl1.class);
+            Assertions.assertEquals(DemoServiceXMLLazyInitImpl1.isInitialized(),true);
+        }finally {
+            if (ctx != null) {
+                ctx.stop();
+                ctx.close();
+            }
+        }
+    }
+
+    @Test
+    public void testNotLazyInitServiceBean() {
+        ClassPathXmlApplicationContext ctx = null;
+        try {
+            ctx = new ClassPathXmlApplicationContext("classpath:/org/apache/dubbo/config/spring/demo-provider-not-lazy-init.xml");
+            ctx.start();
+            /**
+             * {@link DemoServiceXMLNotLazyInitImpl} don't set lazy-init
+             * */
+            Assertions.assertEquals(DemoServiceXMLNotLazyInitImpl.isInitialized(),true);
+        }finally {
+            if (ctx != null) {
+                ctx.stop();
+                ctx.close();
+            }
+        }
     }
 }

--- a/dubbo-config/dubbo-config-spring/src/test/resources/org/apache/dubbo/config/spring/demo-provider-lazy-init.xml
+++ b/dubbo-config/dubbo-config-spring/src/test/resources/org/apache/dubbo/config/spring/demo-provider-lazy-init.xml
@@ -1,0 +1,34 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:dubbo="http://dubbo.apache.org/schema/dubbo"
+       xmlns="http://www.springframework.org/schema/beans"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.3.xsd
+    http://dubbo.apache.org/schema/dubbo http://dubbo.apache.org/schema/dubbo/dubbo.xsd" default-lazy-init="true">
+
+    <dubbo:application name="demo-provider-lazy-init-application"/>
+
+    <dubbo:registry address="N/A"/>
+
+    <dubbo:protocol name="dubbo" port="20899"/>
+
+    <!-- lazy-init="true" -->
+    <bean name="demoServiceXMLLazyInitImpl1" class="org.apache.dubbo.config.spring.impl.DemoServiceXMLLazyInitImpl1" lazy-init="true"/>
+    <!-- default-lazy-init="true" -->
+    <bean name="demoServiceXMLLazyInitImpl2" class="org.apache.dubbo.config.spring.impl.DemoServiceXMLLazyInitImpl2"/>
+
+</beans>

--- a/dubbo-config/dubbo-config-spring/src/test/resources/org/apache/dubbo/config/spring/demo-provider-not-lazy-init.xml
+++ b/dubbo-config/dubbo-config-spring/src/test/resources/org/apache/dubbo/config/spring/demo-provider-not-lazy-init.xml
@@ -1,0 +1,32 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:dubbo="http://dubbo.apache.org/schema/dubbo"
+       xmlns="http://www.springframework.org/schema/beans"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.3.xsd
+    http://dubbo.apache.org/schema/dubbo http://dubbo.apache.org/schema/dubbo/dubbo.xsd">
+
+    <dubbo:application name="demo-provider-not-lazy-init-application"/>
+
+    <dubbo:registry address="N/A"/>
+
+    <dubbo:protocol name="dubbo" port="20910"/>
+
+    <!-- lazy-init="false" -->
+    <bean name="demoServiceXMLNotLazyInitImpl" class="org.apache.dubbo.config.spring.impl.DemoServiceXMLNotLazyInitImpl" lazy-init="false"/>
+
+</beans>


### PR DESCRIPTION
## What is the purpose of the change

see #829 

## Brief changelog

1. support @Lazy
2. add testcase to check default-lazy-init and lazy-init in XML
3. add testcase to check Lazy annotation

## Verifying this change


<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [x] Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [ ] GitHub Actions works fine on your own branch.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
