### PR TITLE
[3.0 triple] Optimize tri header constant & avoid tri header in attachments

### DIFF
--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/AbstractClientStream.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/AbstractClientStream.java
@@ -145,22 +145,18 @@ public abstract class AbstractClientStream extends AbstractStream implements Str
 
     protected Metadata createRequestMeta(RpcInvocation inv) {
         Metadata metadata = new DefaultMetadata();
-        metadata.put(TripleConstant.PATH_KEY, "/" + inv.getObjectAttachment(CommonConstants.PATH_KEY) + "/" + inv.getMethodName())
-                .put(TripleConstant.AUTHORITY_KEY, getUrl().getAddress())
-                .put(TripleConstant.CONTENT_TYPE_KEY, TripleConstant.CONTENT_PROTO)
-                .put(TripleConstant.TIMEOUT, inv.get(CommonConstants.TIMEOUT_KEY) + "m")
+        metadata.put(TripleHeaderEnum.PATH_KEY.getHeader(), "/" + inv.getObjectAttachment(CommonConstants.PATH_KEY) + "/" + inv.getMethodName())
+                .put(TripleHeaderEnum.AUTHORITY_KEY.getHeader(), getUrl().getAddress())
+                .put(TripleHeaderEnum.CONTENT_TYPE_KEY.getHeader(), TripleConstant.CONTENT_PROTO)
+                .put(TripleHeaderEnum.TIMEOUT.getHeader(), inv.get(CommonConstants.TIMEOUT_KEY) + "m")
                 .put(HttpHeaderNames.TE, HttpHeaderValues.TRAILERS);
 
-        metadata.putIfNotNull(TripleConstant.SERVICE_VERSION, inv.getInvoker().getUrl().getVersion())
-                .putIfNotNull(TripleConstant.CONSUMER_APP_NAME_KEY,
+        metadata.putIfNotNull(TripleHeaderEnum.SERVICE_VERSION.getHeader(), inv.getInvoker().getUrl().getVersion())
+                .putIfNotNull(TripleHeaderEnum.CONSUMER_APP_NAME_KEY.getHeader(),
                         (String) inv.getObjectAttachments().remove(CommonConstants.APPLICATION_KEY))
-                .putIfNotNull(TripleConstant.CONSUMER_APP_NAME_KEY,
+                .putIfNotNull(TripleHeaderEnum.CONSUMER_APP_NAME_KEY.getHeader(),
                         (String) inv.getObjectAttachments().remove(CommonConstants.REMOTE_APPLICATION_KEY))
-                .putIfNotNull(TripleConstant.SERVICE_GROUP, inv.getInvoker().getUrl().getGroup());
-        inv.getObjectAttachments().remove(CommonConstants.GROUP_KEY);
-        inv.getObjectAttachments().remove(CommonConstants.INTERFACE_KEY);
-        inv.getObjectAttachments().remove(CommonConstants.PATH_KEY);
-        metadata.forEach(e -> metadata.put(e.getKey(), e.getValue()));
+                .putIfNotNull(TripleHeaderEnum.SERVICE_GROUP.getHeader(), inv.getInvoker().getUrl().getGroup());
         final Map<String, Object> attachments = inv.getObjectAttachments();
         if (attachments != null) {
             convertAttachment(metadata, attachments);

--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/AbstractServerStream.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/AbstractServerStream.java
@@ -119,17 +119,7 @@ public abstract class AbstractServerStream extends AbstractStream implements Str
         inv.setParameterTypes(getMethodDescriptor().getParameterClasses());
         inv.setReturnTypes(getMethodDescriptor().getReturnTypes());
 
-        final Map<String, Object> attachments = parseMetadataToMap(metadata);
-        attachments.remove("interface");
-        attachments.remove("serialization");
-        attachments.remove("te");
-        attachments.remove("path");
-        attachments.remove(TripleConstant.CONTENT_TYPE_KEY);
-        attachments.remove(TripleConstant.SERVICE_GROUP);
-        attachments.remove(TripleConstant.SERVICE_VERSION);
-        attachments.remove(TripleConstant.MESSAGE_KEY);
-        attachments.remove(TripleConstant.STATUS_KEY);
-        attachments.remove(TripleConstant.TIMEOUT);
+        final Map<String, Object> attachments = parseMetadataToAttachmentMap(metadata);
         inv.setObjectAttachments(attachments);
 
         return inv;

--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/ClientTransportObserver.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/ClientTransportObserver.java
@@ -56,8 +56,8 @@ public class ClientTransportObserver implements TransportObserver {
     public void onMetadata(Metadata metadata, boolean endStream, Stream.OperationHandler handler) {
         if (!headerSent) {
             final Http2Headers headers = new DefaultHttp2Headers(true)
-                    .path(metadata.get(TripleConstant.PATH_KEY))
-                    .authority(metadata.get(TripleConstant.AUTHORITY_KEY))
+                    .path(metadata.get(TripleHeaderEnum.PATH_KEY.getHeader()))
+                    .authority(metadata.get(TripleHeaderEnum.AUTHORITY_KEY.getHeader()))
                     .scheme(SCHEME)
                     .method(HttpMethod.POST.asciiName());
             metadata.forEach(e -> headers.set(e.getKey(), e.getValue()));

--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/ServerStream.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/ServerStream.java
@@ -61,8 +61,8 @@ public class ServerStream extends AbstractServerStream implements Stream {
         @Override
         public void onCompleted() {
             Metadata metadata = new DefaultMetadata();
-            metadata.put(TripleConstant.MESSAGE_KEY, "OK");
-            metadata.put(TripleConstant.STATUS_KEY, Integer.toString(GrpcStatus.Code.OK.code));
+            metadata.put(TripleHeaderEnum.MESSAGE_KEY.getHeader(), "OK");
+            metadata.put(TripleHeaderEnum.STATUS_KEY.getHeader(), Integer.toString(GrpcStatus.Code.OK.code));
             getTransportSubscriber().tryOnMetadata(metadata, true);
         }
     }

--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/ServerTransportObserver.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/ServerTransportObserver.java
@@ -42,7 +42,7 @@ public class ServerTransportObserver implements TransportObserver {
         if (!headerSent) {
             headerSent = true;
             headers.status(OK.codeAsText());
-            headers.set(TripleConstant.CONTENT_TYPE_KEY, TripleConstant.CONTENT_PROTO);
+            headers.set(TripleHeaderEnum.CONTENT_TYPE_KEY.getHeader(), TripleConstant.CONTENT_PROTO);
             ctx.writeAndFlush(new DefaultHttp2HeadersFrame(headers, endStream));
         } else {
             ctx.writeAndFlush(new DefaultHttp2HeadersFrame(headers, endStream));

--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/TripleConstant.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/TripleConstant.java
@@ -19,25 +19,12 @@ package org.apache.dubbo.rpc.protocol.tri;
 import io.netty.handler.codec.http2.Http2CodecUtil;
 
 public interface TripleConstant {
-    String AUTHORITY_KEY = ":authority";
-    String PATH_KEY = ":path";
-    String HTTP_STATUS_KEY = "http-status";
-    String STATUS_KEY = "grpc-status";
-    String MESSAGE_KEY = "grpc-message";
-    String STATUS_DETAIL_KEY = "grpc-status-details-bin";
-    String TIMEOUT = "grpc-timeout";
-    String CONTENT_TYPE_KEY = "content-type";
     String CONTENT_PROTO = "application/grpc+proto";
     String APPLICATION_GRPC = "application/grpc";
-    String TRICE_ID_KEY = "tri-trace-traceid";
-    String RPC_ID_KEY = "tri-trace-rpcid";
-    String CONSUMER_APP_NAME_KEY = "tri-consumer-appname";
-    String UNIT_INFO_KEY = "tri-unit-info";
-    String SERVICE_VERSION = "tri-service-version";
-    String SERVICE_GROUP = "tri-service-group";
     String TRI_VERSION = "1.0.0";
-    String EXCEPTION_TW_BIN = "tri-exception-tw-bin";
-    String DEFAULT_TRIPLE_USER_EXCEPTION_SERIALIZATION = "hessian2";
+
+    String SERIALIZATION_KEY = "serialization";
+    String TE_KEY="te";
     // each header size
     long DEFAULT_HEADER_LIST_SIZE = Http2CodecUtil.DEFAULT_HEADER_LIST_SIZE;
 

--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/TripleHeaderEnum.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/TripleHeaderEnum.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.rpc.protocol.tri;
+
+import org.apache.dubbo.common.constants.CommonConstants;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+public enum TripleHeaderEnum {
+
+    AUTHORITY_KEY(":authority"),
+    PATH_KEY(":path"),
+    HTTP_STATUS_KEY("http-status"),
+    STATUS_KEY("grpc-status"),
+    MESSAGE_KEY("grpc-message"),
+    STATUS_DETAIL_KEY("grpc-status-details-bin"),
+    TIMEOUT("grpc-timeout"),
+    CONTENT_TYPE_KEY("content-type"),
+    CONTENT_PROTO("application/grpc+proto"),
+    APPLICATION_GRPC("application/grpc"),
+    TRICE_ID_KEY("tri-trace-traceid"),
+    RPC_ID_KEY("tri-trace-rpcid"),
+    CONSUMER_APP_NAME_KEY("tri-consumer-appname"),
+    UNIT_INFO_KEY("tri-unit-info"),
+    SERVICE_VERSION("tri-service-version"),
+    SERVICE_GROUP("tri-service-group"),
+    EXCEPTION_TW_BIN("tri-exception-tw-bin");
+
+    static Map<String, TripleHeaderEnum> enumMap = new HashMap<>();
+
+    static Set<String> excludeAttachmentsSet = new HashSet<>();
+
+    static {
+        for (TripleHeaderEnum item : TripleHeaderEnum.values()) {
+            enumMap.put(item.getHeader(), item);
+        }
+        excludeAttachmentsSet.add(CommonConstants.GROUP_KEY);
+        excludeAttachmentsSet.add(CommonConstants.INTERFACE_KEY);
+        excludeAttachmentsSet.add(CommonConstants.PATH_KEY);
+        excludeAttachmentsSet.add(CommonConstants.REMOTE_APPLICATION_KEY);
+        excludeAttachmentsSet.add(CommonConstants.APPLICATION_KEY);
+        excludeAttachmentsSet.add(TripleConstant.SERIALIZATION_KEY);
+        excludeAttachmentsSet.add(TripleConstant.TE_KEY);
+    }
+
+    public static TripleHeaderEnum getEnum(String header) {
+        return enumMap.get(header);
+    }
+
+    public static boolean contains(String header) {
+        return enumMap.containsKey(header);
+    }
+
+    public static boolean containsExcludeAttachments(String key) {
+        return excludeAttachmentsSet.contains(key) || enumMap.containsKey(key);
+    }
+
+    private final String header;
+
+    TripleHeaderEnum(String header) {
+        this.header = header;
+    }
+
+    public String getHeader() {
+        return header;
+    }
+}

--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/TripleHttp2ClientResponseHandler.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/TripleHttp2ClientResponseHandler.java
@@ -72,8 +72,8 @@ public final class TripleHttp2ClientResponseHandler extends SimpleChannelInbound
         final GrpcStatus status = GrpcStatus.fromCode(GrpcStatus.Code.INTERNAL)
                 .withCause(cause);
         Metadata metadata = new DefaultMetadata();
-        metadata.put(TripleConstant.STATUS_KEY, Integer.toString(status.code.code));
-        metadata.put(TripleConstant.MESSAGE_KEY, status.toMessage());
+        metadata.put(TripleHeaderEnum.STATUS_KEY.getHeader(), Integer.toString(status.code.code));
+        metadata.put(TripleHeaderEnum.MESSAGE_KEY.getHeader(), status.toMessage());
         logger.warn("Meet Exception on ClientResponseHandler, status code is: " + status.code, cause);
         clientStream.asStreamObserver().onError(status.asException());
         ctx.close();

--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/TripleHttp2FrameServerHandler.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/TripleHttp2FrameServerHandler.java
@@ -92,9 +92,9 @@ public class TripleHttp2FrameServerHandler extends ChannelDuplexHandler {
     }
 
     private Invoker<?> getInvoker(Http2Headers headers, String serviceName) {
-        final String version = headers.contains(TripleConstant.SERVICE_VERSION) ? headers.get(
-                TripleConstant.SERVICE_VERSION).toString() : null;
-        final String group = headers.contains(TripleConstant.SERVICE_GROUP) ? headers.get(TripleConstant.SERVICE_GROUP)
+        final String version = headers.contains(TripleHeaderEnum.SERVICE_VERSION.getHeader()) ? headers.get(
+            TripleHeaderEnum.SERVICE_VERSION.getHeader()).toString() : null;
+        final String group = headers.contains(TripleHeaderEnum.SERVICE_GROUP.getHeader()) ? headers.get(TripleHeaderEnum.SERVICE_GROUP.getHeader())
                 .toString() : null;
         final String key = URL.buildKey(serviceName, group, version);
         Invoker<?> invoker = PATH_RESOLVER.resolve(key);

--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/TripleUtil.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/TripleUtil.java
@@ -85,19 +85,19 @@ public class TripleUtil {
 
     public static void responseErr(ChannelHandlerContext ctx, GrpcStatus status) {
         Http2Headers trailers = new DefaultHttp2Headers()
-                .status(OK.codeAsText())
-                .set(HttpHeaderNames.CONTENT_TYPE, TripleConstant.CONTENT_PROTO)
-                .setInt(TripleConstant.STATUS_KEY, status.code.code)
-                .set(TripleConstant.MESSAGE_KEY, status.toMessage());
+            .status(OK.codeAsText())
+            .set(HttpHeaderNames.CONTENT_TYPE, TripleConstant.CONTENT_PROTO)
+            .setInt(TripleHeaderEnum.STATUS_KEY.getHeader(), status.code.code)
+            .set(TripleHeaderEnum.MESSAGE_KEY.getHeader(), status.toMessage());
         ctx.writeAndFlush(new DefaultHttp2HeadersFrame(trailers, true));
     }
 
     public static void responsePlainTextError(ChannelHandlerContext ctx, int code, GrpcStatus status) {
         Http2Headers headers = new DefaultHttp2Headers(true)
-                .status("" + code)
-                .setInt(TripleConstant.STATUS_KEY, status.code.code)
-                .set(TripleConstant.MESSAGE_KEY, status.description)
-                .set(TripleConstant.CONTENT_TYPE_KEY, "text/plain; encoding=utf-8");
+            .status("" + code)
+            .setInt(TripleHeaderEnum.STATUS_KEY.getHeader(), status.code.code)
+            .set(TripleHeaderEnum.MESSAGE_KEY.getHeader(), status.description)
+            .set(TripleHeaderEnum.CONTENT_TYPE_KEY.getHeader(), "text/plain; encoding=utf-8");
         ctx.write(new DefaultHttp2HeadersFrame(headers));
         ByteBuf buf = ByteBufUtil.writeUtf8(ctx.alloc(), status.description);
         ctx.write(new DefaultHttp2DataFrame(buf, true));
@@ -133,6 +133,10 @@ public class TripleUtil {
             e.printStackTrace();
         }
         return map;
+    }
+
+    public static boolean overEachHeaderListSize(String str) {
+        return TripleConstant.DEFAULT_HEADER_LIST_SIZE <= str.length();
     }
 
 

--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/UnaryServerStream.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/UnaryServerStream.java
@@ -122,7 +122,7 @@ public class UnaryServerStream extends AbstractServerStream implements Stream {
                     getTransportSubscriber().tryOnData(data, false);
 
                     Metadata trailers = new DefaultMetadata()
-                            .put(TripleConstant.STATUS_KEY, Integer.toString(GrpcStatus.Code.OK.code));
+                            .put(TripleHeaderEnum.STATUS_KEY.getHeader(), Integer.toString(GrpcStatus.Code.OK.code));
                     final Map<String, Object> attachments = response.getObjectAttachments();
                     if (attachments != null) {
                         convertAttachment(trailers, attachments);


### PR DESCRIPTION
## What is the purpose of the change

Optimize tri header constant & avoid tri header in attachments


## Brief changelog

- change tri constant to enum
- Unified processing of attachment value & Determine whether it is larger than the default header size

## Verifying this change


<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [ ] GitHub Actions works fine on your own branch.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
