### PR TITLE
[3.0-Triple]Optimize connection  & remove executor

### DIFF
--- a/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/api/Connection.java
+++ b/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/api/Connection.java
@@ -16,7 +16,6 @@
  */
 package org.apache.dubbo.remoting.api;
 
-import io.netty.handler.ssl.SslContext;
 import org.apache.dubbo.common.URL;
 import org.apache.dubbo.common.extension.ExtensionLoader;
 import org.apache.dubbo.common.logger.Logger;
@@ -36,6 +35,7 @@ import io.netty.channel.ChannelOption;
 import io.netty.channel.ChannelPipeline;
 import io.netty.channel.EventLoop;
 import io.netty.channel.socket.SocketChannel;
+import io.netty.handler.ssl.SslContext;
 import io.netty.util.AbstractReferenceCounted;
 import io.netty.util.AttributeKey;
 import io.netty.util.ReferenceCountUtil;
@@ -45,64 +45,58 @@ import io.netty.util.concurrent.GlobalEventExecutor;
 import io.netty.util.concurrent.Promise;
 
 import java.net.InetSocketAddress;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
+import static org.apache.dubbo.common.constants.CommonConstants.DEFAULT_CLIENT_THREADPOOL;
 import static org.apache.dubbo.common.constants.CommonConstants.SSL_ENABLED_KEY;
 import static org.apache.dubbo.common.constants.CommonConstants.THREADPOOL_KEY;
