### PR TITLE
perf: Ignore unnecessary exception stack trace in testcase

### DIFF
--- a/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/ConfigCenterConfigTest.java
+++ b/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/ConfigCenterConfigTest.java
@@ -92,7 +92,7 @@ public class ConfigCenterConfigTest {
                         .configCenter(configCenter)
                         .initialize();
             } catch (Exception e) {
-                e.printStackTrace();
+                // ignore
             }
 
             Collection<ConfigCenterConfig> configCenters = ApplicationModel.getConfigManager().getConfigCenters();

--- a/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/MethodConfigTest.java
+++ b/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/MethodConfigTest.java
@@ -429,7 +429,7 @@ public class MethodConfigTest {
                 .initialize();
             Assertions.fail("Method config verification should failed");
         } catch (Exception e) {
-            e.printStackTrace();
+            // ignore
             Throwable cause = e.getCause();
             Assertions.assertEquals(IllegalStateException.class, cause.getClass());
             Assertions.assertTrue(cause.getMessage().contains("not found method"), cause.toString());

--- a/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/ReferenceConfigTest.java
+++ b/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/ReferenceConfigTest.java
@@ -135,7 +135,7 @@ public class ReferenceConfigTest {
             demoService = rc.get();
             success = true;
         } catch (Exception e) {
-            e.printStackTrace();
+            // ignore
         }
         Assertions.assertFalse(success);
         Assertions.assertNull(demoService);
@@ -152,7 +152,7 @@ public class ReferenceConfigTest {
             demoService = rc.get();
             success = true;
         } catch (Exception e) {
-            e.printStackTrace();
+            // ignore
         } finally {
             rc.destroy();
             sc.unexport();


### PR DESCRIPTION
## What is the purpose of the change

see #8419 

## Brief changelog

1. Ignore of printing exception stack trace in ConfigCenterConfigTest#testOverrideConfig
2. Ignore of printing exception stack trace in MethodConfigTest#testVerifyMethodConfigOfService
3. Ignore of printing exception stack trace in ReferenceConfigTest#test1ReferenceRetry

## Verifying this change


<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [x] Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [x] GitHub Actions works fine on your own branch.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
