### PR TITLE
test: verify the process of exported provider in single registry center

### DIFF
--- a/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/integration/single/SingleRegistryCenterDubboProtocolIntegrationTest.java
+++ b/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/integration/single/SingleRegistryCenterDubboProtocolIntegrationTest.java
@@ -220,8 +220,6 @@ public class SingleRegistryCenterDubboProtocolIntegrationTest implements Integra
         Assertions.assertTrue(serviceDiscoveryRegistry.getServiceDiscovery() instanceof ZookeeperServiceDiscovery);
         // Convert to ZookeeperServiceDiscovery instance
         ZookeeperServiceDiscovery zookeeperServiceDiscovery = (ZookeeperServiceDiscovery) serviceDiscoveryRegistry.getServiceDiscovery();
-        // ServiceDiscoveryRegistry is destroy or not
-        Assertions.assertFalse(zookeeperServiceDiscovery.isDestroy());
         // Gets registered service by ZookeeperServiceDiscovery
         Set<String> services = zookeeperServiceDiscovery.getServices();
         // check service exists

--- a/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/integration/single/exportprovider/SingleRegistryCenterExportProviderExporterListener.java
+++ b/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/integration/single/exportprovider/SingleRegistryCenterExportProviderExporterListener.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.integration.single.exportprovider;
+
+import org.apache.dubbo.common.constants.CommonConstants;
+import org.apache.dubbo.common.extension.Activate;
+import org.apache.dubbo.integration.AbstractRegistryCenterExporterListener;
+
+@Activate(group = CommonConstants.PROVIDER, order = 1000)
+public class SingleRegistryCenterExportProviderExporterListener extends AbstractRegistryCenterExporterListener {
+
+    /**
+     * Returns the interface of exported service.
+     */
+    @Override
+    protected Class<?> getInterface() {
+        return SingleRegistryCenterExportProviderService.class;
+    }
+}

--- a/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/integration/single/exportprovider/SingleRegistryCenterExportProviderFilter.java
+++ b/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/integration/single/exportprovider/SingleRegistryCenterExportProviderFilter.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.integration.single.exportprovider;
+
+import org.apache.dubbo.common.constants.CommonConstants;
+import org.apache.dubbo.common.extension.Activate;
+import org.apache.dubbo.rpc.Filter;
+import org.apache.dubbo.rpc.Invocation;
+import org.apache.dubbo.rpc.Invoker;
+import org.apache.dubbo.rpc.RpcException;
+import org.apache.dubbo.rpc.Result;
+
+@Activate(group = CommonConstants.PROVIDER, order = 10000)
+public class SingleRegistryCenterExportProviderFilter implements Filter,Filter.Listener {
+
+    /**
+     * The filter is called or not
+     */
+    private boolean called = false;
+
+    /**
+     * There has error after invoked
+     */
+    private boolean error = false;
+
+    /**
+     * The returned result
+     */
+    private String response;
+    /**
+     * Always call invoker.invoke() in the implementation to hand over the request to the next filter node.
+     *
+     * @param invoker
+     * @param invocation
+     */
+    @Override
+    public Result invoke(Invoker<?> invoker, Invocation invocation) throws RpcException {
+        called = true;
+        return invoker.invoke(invocation);
+    }
+
+    @Override
+    public void onResponse(Result appResponse, Invoker<?> invoker, Invocation invocation) {
+        response = appResponse.getValue().toString();
+    }
+
+    @Override
+    public void onError(Throwable t, Invoker<?> invoker, Invocation invocation) {
+        error = true;
+    }
+
+    /**
+     * Returns if the filter has called.
+     */
+    public boolean hasCalled() {
+        return called;
+    }
+
+    /**
+     * Returns if there exists error.
+     */
+    public boolean hasError() {
+        return error;
+    }
+
+    /**
+     * Returns the response.
+     */
+    public String getResponse() {
+        return response;
+    }
+}

