### PR TITLE
improve the code of URLStrParser.java

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/URL.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/URL.java
@@ -248,7 +248,7 @@ class URL implements Serializable {
         Map<String, String> parameters = null;
         int i = url.indexOf('?'); // separator between body and parameters
         if (i >= 0) {
-            String[] parts = url.substring(i + 1).split("&");
+            String[] parts = url.substring(i + 1).split("[&;]");
             parameters = new HashMap<>();
             for (String part : parts) {
                 part = part.trim();

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/URLStrParser.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/URLStrParser.java
@@ -224,32 +224,20 @@ public final class URLStrParser {
             valueStart = valueEnd + 1;
         }
 
+        String name;
+        String value;
         if (isEncoded) {
-            String name = decodeComponent(str, nameStart, valueStart - 3, false, tempBuf);
-            String value = decodeComponent(str, valueStart, valueEnd, false, tempBuf);
-            if (valueStart == valueEnd) {
-                value = name;
-            } else {
-                value = decodeComponent(str, valueStart, valueEnd, false, tempBuf);
-            }
-            params.put(name, value);
-            // compatible with lower versions registering "default." keys
-            if (name.startsWith(DEFAULT_KEY_PREFIX)) {
-                params.putIfAbsent(name.substring(DEFAULT_KEY_PREFIX.length()), value);
-            }
+            name = decodeComponent(str, nameStart, valueStart - 3, false, tempBuf);
+            value = valueStart == valueEnd ? name : decodeComponent(str, valueStart, valueEnd, false, tempBuf);
         } else {
-            String name = str.substring(nameStart, valueStart - 1);
-            String value = str.substring(valueStart, valueEnd);
-            if (valueStart == valueEnd) {
-                value = name;
-            } else {
-                value = str.substring(valueStart, valueEnd);
-            }
-            params.put(name, value);
-            // compatible with lower versions registering "default." keys
-            if (name.startsWith(DEFAULT_KEY_PREFIX)) {
-                params.putIfAbsent(name.substring(DEFAULT_KEY_PREFIX.length()), value);
-            }
+            name = str.substring(nameStart, valueStart - 1);
+            value = valueStart == valueEnd ? name : str.substring(valueStart, valueEnd);
+        }
+
+        params.put(name, value);
+        // compatible with lower versions registering "default." keys
+        if (name.startsWith(DEFAULT_KEY_PREFIX)) {
+            params.putIfAbsent(name.substring(DEFAULT_KEY_PREFIX.length()), value);
         }
         return true;
     }


### PR DESCRIPTION
## What is the purpose of the change
1. URLStrParser#parseDecodedStr 和 URL#valueOf都是将String解析成URL，但是parseDecodedStr解析parameters时支持以；作为分割，valueOf不支持。此pr修改了valueOf方法，支持以；作为分隔符。
2. 优化URLStrParser#addParam方法。


## Brief changelog


## Verifying this change


<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [ ] GitHub Actions works fine on your own branch.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
