### PR TITLE
[3.0] Improve config overrides of method and argument

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/config/ConfigurationUtils.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/config/ConfigurationUtils.java
@@ -169,17 +169,21 @@ public class ConfigurationUtils {
         if (!prefix.endsWith(".")) {
             prefix += ".";
         }
-        String finalPrefix = prefix;
         Map<String, V> map = new LinkedHashMap<>();
         for (Map<String, V> configMap : configMaps) {
-            configMap.forEach((key, val) -> {
-                if (StringUtils.startsWithIgnoreCase(key, finalPrefix) && !ConfigurationUtils.isEmptyValue(val)) {
-                    String k = key.substring(finalPrefix.length());
+            for (Map.Entry<String, V> entry : configMap.entrySet()) {
+                String key = entry.getKey();
+                V val = entry.getValue();
+                if (StringUtils.startsWithIgnoreCase(key, prefix)
+                    && key.length() > prefix.length()
+                    && !ConfigurationUtils.isEmptyValue(val)) {
+
+                    String k = key.substring(prefix.length());
                     // convert camelCase/snake_case to kebab-case
                     k = StringUtils.convertToSplitName(k, "-");
                     map.putIfAbsent(k, val);
                 }
-            });
+            }
         }
         return map;
     }
@@ -189,11 +193,23 @@ public class ConfigurationUtils {
             prefix += ".";
         }
         for (Map<String, V> configMap : configMaps) {
-            for (Map.Entry<String, V> entry : configMap.entrySet()) {
-                String key = entry.getKey();
-                if (StringUtils.startsWithIgnoreCase(key, prefix) && !ConfigurationUtils.isEmptyValue(entry.getValue())) {
-                    return true;
-                }
+            if (hasSubProperties(configMap, prefix)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public static <V extends Object> boolean hasSubProperties(Map<String, V> configMap, String prefix) {
+        if (!prefix.endsWith(".")) {
+            prefix += ".";
+        }
+        for (Map.Entry<String, V> entry : configMap.entrySet()) {
+            String key = entry.getKey();
+            if (StringUtils.startsWithIgnoreCase(key, prefix)
+                && key.length() > prefix.length()
+                && !ConfigurationUtils.isEmptyValue(entry.getValue())) {
+                return true;
             }
         }
         return false;
@@ -218,10 +234,18 @@ public class ConfigurationUtils {
      * @return
      */
     public static <V extends Object> Set<String> getSubIds(Collection<Map<String, V>> configMaps, String prefix) {
+        if (!prefix.endsWith(".")) {
+            prefix += ".";
+        }
         Set<String> ids = new LinkedHashSet<>();
         for (Map<String, V> configMap : configMaps) {
-            configMap.forEach((key, val) -> {
-                if (StringUtils.startsWithIgnoreCase(key, prefix) && !ConfigurationUtils.isEmptyValue(val)) {
+            for (Map.Entry<String, V> entry : configMap.entrySet()) {
+                String key = entry.getKey();
+                V val = entry.getValue();
+                if (StringUtils.startsWithIgnoreCase(key, prefix)
+                    && key.length() > prefix.length()
+                    && !ConfigurationUtils.isEmptyValue(val)) {
+
                     String k = key.substring(prefix.length());
                     int endIndex = k.indexOf(".");
                     if (endIndex > 0) {
@@ -229,7 +253,7 @@ public class ConfigurationUtils {
                         ids.add(id);
                     }
                 }
-            });
+            }
         }
         return ids;
     }

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/config/Environment.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/config/Environment.java
@@ -60,6 +60,9 @@ public class Environment extends LifecycleAdapter implements FrameworkExt {
     private CompositeConfiguration dynamicGlobalConfiguration;
 
     private DynamicConfiguration dynamicConfiguration;
+
+    private List<Map<String, String>> globalConfigurationMaps;
+
     private String localMigrationRule;
 
     private AtomicBoolean initialized = new AtomicBoolean(false);
@@ -181,13 +184,14 @@ public class Environment extends LifecycleAdapter implements FrameworkExt {
      */
     public CompositeConfiguration getConfiguration() {
         if (globalConfiguration == null) {
-            globalConfiguration = new CompositeConfiguration();
-            globalConfiguration.addConfiguration(systemConfiguration);
-            globalConfiguration.addConfiguration(environmentConfiguration);
-            globalConfiguration.addConfiguration(appExternalConfiguration);
-            globalConfiguration.addConfiguration(externalConfiguration);
-            globalConfiguration.addConfiguration(appConfiguration);
-            globalConfiguration.addConfiguration(propertiesConfiguration);
+            CompositeConfiguration configuration = new CompositeConfiguration();
+            configuration.addConfiguration(systemConfiguration);
+            configuration.addConfiguration(environmentConfiguration);
+            configuration.addConfiguration(appExternalConfiguration);
+            configuration.addConfiguration(externalConfiguration);
+            configuration.addConfiguration(appConfiguration);
+            configuration.addConfiguration(propertiesConfiguration);
+            globalConfiguration = configuration;
         }
         return globalConfiguration;
     }
@@ -220,7 +224,10 @@ public class Environment extends LifecycleAdapter implements FrameworkExt {
      * @return
      */
     public List<Map<String, String>> getConfigurationMaps() {
-        return getConfigurationMaps(null, null);
+        if (globalConfigurationMaps == null) {
+            globalConfigurationMaps = getConfigurationMaps(null, null);
+        }
+        return globalConfigurationMaps;
     }
 
     public Configuration getDynamicGlobalConfiguration() {
@@ -257,6 +264,7 @@ public class Environment extends LifecycleAdapter implements FrameworkExt {
         appExternalConfiguration = null;
         appConfiguration = null;
         globalConfiguration = null;
+        globalConfigurationMaps = null;
         dynamicConfiguration = null;
         dynamicGlobalConfiguration = null;
     }

--- a/dubbo-common/src/main/java/org/apache/dubbo/config/MethodConfig.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/config/MethodConfig.java
@@ -16,8 +16,14 @@
  */
 package org.apache.dubbo.config;
 
+import org.apache.dubbo.common.config.Environment;
+import org.apache.dubbo.common.config.InmemoryConfiguration;
+import org.apache.dubbo.common.utils.ClassUtils;
+import org.apache.dubbo.common.utils.MethodUtils;
+import org.apache.dubbo.common.utils.StringUtils;
 import org.apache.dubbo.config.annotation.Method;
 import org.apache.dubbo.config.support.Parameter;
+import org.apache.dubbo.rpc.model.ApplicationModel;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -209,6 +215,47 @@ public class MethodConfig extends AbstractMethodConfig {
     }
 
     @Override
+    protected void processExtraRefresh(String preferredPrefix, InmemoryConfiguration subPropsConfiguration) {
+        if (this.getArguments() != null && this.getArguments().size() > 0) {
+            for (ArgumentConfig argument : this.getArguments()) {
+                refreshArgument(argument, subPropsConfiguration);
+            }
+        }
+    }
+
+    private void refreshArgument(ArgumentConfig argument, InmemoryConfiguration subPropsConfiguration) {
+        if (argument.getIndex() != null && argument.getIndex() >= 0) {
+            String prefix = argument.getIndex() + ".";
+            Environment environment = ApplicationModel.getEnvironment();
+            java.lang.reflect.Method[] methods = argument.getClass().getMethods();
+            for (java.lang.reflect.Method method : methods) {
+                if (MethodUtils.isSetter(method)) {
+                    String propertyName = extractPropertyName(method.getName());
+                    // ignore attributes: 'index' / 'type'
+                    if (StringUtils.isEquals(propertyName, "index") ||
+                        StringUtils.isEquals(propertyName, "type")) {
+                        continue;
+                    }
+                    // convert camelCase/snake_case to kebab-case
+                    String kebabPropertyName = prefix + StringUtils.convertToSplitName(propertyName, "-");
+
+                    try {
+                        String value = StringUtils.trim(subPropsConfiguration.getString(kebabPropertyName));
+                        if (StringUtils.hasText(value) && ClassUtils.isTypeMatch(method.getParameterTypes()[0], value)) {
+                            value = environment.resolvePlaceholders(value);
+                            method.invoke(argument, ClassUtils.convertPrimitive(method.getParameterTypes()[0], value));
+                        }
+                    } catch (Exception e) {
+                        logger.info("Failed to override the property " + method.getName() + " in " +
+                            this.getClass().getSimpleName() +
+                            ", please make sure every property has getter/setter method provided.");
+                    }
+                }
+            }
+        }
+    }
+
+    @Override
     public void addIntoConfigManager() {
         // Don't add MethodConfig to ConfigManager
         // super.addIntoConfigManager();
@@ -376,5 +423,12 @@ public class MethodConfig extends AbstractMethodConfig {
     @Parameter(excluded = true, attribute = false)
     public String getParentPrefix() {
         return parentPrefix;
+    }
+
+    public void addArgument(ArgumentConfig argumentConfig) {
+        if (arguments == null) {
+            arguments = new ArrayList<>();
+        }
+        arguments.add(argumentConfig);
     }
 }

--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/ServiceConfig.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/ServiceConfig.java
@@ -368,6 +368,7 @@ public class ServiceConfig<T> extends ServiceConfigBase<T> {
             map.putIfAbsent(METADATA_KEY, REMOTE_METADATA_STORAGE_TYPE);
         }
         if (CollectionUtils.isNotEmpty(getMethods())) {
+            //TODO Improve method config processing
             for (MethodConfig method : getMethods()) {
                 AbstractConfig.appendParameters(map, method, method.getName());
                 String retryKey = method.getName() + ".retry";
@@ -409,6 +410,7 @@ public class ServiceConfig<T> extends ServiceConfigBase<T> {
                                                 }
                                             }
                                         }
+                                        break;
                                     }
                                 }
                             }

--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/bootstrap/DubboBootstrap.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/bootstrap/DubboBootstrap.java
@@ -792,7 +792,9 @@ public class DubboBootstrap {
                 .map(this::registryAsConfigCenter)
                 .forEach(configManager::addConfigCenter);
 
-            logger.info("use registry as config-center: " + configManager.getConfigCenters());
+            if (configManager.getConfigCenters().size() > 0) {
+                logger.info("use registry as config-center: " + configManager.getConfigCenters());
+            }
         }
     }
 
@@ -846,7 +848,9 @@ public class DubboBootstrap {
                 .map(this::registryAsMetadataCenter)
                 .forEach(configManager::addMetadataReport);
 
-            logger.info("use registry as metadata-center: " + configManager.getMetadataConfigs());
+            if (configManager.getMetadataConfigs().size() > 0) {
+                logger.info("use registry as metadata-center: " + configManager.getMetadataConfigs());
+            }
         }
     }
 

--- a/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/AbstractConfigTest.java
+++ b/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/AbstractConfigTest.java
@@ -449,19 +449,14 @@ public class AbstractConfigTest {
 
             Map<String, String> external = new HashMap<>();
             external.put("dubbo.overrides.override-id.address", "external-override-id://127.0.0.1:2181");
-            external.put("dubbo.override.address", "external://127.0.0.1:2181");
-            // @Parameter(exclude=true)
-            external.put("dubbo.override.exclude", "external");
-            // @Parameter(key="key1", useKeyAsProperty=false)
             external.put("dubbo.overrides.override-id.key", "external");
-            // @Parameter(key="key2", useKeyAsProperty=true)
             external.put("dubbo.overrides.override-id.key2", "external");
+            external.put("dubbo.override.address", "external://127.0.0.1:2181");
+            external.put("dubbo.override.exclude", "external");
             ApplicationModel.getEnvironment().initialize();
             ApplicationModel.getEnvironment().setExternalConfigMap(external);
 
-            ConfigCenterConfig configCenter = new ConfigCenterConfig();
-            overrideConfig.setConfigCenter(configCenter);
-            // Load configuration from  system properties -> externalConfiguration -> RegistryConfig -> dubbo.properties
+            // refresh config
             overrideConfig.refresh();
 
             Assertions.assertEquals("external-override-id://127.0.0.1:2181", overrideConfig.getAddress());
@@ -489,9 +484,7 @@ public class AbstractConfigTest {
             ApplicationModel.getEnvironment().initialize();
             ApplicationModel.getEnvironment().setExternalConfigMap(external);
 
-            ConfigCenterConfig configCenter = new ConfigCenterConfig();
-            overrideConfig.setConfigCenter(configCenter);
-            // Load configuration from  system properties -> externalConfiguration -> RegistryConfig -> dubbo.properties
+            // refresh config
             overrideConfig.refresh();
 
             Assertions.assertEquals("value1", overrideConfig.getParameters().get("key1"));
@@ -603,7 +596,7 @@ public class AbstractConfigTest {
         ConfigField configField() default @ConfigField;
     }
 
-    private static class OverrideConfig extends AbstractInterfaceConfig {
+    private static class OverrideConfig extends AbstractConfig {
         public String address;
         public String protocol;
         public String exclude;
@@ -612,6 +605,7 @@ public class AbstractConfigTest {
         public String escape;
         public String notConflictKey;
         public String notConflictKey2;
+        protected Map<String, String> parameters;
 
         public String getAddress() {
             return address;
@@ -679,6 +673,14 @@ public class AbstractConfigTest {
 
         public void setNotConflictKey2(String notConflictKey2) {
             this.notConflictKey2 = notConflictKey2;
+        }
+
+        public Map<String, String> getParameters() {
+            return parameters;
+        }
+
+        public void setParameters(Map<String, String> parameters) {
+            this.parameters = parameters;
         }
     }
 

--- a/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/MethodConfigTest.java
+++ b/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/MethodConfigTest.java
@@ -265,7 +265,7 @@ public class MethodConfigTest {
     }
 
     @Test
-    public void testOverrideMethodConfig() {
+    public void testOverrideMethodConfigOfReference() {
 
         String interfaceName = DemoService.class.getName();
         SysProps.setProperty("dubbo.reference."+ interfaceName +".sayName.timeout", "1234");
@@ -273,29 +273,58 @@ public class MethodConfigTest {
         SysProps.setProperty("dubbo.reference."+ interfaceName +".sayName.parameters", "[{a:1},{b:2}]");
         SysProps.setProperty("dubbo.reference."+ interfaceName +".init", "false");
 
-        try {
-            ReferenceConfig referenceConfig = new ReferenceConfig();
-            referenceConfig.setInterface(interfaceName);
-            MethodConfig methodConfig = new MethodConfig();
-            methodConfig.setName("sayName");
-            methodConfig.setTimeout(1000);
-            referenceConfig.setMethods(Arrays.asList(methodConfig));
+        ReferenceConfig referenceConfig = new ReferenceConfig();
+        referenceConfig.setInterface(interfaceName);
+        MethodConfig methodConfig = new MethodConfig();
+        methodConfig.setName("sayName");
+        methodConfig.setTimeout(1000);
+        referenceConfig.setMethods(Arrays.asList(methodConfig));
 
-            DubboBootstrap.getInstance()
-                    .application("demo-app")
-                    .reference(referenceConfig)
-                    .initialize();
+        DubboBootstrap.getInstance()
+            .application("demo-app")
+            .reference(referenceConfig)
+            .initialize();
 
-            Map<String, String> params = new LinkedHashMap<>();
-            params.put("a", "1");
-            params.put("b", "2");
+        Map<String, String> params = new LinkedHashMap<>();
+        params.put("a", "1");
+        params.put("b", "2");
 
-            Assertions.assertEquals(1234, methodConfig.getTimeout());
-            Assertions.assertEquals(true, methodConfig.getSticky());
-            Assertions.assertEquals(params, methodConfig.getParameters());
-            Assertions.assertEquals(false, referenceConfig.isInit());
-        } finally {
-        }
+        Assertions.assertEquals(1234, methodConfig.getTimeout());
+        Assertions.assertEquals(true, methodConfig.getSticky());
+        Assertions.assertEquals(params, methodConfig.getParameters());
+        Assertions.assertEquals(false, referenceConfig.isInit());
+
+    }
+
+    @Test
+    public void testAddMethodConfigOfReference() {
+
+        String interfaceName = DemoService.class.getName();
+        SysProps.setProperty("dubbo.reference."+ interfaceName +".sayName.timeout", "1234");
+        SysProps.setProperty("dubbo.reference."+ interfaceName +".sayName.sticky", "true");
+        SysProps.setProperty("dubbo.reference."+ interfaceName +".sayName.parameters", "[{a:1},{b:2}]");
+        SysProps.setProperty("dubbo.reference."+ interfaceName +".init", "false");
+
+        ReferenceConfig referenceConfig = new ReferenceConfig();
+        referenceConfig.setInterface(interfaceName);
+
+        DubboBootstrap.getInstance()
+            .application("demo-app")
+            .reference(referenceConfig)
+            .initialize();
+
+        List<MethodConfig> methodConfigs = referenceConfig.getMethods();
+        Assertions.assertEquals(1, methodConfigs.size());
+        MethodConfig methodConfig = methodConfigs.get(0);
+
+        Map<String, String> params = new LinkedHashMap<>();
+        params.put("a", "1");
+        params.put("b", "2");
+
+        Assertions.assertEquals(1234, methodConfig.getTimeout());
+        Assertions.assertEquals(true, methodConfig.getSticky());
+        Assertions.assertEquals(params, methodConfig.getParameters());
+        Assertions.assertEquals(false, referenceConfig.isInit());
 
     }
 
@@ -309,30 +338,71 @@ public class MethodConfigTest {
         SysProps.setProperty("dubbo.service."+ interfaceName +".group", "demo");
         SysProps.setProperty("dubbo.registry.address", "N/A");
 
-        try {
-            ServiceConfig serviceConfig = new ServiceConfig();
-            serviceConfig.setInterface(interfaceName);
-            serviceConfig.setRef(new DemoServiceImpl());
-            MethodConfig methodConfig = new MethodConfig();
-            methodConfig.setName("sayName");
-            methodConfig.setTimeout(1000);
-            serviceConfig.setMethods(Arrays.asList(methodConfig));
+        ServiceConfig serviceConfig = new ServiceConfig();
+        serviceConfig.setInterface(interfaceName);
+        serviceConfig.setRef(new DemoServiceImpl());
+        MethodConfig methodConfig = new MethodConfig();
+        methodConfig.setName("sayName");
+        methodConfig.setTimeout(1000);
+        serviceConfig.setMethods(Arrays.asList(methodConfig));
 
-            DubboBootstrap.getInstance()
-                    .application("demo-app")
-                    .service(serviceConfig)
-                    .initialize();
+        DubboBootstrap.getInstance()
+            .application("demo-app")
+            .service(serviceConfig)
+            .initialize();
 
-            Map<String, String> params = new LinkedHashMap<>();
-            params.put("a", "1");
-            params.put("b", "2");
+        Map<String, String> params = new LinkedHashMap<>();
+        params.put("a", "1");
+        params.put("b", "2");
 
-            Assertions.assertEquals(1234, methodConfig.getTimeout());
-            Assertions.assertEquals(true, methodConfig.getSticky());
-            Assertions.assertEquals(params, methodConfig.getParameters());
-            Assertions.assertEquals("demo", serviceConfig.getGroup());
-        } finally {
-        }
+        Assertions.assertEquals(1234, methodConfig.getTimeout());
+        Assertions.assertEquals(true, methodConfig.getSticky());
+        Assertions.assertEquals(params, methodConfig.getParameters());
+        Assertions.assertEquals("demo", serviceConfig.getGroup());
+
+    }
+
+    @Test
+    public void testAddMethodConfigOfService() {
+
+        String interfaceName = DemoService.class.getName();
+        SysProps.setProperty("dubbo.service."+ interfaceName +".sayName.timeout", "1234");
+        SysProps.setProperty("dubbo.service."+ interfaceName +".sayName.sticky", "true");
+        SysProps.setProperty("dubbo.service."+ interfaceName +".sayName.parameters", "[{a:1},{b:2}]");
+        SysProps.setProperty("dubbo.service."+ interfaceName +".sayName.0.callback", "true");
+        SysProps.setProperty("dubbo.service."+ interfaceName +".group", "demo");
+        SysProps.setProperty("dubbo.service."+ interfaceName +".echo", "non-method-config");
+        SysProps.setProperty("dubbo.registry.address", "N/A");
+
+        ServiceConfig serviceConfig = new ServiceConfig();
+        serviceConfig.setInterface(interfaceName);
+        serviceConfig.setRef(new DemoServiceImpl());
+
+        Assertions.assertEquals(null, serviceConfig.getMethods());
+
+        DubboBootstrap.getInstance()
+            .application("demo-app")
+            .service(serviceConfig)
+            .initialize();
+
+        List<MethodConfig> methodConfigs = serviceConfig.getMethods();
+        Assertions.assertEquals(1, methodConfigs.size());
+        MethodConfig methodConfig = methodConfigs.get(0);
+
+        List<ArgumentConfig> arguments = methodConfig.getArguments();
+        Assertions.assertEquals(1, arguments.size());
+        ArgumentConfig argumentConfig = arguments.get(0);
+
+        Map<String, String> params = new LinkedHashMap<>();
+        params.put("a", "1");
+        params.put("b", "2");
+
+        Assertions.assertEquals("demo", serviceConfig.getGroup());
+        Assertions.assertEquals(params, methodConfig.getParameters());
+        Assertions.assertEquals(1234, methodConfig.getTimeout());
+        Assertions.assertEquals(true, methodConfig.getSticky());
+        Assertions.assertEquals(0, argumentConfig.getIndex());
+        Assertions.assertEquals(true, argumentConfig.isCallback());
 
     }
 


### PR DESCRIPTION
## What is the purpose of the change

Improve config overrides of method and argument.
* Add method and argument config if found relative config props
* Override argument config of service: 
 The match pattern is: `dubbo.service.{interfaceName}.{methodName}.{arg-index}.xxx=xxx`, e.g. `dubbo.service.org.apache.dubbo.config.api.DemoService.sayName.0.callback=true`

## Brief changelog


## Verifying this change


<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [ ] GitHub Actions works fine on your own branch.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
