### PR TITLE
change alibaba_spring_context_support_version to 1.0.11

### DIFF
--- a/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/beans/factory/annotation/ReferenceAnnotationBeanPostProcessor.java
+++ b/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/beans/factory/annotation/ReferenceAnnotationBeanPostProcessor.java
@@ -103,6 +103,8 @@ public class ReferenceAnnotationBeanPostProcessor extends AbstractAnnotationBean
      */
     public ReferenceAnnotationBeanPostProcessor() {
         super(DubboReference.class, Reference.class, com.alibaba.dubbo.config.annotation.Reference.class);
+        setClassValuesAsString(false);
+        setNestedAnnotationsAsMap(false);
     }
 
     /**

--- a/dubbo-dependencies-bom/pom.xml
+++ b/dubbo-dependencies-bom/pom.xml
@@ -150,7 +150,7 @@
         <fabric8_kubernetes_version>4.10.3</fabric8_kubernetes_version>
 
         <!-- Alibaba -->
-        <alibaba_spring_context_support_version>1.0.10</alibaba_spring_context_support_version>
+        <alibaba_spring_context_support_version>1.0.11</alibaba_spring_context_support_version>
 
         <jaxb_version>2.2.7</jaxb_version>
         <activation_version>1.2.0</activation_version>


### PR DESCRIPTION
## What is the purpose of the change
1. change alibaba spring-context-support version of dubbo pom.xml to 1.0.11
2. set classValuesAsString and nestedAnnotationsAsMap attributes of ReferenceAnnotationBeanPostProcessor to false
fix #7797 