### PR TITLE
Dubbo 3.0 Remove hard code about port in URLBuilderTest and ProtocolConfigTest

### DIFF
--- a/dubbo-common/src/test/java/org/apache/dubbo/common/URLBuilderTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/URLBuilderTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.dubbo.common;
 
+import org.apache.dubbo.common.utils.NetUtils;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
@@ -46,19 +47,20 @@ public class URLBuilderTest {
     @Test
     public void shouldSet() {
         URL url1 = URL.valueOf("dubbo://admin:hello1234@10.20.130.230:20880/context/path?version=1.0.0&application=morgan");
+        int port = NetUtils.getAvailablePort();
         URL url2 = URLBuilder.from(url1)
                 .setProtocol("rest")
                 .setUsername("newUsername")
                 .setPassword("newPassword")
                 .setHost("newHost")
                 .setPath("newContext")
-                .setPort(1234)
+                .setPort(port)
                 .build();
         assertThat(url2.getProtocol(), equalTo("rest"));
         assertThat(url2.getUsername(), equalTo("newUsername"));
         assertThat(url2.getPassword(), equalTo("newPassword"));
         assertThat(url2.getHost(), equalTo("newHost"));
-        assertThat(url2.getPort(), equalTo(1234));
+        assertThat(url2.getPort(), equalTo(port));
         assertThat(url2.getPath(), equalTo("newContext"));
 
         url2 = URLBuilder.from(url1)

--- a/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/ProtocolConfigTest.java
+++ b/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/ProtocolConfigTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.dubbo.config;
 
+import org.apache.dubbo.common.utils.NetUtils;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
@@ -54,10 +55,11 @@ public class ProtocolConfigTest {
     @Test
     public void testPort() throws Exception {
         ProtocolConfig protocol = new ProtocolConfig();
-        protocol.setPort(8080);
+        int port = NetUtils.getAvailablePort();
+        protocol.setPort(port);
         Map<String, String> parameters = new HashMap<String, String>();
         ProtocolConfig.appendParameters(parameters, protocol);
-        assertThat(protocol.getPort(), equalTo(8080));
+        assertThat(protocol.getPort(), equalTo(port));
         assertThat(parameters.isEmpty(), is(true));
     }
 


### PR DESCRIPTION

see #8250 

## What is the purpose of the change
use tool to generate port instead of hard coding in URLBuilderTest and ProtocolConfigTest
## Brief changelog
## Verifying this change
<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->
## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [ ] GitHub Actions works fine on your own branch.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).