### PR TITLE
[3.0] p2p invoke support wildcard url match.

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/utils/RegexProperties.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/utils/RegexProperties.java
@@ -16,6 +16,8 @@
  */
 package org.apache.dubbo.common.utils;
 
+import org.apache.dubbo.common.constants.CommonConstants;
+
 import java.util.Comparator;
 import java.util.List;
 import java.util.Properties;
@@ -30,16 +32,28 @@ public class RegexProperties extends Properties {
     @Override
     public String getProperty(String key) {
         String value = super.getProperty(key);
-        if(value != null) {
+        if (value != null) {
             return value;
         }
 
-        List<String> sortedKeyList = keySet().stream().map(k -> (String) k)
+        // Sort the keys to solve the problem of matching priority.
+        List<String> sortedKeyList = keySet()
+                .stream()
+                .map(k -> (String) k)
                 .sorted(Comparator.reverseOrder())
                 .collect(Collectors.toList());
 
         String keyPattern = sortedKeyList
-                .stream().filter(k -> Pattern.matches(k, key)).findFirst().orElse(null);
+                .stream()
+                .filter(k -> {
+                    String matchingKey = k;
+                    if(matchingKey.startsWith(CommonConstants.ANY_VALUE)){
+                        matchingKey = CommonConstants.HIDE_KEY_PREFIX + matchingKey;
+                    }
+                    return Pattern.matches(matchingKey, key);
+                })
+                .findFirst()
+                .orElse(null);
 
         return keyPattern == null ? null : super.getProperty(keyPattern);
     }

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/utils/RegexProperties.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/utils/RegexProperties.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.dubbo.common.utils;
 
 import java.util.Comparator;

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/utils/RegexProperties.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/utils/RegexProperties.java
@@ -1,0 +1,30 @@
+package org.apache.dubbo.common.utils;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Properties;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+/**
+ * Regex matching of keys is supported.
+ */
+public class RegexProperties extends Properties {
+
+    @Override
+    public String getProperty(String key) {
+        String value = super.getProperty(key);
+        if(value != null) {
+            return value;
+        }
+
+        List<String> sortedKeyList = keySet().stream().map(k -> (String) k)
+                .sorted(Comparator.reverseOrder())
+                .collect(Collectors.toList());
+
+        String keyPattern = sortedKeyList
+                .stream().filter(k -> Pattern.matches(k, key)).findFirst().orElse(null);
+
+        return keyPattern == null ? null : super.getProperty(keyPattern);
+    }
+}

--- a/dubbo-common/src/main/java/org/apache/dubbo/config/ReferenceConfigBase.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/config/ReferenceConfigBase.java
@@ -18,6 +18,7 @@ package org.apache.dubbo.config;
 
 import org.apache.dubbo.common.URL;
 import org.apache.dubbo.common.utils.ClassUtils;
+import org.apache.dubbo.common.utils.RegexProperties;
 import org.apache.dubbo.common.utils.StringUtils;
 import org.apache.dubbo.config.annotation.Reference;
 import org.apache.dubbo.config.support.Parameter;
@@ -244,7 +245,7 @@ public abstract class ReferenceConfigBase<T> extends AbstractReferenceConfig {
                 }
             }
             if (resolveFile != null && resolveFile.length() > 0) {
-                Properties properties = new Properties();
+                Properties properties = new RegexProperties();
                 try (FileInputStream fis = new FileInputStream(new File(resolveFile))) {
                     properties.load(fis);
                 } catch (IOException e) {

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/utils/RegexPropertiesTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/utils/RegexPropertiesTest.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.dubbo.common.utils;
 
 import org.junit.jupiter.api.Assertions;

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/utils/RegexPropertiesTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/utils/RegexPropertiesTest.java
@@ -1,0 +1,18 @@
+package org.apache.dubbo.common.utils;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class RegexPropertiesTest {
+    @Test
+    public void testGetProperty(){
+        RegexProperties regexProperties = new RegexProperties();
+        regexProperties.setProperty("org.apache.*", "http://localhost:20880");
+        regexProperties.setProperty("org.apache.dubbo.*", "http://localhost:30880");
+        regexProperties.setProperty("org.apache.dubbo.demo", "http://localhost:40880");
+
+        Assertions.assertEquals("http://localhost:40880", regexProperties.getProperty("org.apache.dubbo.demo"));
+        Assertions.assertEquals("http://localhost:30880", regexProperties.getProperty("org.apache.dubbo.provider"));
+        Assertions.assertEquals("http://localhost:20880", regexProperties.getProperty("org.apache.demo"));
+    }
+}

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/utils/RegexPropertiesTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/utils/RegexPropertiesTest.java
@@ -23,12 +23,16 @@ public class RegexPropertiesTest {
     @Test
     public void testGetProperty(){
         RegexProperties regexProperties = new RegexProperties();
-        regexProperties.setProperty("org.apache.*", "http://localhost:20880");
-        regexProperties.setProperty("org.apache.dubbo.*", "http://localhost:30880");
-        regexProperties.setProperty("org.apache.dubbo.demo", "http://localhost:40880");
+        regexProperties.setProperty("org.apache.dubbo.provider.*", "http://localhost:20880");
+        regexProperties.setProperty("org.apache.dubbo.provider.config.*", "http://localhost:30880");
+        regexProperties.setProperty("org.apache.dubbo.provider.config.demo", "http://localhost:40880");
+        regexProperties.setProperty("org.apache.dubbo.consumer.*.demo", "http://localhost:50880");
+        regexProperties.setProperty("*.service", "http://localhost:60880");
 
-        Assertions.assertEquals("http://localhost:40880", regexProperties.getProperty("org.apache.dubbo.demo"));
-        Assertions.assertEquals("http://localhost:30880", regexProperties.getProperty("org.apache.dubbo.provider"));
-        Assertions.assertEquals("http://localhost:20880", regexProperties.getProperty("org.apache.demo"));
+        Assertions.assertEquals("http://localhost:20880", regexProperties.getProperty("org.apache.dubbo.provider.cluster"));
+        Assertions.assertEquals("http://localhost:30880", regexProperties.getProperty("org.apache.dubbo.provider.config.cluster"));
+        Assertions.assertEquals("http://localhost:40880", regexProperties.getProperty("org.apache.dubbo.provider.config.demo"));
+        Assertions.assertEquals("http://localhost:50880", regexProperties.getProperty("org.apache.dubbo.consumer.service.demo"));
+        Assertions.assertEquals("http://localhost:60880", regexProperties.getProperty("org.apache.dubbo.service"));
     }
 }


### PR DESCRIPTION
## What is the purpose of the change
see #3168 

## Brief changelog
Solution: Extend Properties.class to support regex matching keys.

## Verifying this change


<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [x] Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [x] GitHub Actions works fine on your own branch.
- [x] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
