### PR TITLE
[3.0] Add ServiceListener SPI for ServiceConfig

### DIFF
--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/ServiceListener.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/ServiceListener.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.config;
+
+import org.apache.dubbo.common.extension.SPI;
+
+/**
+ * Listener for service config
+ */
+@SPI
+public interface ServiceListener {
+
+    /**
+     * Callback when ServiceConfig is exported
+     * @param sc
+     */
+    void exported(ServiceConfig sc);
+
+    /**
+     * Callback when ServiceConfig is unexported
+     * @param sc
+     */
+    void unexported(ServiceConfig sc);
+}

--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/bootstrap/DubboBootstrap.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/bootstrap/DubboBootstrap.java
@@ -257,9 +257,9 @@ public class DubboBootstrap {
         DubboShutdownHook.getDubboShutdownHook().unregister();
     }
 
-    private boolean isOnlyRegisterProvider() {
+    private boolean isRegisterConsumerInstance() {
         Boolean registerConsumer = getApplication().getRegisterConsumer();
-        return registerConsumer == null || !registerConsumer;
+        return Boolean.TRUE.equals(registerConsumer);
     }
 
     private String getMetadataType() {
@@ -1095,8 +1095,8 @@ public class DubboBootstrap {
             // 1. export Dubbo Services
             exportServices();
 
-            // Not only provider register
-            if (!isOnlyRegisterProvider() || hasExportedServices()) {
+            // If register consumer instance or has exported services
+            if (isRegisterConsumerInstance() || hasExportedServices()) {
                 // 2. export MetadataService
                 exportMetadataService();
                 // 3. Register the local ServiceInstance if required

--- a/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/mock/MockServiceListener.java
+++ b/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/mock/MockServiceListener.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.config.mock;
+
+import org.apache.dubbo.config.ServiceConfig;
+import org.apache.dubbo.config.ServiceListener;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class MockServiceListener implements ServiceListener {
+
+    private Map<String, ServiceConfig> exportedServices = new ConcurrentHashMap<>();
+
+    @Override
+    public void exported(ServiceConfig sc) {
+        exportedServices.put(sc.getUniqueServiceName(), sc);
+    }
+
+    @Override
+    public void unexported(ServiceConfig sc) {
+    }
+
+    public Map<String, ServiceConfig> getExportedServices() {
+        return exportedServices;
+    }
+
+    public void clearExportedServices() {
+        exportedServices.clear();
+    }
+}

--- a/dubbo-config/dubbo-config-api/src/test/resources/META-INF/services/org.apache.dubbo.config.ServiceListener
+++ b/dubbo-config/dubbo-config-api/src/test/resources/META-INF/services/org.apache.dubbo.config.ServiceListener
@@ -1,0 +1,1 @@
+mock=org.apache.dubbo.config.mock.MockServiceListener


### PR DESCRIPTION
## What is the purpose of the change

Add ServiceListener SPI to watch export events of ServiceConfig 

## Brief changelog


## Verifying this change


<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [ ] GitHub Actions works fine on your own branch.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
