### PR TITLE
Remove redundant 'get' action after calling 'computeIFAbsent' on a ConcurrentHashMap.

### DIFF
--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/utils/ReferenceConfigCache.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/utils/ReferenceConfigCache.java
@@ -107,16 +107,13 @@ public class ReferenceConfigCache {
         String key = generator.generateKey(referenceConfig);
         Class<?> type = referenceConfig.getInterfaceClass();
 
-        proxies.computeIfAbsent(type, _t -> new ConcurrentHashMap<>());
+        ConcurrentMap<String, Object> proxiesOfType = proxies.computeIfAbsent(type, _t -> new ConcurrentHashMap<>());
 
-        ConcurrentMap<String, Object> proxiesOfType = proxies.get(type);
-        proxiesOfType.computeIfAbsent(key, _k -> {
+        return (T) proxiesOfType.computeIfAbsent(key, _k -> {
             Object proxy = referenceConfig.get();
             referredReferences.put(key, referenceConfig);
             return proxy;
         });
-
-        return (T) proxiesOfType.get(key);
     }
 
     /**


### PR DESCRIPTION
## What is the purpose of the change
see #8259 

## Brief changelog
Remove redundant 'get' action after calling 'computeIFAbsent' on a ConcurrentHashMap.

## Verifying this change


<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [x] Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [x] GitHub Actions works fine on your own branch.
- [x] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
