### PR TITLE
[Dubbo-8172]Not shuwdown ExecutorService when DefaultFuture. closeChannel()

### DIFF
--- a/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/exchange/support/DefaultFuture.java
+++ b/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/exchange/support/DefaultFuture.java
@@ -142,11 +142,6 @@ public class DefaultFuture extends CompletableFuture<Object> {
             if (channel.equals(entry.getValue())) {
                 DefaultFuture future = getFuture(entry.getKey());
                 if (future != null && !future.isDone()) {
-                    ExecutorService futureExecutor = future.getExecutor();
-                    if (futureExecutor != null && !futureExecutor.isTerminated()) {
-                        futureExecutor.shutdownNow();
-                    }
-
                     Response disconnectResponse = new Response(future.getId());
                     disconnectResponse.setStatus(Response.CHANNEL_INACTIVE);
                     disconnectResponse.setErrorMessage("Channel " +

--- a/dubbo-remoting/dubbo-remoting-api/src/test/java/org/apache/dubbo/remoting/exchange/support/DefaultFutureTest.java
+++ b/dubbo-remoting/dubbo-remoting-api/src/test/java/org/apache/dubbo/remoting/exchange/support/DefaultFutureTest.java
@@ -158,6 +158,17 @@ public class DefaultFutureTest {
         Assertions.assertNull(future);
     }
 
+    @Test
+    public void testClose() throws Exception {
+        Channel channel = new MockedChannel();
+        Request request = new Request(123);
+        ExecutorService executor = ExtensionLoader.getExtensionLoader(ExecutorRepository.class)
+                .getDefaultExtension().createExecutorIfAbsent(URL.valueOf("dubbo://127.0.0.1:23456"));
+        DefaultFuture.newFuture(channel, request, 1000, executor);
+        DefaultFuture.closeChannel(channel);
+        Assertions.assertFalse(executor.isTerminated());
+    }
+
     /**
      * mock a default future
      */


### PR DESCRIPTION
消费者端ExecutorService在运行期间不应该shutdown

复现了 #8172 的的一种场景
1，启动3个提供者
2，启动1个消费者，开始服务调用（异步调用）
3，kill -9 提供者1，会发现消费者全局ExecutorService被CLOSE，后续服务调用使用SHARED_EXECUTOR
4，kill -9 提供者2，会发现SHARED_EXECUTOR被CLOSE
5，后续服务调用，报错及堆栈基本同issue描述

分析：提供者非正常下线（如netty先关闭，注册中心服务尚未下线），消费者端netty触发AbstractChannelHandlerDelegate.disconnected，从而触发futureExecutor.shutdownNow()。
而消费者端服务调用线程池是全局共享，在运行期间不应该被shutdown。

## Brief changelog

DefaultFuture. closeChannel时，不关闭ExecutorService。

<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [x] Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [ ] GitHub Actions works fine on your own branch.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
