### PR TITLE
fixbug: isAnnotatedReferenceBean npe

### DIFF
--- a/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/beans/factory/annotation/ReferenceAnnotationBeanPostProcessor.java
+++ b/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/beans/factory/annotation/ReferenceAnnotationBeanPostProcessor.java
@@ -45,6 +45,7 @@ import org.springframework.beans.factory.support.GenericBeanDefinition;
 import org.springframework.beans.factory.support.RootBeanDefinition;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
+import org.springframework.context.annotation.ScannedGenericBeanDefinition;
 import org.springframework.core.annotation.AnnotationAttributes;
 import org.springframework.core.type.MethodMetadata;
 
@@ -161,13 +162,15 @@ public class ReferenceAnnotationBeanPostProcessor extends AbstractAnnotationBean
      */
     private boolean isAnnotatedReferenceBean(BeanDefinition beanDefinition) {
         if (beanDefinition instanceof AnnotatedBeanDefinition) {
-            AnnotatedBeanDefinition annotatedBeanDefinition = (AnnotatedBeanDefinition) beanDefinition;
+            AnnotatedBeanDefinition annotatedBeanDefinition = (AnnotatedBeanDefinition)beanDefinition;
             if (annotatedBeanDefinition.getFactoryMethodMetadata() == null) {
                 return false;
             }
-            String beanClassName = annotatedBeanDefinition.getFactoryMethodMetadata().getReturnTypeName();
-            if (ReferenceBean.class.getName().equals(beanClassName)) {
-                return true;
+            if (!(annotatedBeanDefinition instanceof ScannedGenericBeanDefinition)) {
+                String beanClassName = annotatedBeanDefinition.getFactoryMethodMetadata().getReturnTypeName();
+                if (StringUtils.isEquals(ReferenceBean.class.getName(), beanClassName)) {
+                    return true;
+                }
             }
         }
         return false;


### PR DESCRIPTION
## What is the purpose of the change
如果beanDefinition 是 ScannedGenericBeanDefinition,那么getFactoryMethodMetadata 一定是null,这里存在npe的异常
![image](https://user-images.githubusercontent.com/19943636/122636708-3944d080-d11d-11eb-87e5-7a2568f9dfe7.png)


## Brief changelog


## Verifying this change


<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [ ] GitHub Actions works fine on your own branch.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
