### PR TITLE
[3.0]Change mesh rule group to config default value

### DIFF
--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/router/mesh/route/MeshRuleManager.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/router/mesh/route/MeshRuleManager.java
@@ -31,7 +31,6 @@ public final class MeshRuleManager {
     public static final Logger logger = LoggerFactory.getLogger(MeshRuleManager.class);
 
     private static final String MESH_RULE_DATA_ID_SUFFIX = ".MESHAPPRULE";
-    private static final String GROUP = "DEFAULT_GROUP";
 
     private static final ConcurrentHashMap<String, MeshAppRuleListener> APP_RULE_LISTENERS = new ConcurrentHashMap<>();
 
@@ -48,7 +47,7 @@ public final class MeshRuleManager {
         }
 
         try {
-            String rawConfig = configuration.getConfig(appRuleDataId, GROUP, 5000L);
+            String rawConfig = configuration.getConfig(appRuleDataId, DynamicConfiguration.DEFAULT_GROUP, 5000L);
             if (rawConfig != null) {
                 meshAppRuleListener.receiveConfigInfo(rawConfig);
             }
@@ -56,7 +55,7 @@ public final class MeshRuleManager {
             logger.error("get MeshRuleManager app rule failed.", throwable);
         }
 
-        configuration.addListener(appRuleDataId, GROUP, meshAppRuleListener);
+        configuration.addListener(appRuleDataId, DynamicConfiguration.DEFAULT_GROUP, meshAppRuleListener);
         APP_RULE_LISTENERS.put(app, meshAppRuleListener);
     }
 


### PR DESCRIPTION
## What is the purpose of the change
Other routing group default to `dubbo`, mesh rule group default value should be `dubbo`.


## Brief changelog


## Verifying this change


<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [ ] GitHub Actions works fine on your own branch.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
