### PR TITLE
Registry cannot work under k8s API server using SSL

### DIFF
--- a/dubbo-registry/dubbo-registry-kubernetes/src/main/java/org/apache/dubbo/registry/kubernetes/util/KubernetesConfigUtils.java
+++ b/dubbo-registry/dubbo-registry-kubernetes/src/main/java/org/apache/dubbo/registry/kubernetes/util/KubernetesConfigUtils.java
@@ -106,6 +106,6 @@ public class KubernetesConfigUtils {
     private static String decodeBase64(String str) {
         return StringUtils.isNotEmpty(str) ?
                 new String(Base64.getDecoder().decode(str)) :
-                "";
+                null;
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

The registry cannot work under the k8s API server using SSL. If there is no certificate related parameter, the empty string will be used by default. This is the result of not using kubernetes client ConfigFluentImpl correctly

see  ConfigFluentImpl#hasCaCertData(),hasClientCertData(),hasClientKeyData in kubernetes client

## Brief changelog


## Verifying this change


<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [x] Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [x] GitHub Actions works fine on your own branch.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