-import static org.apache.dubbo.common.constants.CommonConstants.DEFAULT_CLIENT_THREADPOOL;
-
 import static org.apache.dubbo.remoting.api.NettyEventLoopFactory.socketChannelClass;
 
 public class Connection extends AbstractReferenceCounted implements ReferenceCounted {
 
     public static final AttributeKey<Connection> CONNECTION = AttributeKey.valueOf("connection");
     private static final Logger logger = LoggerFactory.getLogger(Connection.class);
+    private static final Object CONNECTED_OBJECT = new Object();
     private final URL url;
     private final int connectTimeout;
     private final WireProtocol protocol;
-    private final Promise<Void> closeFuture;
     private final InetSocketAddress remote;
     private final AtomicBoolean closed = new AtomicBoolean(false);
+    private final AtomicBoolean init = new AtomicBoolean(false);
+    private final Promise<Void> closePromise = new DefaultPromise<>(GlobalEventExecutor.INSTANCE);
     private final AtomicReference<Channel> channel = new AtomicReference<>();
-    private final ChannelFuture initPromise;
-    private volatile CompletableFuture<Object> connectedFuture = new CompletableFuture<>();
-    private static final Object CONNECTED_OBJECT = new Object();
     private final Bootstrap bootstrap;
     private final ConnectionListener connectionListener = new ConnectionListener();
+    private volatile Promise<Object> connectingPromise;
 
     public Connection(URL url) {
         url = ExecutorUtil.setThreadName(url, "DubboClientHandler");
         url = url.addParameterIfAbsent(THREADPOOL_KEY, DEFAULT_CLIENT_THREADPOOL);
         this.url = url;
         this.protocol = ExtensionLoader.getExtensionLoader(WireProtocol.class).getExtension(url.getProtocol());
-        this.connectTimeout = Math.max(3000, url.getPositiveParameter(Constants.CONNECT_TIMEOUT_KEY, Constants.DEFAULT_CONNECT_TIMEOUT));
-        this.closeFuture = new DefaultPromise<>(GlobalEventExecutor.INSTANCE);
+        this.connectTimeout = url.getPositiveParameter(Constants.CONNECT_TIMEOUT_KEY, Constants.DEFAULT_CONNECT_TIMEOUT);
         this.remote = getConnectAddress();
         this.bootstrap = create();
-        this.initPromise = connect();
     }
 
     public static Connection getConnectionFromChannel(Channel channel) {
         return channel.attr(CONNECTION).get();
     }
 
-    public Promise<Void> getCloseFuture() {
-        return closeFuture;
+    public Promise<Void> getClosePromise() {
+        return closePromise;
     }
 
     private Bootstrap create() {
         final Bootstrap bootstrap = new Bootstrap();
         bootstrap.group(NettyEventLoopFactory.NIO_EVENT_LOOP_GROUP)
-            .option(ChannelOption.SO_KEEPALIVE, true)
-            .option(ChannelOption.TCP_NODELAY, true)
-            .option(ChannelOption.ALLOCATOR, PooledByteBufAllocator.DEFAULT)
-            .remoteAddress(getConnectAddress())
-            .channel(socketChannelClass());
+                .option(ChannelOption.SO_KEEPALIVE, true)
+                .option(ChannelOption.TCP_NODELAY, true)
+                .option(ChannelOption.ALLOCATOR, PooledByteBufAllocator.DEFAULT)
+                .remoteAddress(getConnectAddress())
+                .channel(socketChannelClass());
 
         final ConnectionHandler connectionHandler = new ConnectionHandler(this);
         bootstrap.option(ChannelOption.CONNECT_TIMEOUT_MILLIS, connectTimeout);
@@ -110,8 +104,6 @@ public class Connection extends AbstractReferenceCounted implements ReferenceCou
 
             @Override
             protected void initChannel(SocketChannel ch) {
-                ch.attr(CONNECTION).set(Connection.this);
-
                 SslContext sslContext = null;
                 if (getUrl().getParameter(SSL_ENABLED_KEY, false)) {
                     ch.pipeline().addLast("negotiation", new SslClientTlsHandler(url));
@@ -120,7 +112,6 @@ public class Connection extends AbstractReferenceCounted implements ReferenceCou
                 final ChannelPipeline p = ch.pipeline();//.addLast("logging",new LoggingHandler(LogLevel.INFO))//for debug
                 // TODO support IDLE
 //                int heartbeatInterval = UrlUtils.getHeartbeat(getUrl());
-//                p.addLast("client-idle-handler", new IdleStateHandler(heartbeatInterval, 0, 0, MILLISECONDS));
                 p.addLast(connectionHandler);
                 protocol.configClientPipeline(p, sslContext);
                 // TODO support Socks5
@@ -131,12 +122,12 @@ public class Connection extends AbstractReferenceCounted implements ReferenceCou
 
     public ChannelFuture connect() {
         if (isClosed()) {
-            if (logger.isInfoEnabled()) {
-                logger.info(String.format("%s aborted to reconnect cause connection closed. ", Connection.this));
+            if (logger.isDebugEnabled()) {
+                logger.debug(String.format("%s aborted to reconnect cause connection closed. ", Connection.this));
             }
             return null;
         }
-
+        this.connectingPromise = new DefaultPromise<>(GlobalEventExecutor.INSTANCE);
         final ChannelFuture promise = bootstrap.connect();
         promise.addListener(this.connectionListener);
         return promise;
@@ -149,34 +140,42 @@ public class Connection extends AbstractReferenceCounted implements ReferenceCou
     @Override
     public String toString() {
         return super.toString() + " (Ref=" + ReferenceCountUtil.refCnt(this) + ",local=" +
-            (getChannel() == null ? null : getChannel().localAddress()) + ",remote=" + getRemote();
+                (getChannel() == null ? null : getChannel().localAddress()) + ",remote=" + getRemote();
     }
 
     public void onGoaway(Channel channel) {
         if (this.channel.compareAndSet(channel, null)) {
-            if (logger.isInfoEnabled()) {
-                logger.info(String.format("%s goaway", this));
+            if (logger.isDebugEnabled()) {
+                logger.debug(String.format("%s goaway", this));
             }
         }
-        this.connectedFuture = new CompletableFuture<>();
     }
 
     public void onConnected(Channel channel) {
         this.channel.set(channel);
         // This indicates that the connection is available.
-        this.connectedFuture.complete(CONNECTED_OBJECT);
+        this.connectingPromise.setSuccess(CONNECTED_OBJECT);
         channel.attr(CONNECTION).set(this);
-        if (logger.isInfoEnabled()) {
-            logger.info(String.format("%s connected ", this));
+        if (logger.isDebugEnabled()) {
+            logger.debug(String.format("%s connected ", this));
         }
     }
 
-    public void connectSync() throws InterruptedException, ExecutionException, TimeoutException {
-        this.connectedFuture.get(this.connectTimeout, TimeUnit.MILLISECONDS);
-    }
-
     public boolean isAvailable() {
-        final Channel channel = getChannel();
+        if (isClosed()) {
+            return false;
+        }
+        Channel channel = getChannel();
+        if (channel != null && channel.isActive()) {
+            return true;
+        }
+        synchronized (this) {
+            if (init.compareAndSet(false, true)) {
+                connect();
+            }
+        }
+        this.connectingPromise.awaitUninterruptibly(this.connectTimeout, TimeUnit.MILLISECONDS);
+        channel = getChannel();
         return channel != null && channel.isActive();
     }
 
@@ -188,7 +187,7 @@ public class Connection extends AbstractReferenceCounted implements ReferenceCou
     public ChannelFuture write(Object request) throws RemotingException {
         if (!isAvailable()) {
             throw new RemotingException(null, null,
-                "Failed to send request " + request + ", cause: The channel to " + remote + " is closed!");
+                    "Failed to send request " + request + ", cause: The channel to " + remote + " is closed!");
         }
         return getChannel().writeAndFlush(request);
     }
@@ -202,19 +201,18 @@ public class Connection extends AbstractReferenceCounted implements ReferenceCou
         if (closed.compareAndSet(false, true)) {
             close();
         }
-        closeFuture.setSuccess(null);
+        closePromise.setSuccess(null);
     }
 
     public void close() {
-        if (logger.isInfoEnabled()) {
-            logger.info(String.format("Connection:%s freed ", this));
+        if (logger.isDebugEnabled()) {
+            logger.debug(String.format("Connection:%s freed ", this));
         }
         final Channel current = this.channel.get();
         if (current != null) {
             current.close();
         }
         this.channel.set(null);
-        this.connectedFuture = new CompletableFuture<>();
     }
 
     @Override
@@ -244,13 +242,13 @@ public class Connection extends AbstractReferenceCounted implements ReferenceCou
             }
             final Connection conn = Connection.this;
             if (conn.isClosed() || conn.refCnt() == 0) {
-                if (logger.isInfoEnabled()) {
-                    logger.info(String.format("%s aborted to reconnect. %s", conn, future.cause().getMessage()));
+                if (logger.isDebugEnabled()) {
+                    logger.debug(String.format("%s aborted to reconnect. %s", conn, future.cause().getMessage()));
                 }
                 return;
             }
-            if (logger.isInfoEnabled()) {
-                logger.info(String.format("%s is reconnecting, attempt=%d cause=%s", conn, 0, future.cause().getMessage()));
+            if (logger.isDebugEnabled()) {
+                logger.debug(String.format("%s is reconnecting, attempt=%d cause=%s", conn, 0, future.cause().getMessage()));
             }
             final EventLoop loop = future.channel().eventLoop();
             loop.schedule((Runnable) conn::connect, 1L, TimeUnit.SECONDS);

--- a/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/api/ConnectionHandler.java
+++ b/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/api/ConnectionHandler.java
@@ -49,8 +49,8 @@ public class ConnectionHandler extends ChannelInboundHandlerAdapter {
         if (connection != null) {
             connection.onGoaway(channel);
         }
-        if (log.isInfoEnabled()) {
-            log.info(String.format("Channel %s go away ,schedule reconnect", channel));
+        if (log.isDebugEnabled()) {
+            log.debug(String.format("Channel %s go away ,schedule reconnect", channel));
         }
         reconnect(channel);
     }
@@ -82,8 +82,8 @@ public class ConnectionHandler extends ChannelInboundHandlerAdapter {
     }
 
     private void reconnect(Channel channel) {
-        if (log.isInfoEnabled()) {
-            log.info(String.format("Connection %s is reconnecting, attempt=%d", connection, 1));
+        if (log.isDebugEnabled()) {
+            log.debug(String.format("Connection %s is reconnecting, attempt=%d", connection, 1));
         }
         final EventLoop eventLoop = channel.eventLoop();
         eventLoop.schedule(connection::connect, 1, TimeUnit.SECONDS);

--- a/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/api/SingleProtocolConnectionManager.java
+++ b/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/api/SingleProtocolConnectionManager.java
@@ -35,7 +35,7 @@ public class SingleProtocolConnectionManager implements ConnectionManager {
         return connections.compute(url.getAddress(), (address, conn) -> {
             if (conn == null) {
                 final Connection created = new Connection(url);
-                created.getCloseFuture().addListener(future -> connections.remove(address, created));
+                created.getClosePromise().addListener(future -> connections.remove(address, created));
                 return created;
             } else {
                 conn.retain();

--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/AbstractClientStream.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/AbstractClientStream.java
@@ -44,8 +44,8 @@ public abstract class AbstractClientStream extends AbstractStream implements Str
         super(url, executor);
     }
 
-    public static UnaryClientStream unary(URL url, Executor executor) {
-        return new UnaryClientStream(url, executor);
+    public static UnaryClientStream unary(URL url) {
+        return new UnaryClientStream(url);
     }
 
     public static AbstractClientStream stream(URL url) {

--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/AbstractStream.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/AbstractStream.java
@@ -103,10 +103,6 @@ public abstract class AbstractStream implements Stream {
         return this;
     }
 
-    public Executor getExecutor() {
-        return executor;
-    }
-
     @Override
     public void execute(Runnable runnable) {
         executor.execute(runnable);

--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/TripleClientHandler.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/TripleClientHandler.java
@@ -38,8 +38,6 @@ import io.netty.handler.codec.http2.Http2GoAwayFrame;
 import io.netty.handler.codec.http2.Http2SettingsFrame;
 import io.netty.util.ReferenceCountUtil;
 
-import java.util.concurrent.Executor;
-
 public class TripleClientHandler extends ChannelDuplexHandler {
 
     @Override
@@ -78,10 +76,9 @@ public class TripleClientHandler extends ChannelDuplexHandler {
         if (service != null) {
             ClassLoadUtil.switchContextLoader(service.getServiceInterfaceClass().getClassLoader());
         }
-        final Executor executor = (Executor) inv.getAttributes().remove("callback.executor");
         AbstractClientStream stream;
         if (methodDescriptor.isUnary()) {
-            stream = AbstractClientStream.unary(url, executor);
+            stream = AbstractClientStream.unary(url);
         } else {
             stream = AbstractClientStream.stream(url);
         }

--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/TripleInvoker.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/TripleInvoker.java
@@ -94,7 +94,8 @@ public class TripleInvoker<T> extends AbstractInvoker<T> {
             req.setTwoWay(true);
             req.setData(inv);
 
-            connection.connectSync();
+            // try connect
+            connection.isAvailable();
 
             DefaultFuture2 future = DefaultFuture2.newFuture(this.connection, req, timeout, executor);
             final CompletableFuture<AppResponse> respFuture = future.thenApply(obj -> (AppResponse) obj);
@@ -102,7 +103,6 @@ public class TripleInvoker<T> extends AbstractInvoker<T> {
             FutureContext.getContext().setCompatibleFuture(respFuture);
             AsyncRpcResult result = new AsyncRpcResult(respFuture, inv);
             result.setExecutor(executor);
-            inv.put("callback.executor", executor);
 
             if (!connection.isAvailable()) {
                 Response response = new Response(req.getId(), req.getVersion());

--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/UnaryClientStream.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/UnaryClientStream.java
@@ -30,13 +30,12 @@ import com.google.rpc.Status;
 
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.Executor;
 
 public class UnaryClientStream extends AbstractClientStream implements Stream {
 
 
-    protected UnaryClientStream(URL url, Executor executor) {
-        super(url, executor);
+    protected UnaryClientStream(URL url) {
+        super(url);
     }
 
     @Override

--- a/dubbo-rpc/dubbo-rpc-triple/src/test/java/org/apache/dubbo/rpc/protocol/tri/UnaryClientStreamTest.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/test/java/org/apache/dubbo/rpc/protocol/tri/UnaryClientStreamTest.java
@@ -28,8 +28,6 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
-import java.util.concurrent.Executor;
-
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.times;
@@ -41,8 +39,7 @@ class UnaryClientStreamTest {
     @SuppressWarnings("all")
     public void testInit() {
         URL url = new ServiceConfigURL("test", "1.2.3.4", 8080);
-        final Executor executor = Mockito.mock(Executor.class);
-        final UnaryClientStream stream = UnaryClientStream.unary(url, executor);
+        final UnaryClientStream stream = UnaryClientStream.unary(url);
         final StreamObserver<Object> observer = stream.asStreamObserver();
         RpcInvocation inv = Mockito.mock(RpcInvocation.class);
         // no invoker


### PR DESCRIPTION
## What is the purpose of the change
1. Connect when invoking  instead of connecting after `Connection` created
2. Lower connection log from `INFO` to `DEBUG` to reduce log 
3. Fix async unary invocation's `callback.executor' NPE bug


## Brief changelog


## Verifying this change


<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [ ] GitHub Actions works fine on your own branch.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