--- a/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/integration/single/exportprovider/SingleRegistryCenterExportProviderIntegrationTest.java
+++ b/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/integration/single/exportprovider/SingleRegistryCenterExportProviderIntegrationTest.java
@@ -1,0 +1,230 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.integration.single.exportprovider;
+
+import org.apache.dubbo.common.constants.CommonConstants;
+import org.apache.dubbo.common.extension.ExtensionLoader;
+import org.apache.dubbo.config.ServiceConfig;
+import org.apache.dubbo.config.ReferenceConfig;
+import org.apache.dubbo.config.ServiceListener;
+import org.apache.dubbo.config.ApplicationConfig;
+import org.apache.dubbo.config.ProtocolConfig;
+import org.apache.dubbo.config.bootstrap.DubboBootstrap;
+import org.apache.dubbo.integration.IntegrationTest;
+import org.apache.dubbo.registry.integration.RegistryProtocolListener;
+import org.apache.dubbo.registrycenter.DefaultSingleRegistryCenter;
+import org.apache.dubbo.registrycenter.SingleRegistryCenter;
+import org.apache.dubbo.rpc.ExporterListener;
+import org.apache.dubbo.rpc.Filter;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+
+import static org.apache.dubbo.rpc.Constants.SCOPE_LOCAL;
+
+/**
+ * The testcases are only for checking the core process of exporting provider.
+ */
+public class SingleRegistryCenterExportProviderIntegrationTest implements IntegrationTest {
+
+    private static final Logger logger = LoggerFactory.getLogger(SingleRegistryCenterExportProviderIntegrationTest.class);
+
+    /**
+     * Define the provider application name.
+     */
+    private static String PROVIDER_APPLICATION_NAME = "single-registry-center-for-export-provider";
+
+    /**
+     * The name for getting the specified instance, which is loaded using SPI.
+     */
+    private static String SPI_NAME = "singleConfigCenterExportProvider";
+
+    /**
+     * Define the protocol's name.
+     */
+    private static String PROTOCOL_NAME = CommonConstants.DUBBO;
+    /**
+     * Define the protocol's port.
+     */
+    private static int PROTOCOL_PORT = 20800;
+
+    /**
+     * Define the {@link ServiceConfig} instance.
+     */
+    private ServiceConfig<SingleRegistryCenterExportProviderService> serviceConfig;
+
+    /**
+     * Define a registry center.
+     */
+    private SingleRegistryCenter registryCenter;
+
+    /**
+     * Define a {@link RegistryProtocolListener} instance.
+     */
+    private SingleRegistryCenterExportProviderRegistryProtocolListener registryProtocolListener;
+
+    /**
+     * Define a {@link ExporterListener} instance.
+     */
+    private SingleRegistryCenterExportProviderExporterListener exporterListener;
+
+    /**
+     * Define a {@link Filter} instance.
+     */
+    private SingleRegistryCenterExportProviderFilter filter;
+
+    /**
+     * Define a {@link ServiceListener} instance.
+     */
+    private SingleRegistryCenterExportProviderServiceListener serviceListener;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        logger.info(getClass().getSimpleName() + " testcase is beginning...");
+        DubboBootstrap.reset();
+        registryCenter = new DefaultSingleRegistryCenter();
+        registryCenter.startup();
+        // initialize service config
+        serviceConfig = new ServiceConfig<>();
+        serviceConfig.setInterface(SingleRegistryCenterExportProviderService.class);
+        serviceConfig.setRef(new SingleRegistryCenterExportProviderServiceImpl());
+        serviceConfig.setAsync(false);
+
+        // initailize bootstrap
+        DubboBootstrap.getInstance()
+            .application(new ApplicationConfig(PROVIDER_APPLICATION_NAME))
+            .registry(registryCenter.getRegistryConfig())
+            .protocol(new ProtocolConfig(PROTOCOL_NAME, PROTOCOL_PORT))
+            .service(serviceConfig);
+    }
+
+    /**
+     * There are some checkpoints need to verify as follow:
+     * <ul>
+     *     <li>ServiceConfig is exported or not</li>
+     *     <li>SingleRegistryCenterExportProviderRegistryProtocolListener is null or not</li>
+     *     <li>There is nothing in ServiceListener or not</li>
+     *     <li>There is nothing in ExporterListener or not</li>
+     * </ul>
+     */
+    private void beforeExport() {
+        registryProtocolListener = (SingleRegistryCenterExportProviderRegistryProtocolListener) ExtensionLoader
+            .getExtensionLoader(RegistryProtocolListener.class)
+            .getExtension(SPI_NAME);
+        exporterListener = (SingleRegistryCenterExportProviderExporterListener) ExtensionLoader
+            .getExtensionLoader(ExporterListener.class)
+            .getExtension(SPI_NAME);
+        filter = (SingleRegistryCenterExportProviderFilter) ExtensionLoader
+            .getExtensionLoader(Filter.class)
+            .getExtension(SPI_NAME);
+        serviceListener = (SingleRegistryCenterExportProviderServiceListener) ExtensionLoader
+            .getExtensionLoader(ServiceListener.class)
+            .getExtension(SPI_NAME);
+        // ---------------checkpoints--------------- //
+        // ServiceConfig isn't exported
+        Assertions.assertFalse(serviceConfig.isExported());
+        // registryProtocolListener is just initialized by SPI
+        // so, all of fields are the default value.
+        Assertions.assertNotNull(registryProtocolListener);
+        Assertions.assertFalse(registryProtocolListener.isExported());
+        // There is nothing in ServiceListener
+        Assertions.assertTrue(serviceListener.getExportedServices().isEmpty());
+        // There is nothing in ExporterListener
+        Assertions.assertTrue(exporterListener.getExportedExporters().isEmpty());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Test
+    @Override
+    public void integrate() {
+        beforeExport();
+        DubboBootstrap.getInstance().start();
+        afterExport();
+        ReferenceConfig<SingleRegistryCenterExportProviderService> referenceConfig = new ReferenceConfig<>();
+        referenceConfig.setInterface(SingleRegistryCenterExportProviderService.class);
+        referenceConfig.setBootstrap(DubboBootstrap.getInstance());
+        referenceConfig.setScope(SCOPE_LOCAL);
+        referenceConfig.get().hello(PROVIDER_APPLICATION_NAME);
+        afterInvoke();
+    }
+
+    /**
+     * There are some checkpoints need to check after exported as follow:
+     * <ul>
+     *     <li>the exporter is exported or not</li>
+     *     <li>The exported exporter are three</li>
+     *     <li>The exported service is SingleRegistryCenterExportProviderService or not</li>
+     *     <li>The SingleRegistryCenterExportProviderService is exported or not</li>
+     *     <li>The exported exporter contains SingleRegistryCenterExportProviderFilter or not</li>
+     * </ul>
+     */
+    private void afterExport() {
+        // The exporter is exported
+        Assertions.assertTrue(registryProtocolListener.isExported());
+        // The exported service is only one
+        Assertions.assertEquals(serviceListener.getExportedServices().size(), 1);
+        // The exported service is SingleRegistryCenterExportProviderService
+        Assertions.assertEquals(serviceListener.getExportedServices().get(0).getInterfaceClass(),
+            SingleRegistryCenterExportProviderService.class);
+        // The SingleRegistryCenterExportProviderService is exported
+        Assertions.assertTrue(serviceListener.getExportedServices().get(0).isExported());
+        // The exported exporter are three
+        // 1. InjvmExporter
+        // 2. DubboExporter with service-discovery-registry protocol
+        // 3. DubboExporter with registry protocol
+        Assertions.assertEquals(exporterListener.getExportedExporters().size(), 3);
+        // The exported exporter contains SingleRegistryCenterExportProviderFilter
+        Assertions.assertTrue(exporterListener.getFilters().contains(filter));
+    }
+
+    /**
+     * There are some checkpoints need to check after invoked as follow:
+     * <ul>
+     *     <li>The SingleRegistryCenterExportProviderFilter has called or not</li>
+     *     <li>The SingleRegistryCenterExportProviderFilter exists error after invoked</li>
+     *     <li>The SingleRegistryCenterExportProviderFilter's response is right or not</li>
+     * </ul>
+     */
+    private void afterInvoke() {
+        // The SingleRegistryCenterInjvmFilter has called
+        Assertions.assertTrue(filter.hasCalled());
+        // The SingleRegistryCenterInjvmFilter doesn't exist error
+        Assertions.assertFalse(filter.hasError());
+        // Check the SingleRegistryCenterInjvmFilter's response
+        Assertions.assertEquals("Hello " + PROVIDER_APPLICATION_NAME, filter.getResponse());
+    }
+
+    @AfterEach
+    public void tearDown() throws IOException {
+        DubboBootstrap.reset();
+        PROVIDER_APPLICATION_NAME = null;
+        serviceConfig = null;
+        // The exported service has been unexported
+        Assertions.assertTrue(serviceListener.getExportedServices().isEmpty());
+        logger.info(getClass().getSimpleName() + " testcase is ending...");
+        registryCenter.shutdown();
+        registryProtocolListener = null;
+        registryCenter = null;
+    }
+}

