### PR TITLE
[WIP][3.0] Make bootstrap wait async export/refer finish

### DIFF
--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/bootstrap/DubboBootstrap.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/bootstrap/DubboBootstrap.java
@@ -1098,27 +1098,21 @@ public class DubboBootstrap {
             }
 
             referServices();
+
             if (asyncExportingFutures.size() > 0 || asyncReferringFutures.size() > 0) {
-                new Thread(() -> {
-                    try {
-                        this.awaitFinish();
-                    } catch (Exception e) {
-                        logger.warn(NAME + " asynchronous export / refer occurred an exception.");
-                    }
-                    startup.set(true);
-                    if (logger.isInfoEnabled()) {
-                        logger.info(NAME + " is ready.");
-                    }
-                    onStart();
-                }).start();
-            } else {
-                startup.set(true);
-                if (logger.isInfoEnabled()) {
-                    logger.info(NAME + " is ready.");
+                try {
+                    this.awaitFinish();
+                } catch (Exception e) {
+                    logger.warn(NAME + " asynchronous export / refer occurred an exception.");
                 }
-                onStart();
             }
 
+            startup.set(true);
+            if (logger.isInfoEnabled()) {
+                logger.info(NAME + " is ready.");
+            }
+
+            onStart();
             if (logger.isInfoEnabled()) {
                 logger.info(NAME + " has started.");
             }


### PR DESCRIPTION
## What is the purpose of the change

When there is high qps system call an un-initialized reference, plenty of threads will be blocked until the initialize is done. This may un-acceptable for some user, so here we make the bootstrap wait until all async export/refer is done. Only take the advantage of multi-thread export/refer.