### PR TITLE
add a new method for getting the number of consumer service addresses…

### DIFF
--- a/dubbo-plugin/dubbo-qos/src/main/java/org/apache/dubbo/qos/command/util/ServiceCheckUtils.java
+++ b/dubbo-plugin/dubbo-qos/src/main/java/org/apache/dubbo/qos/command/util/ServiceCheckUtils.java
@@ -59,4 +59,24 @@ public class ServiceCheckUtils {
         }
         return num;
     }
+
+    //for the situation that QoS wants to query the address number of a consumer in all Registries
+    public static int getConsumerAddressNumInAllRegistries(ConsumerModel consumerModel){
+        int num = 0;
+
+        Collection<Registry> registries = AbstractRegistryFactory.getRegistries();
+        if(CollectionUtils.isNotEmpty(registries)){
+            for(Registry registry: registries){
+                AbstractRegistry abstractRegistry = (AbstractRegistry) registry;
+                for(Map.Entry<URL, Map<String, List<URL>>> entry: abstractRegistry.getNotified().entrySet()){
+                    if(entry.getKey().getServiceKey().equals(consumerModel.getServiceKey())){
+                        if(CollectionUtils.isNotEmptyMap(entry.getValue())){
+                            num += entry.getValue().size();
+                        }
+                    }
+                }
+            }
+        }
+        return num;
+    }
 }


### PR DESCRIPTION
## What is the purpose of the change
fix #8025 

## Brief changelog
**Add** getConsumerAddressNumInAllRegistries in ServiceCheckUtils

## Verifying this change
before:
the Consumer Sevice Name's list is null
after:
![image](https://user-images.githubusercontent.com/18096538/121474805-766cce00-c979-11eb-882c-ad48c1cb18d4.png)

<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [x] Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [x] GitHub Actions works fine on your own branch.
- [x] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
