### PR TITLE
Fix the issue that the ReferenceConfigCache#destroy method does not call proxy.$destroy()

### DIFF
--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/utils/ReferenceConfigCache.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/utils/ReferenceConfigCache.java
@@ -175,7 +175,8 @@ public class ReferenceConfigCache {
 
         Map<String, Object> proxiesOftype = proxies.get(type);
         if (CollectionUtils.isNotEmptyMap(proxiesOftype)) {
-            proxiesOftype.remove(key);
+            Destroyable proxy = (Destroyable) proxiesOftype.remove(key);
+            proxy.$destroy();
             if (proxiesOftype.isEmpty()) {
                 proxies.remove(type);
             }


### PR DESCRIPTION
## What is the purpose of the change

The destroy method should trigger the call of proxy.$destroy() like the destroyAll method
![Uploading image.png…]()
