### PR TITLE
Fix instance change event name format problem.

### DIFF
--- a/dubbo-registry/dubbo-registry-nacos/src/main/java/org/apache/dubbo/registry/nacos/NacosServiceDiscovery.java
+++ b/dubbo-registry/dubbo-registry-nacos/src/main/java/org/apache/dubbo/registry/nacos/NacosServiceDiscovery.java
@@ -30,6 +30,7 @@ import com.alibaba.nacos.api.exception.NacosException;
 import com.alibaba.nacos.api.naming.listener.NamingEvent;
 import com.alibaba.nacos.api.naming.pojo.Instance;
 import com.alibaba.nacos.api.naming.pojo.ListView;
+import com.alibaba.nacos.api.naming.utils.NamingUtils;
 
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -139,7 +140,7 @@ public class NacosServiceDiscovery extends AbstractServiceDiscovery {
     }
 
     private void handleEvent(NamingEvent event, ServiceInstancesChangedListener listener) {
-        String serviceName = event.getServiceName();
+        String serviceName = NamingUtils.getServiceName(event.getServiceName());
         List<ServiceInstance> serviceInstances = event.getInstances()
                 .stream()
                 .map(NacosNamingServiceUtils::toServiceInstance)


### PR DESCRIPTION
## What is the purpose of the change
Nacos `NamingEvent`'s name is group@@serviceName. 


It can't be pass by predicateEventListener.accept(event), the predicateEventListener's hold serviceNames format is serviceName, which is not formatted as group@@serviceName.
https://github.com/apache/dubbo/blob/41e989b853b151e01aae53e41b9504e31f5e8f4a/dubbo-common/src/main/java/org/apache/dubbo/event/AbstractEventDispatcher.java#L125
