### PR TITLE
fix org.apache.dubbo.common.url.component.URLAddress#parse method to judge the isPathAddress problem

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/url/component/URLAddress.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/url/component/URLAddress.java
@@ -24,6 +24,8 @@ import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.util.Objects;
 
+import static org.apache.dubbo.common.constants.CommonConstants.PATH_SEPARATOR;
+
 public class URLAddress implements Serializable {
     private static final long serialVersionUID = -1985165475234910535L;
 
@@ -168,7 +170,7 @@ public class URLAddress implements Serializable {
                 decodeStr = URLDecoder.decode(rawAddress, "UTF-8");
             }
 
-            boolean isPathAddress = !Character.isDigit(decodeStr.charAt(0));
+            boolean isPathAddress = decodeStr.contains(PATH_SEPARATOR);
             if (isPathAddress) {
                 return createPathURLAddress(decodeStr, rawAddress, defaultProtocol);
             }


### PR DESCRIPTION
## What is the purpose of the change

movitation:

fix org.apache.dubbo.common.url.component.URLAddress#parse method to judge the isPathAddress problem.

see #8285 


## Brief changelog


## Verifying this change


<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [ ] GitHub Actions works fine on your own branch.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
