### PR TITLE
[3.0] Support config mode for unique config types

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/config/AbstractInterfaceConfig.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/config/AbstractInterfaceConfig.java
@@ -223,7 +223,8 @@ public abstract class AbstractInterfaceConfig extends AbstractMethodConfig {
             try {
                 interfaceClass = ClassUtils.forName(interfaceName);
             } catch (ClassNotFoundException e) {
-                throw new IllegalStateException("The interface class is not found", e);
+                // There may be no interface class when generic call
+                return;
             }
             if (!interfaceClass.isInterface()) {
                 throw new IllegalStateException(interfaceName+" is not an interface");

--- a/dubbo-common/src/main/java/org/apache/dubbo/config/context/ConfigMode.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/config/context/ConfigMode.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.config.context;
+
+/**
+ * Config processing mode for unique config type, e.g. ApplicationConfig, ModuleConfig, MonitorConfig, SslConfig, MetricsConfig
+ * @see ConfigManager#uniqueConfigTypes
+ */
+public enum ConfigMode {
+    /**
+     * Strict mode: accept only one config for unique config type, throw exceptions if found more than one configs for an unique config type.
+     */
+    STRICT,
+
+    /**
+     * Override mode: accept last config, override previous config
+     */
+    OVERRIDE,
+
+    /**
+     * Ignore mode: accept first config, ignore later configs
+     */
+    IGNORE
+}

--- a/dubbo-common/src/main/java/org/apache/dubbo/rpc/model/ApplicationModel.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/rpc/model/ApplicationModel.java
@@ -49,6 +49,9 @@ public class ApplicationModel {
     public static final String NAME = "application";
 
     private static AtomicBoolean INIT_FLAG = new AtomicBoolean(false);
+    private static Environment environment;
+    private static ConfigManager configManager;
+    private static ServiceRepository serviceRepository;
 
     public static void init() {
         if (INIT_FLAG.compareAndSet(false, true)) {
@@ -76,7 +79,7 @@ public class ApplicationModel {
         return getServiceRepository().lookupReferredService(serviceKey);
     }
 
-    private static final ExtensionLoader<FrameworkExt> LOADER = ExtensionLoader.getExtensionLoader(FrameworkExt.class);
+    private static ExtensionLoader<FrameworkExt> LOADER = ExtensionLoader.getExtensionLoader(FrameworkExt.class);
 
     public static void initFrameworkExts() {
         Set<FrameworkExt> exts = ExtensionLoader.getExtensionLoader(FrameworkExt.class).getSupportedExtensionInstances();
@@ -86,15 +89,24 @@ public class ApplicationModel {
     }
 
     public static Environment getEnvironment() {
-        return (Environment) LOADER.getExtension(Environment.NAME);
+        if (environment == null) {
+            environment = (Environment) LOADER.getExtension(Environment.NAME);
+        }
+        return environment;
     }
 
     public static ConfigManager getConfigManager() {
-        return (ConfigManager) LOADER.getExtension(ConfigManager.NAME);
+        if (configManager == null) {
+            configManager = (ConfigManager) LOADER.getExtension(ConfigManager.NAME);
+        }
+        return configManager;
     }
 
     public static ServiceRepository getServiceRepository() {
-        return (ServiceRepository) LOADER.getExtension(ServiceRepository.NAME);
+        if (serviceRepository == null) {
+            serviceRepository = (ServiceRepository) LOADER.getExtension(ServiceRepository.NAME);
+        }
+        return serviceRepository;
     }
 
     public static ExecutorRepository getExecutorRepository() {
@@ -125,9 +137,20 @@ public class ApplicationModel {
 
     // only for unit test
     public static void reset() {
-        getServiceRepository().destroy();
-        getConfigManager().destroy();
-        getEnvironment().reset();
+        if (serviceRepository!=null){
+            serviceRepository.destroy();
+            serviceRepository = null;
+        }
+        if (configManager != null) {
+            configManager.destroy();
+            configManager = null;
+        }
+        if (environment != null) {
+            environment.destroy();
+            environment = null;
+        }
+        ExtensionLoader.resetExtensionLoader(FrameworkExt.class);
+        LOADER = ExtensionLoader.getExtensionLoader(FrameworkExt.class);
     }
 
 }

--- a/dubbo-common/src/test/java/org/apache/dubbo/config/context/ConfigManagerTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/config/context/ConfigManagerTest.java
@@ -253,41 +253,44 @@ public class ConfigManagerTest {
         ApplicationConfig applicationConfig1 = new ApplicationConfig("app1");
         ApplicationConfig applicationConfig2 = new ApplicationConfig("app2");
 
-        // test strict mode
-        ApplicationModel.reset();
-        Assertions.assertEquals(ConfigMode.STRICT, getConfigManager().getConfigMode());
-
-        System.setProperty(DUBBO_CONFIG_MODE, ConfigMode.STRICT.name());
-        ApplicationModel.reset();
-        Assertions.assertEquals(ConfigMode.STRICT, getConfigManager().getConfigMode());
-
-        getConfigManager().addConfig(applicationConfig1);
         try {
+            // test strict mode
+            ApplicationModel.reset();
+            Assertions.assertEquals(ConfigMode.STRICT, getConfigManager().getConfigMode());
+
+            System.setProperty(DUBBO_CONFIG_MODE, ConfigMode.STRICT.name());
+            ApplicationModel.reset();
+            Assertions.assertEquals(ConfigMode.STRICT, getConfigManager().getConfigMode());
+
+            getConfigManager().addConfig(applicationConfig1);
+            try {
+                getConfigManager().addConfig(applicationConfig2);
+                fail("strict mode cannot add two application configs");
+            } catch (Exception e) {
+                assertEquals(IllegalStateException.class, e.getClass());
+                assertTrue(e.getMessage().contains("please remove redundant configs and keep only one"));
+            }
+
+            // test override mode
+            System.setProperty(DUBBO_CONFIG_MODE, ConfigMode.OVERRIDE.name());
+            ApplicationModel.reset();
+            Assertions.assertEquals(ConfigMode.OVERRIDE, getConfigManager().getConfigMode());
+
+            getConfigManager().addConfig(applicationConfig1);
             getConfigManager().addConfig(applicationConfig2);
-            fail("strict mode cannot add two application configs");
-        } catch (Exception e) {
-            assertEquals(IllegalStateException.class, e.getClass());
-            assertTrue(e.getMessage().contains("please remove redundant configs and keep only one"));
+            assertEquals(applicationConfig2, getConfigManager().getApplicationOrElseThrow());
+
+
+            // test ignore mode
+            System.setProperty(DUBBO_CONFIG_MODE, ConfigMode.IGNORE.name());
+            ApplicationModel.reset();
+            Assertions.assertEquals(ConfigMode.IGNORE, getConfigManager().getConfigMode());
+
+            getConfigManager().addConfig(applicationConfig1);
+            getConfigManager().addConfig(applicationConfig2);
+            assertEquals(applicationConfig1, getConfigManager().getApplicationOrElseThrow());
+        } finally {
+            System.clearProperty(DUBBO_CONFIG_MODE);
         }
-
-        // test override mode
-        System.setProperty(DUBBO_CONFIG_MODE, ConfigMode.OVERRIDE.name());
-        ApplicationModel.reset();
-        Assertions.assertEquals(ConfigMode.OVERRIDE, getConfigManager().getConfigMode());
-
-        getConfigManager().addConfig(applicationConfig1);
-        getConfigManager().addConfig(applicationConfig2);
-        assertEquals(applicationConfig2, getConfigManager().getApplicationOrElseThrow());
-
-
-        // test ignore mode
-        System.setProperty(DUBBO_CONFIG_MODE, ConfigMode.IGNORE.name());
-        ApplicationModel.reset();
-        Assertions.assertEquals(ConfigMode.IGNORE, getConfigManager().getConfigMode());
-
-        getConfigManager().addConfig(applicationConfig1);
-        getConfigManager().addConfig(applicationConfig2);
-        assertEquals(applicationConfig1, getConfigManager().getApplicationOrElseThrow());
-
     }
 }

--- a/dubbo-common/src/test/java/org/apache/dubbo/config/context/ConfigManagerTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/config/context/ConfigManagerTest.java
@@ -26,6 +26,8 @@ import org.apache.dubbo.config.ProtocolConfig;
 import org.apache.dubbo.config.ProviderConfig;
 import org.apache.dubbo.config.RegistryConfig;
 
+import org.apache.dubbo.rpc.model.ApplicationModel;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -33,11 +35,13 @@ import java.util.Collection;
 
 import static java.util.Arrays.asList;
 import static org.apache.dubbo.common.constants.CommonConstants.DEFAULT_KEY;
+import static org.apache.dubbo.config.context.ConfigManager.DUBBO_CONFIG_MODE;
 import static org.apache.dubbo.rpc.model.ApplicationModel.getConfigManager;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * {@link ConfigManager} Test
@@ -242,5 +246,48 @@ public class ConfigManagerTest {
         ProtocolConfig protocolConfig = new ProtocolConfig();
         protocolConfig.setDefault(false);
         assertFalse(ConfigManager.isDefaultConfig(protocolConfig));
+    }
+
+    @Test
+    public void testConfigMode() {
+        ApplicationConfig applicationConfig1 = new ApplicationConfig("app1");
+        ApplicationConfig applicationConfig2 = new ApplicationConfig("app2");
+
+        // test strict mode
+        ApplicationModel.reset();
+        Assertions.assertEquals(ConfigMode.STRICT, getConfigManager().getConfigMode());
+
+        System.setProperty(DUBBO_CONFIG_MODE, ConfigMode.STRICT.name());
+        ApplicationModel.reset();
+        Assertions.assertEquals(ConfigMode.STRICT, getConfigManager().getConfigMode());
+
+        getConfigManager().addConfig(applicationConfig1);
+        try {
+            getConfigManager().addConfig(applicationConfig2);
+            fail("strict mode cannot add two application configs");
+        } catch (Exception e) {
+            assertEquals(IllegalStateException.class, e.getClass());
+            assertTrue(e.getMessage().contains("please remove redundant configs and keep only one"));
+        }
+
+        // test override mode
+        System.setProperty(DUBBO_CONFIG_MODE, ConfigMode.OVERRIDE.name());
+        ApplicationModel.reset();
+        Assertions.assertEquals(ConfigMode.OVERRIDE, getConfigManager().getConfigMode());
+
+        getConfigManager().addConfig(applicationConfig1);
+        getConfigManager().addConfig(applicationConfig2);
+        assertEquals(applicationConfig2, getConfigManager().getApplicationOrElseThrow());
+
+
+        // test ignore mode
+        System.setProperty(DUBBO_CONFIG_MODE, ConfigMode.IGNORE.name());
+        ApplicationModel.reset();
+        Assertions.assertEquals(ConfigMode.IGNORE, getConfigManager().getConfigMode());
+
+        getConfigManager().addConfig(applicationConfig1);
+        getConfigManager().addConfig(applicationConfig2);
+        assertEquals(applicationConfig1, getConfigManager().getApplicationOrElseThrow());
+
     }
 }

--- a/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/context/DubboConfigInitializationPostProcessor.java
+++ b/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/context/DubboConfigInitializationPostProcessor.java
@@ -103,7 +103,6 @@ public class DubboConfigInitializationPostProcessor implements BeanPostProcessor
     }
 
     private void prepareReferenceBeans(ConfigurableListableBeanFactory beanFactory) throws Exception {
-        ReferenceBeanManager referenceBeanManager = beanFactory.getBean(ReferenceBeanManager.BEAN_NAME, ReferenceBeanManager.class);
         referenceBeanManager.prepareReferenceBeans();
     }
 
@@ -132,10 +131,5 @@ public class DubboConfigInitializationPostProcessor implements BeanPostProcessor
     @Override
     public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
         this.applicationContext = applicationContext;
-
-        // Extract dubbo props from Spring env and put them to app config
-        ConfigurableEnvironment environment = (ConfigurableEnvironment) applicationContext.getEnvironment();
-        SortedMap<String, String> dubboProperties = EnvironmentUtils.filterDubboProperties(environment);
-        ApplicationModel.getEnvironment().setAppConfigMap(dubboProperties);
     }
 }

--- a/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/context/DubboConfigInitializationPostProcessor.java
+++ b/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/context/DubboConfigInitializationPostProcessor.java
@@ -28,8 +28,6 @@ import org.apache.dubbo.config.RegistryConfig;
 import org.apache.dubbo.config.SslConfig;
 import org.apache.dubbo.config.spring.ConfigCenterBean;
 import org.apache.dubbo.config.spring.reference.ReferenceBeanManager;
-import org.apache.dubbo.config.spring.util.EnvironmentUtils;
-import org.apache.dubbo.rpc.model.ApplicationModel;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.FatalBeanException;
 import org.springframework.beans.factory.BeanFactory;
@@ -40,9 +38,7 @@ import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
 import org.springframework.core.Ordered;
-import org.springframework.core.env.ConfigurableEnvironment;
 
-import java.util.SortedMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.springframework.beans.factory.BeanFactoryUtils.beansOfTypeIncludingAncestors;

--- a/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/context/DubboInfraBeanRegisterPostProcessor.java
+++ b/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/context/DubboInfraBeanRegisterPostProcessor.java
@@ -20,6 +20,7 @@ import org.apache.dubbo.config.context.ConfigManager;
 import org.apache.dubbo.config.spring.beans.factory.annotation.ReferenceAnnotationBeanPostProcessor;
 import org.apache.dubbo.config.spring.extension.SpringExtensionFactory;
 import org.apache.dubbo.config.spring.util.DubboBeanUtils;
+import org.apache.dubbo.config.spring.util.EnvironmentUtils;
 import org.apache.dubbo.rpc.model.ApplicationModel;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
@@ -27,6 +28,9 @@ import org.springframework.beans.factory.support.BeanDefinitionRegistry;
 import org.springframework.beans.factory.support.BeanDefinitionRegistryPostProcessor;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
+import org.springframework.core.env.ConfigurableEnvironment;
+
+import java.util.SortedMap;
 
 
 /**
@@ -62,5 +66,11 @@ public class DubboInfraBeanRegisterPostProcessor implements BeanDefinitionRegist
     public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
         this.applicationContext = applicationContext;
         SpringExtensionFactory.addApplicationContext(applicationContext);
+
+        // Initialize dubbo Environment before ConfigManager
+        // Extract dubbo props from Spring env and put them to app config
+        ConfigurableEnvironment environment = (ConfigurableEnvironment) applicationContext.getEnvironment();
+        SortedMap<String, String> dubboProperties = EnvironmentUtils.filterDubboProperties(environment);
+        ApplicationModel.getEnvironment().setAppConfigMap(dubboProperties);
     }
 }

--- a/dubbo-spring-boot/dubbo-spring-boot-compatible/autoconfigure/src/main/java/org/apache/dubbo/spring/boot/autoconfigure/DubboConfigurationProperties.java
+++ b/dubbo-spring-boot/dubbo-spring-boot-compatible/autoconfigure/src/main/java/org/apache/dubbo/spring/boot/autoconfigure/DubboConfigurationProperties.java
@@ -24,6 +24,7 @@ import org.apache.dubbo.config.MonitorConfig;
 import org.apache.dubbo.config.ProtocolConfig;
 import org.apache.dubbo.config.ProviderConfig;
 import org.apache.dubbo.config.RegistryConfig;
+import org.apache.dubbo.config.context.ConfigMode;
 import org.apache.dubbo.config.spring.ConfigCenterBean;
 import org.apache.dubbo.config.spring.context.annotation.EnableDubbo;
 
@@ -254,6 +255,12 @@ public class DubboConfigurationProperties {
     static class Config {
 
         /**
+         * Config processing mode
+         * @see ConfigMode
+         */
+        private ConfigMode mode = ConfigMode.STRICT;
+
+        /**
          * Indicates multiple properties binding from externalized configuration or not.
          */
         private boolean multiple = DEFAULT_MULTIPLE_CONFIG_PROPERTY_VALUE;
@@ -277,6 +284,14 @@ public class DubboConfigurationProperties {
 
         public void setMultiple(boolean multiple) {
             this.multiple = multiple;
+        }
+
+        public ConfigMode getMode() {
+            return mode;
+        }
+
+        public void setMode(ConfigMode mode) {
+            this.mode = mode;
         }
     }
 


### PR DESCRIPTION
## What is the purpose of the change

Support config mode for unique config types.
*  Strict mode: accept only one config for unique config type, throw exceptions if found more than one configs for an unique config type.
* Override mode: accept last config, override previous config
* Ignore mode: accept first config, ignore later configs

Change config mode (`strict` by default): 
`dubbo.config.mode=strict`
OR override mode:
`dubbo.config.mode=override`
OR ignore mode:
`dubbo.config.mode=ignore`


## Brief changelog


## Verifying this change


<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [ ] GitHub Actions works fine on your own branch.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
