### PR TITLE
generic serialization decode need use readObject()

### DIFF
--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/support/RpcUtils.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/support/RpcUtils.java
@@ -38,7 +38,13 @@ import static org.apache.dubbo.common.constants.CommonConstants.DOT_SEPARATOR;
 import static org.apache.dubbo.common.constants.CommonConstants.GENERIC_PARAMETER_DESC;
 import static org.apache.dubbo.common.constants.CommonConstants.TIMEOUT_ATTACHMENT_KEY;
 import static org.apache.dubbo.common.constants.CommonConstants.TIMEOUT_KEY;
-import static org.apache.dubbo.rpc.Constants.*;
+import static org.apache.dubbo.rpc.Constants.$ECHO;
+import static org.apache.dubbo.rpc.Constants.$ECHO_PARAMETER_DESC;
+import static org.apache.dubbo.rpc.Constants.ASYNC_KEY;
+import static org.apache.dubbo.rpc.Constants.AUTO_ATTACH_INVOCATIONID_KEY;
+import static org.apache.dubbo.rpc.Constants.ID_KEY;
+import static org.apache.dubbo.rpc.Constants.RETURN_KEY;
+import static org.apache.dubbo.rpc.Constants.GENERIC_KEY;
 
 /**
  * RpcUtils

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/support/RpcUtils.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/support/RpcUtils.java
@@ -38,12 +38,7 @@ import static org.apache.dubbo.common.constants.CommonConstants.DOT_SEPARATOR;
 import static org.apache.dubbo.common.constants.CommonConstants.GENERIC_PARAMETER_DESC;
 import static org.apache.dubbo.common.constants.CommonConstants.TIMEOUT_ATTACHMENT_KEY;
 import static org.apache.dubbo.common.constants.CommonConstants.TIMEOUT_KEY;
-import static org.apache.dubbo.rpc.Constants.$ECHO;
-import static org.apache.dubbo.rpc.Constants.$ECHO_PARAMETER_DESC;
-import static org.apache.dubbo.rpc.Constants.ASYNC_KEY;
-import static org.apache.dubbo.rpc.Constants.AUTO_ATTACH_INVOCATIONID_KEY;
-import static org.apache.dubbo.rpc.Constants.ID_KEY;
-import static org.apache.dubbo.rpc.Constants.RETURN_KEY;
+import static org.apache.dubbo.rpc.Constants.*;
 
 /**
  * RpcUtils
@@ -77,10 +72,20 @@ public class RpcUtils {
                     && invocation.getInvoker().getUrl() != null
                     && invocation.getInvoker().getInterface() != GenericService.class
                     && !invocation.getMethodName().startsWith("$")) {
-                String service = invocation.getInvoker().getUrl().getServiceInterface();
-                if (StringUtils.isNotEmpty(service)) {
-                    Method method = getMethodByService(invocation, service);
-                    return ReflectUtils.getReturnTypes(method);
+                /**
+                 * if is generic, must use readObject()
+                 * the serialization like hession2, avro when use readObject(class), when the class is Template like class A<T>
+                 *  it use the A class to create and T is jsonobject, so it muse be error
+                 *  so it can depend to the data describe or GenericImplFilter to PojoUtils.realize it use Type
+                 *  of course we can change the serialization to use Type to create, but this work is to large....
+                 */
+                String generic = invocation.getInvoker().getUrl().getParameter(GENERIC_KEY);
+                if(!ProtocolUtils.isGeneric(generic)){
+                    String service = invocation.getInvoker().getUrl().getServiceInterface();
+                    if (StringUtils.isNotEmpty(service)) {
+                        Method method = getMethodByService(invocation, service);
+                        return ReflectUtils.getReturnTypes(method);
+                    }
                 }
             }
         } catch (Throwable t) {


### PR DESCRIPTION
## What is the purpose of the change
when the return is template like class A<T>
the serialization decode like hession2 is use class A to create
so the result instance contain T is jsonobject, not the real type.
it must be error.

## Brief changelog


## Verifying this change


<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [ ] GitHub Actions works fine on your own branch.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
