### PR TITLE
Keep the ProviderURLMergeProcessor API unchanged

### DIFF
--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/Constants.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/Constants.java
@@ -104,8 +104,4 @@ public interface Constants {
      */
     String ARGUMENTS = "arguments";
 
-    /**
-     * Url merge processor key
-     */
-    String URL_MERGE_PROCESSOR_KEY = "urlmergeprocessor";
 }

--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/ProviderURLMergeProcessor.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/ProviderURLMergeProcessor.java
@@ -22,14 +22,18 @@ import org.apache.dubbo.common.extension.SPI;
 import java.util.Map;
 
 @SPI("default")
-public interface UrlMergeProcessor {
+public interface ProviderURLMergeProcessor {
 
     /**
      * Merging the URL parameters of provider and consumer
-     * @param remoteUrl providerUrl
+     *
+     * @param remoteUrl          providerUrl
      * @param localParametersMap consumer url parameters
      * @return
      */
     URL mergeUrl(URL remoteUrl, Map<String, String> localParametersMap);
 
+    default boolean accept(URL providerUrl, Map<String, String> localParametersMap) {
+        return true;
+    }
 }

--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/support/ClusterUtils.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/support/ClusterUtils.java
@@ -19,11 +19,12 @@ package org.apache.dubbo.rpc.cluster.support;
 import org.apache.dubbo.common.URL;
 import org.apache.dubbo.common.extension.ExtensionLoader;
 import org.apache.dubbo.common.utils.StringUtils;
-import org.apache.dubbo.rpc.cluster.UrlMergeProcessor;
+import org.apache.dubbo.rpc.cluster.ProviderURLMergeProcessor;
 
 import java.util.Map;
 
-import static org.apache.dubbo.rpc.cluster.Constants.URL_MERGE_PROCESSOR_KEY;
+import static org.apache.dubbo.config.Constants.URL_MERGE_PROCESSOR_KEY;
+
 
 /**
  * ClusterUtils
@@ -36,15 +37,15 @@ public class ClusterUtils {
     public static URL mergeUrl(URL remoteUrl, Map<String, String> localMap) {
 
         String ump = localMap.get(URL_MERGE_PROCESSOR_KEY);
-        UrlMergeProcessor urlMergeProcessor;
+        ProviderURLMergeProcessor providerURLMergeProcessor;
 
         if (StringUtils.isNotEmpty(ump)) {
-            urlMergeProcessor = ExtensionLoader.getExtensionLoader(UrlMergeProcessor.class).getExtension(ump);
+            providerURLMergeProcessor = ExtensionLoader.getExtensionLoader(ProviderURLMergeProcessor.class).getExtension(ump);
         } else {
-            urlMergeProcessor = ExtensionLoader.getExtensionLoader(UrlMergeProcessor.class).getExtension("default");
+            providerURLMergeProcessor = ExtensionLoader.getExtensionLoader(ProviderURLMergeProcessor.class).getExtension("default");
         }
 
-        return urlMergeProcessor.mergeUrl(remoteUrl, localMap);
+        return providerURLMergeProcessor.mergeUrl(remoteUrl, localMap);
     }
 
 }

--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/support/merger/DefaultProviderURLMergeProcessor.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/support/merger/DefaultProviderURLMergeProcessor.java
@@ -14,11 +14,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.dubbo.rpc.cluster.support;
+package org.apache.dubbo.rpc.cluster.support.merger;
 
 import org.apache.dubbo.common.URL;
 import org.apache.dubbo.remoting.Constants;
-import org.apache.dubbo.rpc.cluster.UrlMergeProcessor;
+import org.apache.dubbo.rpc.cluster.ProviderURLMergeProcessor;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -44,7 +44,7 @@ import static org.apache.dubbo.common.constants.CommonConstants.VERSION_KEY;
 import static org.apache.dubbo.common.constants.CommonConstants.GENERIC_KEY;
 
 
-public class DefaultUrlMergeProcessor implements UrlMergeProcessor {
+public class DefaultProviderURLMergeProcessor implements ProviderURLMergeProcessor {
 
     @Override
     public URL mergeUrl(URL remoteUrl, Map<String, String> localParametersMap) {

--- a/dubbo-cluster/src/main/resources/META-INF/dubbo/internal/org.apache.dubbo.rpc.cluster.ProviderURLMergeProcessor
+++ b/dubbo-cluster/src/main/resources/META-INF/dubbo/internal/org.apache.dubbo.rpc.cluster.ProviderURLMergeProcessor
@@ -1,0 +1,1 @@
+default=org.apache.dubbo.rpc.cluster.support.merger.DefaultProviderURLMergeProcessor

--- a/dubbo-cluster/src/main/resources/META-INF/dubbo/internal/org.apache.dubbo.rpc.cluster.UrlMergeProcessor
+++ b/dubbo-cluster/src/main/resources/META-INF/dubbo/internal/org.apache.dubbo.rpc.cluster.UrlMergeProcessor
@@ -1,1 +1,0 @@
-default=org.apache.dubbo.rpc.cluster.support.DefaultUrlMergeProcessor

--- a/dubbo-common/src/main/java/org/apache/dubbo/config/Constants.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/config/Constants.java
@@ -120,4 +120,9 @@ public interface Constants {
     String REGISTER_KEY = "register";
 
     String IGNORE_CHECK_KEYS = "ignoreCheckKeys";
+
+    /**
+     * Url merge processor key
+     */
+    String URL_MERGE_PROCESSOR_KEY = "url-merge-processor";
 }