--- a/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/integration/single/exportprovider/SingleRegistryCenterExportProviderRegistryProtocolListener.java
+++ b/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/integration/single/exportprovider/SingleRegistryCenterExportProviderRegistryProtocolListener.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.integration.single.exportprovider;
+
+import org.apache.dubbo.common.URL;
+import org.apache.dubbo.common.extension.Activate;
+import org.apache.dubbo.registry.integration.InterfaceCompatibleRegistryProtocol;
+import org.apache.dubbo.registry.integration.RegistryProtocol;
+import org.apache.dubbo.registry.integration.RegistryProtocolListener;
+import org.apache.dubbo.rpc.Exporter;
+import org.apache.dubbo.rpc.cluster.ClusterInvoker;
+
+/**
+ * The {@link RegistryProtocolListener} for {@link SingleRegistryCenterExportProviderService}
+ */
+@Activate(order = 100)
+public class SingleRegistryCenterExportProviderRegistryProtocolListener implements RegistryProtocolListener {
+
+    private boolean exported = false;
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void onExport(RegistryProtocol registryProtocol, Exporter<?> exporter) {
+        if (registryProtocol instanceof InterfaceCompatibleRegistryProtocol
+            && exporter != null
+            && exporter.getInvoker() != null
+            && exporter.getInvoker().getInterface().equals(SingleRegistryCenterExportProviderService.class)) {
+            this.exported = true;
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void onRefer(RegistryProtocol registryProtocol, ClusterInvoker<?> invoker, URL url, URL registryURL) {
+
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void onDestroy() {
+    }
+
+    /**
+     * Returns if this exporter is exported.
+     */
+    public boolean isExported() {
+        return exported;
+    }
+}

--- a/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/integration/single/exportprovider/SingleRegistryCenterExportProviderService.java
+++ b/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/integration/single/exportprovider/SingleRegistryCenterExportProviderService.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.integration.single.exportprovider;
+
+/**
+ * This interface is used to check if the exported provider works well or not.
+ */
+public interface SingleRegistryCenterExportProviderService {
+
+    /**
+     * The simple method for testing.
+     */
+    String hello(String name);
+}

--- a/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/integration/single/exportprovider/SingleRegistryCenterExportProviderServiceImpl.java
+++ b/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/integration/single/exportprovider/SingleRegistryCenterExportProviderServiceImpl.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.integration.single.exportprovider;
+
+/**
+ * The implementation of {@link SingleRegistryCenterExportProviderService}
+ */
+public class SingleRegistryCenterExportProviderServiceImpl implements SingleRegistryCenterExportProviderService {
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String hello(String name) {
+        return "Hello " + name;
+    }
+}

--- a/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/integration/single/exportprovider/SingleRegistryCenterExportProviderServiceListener.java
+++ b/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/integration/single/exportprovider/SingleRegistryCenterExportProviderServiceListener.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.integration.single.exportprovider;
+
+import org.apache.dubbo.config.ServiceListener;
+import org.apache.dubbo.integration.AbstractRegistryCenterServiceListener;
+
+/**
+ * This implementation of {@link ServiceListener} is to record exported services with injvm protocol in single registry center.
+ */
+public class SingleRegistryCenterExportProviderServiceListener extends AbstractRegistryCenterServiceListener {
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected Class<?> getInterface() {
+        return SingleRegistryCenterExportProviderService.class;
+    }
+}

--- a/dubbo-config/dubbo-config-api/src/test/resources/META-INF/services/org.apache.dubbo.config.ServiceListener
+++ b/dubbo-config/dubbo-config-api/src/test/resources/META-INF/services/org.apache.dubbo.config.ServiceListener
@@ -2,3 +2,4 @@ mock=org.apache.dubbo.config.mock.MockServiceListener
 exported=org.apache.dubbo.integration.single.SingleRegistryCenterExportedServiceListener
 singleConfigCenterInjvm=org.apache.dubbo.integration.single.injvm.SingleRegistryCenterInjvmServiceListener
 multipleConfigCenterInjvm=org.apache.dubbo.integration.multiple.injvm.MultipleRegistryCenterInjvmServiceListener
+singleConfigCenterExportProvider=org.apache.dubbo.integration.single.exportprovider.SingleRegistryCenterExportProviderServiceListener

--- a/dubbo-config/dubbo-config-api/src/test/resources/META-INF/services/org.apache.dubbo.registry.integration.RegistryProtocolListener
+++ b/dubbo-config/dubbo-config-api/src/test/resources/META-INF/services/org.apache.dubbo.registry.integration.RegistryProtocolListener
@@ -15,7 +15,4 @@
 # limitations under the License.
 #
 
-mockexporterlistener=org.apache.dubbo.config.mock.MockExporterListener
-singleConfigCenterInjvm=org.apache.dubbo.integration.single.injvm.SingleRegistryCenterInjvmExporterListener
-multipleConfigCenterInjvm=org.apache.dubbo.integration.multiple.injvm.MultipleRegistryCenterInjvmExporterListener
-singleConfigCenterExportProvider=org.apache.dubbo.integration.single.exportprovider.SingleRegistryCenterExportProviderExporterListener
+singleConfigCenterExportProvider=org.apache.dubbo.integration.single.exportprovider.SingleRegistryCenterExportProviderRegistryProtocolListener

--- a/dubbo-config/dubbo-config-api/src/test/resources/META-INF/services/org.apache.dubbo.rpc.Filter
+++ b/dubbo-config/dubbo-config-api/src/test/resources/META-INF/services/org.apache.dubbo.rpc.Filter
@@ -1,3 +1,4 @@
 mockfilter=org.apache.dubbo.config.mock.MockFilter
 singleConfigCenterInjvm=org.apache.dubbo.integration.single.injvm.SingleRegistryCenterInjvmFilter
 multipleConfigCenterInjvm=org.apache.dubbo.integration.multiple.injvm.MultipleRegistryCenterInjvmFilter
+singleConfigCenterExportProvider=org.apache.dubbo.integration.single.exportprovider.SingleRegistryCenterExportProviderFilter


### PR DESCRIPTION
## What is the purpose of the change

see #8500 

## Brief changelog

1. Check if the exporter exported by RegistryProtocolListener, ServiceListener and ExporterListener
2. Check if the provider works well by Filter

## Verifying this change


<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [x] Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [x] GitHub Actions works fine on your own branch.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
