### PR TITLE
Dubbo 3 Remove hard code about port in URLBuilderTest and ProtocolConfigTest

### DIFF
--- a/dubbo-common/src/test/java/org/apache/dubbo/common/URLBuilderTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/URLBuilderTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.dubbo.common;
 
+import org.apache.dubbo.common.utils.NetUtils;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
@@ -48,26 +49,28 @@ public class URLBuilderTest {
     @Test
     public void shouldSet() {
         URL url1 = URL.valueOf("dubbo://admin:hello1234@10.20.130.230:20880/context/path?version=1.0.0&application=morgan");
+        int port = NetUtils.getAvailablePort();
         URL url2 = URLBuilder.from(url1)
                 .setProtocol("rest")
                 .setUsername("newUsername")
                 .setPassword("newPassword")
                 .setHost("newHost")
                 .setPath("newContext")
-                .setPort(1234)
+                .setPort(port)
                 .build();
         assertThat(url2.getProtocol(), equalTo("rest"));
         assertThat(url2.getUsername(), equalTo("newUsername"));
         assertThat(url2.getPassword(), equalTo("newPassword"));
         assertThat(url2.getHost(), equalTo("newHost"));
-        assertThat(url2.getPort(), equalTo(1234));
+        assertThat(url2.getPort(), equalTo(port));
         assertThat(url2.getPath(), equalTo("newContext"));
 
+        int port2 = NetUtils.getAvailablePort();
         url2 = URLBuilder.from(url1)
-                .setAddress("newHost2:2345")
+                .setAddress("newHost2:"+ port2)
                 .build();
         assertThat(url2.getHost(), equalTo("newHost2"));
-        assertThat(url2.getPort(), equalTo(2345));
+        assertThat(url2.getPort(), equalTo(port2));
     }
 
     @Test

--- a/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/ProtocolConfigTest.java
+++ b/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/ProtocolConfigTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.dubbo.config;
 
+import org.apache.dubbo.common.utils.NetUtils;
 import org.apache.dubbo.config.bootstrap.DubboBootstrap;
 import org.apache.dubbo.config.context.ConfigManager;
 import org.junit.jupiter.api.AfterEach;
@@ -30,9 +31,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasEntry;
-import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.*;
 
 public class ProtocolConfigTest {
 
@@ -71,10 +70,11 @@ public class ProtocolConfigTest {
     @Test
     public void testPort() throws Exception {
         ProtocolConfig protocol = new ProtocolConfig();
-        protocol.setPort(8080);
+        int port = NetUtils.getAvailablePort();
+        protocol.setPort(port);
         Map<String, String> parameters = new HashMap<String, String>();
         ProtocolConfig.appendParameters(parameters, protocol);
-        assertThat(protocol.getPort(), equalTo(8080));
+        assertThat(protocol.getPort(), equalTo(port));
         assertThat(parameters.isEmpty(), is(true));
     }
 
@@ -228,10 +228,11 @@ public class ProtocolConfigTest {
 
     @Test
     public void testOverrideEmptyConfig() {
+        int port = NetUtils.getAvailablePort();
         //dubbo.protocol.name=rest
-        //dubbo.protocol.port=1234
+        //dubbo.protocol.port=port
         SysProps.setProperty("dubbo.protocol.name", "rest");
-        SysProps.setProperty("dubbo.protocol.port", "1234");
+        SysProps.setProperty("dubbo.protocol.port", String.valueOf(port));
 
         try {
             ProtocolConfig protocolConfig = new ProtocolConfig();
@@ -242,14 +243,15 @@ public class ProtocolConfigTest {
                     .initialize();
 
             Assertions.assertEquals("rest", protocolConfig.getName());
-            Assertions.assertEquals(1234, protocolConfig.getPort());
+            Assertions.assertEquals(port, protocolConfig.getPort());
         } finally {
         }
     }
 
     @Test
     public void testOverrideConfigByName() {
-        SysProps.setProperty("dubbo.protocols.rest.port", "1234");
+        int port = NetUtils.getAvailablePort();
+        SysProps.setProperty("dubbo.protocols.rest.port", String.valueOf(port));
 
         try {
             ProtocolConfig protocolConfig = new ProtocolConfig();
@@ -261,15 +263,16 @@ public class ProtocolConfigTest {
                     .initialize();
 
             Assertions.assertEquals("rest", protocolConfig.getName());
-            Assertions.assertEquals(1234, protocolConfig.getPort());
+            Assertions.assertEquals(port, protocolConfig.getPort());
         } finally {
         }
     }
 
     @Test
     public void testOverrideConfigById() {
+        int port = NetUtils.getAvailablePort();
         SysProps.setProperty("dubbo.protocols.rest1.name", "rest");
-        SysProps.setProperty("dubbo.protocols.rest1.port", "1234");
+        SysProps.setProperty("dubbo.protocols.rest1.port",  String.valueOf(port));
 
         try {
             ProtocolConfig protocolConfig = new ProtocolConfig();
@@ -282,17 +285,19 @@ public class ProtocolConfigTest {
                     .initialize();
 
             Assertions.assertEquals("rest", protocolConfig.getName());
-            Assertions.assertEquals(1234, protocolConfig.getPort());
+            Assertions.assertEquals(port, protocolConfig.getPort());
         } finally {
         }
     }
 
     @Test
     public void testCreateConfigFromPropsWithId() {
+        int port1 = NetUtils.getAvailablePort();
+        int port2 = NetUtils.getAvailablePort();
         SysProps.setProperty("dubbo.protocols.rest1.name", "rest");
-        SysProps.setProperty("dubbo.protocols.rest1.port", "1234");
+        SysProps.setProperty("dubbo.protocols.rest1.port", String.valueOf(port1));
         SysProps.setProperty("dubbo.protocol.name", "dubbo"); // ignore
-        SysProps.setProperty("dubbo.protocol.port", "2346");
+        SysProps.setProperty("dubbo.protocol.port", String.valueOf(port2));
 
         try {
 
@@ -307,16 +312,18 @@ public class ProtocolConfigTest {
             ProtocolConfig protocol = configManager.getProtocol("rest1").get();
 
             Assertions.assertEquals("rest", protocol.getName());
-            Assertions.assertEquals(1234, protocol.getPort());
+            Assertions.assertEquals(port1, protocol.getPort());
         } finally {
         }
     }
 
     @Test
     public void testCreateConfigFromPropsWithName() {
-        SysProps.setProperty("dubbo.protocols.rest.port", "1234");
+        int port1 = NetUtils.getAvailablePort();
+        int port2 = NetUtils.getAvailablePort();
+        SysProps.setProperty("dubbo.protocols.rest.port", String.valueOf(port1));
         SysProps.setProperty("dubbo.protocol.name", "dubbo"); // ignore
-        SysProps.setProperty("dubbo.protocol.port", "2346");
+        SysProps.setProperty("dubbo.protocol.port", String.valueOf(port2));
 
         try {
 
@@ -331,15 +338,16 @@ public class ProtocolConfigTest {
             ProtocolConfig protocol = configManager.getProtocol("rest").get();
 
             Assertions.assertEquals("rest", protocol.getName());
-            Assertions.assertEquals(1234, protocol.getPort());
+            Assertions.assertEquals(port1, protocol.getPort());
         } finally {
         }
     }
 
     @Test
     public void testCreateDefaultConfigFromProps() {
+        int port = NetUtils.getAvailablePort();
         SysProps.setProperty("dubbo.protocol.name", "rest");
-        SysProps.setProperty("dubbo.protocol.port", "2346");
+        SysProps.setProperty("dubbo.protocol.port", String.valueOf(port));
         String protocolId = "rest-protocol";
         SysProps.setProperty("dubbo.protocol.id", protocolId); // Allow override config id from props
 
@@ -355,7 +363,7 @@ public class ProtocolConfigTest {
 
             ProtocolConfig protocol = configManager.getProtocol("rest").get();
             Assertions.assertEquals("rest", protocol.getName());
-            Assertions.assertEquals(2346, protocol.getPort());
+            Assertions.assertEquals(port, protocol.getPort());
             Assertions.assertEquals(protocolId, protocol.getId());
 
             ProtocolConfig protocolConfig = configManager.getProtocol(protocolId).get();


### PR DESCRIPTION

see #8250 
## What is the purpose of the change
use tool to generate port instead of hard coding in URLBuilderTest and ProtocolConfigTest
## Brief changelog
## Verifying this change
<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->
## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [x] Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [x] GitHub Actions works fine on your own branch.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).