### PR TITLE
Refactor service change listener.

### DIFF
--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/SelfHostMetaServiceDiscovery.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/SelfHostMetaServiceDiscovery.java
@@ -223,7 +223,7 @@ public abstract class SelfHostMetaServiceDiscovery implements ServiceDiscovery {
             serviceInstance.setMetadata(JSONObject.parseObject(metadataString, Map.class));
         } else {
             // refer from MetadataUtils, this proxy is different from the one used to refer exportedURL
-            MetadataService metadataService = MetadataUtils.getMetadataServiceProxy(serviceInstance, this);
+            MetadataService metadataService = MetadataUtils.getMetadataServiceProxy(serviceInstance);
 
             String consumerId = ApplicationModel.getName() + NetUtils.getLocalHost();
             String metadata = metadataService.getAndListenInstanceMetadata(

--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/SelfHostMetaServiceDiscovery.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/SelfHostMetaServiceDiscovery.java
@@ -264,7 +264,7 @@ public abstract class SelfHostMetaServiceDiscovery implements ServiceDiscovery {
             allServiceInstances.removeAll(oldServiceInstances);
 
             allServiceInstances.forEach(removedServiceInstance -> {
-                MetadataUtils.destroyMetadataServiceProxy(removedServiceInstance, this);
+                MetadataUtils.destroyMetadataServiceProxy(removedServiceInstance);
             });
 
             cachedServiceInstances.put(serviceName, instances);

--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/event/listener/ServiceInstancesChangedListener.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/event/listener/ServiceInstancesChangedListener.java
@@ -177,7 +177,7 @@ public class ServiceInstancesChangedListener {
 
     public synchronized void addListenerAndNotify(String serviceKey, NotifyListener listener) {
         this.listeners.put(serviceKey, listener);
-        List<URL> urls = getAddresses(serviceKey);
+        List<URL> urls = getAddresses(serviceKey, listener.getConsumerUrl());
         if (CollectionUtils.isNotEmpty(urls)) {
             listener.notify(urls);
         }
@@ -374,14 +374,14 @@ public class ServiceInstancesChangedListener {
         return urls;
     }
 
-    protected List<URL> getAddresses(String serviceProtocolKey) {
+    protected List<URL> getAddresses(String serviceProtocolKey, URL consumerURL) {
         return (List<URL>) serviceUrls.get(serviceProtocolKey);
     }
 
     protected void notifyAddressChanged() {
         listeners.forEach((key, notifyListener) -> {
             //FIXME, group wildcard match
-            List<URL> urls = toUrlsWithEmpty(getAddresses(key));
+            List<URL> urls = toUrlsWithEmpty(getAddresses(key, notifyListener.getConsumerUrl()));
             logger.info("Notify service " + key + " with urls " + urls.size());
             notifyListener.notify(urls);
         });

--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/metadata/MetadataUtils.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/metadata/MetadataUtils.java
@@ -22,7 +22,6 @@ import org.apache.dubbo.common.utils.CollectionUtils;
 import org.apache.dubbo.common.utils.StringUtils;
 import org.apache.dubbo.metadata.MetadataService;
 import org.apache.dubbo.metadata.WritableMetadataService;
-import org.apache.dubbo.registry.client.ServiceDiscovery;
 import org.apache.dubbo.registry.client.ServiceInstance;
 import org.apache.dubbo.registry.client.metadata.store.RemoteMetadataServiceImpl;
 import org.apache.dubbo.rpc.Invoker;
@@ -102,7 +101,7 @@ public class MetadataUtils {
         }
     }
 
-    public static void destroyMetadataServiceProxy(ServiceInstance instance, ServiceDiscovery serviceDiscovery) {
+    public static void destroyMetadataServiceProxy(ServiceInstance instance) {
         String key = computeKey(instance);
         Lock lock = metadataServiceLocks.computeIfAbsent(key, k -> new ReentrantLock());
 

--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/metadata/MetadataUtils.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/metadata/MetadataUtils.java
@@ -90,7 +90,7 @@ public class MetadataUtils {
                 ServiceInstanceMetadataUtils.getExportedServicesRevision(serviceInstance);
     }
 
-    public static MetadataService getMetadataServiceProxy(ServiceInstance instance, ServiceDiscovery serviceDiscovery) {
+    public static MetadataService getMetadataServiceProxy(ServiceInstance instance) {
         String key = computeKey(instance);
         Lock lock = metadataServiceLocks.computeIfAbsent(key, k -> new ReentrantLock());
 

--- a/dubbo-registry/dubbo-registry-api/src/test/java/org/apache/dubbo/registry/client/event/listener/ServiceInstancesChangedListenerTest.java
+++ b/dubbo-registry/dubbo-registry-api/src/test/java/org/apache/dubbo/registry/client/event/listener/ServiceInstancesChangedListenerTest.java
@@ -182,7 +182,7 @@ public class ServiceInstancesChangedListenerTest {
         ServiceInstancesChangedListener listener = new ServiceInstancesChangedListener(serviceNames, serviceDiscovery);
 
         try (MockedStatic<MetadataUtils> mockedMetadataUtils = Mockito.mockStatic(MetadataUtils.class)) {
-            mockedMetadataUtils.when(() -> MetadataUtils.getMetadataServiceProxy(Mockito.any(), Mockito.any())).thenReturn(metadataService);
+            mockedMetadataUtils.when(() -> MetadataUtils.getMetadataServiceProxy(Mockito.any())).thenReturn(metadataService);
             // notify instance change
             ServiceInstancesChangedEvent event = new ServiceInstancesChangedEvent("app1", app1Instances);
             listener.onEvent(event);
@@ -195,7 +195,7 @@ public class ServiceInstancesChangedListenerTest {
             Assertions.assertEquals(1, revisionToMetadata.size());
             Assertions.assertEquals(metadataInfo_111, revisionToMetadata.get("111"));
 
-            List<URL> serviceUrls = listener.getAddresses(service1 + ":dubbo", consumerURL);
+            List<URL> serviceUrls = listener.getAddresses(service1 + ":dubbo");
             Assertions.assertEquals(3, serviceUrls.size());
             Assertions.assertTrue(serviceUrls.get(0) instanceof InstanceAddressURL);
 
@@ -215,7 +215,7 @@ public class ServiceInstancesChangedListenerTest {
         ServiceInstancesChangedListener listener = new ServiceInstancesChangedListener(serviceNames, serviceDiscovery);
 
         try (MockedStatic<MetadataUtils> mockedMetadataUtils = Mockito.mockStatic(MetadataUtils.class)) {
-            mockedMetadataUtils.when(() -> MetadataUtils.getMetadataServiceProxy(Mockito.any(), Mockito.any())).thenReturn(metadataService);
+            mockedMetadataUtils.when(() -> MetadataUtils.getMetadataServiceProxy(Mockito.any())).thenReturn(metadataService);
             // notify app1 instance change
             ServiceInstancesChangedEvent app1_event = new ServiceInstancesChangedEvent("app1", app1Instances);
             listener.onEvent(app1_event);
@@ -236,12 +236,12 @@ public class ServiceInstancesChangedListenerTest {
             Assertions.assertEquals(metadataInfo_222, revisionToMetadata.get("222"));
             Assertions.assertEquals(metadataInfo_333, revisionToMetadata.get("333"));
 
-            List<URL> serviceUrls = listener.getAddresses(service1 + ":dubbo", consumerURL);
+            List<URL> serviceUrls = listener.getAddresses(service1 + ":dubbo");
             Assertions.assertEquals(7, serviceUrls.size());
-            List<URL> serviceUrls2 = listener.getAddresses(service2 + ":dubbo", consumerURL);
+            List<URL> serviceUrls2 = listener.getAddresses(service2 + ":dubbo");
             Assertions.assertEquals(4, serviceUrls2.size());
             Assertions.assertTrue(serviceUrls2.get(0).getIp().contains("30.10."));
-            List<URL> serviceUrls3 = listener.getAddresses(service3 + ":dubbo", consumerURL);
+            List<URL> serviceUrls3 = listener.getAddresses(service3 + ":dubbo");
             Assertions.assertEquals(2, serviceUrls3.size());
             Assertions.assertTrue(serviceUrls3.get(0).getIp().contains("30.10."));
         }
@@ -257,7 +257,7 @@ public class ServiceInstancesChangedListenerTest {
         ServiceInstancesChangedListener listener = new ServiceInstancesChangedListener(serviceNames, serviceDiscovery);
 
         try (MockedStatic<MetadataUtils> mockedMetadataUtils = Mockito.mockStatic(MetadataUtils.class)) {
-            mockedMetadataUtils.when(() -> MetadataUtils.getMetadataServiceProxy(Mockito.any(), Mockito.any())).thenReturn(metadataService);
+            mockedMetadataUtils.when(() -> MetadataUtils.getMetadataServiceProxy(Mockito.any())).thenReturn(metadataService);
             // notify app1 instance change
             ServiceInstancesChangedEvent app1_event = new ServiceInstancesChangedEvent("app1", app1Instances);
             listener.onEvent(app1_event);
@@ -282,13 +282,13 @@ public class ServiceInstancesChangedListenerTest {
             Assertions.assertEquals(metadataInfo_222, revisionToMetadata.get("222"));
             Assertions.assertEquals(metadataInfo_333, revisionToMetadata.get("333"));
 
-            List<URL> serviceUrls = listener.getAddresses(service1 + ":dubbo", consumerURL);
+            List<URL> serviceUrls = listener.getAddresses(service1 + ":dubbo");
             Assertions.assertEquals(4, serviceUrls.size());
             Assertions.assertTrue(serviceUrls.get(0).getIp().contains("30.10."));
-            List<URL> serviceUrls2 = listener.getAddresses(service2 + ":dubbo", consumerURL);
+            List<URL> serviceUrls2 = listener.getAddresses(service2 + ":dubbo");
             Assertions.assertEquals(4, serviceUrls2.size());
             Assertions.assertTrue(serviceUrls2.get(0).getIp().contains("30.10."));
-            List<URL> serviceUrls3 = listener.getAddresses(service3 + ":dubbo", consumerURL);
+            List<URL> serviceUrls3 = listener.getAddresses(service3 + ":dubbo");
             Assertions.assertEquals(2, serviceUrls3.size());
             Assertions.assertTrue(serviceUrls3.get(0).getIp().contains("30.10."));
 
@@ -305,9 +305,9 @@ public class ServiceInstancesChangedListenerTest {
             Map<String, MetadataInfo> revisionToMetadata_app2 = listener.getRevisionToMetadata();
             Assertions.assertEquals(0, revisionToMetadata_app2.size());
 
-            Assertions.assertTrue(isEmpty(listener.getAddresses(service1 + ":dubbo", consumerURL)));
-            Assertions.assertTrue(isEmpty(listener.getAddresses(service2+ ":dubbo", consumerURL)));
-            Assertions.assertTrue(isEmpty(listener.getAddresses(service3 + ":dubbo", consumerURL)));
+            Assertions.assertTrue(isEmpty(listener.getAddresses(service1 + ":dubbo")));
+            Assertions.assertTrue(isEmpty(listener.getAddresses(service2+ ":dubbo")));
+            Assertions.assertTrue(isEmpty(listener.getAddresses(service3 + ":dubbo")));
         }
     }
 
@@ -325,7 +325,7 @@ public class ServiceInstancesChangedListenerTest {
         listener.addListenerAndNotify(service2 + ":dubbo", demoService2Listener);
 
         try (MockedStatic<MetadataUtils> mockedMetadataUtils = Mockito.mockStatic(MetadataUtils.class)) {
-            mockedMetadataUtils.when(() -> MetadataUtils.getMetadataServiceProxy(Mockito.any(), Mockito.any())).thenReturn(metadataService);
+            mockedMetadataUtils.when(() -> MetadataUtils.getMetadataServiceProxy(Mockito.any())).thenReturn(metadataService);
             // notify app1 instance change
             ServiceInstancesChangedEvent app1_event = new ServiceInstancesChangedEvent("app1", app1Instances);
             listener.onEvent(app1_event);
@@ -369,13 +369,13 @@ public class ServiceInstancesChangedListenerTest {
         serviceNames.add("app1");
         ServiceInstancesChangedListener listener = new ServiceInstancesChangedListener(serviceNames, serviceDiscovery);
         try (MockedStatic<MetadataUtils> mockedMetadataUtils = Mockito.mockStatic(MetadataUtils.class)) {
-            mockedMetadataUtils.when(() -> MetadataUtils.getMetadataServiceProxy(Mockito.any(), Mockito.any())).thenReturn(metadataService);
+            mockedMetadataUtils.when(() -> MetadataUtils.getMetadataServiceProxy(Mockito.any())).thenReturn(metadataService);
             // notify app1 instance change
             ServiceInstancesChangedEvent failed_revision_event = new ServiceInstancesChangedEvent("app1", app1FailedInstances);
             listener.onEvent(failed_revision_event);
 
-            List<URL> serviceUrls = listener.getAddresses(service1 + ":dubbo", consumerURL);
-            List<URL> serviceUrls2 = listener.getAddresses(service2 + ":dubbo", consumerURL);
+            List<URL> serviceUrls = listener.getAddresses(service1 + ":dubbo");
+            List<URL> serviceUrls2 = listener.getAddresses(service2 + ":dubbo");
 
             Assertions.assertTrue(isEmpty(serviceUrls));
             Assertions.assertTrue(isEmpty(serviceUrls2));
@@ -398,7 +398,7 @@ public class ServiceInstancesChangedListenerTest {
         ConcurrentMap tmpProxyMap = MetadataUtils.metadataServiceProxies;
 
         try (MockedStatic<MetadataUtils> mockedMetadataUtils = Mockito.mockStatic(MetadataUtils.class)) {
-            mockedMetadataUtils.when(() -> MetadataUtils.getMetadataServiceProxy(Mockito.any(), Mockito.any())).thenReturn(metadataService);
+            mockedMetadataUtils.when(() -> MetadataUtils.getMetadataServiceProxy(Mockito.any())).thenReturn(metadataService);
 
             // notify app1 instance change
             ServiceInstancesChangedEvent event = new ServiceInstancesChangedEvent("app1", app1Instances);
@@ -438,8 +438,8 @@ public class ServiceInstancesChangedListenerTest {
             Assertions.assertEquals(metadataInfo_111, revisionToMetadata.get("111"));
             Assertions.assertEquals(MetadataInfo.EMPTY, revisionToMetadata.get("222"));
 
-            Assertions.assertEquals(3, listener.getAddresses(service1 + ":dubbo", consumerURL).size());
-            Assertions.assertTrue(isEmpty(listener.getAddresses(service2 + ":dubbo", consumerURL)));
+            Assertions.assertEquals(3, listener.getAddresses(service1 + ":dubbo").size());
+            Assertions.assertTrue(isEmpty(listener.getAddresses(service2 + ":dubbo")));
 
             try {
                 Thread.sleep(15000);
@@ -452,9 +452,9 @@ public class ServiceInstancesChangedListenerTest {
             Assertions.assertEquals(metadataInfo_111, revisionToMetadata_after_retry.get("111"));
             Assertions.assertEquals(metadataInfo_222, revisionToMetadata_after_retry.get("222"));
 
-            List<URL> serviceUrls_after_retry = listener.getAddresses(service1 + ":dubbo", consumerURL);
+            List<URL> serviceUrls_after_retry = listener.getAddresses(service1 + ":dubbo");
             Assertions.assertEquals(5, serviceUrls_after_retry.size());
-            List<URL> serviceUrls2_after_retry = listener.getAddresses(service2 + ":dubbo", consumerURL);
+            List<URL> serviceUrls2_after_retry = listener.getAddresses(service2 + ":dubbo");
             Assertions.assertEquals(2, serviceUrls2_after_retry.size());
         } finally {
             MetadataUtils.metadataServiceProxies = tmpProxyMap;

--- a/dubbo-registry/dubbo-registry-api/src/test/java/org/apache/dubbo/registry/client/event/listener/ServiceInstancesChangedListenerTest.java
+++ b/dubbo-registry/dubbo-registry-api/src/test/java/org/apache/dubbo/registry/client/event/listener/ServiceInstancesChangedListenerTest.java
@@ -195,7 +195,7 @@ public class ServiceInstancesChangedListenerTest {
             Assertions.assertEquals(1, revisionToMetadata.size());
             Assertions.assertEquals(metadataInfo_111, revisionToMetadata.get("111"));
 
-            List<URL> serviceUrls = listener.getAddresses(service1 + ":dubbo");
+            List<URL> serviceUrls = listener.getAddresses(service1 + ":dubbo", consumerURL);
             Assertions.assertEquals(3, serviceUrls.size());
             Assertions.assertTrue(serviceUrls.get(0) instanceof InstanceAddressURL);
 
@@ -236,12 +236,12 @@ public class ServiceInstancesChangedListenerTest {
             Assertions.assertEquals(metadataInfo_222, revisionToMetadata.get("222"));
             Assertions.assertEquals(metadataInfo_333, revisionToMetadata.get("333"));
 
-            List<URL> serviceUrls = listener.getAddresses(service1 + ":dubbo");
+            List<URL> serviceUrls = listener.getAddresses(service1 + ":dubbo", consumerURL);
             Assertions.assertEquals(7, serviceUrls.size());
-            List<URL> serviceUrls2 = listener.getAddresses(service2 + ":dubbo");
+            List<URL> serviceUrls2 = listener.getAddresses(service2 + ":dubbo", consumerURL);
             Assertions.assertEquals(4, serviceUrls2.size());
             Assertions.assertTrue(serviceUrls2.get(0).getIp().contains("30.10."));
-            List<URL> serviceUrls3 = listener.getAddresses(service3 + ":dubbo");
+            List<URL> serviceUrls3 = listener.getAddresses(service3 + ":dubbo", consumerURL);
             Assertions.assertEquals(2, serviceUrls3.size());
             Assertions.assertTrue(serviceUrls3.get(0).getIp().contains("30.10."));
         }
@@ -282,13 +282,13 @@ public class ServiceInstancesChangedListenerTest {
             Assertions.assertEquals(metadataInfo_222, revisionToMetadata.get("222"));
             Assertions.assertEquals(metadataInfo_333, revisionToMetadata.get("333"));
 
-            List<URL> serviceUrls = listener.getAddresses(service1 + ":dubbo");
+            List<URL> serviceUrls = listener.getAddresses(service1 + ":dubbo", consumerURL);
             Assertions.assertEquals(4, serviceUrls.size());
             Assertions.assertTrue(serviceUrls.get(0).getIp().contains("30.10."));
-            List<URL> serviceUrls2 = listener.getAddresses(service2 + ":dubbo");
+            List<URL> serviceUrls2 = listener.getAddresses(service2 + ":dubbo", consumerURL);
             Assertions.assertEquals(4, serviceUrls2.size());
             Assertions.assertTrue(serviceUrls2.get(0).getIp().contains("30.10."));
-            List<URL> serviceUrls3 = listener.getAddresses(service3 + ":dubbo");
+            List<URL> serviceUrls3 = listener.getAddresses(service3 + ":dubbo", consumerURL);
             Assertions.assertEquals(2, serviceUrls3.size());
             Assertions.assertTrue(serviceUrls3.get(0).getIp().contains("30.10."));
 
@@ -305,9 +305,9 @@ public class ServiceInstancesChangedListenerTest {
             Map<String, MetadataInfo> revisionToMetadata_app2 = listener.getRevisionToMetadata();
             Assertions.assertEquals(0, revisionToMetadata_app2.size());
 
-            Assertions.assertTrue(isEmpty(listener.getAddresses(service1 + ":dubbo")));
-            Assertions.assertTrue(isEmpty(listener.getAddresses(service2+ ":dubbo")));
-            Assertions.assertTrue(isEmpty(listener.getAddresses(service3 + ":dubbo")));
+            Assertions.assertTrue(isEmpty(listener.getAddresses(service1 + ":dubbo", consumerURL)));
+            Assertions.assertTrue(isEmpty(listener.getAddresses(service2+ ":dubbo", consumerURL)));
+            Assertions.assertTrue(isEmpty(listener.getAddresses(service3 + ":dubbo", consumerURL)));
         }
     }
 
@@ -374,8 +374,8 @@ public class ServiceInstancesChangedListenerTest {
             ServiceInstancesChangedEvent failed_revision_event = new ServiceInstancesChangedEvent("app1", app1FailedInstances);
             listener.onEvent(failed_revision_event);
 
-            List<URL> serviceUrls = listener.getAddresses(service1 + ":dubbo");
-            List<URL> serviceUrls2 = listener.getAddresses(service2 + ":dubbo");
+            List<URL> serviceUrls = listener.getAddresses(service1 + ":dubbo", consumerURL);
+            List<URL> serviceUrls2 = listener.getAddresses(service2 + ":dubbo", consumerURL);
 
             Assertions.assertTrue(isEmpty(serviceUrls));
             Assertions.assertTrue(isEmpty(serviceUrls2));
@@ -438,8 +438,8 @@ public class ServiceInstancesChangedListenerTest {
             Assertions.assertEquals(metadataInfo_111, revisionToMetadata.get("111"));
             Assertions.assertEquals(MetadataInfo.EMPTY, revisionToMetadata.get("222"));
 
-            Assertions.assertEquals(3, listener.getAddresses(service1 + ":dubbo").size());
-            Assertions.assertTrue(isEmpty(listener.getAddresses(service2 + ":dubbo")));
+            Assertions.assertEquals(3, listener.getAddresses(service1 + ":dubbo", consumerURL).size());
+            Assertions.assertTrue(isEmpty(listener.getAddresses(service2 + ":dubbo", consumerURL)));
 
             try {
                 Thread.sleep(15000);
@@ -452,9 +452,9 @@ public class ServiceInstancesChangedListenerTest {
             Assertions.assertEquals(metadataInfo_111, revisionToMetadata_after_retry.get("111"));
             Assertions.assertEquals(metadataInfo_222, revisionToMetadata_after_retry.get("222"));
 
-            List<URL> serviceUrls_after_retry = listener.getAddresses(service1 + ":dubbo");
+            List<URL> serviceUrls_after_retry = listener.getAddresses(service1 + ":dubbo", consumerURL);
             Assertions.assertEquals(5, serviceUrls_after_retry.size());
-            List<URL> serviceUrls2_after_retry = listener.getAddresses(service2 + ":dubbo");
+            List<URL> serviceUrls2_after_retry = listener.getAddresses(service2 + ":dubbo", consumerURL);
             Assertions.assertEquals(2, serviceUrls2_after_retry.size());
         } finally {
             MetadataUtils.metadataServiceProxies = tmpProxyMap;


### PR DESCRIPTION
## What is the purpose of the change
1. add a method to refresh instance, remove instance refresh logic in `isRetryAndExpired`.
2. remove second param `consumerUrl` at `ServiceInstancesChangedListener#getAddresses`.
3. remove second param `ServiceDiscovery` at `MetadataUtils#destroyMetadataServiceProxy`.
4. remove second param `ServiceDiscovery` at `MetadataUtils#getMetadataServiceProxy`

