### PR TITLE
support  dubbo.registry.parameters.item3=value3 configuration properties

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/config/ConfigurationUtils.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/config/ConfigurationUtils.java
@@ -166,12 +166,28 @@ public class ConfigurationUtils {
      * @return
      */
     public static <V extends Object> Map<String, V> getSubProperties(Collection<Map<String, V>> configMaps, String prefix) {
+        Map<String, V> map = new LinkedHashMap<>();
+        for (Map<String, V> configMap : configMaps) {
+            getSubProperties(configMap, prefix, map);
+        }
+        return map;
+    }
+
+    public static <V extends Object> Map<String, V> getSubProperties(Map<String, V> configMap, String prefix) {
+        return getSubProperties(configMap, prefix, null);
+    }
+
+    private static <V extends Object> Map<String, V> getSubProperties(Map<String, V> configMap, String prefix, Map<String, V> resultMap) {
         if (!prefix.endsWith(".")) {
             prefix += ".";
         }
-        Map<String, V> map = new LinkedHashMap<>();
-        for (Map<String, V> configMap : configMaps) {
-            for (Map.Entry<String, V> entry : configMap.entrySet()) {
+
+        if (null == resultMap) {
+            resultMap = new LinkedHashMap<>();
+        }
+
+        if (null != configMap) {
+            for(Map.Entry<String, V> entry : configMap.entrySet()) {
                 String key = entry.getKey();
                 V val = entry.getValue();
                 if (StringUtils.startsWithIgnoreCase(key, prefix)
@@ -181,11 +197,12 @@ public class ConfigurationUtils {
                     String k = key.substring(prefix.length());
                     // convert camelCase/snake_case to kebab-case
                     k = StringUtils.convertToSplitName(k, "-");
-                    map.putIfAbsent(k, val);
+                    resultMap.putIfAbsent(k, val);
                 }
             }
         }
-        return map;
+
+        return resultMap;
     }
 
     public static <V extends Object> boolean hasSubProperties(Collection<Map<String, V>> configMaps, String prefix) {

--- a/dubbo-common/src/main/java/org/apache/dubbo/config/AbstractConfig.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/config/AbstractConfig.java
@@ -561,6 +561,9 @@ public abstract class AbstractConfig implements Serializable {
     }
 
     private void invokeSetParameters(Map<String, String> values) {
+        if (CollectionUtils.isEmptyMap(values)) {
+            return;
+        }
         Map<String, String> map = invokeGetParameters(getClass(), this);
         map = map == null ? new HashMap<>() : map;
         map.putAll(values);

--- a/dubbo-common/src/main/java/org/apache/dubbo/config/AbstractConfig.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/config/AbstractConfig.java
@@ -540,12 +540,14 @@ public abstract class AbstractConfig implements Serializable {
                 } else if (isParametersSetter(method)) {
                     String propertyName = extractPropertyName(method.getName());
                     String value = StringUtils.trim(subPropsConfiguration.getString(propertyName));
+                    Map<String, String> parameterMap = null;
                     if (StringUtils.hasText(value)) {
-                        invokeSetParameters(convert(StringUtils.parseParameters(value), ""));
+                        parameterMap = StringUtils.parseParameters(value);
                     } else {
                         // in this case, maybe parameters.item3=value3.
-                        invokeSetParameters(ConfigurationUtils.getSubProperties(subProperties, PARAMETERS));
+                        parameterMap = ConfigurationUtils.getSubProperties(subProperties, PARAMETERS);
                     }
+                    invokeSetParameters(convert(parameterMap, ""));
                 }
             }
 

--- a/dubbo-common/src/main/java/org/apache/dubbo/config/AbstractConfig.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/config/AbstractConfig.java
@@ -55,6 +55,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 
 import static org.apache.dubbo.common.utils.ReflectUtils.findMethodByMethodSignature;
+import static org.apache.dubbo.config.Constants.PARAMETERS;
 
 /**
  * Utility methods and public methods for parsing configuration
@@ -540,10 +541,10 @@ public abstract class AbstractConfig implements Serializable {
                     String propertyName = extractPropertyName(method.getName());
                     String value = StringUtils.trim(subPropsConfiguration.getString(propertyName));
                     if (StringUtils.hasText(value)) {
-                        Map<String, String> map = invokeGetParameters(getClass(), this);
-                        map = map == null ? new HashMap<>() : map;
-                        map.putAll(convert(StringUtils.parseParameters(value), ""));
-                        invokeSetParameters(getClass(), this, map);
+                        invokeSetParameters(convert(StringUtils.parseParameters(value), ""));
+                    } else {
+                        // in this case, maybe parameters.item3=value3.
+                        invokeSetParameters(ConfigurationUtils.getSubProperties(subProperties, PARAMETERS));
                     }
                 }
             }
@@ -557,6 +558,13 @@ public abstract class AbstractConfig implements Serializable {
         }
 
         postProcessRefresh();
+    }
+
+    private void invokeSetParameters(Map<String, String> values) {
+        Map<String, String> map = invokeGetParameters(getClass(), this);
+        map = map == null ? new HashMap<>() : map;
+        map.putAll(values);
+        invokeSetParameters(getClass(), this, map);
     }
 
     private boolean isIgnoredAttribute(Class<? extends AbstractConfig> clazz, String propertyName) {

--- a/dubbo-common/src/main/java/org/apache/dubbo/config/Constants.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/config/Constants.java
@@ -125,4 +125,6 @@ public interface Constants {
     String[] DOT_COMPATIBLE_KEYS = new String[]{"qos-enable", "qos-port", "qos-accept-foreign-ip"};
 
     String IGNORE_CHECK_KEYS = "ignoreCheckKeys";
+
+    String PARAMETERS = "parameters";
 }

--- a/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/AbstractConfigTest.java
+++ b/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/AbstractConfigTest.java
@@ -43,6 +43,7 @@ import java.util.Map;
 import java.util.Properties;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -498,6 +499,19 @@ public class AbstractConfigTest {
 
             Assertions.assertEquals("value6", overrideConfig.getParameters().get("key3"));
             Assertions.assertEquals("value4", overrideConfig.getParameters().get("key4"));
+        } finally {
+            SysProps.clear();
+            ApplicationModel.getEnvironment().destroy();
+        }
+    }
+
+    @Test
+    public void testRefreshParametersWithAttribute() {
+        try {
+            OverrideConfig overrideConfig = new OverrideConfig();
+            SysProps.setProperty("dubbo.override.parameters.key00", "value00");
+            overrideConfig.refresh();
+            assertEquals("value00", overrideConfig.getParameters().get("key00"));
         } finally {
             SysProps.clear();
             ApplicationModel.getEnvironment().destroy();


### PR DESCRIPTION
## What is the purpose of the change

Support the following format configuration properties. such as:

dubbo.registry.parameters.item3=value3

see #8303 

## Brief changelog


## Verifying this change


<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [ ] GitHub Actions works fine on your own branch.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
