### PR TITLE
For compatible nacos server lower version, we should check the response from nacos server is null.

### DIFF
--- a/dubbo-configcenter/dubbo-configcenter-nacos/src/main/java/org/apache/dubbo/configcenter/support/nacos/NacosDynamicConfiguration.java
+++ b/dubbo-configcenter/dubbo-configcenter-nacos/src/main/java/org/apache/dubbo/configcenter/support/nacos/NacosDynamicConfiguration.java
@@ -260,7 +260,9 @@ public class NacosDynamicConfiguration implements DynamicConfiguration {
 
             HttpRestResult<String> result = httpAgent.httpGet(GET_CONFIG_KEYS_PATH, emptyMap(), paramsValues, encoding, 5 * 1000);
             Stream<String> keysStream = toKeysStream(result.getData());
-            keysStream.forEach(keys::add);
+            if (keysStream != null) {
+                keysStream.forEach(keys::add);
+            }
         } catch (Exception e) {
             if (logger.isErrorEnabled()) {
                 logger.error(e.getMessage(), e);
@@ -284,7 +286,13 @@ public class NacosDynamicConfiguration implements DynamicConfiguration {
 
     private Stream<String> toKeysStream(String content) {
         JSONObject jsonObject = JSON.parseObject(content);
+        if (jsonObject == null) {
+            return null;
+        }
         JSONArray pageItems = jsonObject.getJSONArray("pageItems");
+        if (pageItems == null) {
+            return null;
+        }
         return pageItems.stream()
                 .map(object -> (JSONObject) object)
                 .map(json -> json.getString("dataId"));


### PR DESCRIPTION
## What is the purpose of the change
Fix #8181 

At provider, it won't register service name mapping info.
At consumer, we will use application_first, it will use service discovery logic to find service name mapping info,
in NacosDynamicConfiguration, use httpAgent to get service name mapping info, but at nacos server lower version, if the config is not found, will return null response.

So we should do compatible work for lower nacos server version.
