### PR TITLE
[3.0-Triple]Remove auto wrap when attachment is an object instance 

### DIFF
--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/UnaryClientStream.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/UnaryClientStream.java
@@ -76,6 +76,9 @@ public class UnaryClientStream extends AbstractClientStream implements Stream {
             response.setErrorMessage(status.description);
             final AppResponse result = new AppResponse();
             result.setException(getThrowable(this.getTrailers()));
+            // avoid subsequent parse header problems
+            this.getTrailers().remove(TripleConstant.EXCEPTION_TW_BIN);
+            this.getTrailers().remove(TripleConstant.STATUS_KEY);
             result.setObjectAttachments(UnaryClientStream.this.parseMetadataToMap(this.getTrailers()));
             response.setResult(result);
             if (!result.hasException()) {
@@ -103,8 +106,6 @@ public class UnaryClientStream extends AbstractClientStream implements Stream {
                     } finally {
                         ClassLoadUtil.switchContextLoader(tccl);
                     }
-                    // avoid subsequent parse header problems
-                    metadata.remove(TripleConstant.EXCEPTION_TW_BIN);
                 }
             } catch (Throwable t) {
                 LOGGER.warn(String.format("Decode exception instance from triple trailers:%s failed", metadata), t);


### PR DESCRIPTION


## What is the purpose of the change

1. Do not wrap object in attachment
2. Fix triple server thread pool name's typo
3. Remove hanlded exception info from metadata


## Brief changelog


## Verifying this change


<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [ ] GitHub Actions works fine on your own branch.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
