### PR TITLE
[3.0] verify method config, extract ConfigKeys

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/config/AbstractInterfaceConfig.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/config/AbstractInterfaceConfig.java
@@ -606,7 +606,7 @@ public abstract class AbstractInterfaceConfig extends AbstractMethodConfig {
 
     @SuppressWarnings("unchecked")
     public void setMethods(List<? extends MethodConfig> methods) {
-        this.methods = new ArrayList<>(methods);
+        this.methods = (methods != null) ? new ArrayList<>(methods) : null;
     }
 
     public void addMethod(MethodConfig methodConfig) {

--- a/dubbo-common/src/main/java/org/apache/dubbo/config/AbstractInterfaceConfig.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/config/AbstractInterfaceConfig.java
@@ -37,6 +37,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import static org.apache.dubbo.common.constants.CommonConstants.COMMA_SPLIT_PATTERN;
 import static org.apache.dubbo.common.constants.CommonConstants.DUBBO_VERSION_KEY;
@@ -260,42 +261,50 @@ public abstract class AbstractInterfaceConfig extends AbstractMethodConfig {
             // refresh MethodConfigs
             List<MethodConfig> methodConfigs = this.getMethods();
             if (methodConfigs != null && methodConfigs.size() > 0) {
-                // whether ignore method config error
-                Object ignoreMethodConfigErrorVal = ApplicationModel.getEnvironment().getConfiguration()
-                    .getProperty(ConfigKeys.DUBBO_CONFIG_IGNORE_METHOD_ERROR, "false");
-                boolean ignoreMethodConfigError = Boolean.parseBoolean(ignoreMethodConfigErrorVal.toString());
+                // whether ignore invalid method config
+                Object ignoreInvalidMethodConfigVal = ApplicationModel.getEnvironment().getConfiguration()
+                    .getProperty(ConfigKeys.DUBBO_CONFIG_IGNORE_INVALID_METHOD_CONFIG, "false");
+                boolean ignoreInvalidMethodConfig = Boolean.parseBoolean(ignoreInvalidMethodConfigVal.toString());
 
-                for (MethodConfig methodConfig : methodConfigs) {
+                Class<?> finalInterfaceClass = interfaceClass;
+                List<MethodConfig> validMethodConfigs = methodConfigs.stream().filter(methodConfig -> {
                     methodConfig.setParentPrefix(preferredPrefix);
                     methodConfig.refresh();
-
-                    // check method exist
-                    String methodName = methodConfig.getName();
-                    if (StringUtils.isEmpty(methodName)) {
-                        String msg = "<dubbo:method> name attribute is required! Please check: " +
-                            "<dubbo:service interface=\"" + interfaceName + "\" ... >" +
-                            "<dubbo:method name=\"\" ... /></<dubbo:reference>";
-                        if (ignoreMethodConfigError) {
-                            logger.warn(msg);
-                            continue;
-                        } else {
-                            throw new IllegalStateException(msg);
-                        }
-                    }
-
-                    boolean hasMethod = Arrays.stream(interfaceClass.getMethods()).anyMatch(method -> method.getName().equals(methodName));
-                    if (!hasMethod) {
-                        String msg = "The interface " + interfaceClass.getName() + " not found method " + methodName;
-                        if (ignoreMethodConfigError) {
-                            logger.warn(msg);
-                        } else {
-                            throw new IllegalStateException(msg);
-                        }
-                    }
-                }
+                    // verify method config
+                    return verifyMethodConfig(methodConfig, finalInterfaceClass, ignoreInvalidMethodConfig);
+                }).collect(Collectors.toList());
+                this.setMethods(validMethodConfigs);
             }
         }
 
+    }
+
+    private boolean verifyMethodConfig(MethodConfig methodConfig, Class<?> interfaceClass, boolean ignoreInvalidMethodConfig) {
+        String methodName = methodConfig.getName();
+        if (StringUtils.isEmpty(methodName)) {
+            String msg = "<dubbo:method> name attribute is required! Please check: " +
+                "<dubbo:service interface=\"" + interfaceName + "\" ... >" +
+                "<dubbo:method name=\"\" ... /></<dubbo:reference>";
+            if (ignoreInvalidMethodConfig) {
+                logger.warn(msg);
+                return false;
+            } else {
+                throw new IllegalStateException(msg);
+            }
+        }
+
+        boolean hasMethod = Arrays.stream(interfaceClass.getMethods()).anyMatch(method -> method.getName().equals(methodName));
+        if (!hasMethod) {
+            String msg = "Found invalid method config, the interface " + interfaceClass.getName() + " not found method \""
+                + methodName + "\" : [" + methodConfig + "]";
+            if (ignoreInvalidMethodConfig) {
+                logger.warn(msg);
+                return false;
+            } else {
+                throw new IllegalStateException(msg);
+            }
+        }
+        return true;
     }
 
     private ArgumentConfig getArgumentByIndex(MethodConfig methodConfig, int argIndex) {
@@ -597,7 +606,7 @@ public abstract class AbstractInterfaceConfig extends AbstractMethodConfig {
 
     @SuppressWarnings("unchecked")
     public void setMethods(List<? extends MethodConfig> methods) {
-        this.methods = (List<MethodConfig>) methods;
+        this.methods = new ArrayList<>(methods);
     }
 
     public void addMethod(MethodConfig methodConfig) {

--- a/dubbo-common/src/main/java/org/apache/dubbo/config/ConfigKeys.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/config/ConfigKeys.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.config;
+
+import org.apache.dubbo.config.context.ConfigManager;
+import org.apache.dubbo.config.context.ConfigMode;
+
+/**
+ * External config keys list
+ * @see org.apache.dubbo.spring.boot.autoconfigure.DubboConfigurationProperties
+ */
+public interface ConfigKeys {
+
+    /**
+     * The basePackages to scan , the multiple-value is delimited by comma
+     * @see org.apache.dubbo.config.spring.context.annotation.EnableDubbo#scanBasePackages()
+     */
+    String DUBBO_SCAN_BASE_PACKAGES = "dubbo.scan.base-packages";
+
+    /**
+     * Change dubbo config mode, available values from {@link ConfigMode}. Default value is {@link ConfigMode#STRICT}.
+     * @see ConfigMode
+     * @see ConfigManager#configMode
+     */
+    String DUBBO_CONFIG_MODE = "dubbo.config.mode";
+
+    /**
+     * Ignore method config verification error. Default value is false.
+     */
+    String DUBBO_CONFIG_IGNORE_METHOD_ERROR = "dubbo.config.ignore-method-error";
+
+
+}

--- a/dubbo-common/src/main/java/org/apache/dubbo/config/ConfigKeys.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/config/ConfigKeys.java
@@ -39,9 +39,9 @@ public interface ConfigKeys {
     String DUBBO_CONFIG_MODE = "dubbo.config.mode";
 
     /**
-     * Ignore method config verification error. Default value is false.
+     * Ignore invalid method config. Default value is false.
      */
-    String DUBBO_CONFIG_IGNORE_METHOD_ERROR = "dubbo.config.ignore-method-error";
+    String DUBBO_CONFIG_IGNORE_INVALID_METHOD_CONFIG = "dubbo.config.ignore-invalid-method-config";
 
 
 }

--- a/dubbo-common/src/main/java/org/apache/dubbo/config/MethodConfig.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/config/MethodConfig.java
@@ -216,6 +216,7 @@ public class MethodConfig extends AbstractMethodConfig {
 
     @Override
     protected void processExtraRefresh(String preferredPrefix, InmemoryConfiguration subPropsConfiguration) {
+        // refresh ArgumentConfigs
         if (this.getArguments() != null && this.getArguments().size() > 0) {
             for (ArgumentConfig argument : this.getArguments()) {
                 refreshArgument(argument, subPropsConfiguration);

--- a/dubbo-common/src/main/java/org/apache/dubbo/config/context/ConfigManager.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/config/context/ConfigManager.java
@@ -28,6 +28,7 @@ import org.apache.dubbo.common.utils.StringUtils;
 import org.apache.dubbo.config.AbstractConfig;
 import org.apache.dubbo.config.ApplicationConfig;
 import org.apache.dubbo.config.ConfigCenterConfig;
+import org.apache.dubbo.config.ConfigKeys;
 import org.apache.dubbo.config.ConsumerConfig;
 import org.apache.dubbo.config.MetadataReportConfig;
 import org.apache.dubbo.config.MethodConfig;
@@ -71,7 +72,7 @@ public class ConfigManager extends LifecycleAdapter implements FrameworkExt {
     public static final String NAME = "config";
     public static final String BEAN_NAME = "dubboConfigManager";
     private static final String CONFIG_NAME_READ_METHOD = "getName";
-    public static final String DUBBO_CONFIG_MODE = "dubbo.config.mode";
+    public static final String DUBBO_CONFIG_MODE = ConfigKeys.DUBBO_CONFIG_MODE;
 
     private final ReadWriteLock lock = new ReentrantReadWriteLock();
 

--- a/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/MethodConfigTest.java
+++ b/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/MethodConfigTest.java
@@ -407,6 +407,63 @@ public class MethodConfigTest {
     }
 
     @Test
+    public void testVerifyMethodConfigOfService() {
+
+        String interfaceName = DemoService.class.getName();
+        SysProps.setProperty("dubbo.service."+ interfaceName +".sayHello.timeout", "1234");
+        SysProps.setProperty("dubbo.service."+ interfaceName +".group", "demo");
+        SysProps.setProperty("dubbo.registry.address", "N/A");
+
+        ServiceConfig serviceConfig = new ServiceConfig();
+        serviceConfig.setInterface(interfaceName);
+        serviceConfig.setRef(new DemoServiceImpl());
+        MethodConfig methodConfig = new MethodConfig();
+        methodConfig.setName("sayHello");
+        methodConfig.setTimeout(1000);
+        serviceConfig.setMethods(Arrays.asList(methodConfig));
+
+        try {
+            DubboBootstrap.getInstance()
+                .application("demo-app")
+                .service(serviceConfig)
+                .initialize();
+            Assertions.fail("Method config verification should failed");
+        } catch (Exception e) {
+            e.printStackTrace();
+            Throwable cause = e.getCause();
+            Assertions.assertEquals(IllegalStateException.class, cause.getClass());
+            Assertions.assertTrue(cause.getMessage().contains("not found method"), cause.toString());
+        }
+    }
+
+    @Test
+    public void testIgnoreInvalidMethodConfigOfService() {
+
+        String interfaceName = DemoService.class.getName();
+        SysProps.setProperty("dubbo.service."+ interfaceName +".sayHello.timeout", "1234");
+        SysProps.setProperty("dubbo.service."+ interfaceName +".sayName.timeout", "1234");
+        SysProps.setProperty("dubbo.registry.address", "N/A");
+        SysProps.setProperty(ConfigKeys.DUBBO_CONFIG_IGNORE_INVALID_METHOD_CONFIG, "true");
+
+        ServiceConfig serviceConfig = new ServiceConfig();
+        serviceConfig.setInterface(interfaceName);
+        serviceConfig.setRef(new DemoServiceImpl());
+        MethodConfig methodConfig = new MethodConfig();
+        methodConfig.setName("sayHello");
+        methodConfig.setTimeout(1000);
+        serviceConfig.setMethods(Arrays.asList(methodConfig));
+
+        DubboBootstrap.getInstance()
+            .application("demo-app")
+            .service(serviceConfig)
+            .initialize();
+
+        // expect sayHello method config will be ignore, and sayName method config will be create.
+        Assertions.assertEquals(1, serviceConfig.getMethods().size());
+        Assertions.assertEquals("sayName", serviceConfig.getMethods().get(0).getName());
+    }
+
+    @Test
     public void testMetaData() {
         MethodConfig methodConfig = new MethodConfig();
         Map<String, String> metaData = methodConfig.getMetaData();

--- a/dubbo-spring-boot/dubbo-spring-boot-compatible/autoconfigure/src/main/java/org/apache/dubbo/spring/boot/autoconfigure/DubboConfigurationProperties.java
+++ b/dubbo-spring-boot/dubbo-spring-boot-compatible/autoconfigure/src/main/java/org/apache/dubbo/spring/boot/autoconfigure/DubboConfigurationProperties.java
@@ -17,6 +17,7 @@
 package org.apache.dubbo.spring.boot.autoconfigure;
 
 import org.apache.dubbo.config.ApplicationConfig;
+import org.apache.dubbo.config.ConfigKeys;
 import org.apache.dubbo.config.ConsumerConfig;
 import org.apache.dubbo.config.MetadataReportConfig;
 import org.apache.dubbo.config.ModuleConfig;
@@ -43,6 +44,7 @@ import static org.apache.dubbo.spring.boot.util.DubboUtils.DUBBO_PREFIX;
 /**
  * Dubbo {@link ConfigurationProperties Config Properties} only used to generate JSON metadata(non-public class)
  *
+ * @see ConfigKeys
  * @since 2.7.1
  */
 @ConfigurationProperties(DUBBO_PREFIX)


### PR DESCRIPTION
## What is the purpose of the change

Verify method config, extract `ConfigKeys`.
How to ignore invalid method config:  `dubbo.config.ignore-invalid-method-config=true`

## Brief changelog


## Verifying this change


<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [ ] GitHub Actions works fine on your own branch.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
