### PR TITLE
Add the lost annotation of the Subclass of Protocol.

### DIFF
--- a/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/mock/MockProtocol.java
+++ b/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/mock/MockProtocol.java
@@ -40,6 +40,7 @@ public class MockProtocol implements Protocol {
     /* (non-Javadoc)
      * @see org.apache.dubbo.rpc.Protocol#export(org.apache.dubbo.rpc.Invoker)
      */
+    @Override
     public <T> Exporter<T> export(Invoker<T> invoker) throws RpcException {
         return Mockito.mock(Exporter.class);
     }
@@ -47,6 +48,7 @@ public class MockProtocol implements Protocol {
     /* (non-Javadoc)
      * @see org.apache.dubbo.rpc.Protocol#refer(java.lang.Class, org.apache.dubbo.common.URL)
      */
+    @Override
     public <T> Invoker<T> refer(Class<T> type, URL url) throws RpcException {
 
         final URL u = url;

--- a/dubbo-native/src/main/java/org/apache/dubbo/rpc/Protocol$Adaptive.java
+++ b/dubbo-native/src/main/java/org/apache/dubbo/rpc/Protocol$Adaptive.java
@@ -17,7 +17,6 @@
 package org.apache.dubbo.rpc;
 import org.apache.dubbo.common.extension.ExtensionLoader;
 public class Protocol$Adaptive implements org.apache.dubbo.rpc.Protocol {
-@Override
 public org.apache.dubbo.rpc.Exporter export(org.apache.dubbo.rpc.Invoker arg0) throws org.apache.dubbo.rpc.RpcException {
 if (arg0 == null) throw new IllegalArgumentException("org.apache.dubbo.rpc.Invoker argument == null");
 if (arg0.getUrl() == null) throw new IllegalArgumentException("org.apache.dubbo.rpc.Invoker argument getUrl() == null");
@@ -27,7 +26,6 @@ if(extName == null) throw new IllegalStateException("Failed to get extension (or
 org.apache.dubbo.rpc.Protocol extension = (org.apache.dubbo.rpc.Protocol)ExtensionLoader.getExtensionLoader(org.apache.dubbo.rpc.Protocol.class).getExtension(extName);
 return extension.export(arg0);
 }
-@Override
 public org.apache.dubbo.rpc.Invoker refer(java.lang.Class arg0, org.apache.dubbo.common.URL arg1) throws org.apache.dubbo.rpc.RpcException {
 if (arg1 == null) throw new IllegalArgumentException("url == null");
 org.apache.dubbo.common.URL url = arg1;
@@ -36,14 +34,12 @@ if(extName == null) throw new IllegalStateException("Failed to get extension (or
 org.apache.dubbo.rpc.Protocol extension = (org.apache.dubbo.rpc.Protocol)ExtensionLoader.getExtensionLoader(org.apache.dubbo.rpc.Protocol.class).getExtension(extName);
 return extension.refer(arg0, arg1);
 }
-@Override
 public java.util.List getServers()  {
 throw new UnsupportedOperationException("The method public default java.util.List org.apache.dubbo.rpc.Protocol.getServers() of interface org.apache.dubbo.rpc.Protocol is not adaptive method!");
 }
 public void destroy()  {
 throw new UnsupportedOperationException("The method public abstract void org.apache.dubbo.rpc.Protocol.destroy() of interface org.apache.dubbo.rpc.Protocol is not adaptive method!");
 }
-@Override
 public int getDefaultPort()  {
 throw new UnsupportedOperationException("The method public abstract int org.apache.dubbo.rpc.Protocol.getDefaultPort() of interface org.apache.dubbo.rpc.Protocol is not adaptive method!");
 }

--- a/dubbo-native/src/main/java/org/apache/dubbo/rpc/Protocol$Adaptive.java
+++ b/dubbo-native/src/main/java/org/apache/dubbo/rpc/Protocol$Adaptive.java
@@ -17,6 +17,7 @@
 package org.apache.dubbo.rpc;
 import org.apache.dubbo.common.extension.ExtensionLoader;
 public class Protocol$Adaptive implements org.apache.dubbo.rpc.Protocol {
+@Override
 public org.apache.dubbo.rpc.Exporter export(org.apache.dubbo.rpc.Invoker arg0) throws org.apache.dubbo.rpc.RpcException {
 if (arg0 == null) throw new IllegalArgumentException("org.apache.dubbo.rpc.Invoker argument == null");
 if (arg0.getUrl() == null) throw new IllegalArgumentException("org.apache.dubbo.rpc.Invoker argument getUrl() == null");
@@ -26,6 +27,7 @@ if(extName == null) throw new IllegalStateException("Failed to get extension (or
 org.apache.dubbo.rpc.Protocol extension = (org.apache.dubbo.rpc.Protocol)ExtensionLoader.getExtensionLoader(org.apache.dubbo.rpc.Protocol.class).getExtension(extName);
 return extension.export(arg0);
 }
+@Override
 public org.apache.dubbo.rpc.Invoker refer(java.lang.Class arg0, org.apache.dubbo.common.URL arg1) throws org.apache.dubbo.rpc.RpcException {
 if (arg1 == null) throw new IllegalArgumentException("url == null");
 org.apache.dubbo.common.URL url = arg1;
@@ -34,12 +36,14 @@ if(extName == null) throw new IllegalStateException("Failed to get extension (or
 org.apache.dubbo.rpc.Protocol extension = (org.apache.dubbo.rpc.Protocol)ExtensionLoader.getExtensionLoader(org.apache.dubbo.rpc.Protocol.class).getExtension(extName);
 return extension.refer(arg0, arg1);
 }
+@Override
 public java.util.List getServers()  {
 throw new UnsupportedOperationException("The method public default java.util.List org.apache.dubbo.rpc.Protocol.getServers() of interface org.apache.dubbo.rpc.Protocol is not adaptive method!");
 }
 public void destroy()  {
 throw new UnsupportedOperationException("The method public abstract void org.apache.dubbo.rpc.Protocol.destroy() of interface org.apache.dubbo.rpc.Protocol is not adaptive method!");
 }
+@Override
 public int getDefaultPort()  {
 throw new UnsupportedOperationException("The method public abstract int org.apache.dubbo.rpc.Protocol.getDefaultPort() of interface org.apache.dubbo.rpc.Protocol is not adaptive method!");
 }

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/protocol/AbstractProtocol.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/protocol/AbstractProtocol.java
@@ -62,6 +62,7 @@ public abstract class AbstractProtocol implements Protocol {
         return ProtocolUtils.serviceKey(port, serviceName, serviceVersion, serviceGroup);
     }
 
+    @Override
     public List<ProtocolServer> getServers() {
         return Collections.unmodifiableList(new ArrayList<>(serverMap.values()));
     }


### PR DESCRIPTION
## What is the purpose of the change

Add the lost annotation of the Subclass of Protocol.

## Brief changelog

- add override annotation in MockProtocol and AbstractProtocol.

## Verifying this change


<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [ ] GitHub Actions works fine on your own branch.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
