### PR TITLE
Optimize the AbstractConfig#refresh method to avoid multiple refreshes

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/config/AbstractConfig.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/config/AbstractConfig.java
@@ -468,6 +468,10 @@ public abstract class AbstractConfig implements Serializable {
     }
 
     public void refresh() {
+        if (!refreshed.compareAndSet(false, true)) {
+            return;
+        }
+
         Environment env = ApplicationModel.getEnvironment();
         try {
             CompositeConfiguration compositeConfiguration = env.getPrefixedConfiguration(this);


### PR DESCRIPTION
## What is the purpose of the change

For example, the DubboBootstrap#getApplication method will be called multiple times, which will cause AbstractConfig#refresh to be called multiple times. Actually, it only needs to be called once.