### PR TITLE
Make ServiceConfigTest#testDelayExport more reasonable

### DIFF
--- a/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/ServiceConfigTest.java
+++ b/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/ServiceConfigTest.java
@@ -18,6 +18,7 @@
 package org.apache.dubbo.config;
 
 import com.google.common.collect.Lists;
+
 import org.apache.dubbo.common.URL;
 import org.apache.dubbo.common.extension.ExtensionLoader;
 import org.apache.dubbo.config.api.DemoService;
@@ -43,7 +44,7 @@ import org.mockito.Mockito;
 
 import java.util.Collections;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.CountDownLatch;
 
 import static org.apache.dubbo.common.constants.CommonConstants.ANYHOST_KEY;
 import static org.apache.dubbo.common.constants.CommonConstants.APPLICATION_KEY;
@@ -204,11 +205,22 @@ public class ServiceConfigTest {
 
     @Test
     public void testDelayExport() throws Exception {
+        CountDownLatch latch = new CountDownLatch(1);
+        delayService.addServiceListener(new ServiceListener() {
+            @Override
+            public void exported(ServiceConfig sc) {
+                assertThat(delayService.getExportedUrls(), hasSize(1));
+                latch.countDown();
+            }
+
+            @Override
+            public void unexported(ServiceConfig sc) {
+
+            }
+        });
         delayService.export();
         assertTrue(delayService.getExportedUrls().isEmpty());
-        //add 300ms to ensure that the delayService has been exported
-        TimeUnit.MILLISECONDS.sleep(delayService.getDelay() + 300);
-        assertThat(delayService.getExportedUrls(), hasSize(1));
+        latch.await();
     }
 
     @Test


### PR DESCRIPTION
## What is the purpose of the change
https://github.com/apache/dubbo/blob/b64ea1d8c6c5b64828ef3d08f8cc432de59bb559/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/ServiceConfigTest.java#L205-L212

Here use sleep to test delay, it's not suitable. It can't guarantee that delayService already exported.

So here use listener to check it.