--- a/dubbo-common/src/main/java/org/apache/dubbo/config/ConsumerConfig.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/config/ConsumerConfig.java
@@ -17,6 +17,9 @@
 package org.apache.dubbo.config;
 
 import org.apache.dubbo.common.utils.StringUtils;
+import org.apache.dubbo.config.support.Parameter;
+
+import static org.apache.dubbo.config.Constants.URL_MERGE_PROCESSOR_KEY;
 
 /**
  * The service consumer default configuration
@@ -63,7 +66,7 @@ public class ConsumerConfig extends AbstractReferenceConfig {
      *  Url Merge Processor
      *  Used to customize the URL merge of consumer and provider
      */
-    private String urlmergeprocessor;
+    private String urlMergeProcessor;
 
     @Override
     public void setTimeout(Integer timeout) {
@@ -123,11 +126,12 @@ public class ConsumerConfig extends AbstractReferenceConfig {
         this.shareconnections = shareconnections;
     }
 
-    public String getUrlmergeprocessor() {
-        return urlmergeprocessor;
+    @Parameter(key = URL_MERGE_PROCESSOR_KEY)
+    public String getUrlMergeProcessor() {
+        return urlMergeProcessor;
     }
 
-    public void setUrlmergeprocessor(String urlmergeprocessor) {
-        this.urlmergeprocessor = urlmergeprocessor;
+    public void setUrlMergeProcessor(String urlMergeProcessor) {
+        this.urlMergeProcessor = urlMergeProcessor;
     }
 }

--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/bootstrap/builders/ConsumerBuilder.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/bootstrap/builders/ConsumerBuilder.java
@@ -65,7 +65,7 @@ public class ConsumerBuilder extends AbstractReferenceBuilder<ConsumerConfig, Co
      *  Url Merge Processor
      *  Used to customize the URL merge of consumer and provider
      */
-    private String urlmergeprocessor;
+    private String urlMergeProcessor;
 
     public ConsumerBuilder isDefault(Boolean isDefault) {
         this.isDefault = isDefault;
@@ -102,11 +102,12 @@ public class ConsumerBuilder extends AbstractReferenceBuilder<ConsumerConfig, Co
         return getThis();
     }
 
-    public ConsumerBuilder urlMergeProcessor(String urlmergeprocessor) {
-        this.urlmergeprocessor = urlmergeprocessor;
+    public ConsumerBuilder urlMergeProcessor(String urlMergeProcessor) {
+        this.urlMergeProcessor = urlMergeProcessor;
         return getThis();
     }
 
+    @Override
     public ConsumerConfig build() {
         ConsumerConfig consumer = new ConsumerConfig();
         super.build(consumer);
@@ -118,7 +119,7 @@ public class ConsumerBuilder extends AbstractReferenceBuilder<ConsumerConfig, Co
         consumer.setThreads(threads);
         consumer.setQueues(queues);
         consumer.setShareconnections(shareconnections);
-        consumer.setUrlmergeprocessor(urlmergeprocessor);
+        consumer.setUrlMergeProcessor(urlMergeProcessor);
 
         return consumer;
     }

--- a/dubbo-config/dubbo-config-spring/src/main/resources/META-INF/dubbo.xsd
+++ b/dubbo-config/dubbo-config-spring/src/main/resources/META-INF/dubbo.xsd
@@ -982,7 +982,7 @@
                             <![CDATA[ The default share connections. default share one connection. ]]></xsd:documentation>
                     </xsd:annotation>
                 </xsd:attribute>
-                <xsd:attribute name="urlmergeprocessor" type="xsd:string">
+                <xsd:attribute name="url-merge-processor" type="xsd:string">
                     <xsd:annotation>
                         <xsd:documentation><![CDATA[ The Url merge processor. ]]></xsd:documentation>
                     </xsd:annotation>


### PR DESCRIPTION
## What is the purpose of the change

Keep the ProviderURLMergeProcessor API unchanged.
Change the name of the configuration item.

follow #7860

## Brief changelog


## Verifying this change


<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [ ] GitHub Actions works fine on your own branch.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
