### PR TITLE
[3.0] Fix class cast error and add unit test for ZoneAwareClusterInvoker

### DIFF
--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/support/registry/ZoneAwareClusterInvoker.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/support/registry/ZoneAwareClusterInvoker.java
@@ -27,7 +27,6 @@ import org.apache.dubbo.rpc.cluster.ClusterInvoker;
 import org.apache.dubbo.rpc.cluster.Directory;
 import org.apache.dubbo.rpc.cluster.LoadBalance;
 import org.apache.dubbo.rpc.cluster.support.AbstractClusterInvoker;
-import org.apache.dubbo.rpc.cluster.support.wrapper.MockClusterInvoker;
 
 import java.util.List;
 import java.util.stream.Collectors;

--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/support/registry/ZoneAwareClusterInvoker.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/support/registry/ZoneAwareClusterInvoker.java
@@ -79,7 +79,7 @@ public class ZoneAwareClusterInvoker<T> extends AbstractClusterInvoker<T> {
             if (StringUtils.isNotEmpty(force) && "true".equalsIgnoreCase(force)) {
                 throw new IllegalStateException("No registry instance in zone or no available providers in the registry, zone: "
                         + zone
-                        + ", registries: " + invokers.stream().map(invoker -> ((MockClusterInvoker<T>) invoker).getRegistryUrl().toString()).collect(Collectors.joining(",")));
+                        + ", registries: " + invokers.stream().map(invoker -> ((ClusterInvoker<T>) invoker).getRegistryUrl().toString()).collect(Collectors.joining(",")));
             }
         }
 

--- a/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/support/registry/ZoneAwareClusterInvokerTest.java
+++ b/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/support/registry/ZoneAwareClusterInvokerTest.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.dubbo.rpc.cluster.support.registry;
 
 import org.apache.dubbo.common.URL;

--- a/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/support/registry/ZoneAwareClusterInvokerTest.java
+++ b/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/support/registry/ZoneAwareClusterInvokerTest.java
@@ -1,0 +1,171 @@
+package org.apache.dubbo.rpc.cluster.support.registry;
+
+import org.apache.dubbo.common.URL;
+import org.apache.dubbo.rpc.AppResponse;
+import org.apache.dubbo.rpc.Invocation;
+import org.apache.dubbo.rpc.cluster.ClusterInvoker;
+import org.apache.dubbo.rpc.cluster.Directory;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Proxy;
+import java.util.ArrayList;
+import java.util.HashMap;
+
+import static org.apache.dubbo.common.constants.CommonConstants.PREFERRED_KEY;
+import static org.apache.dubbo.common.constants.RegistryConstants.REGISTRY_ZONE;
+import static org.apache.dubbo.common.constants.RegistryConstants.REGISTRY_ZONE_FORCE;
+import static org.apache.dubbo.common.constants.RegistryConstants.ZONE_KEY;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+public class ZoneAwareClusterInvokerTest {
+
+    private Directory directory = mock(Directory.class);
+    private ClusterInvoker firstInvoker = mock(ClusterInvoker.class);
+    private ClusterInvoker secondInvoker = mock(ClusterInvoker.class);
+    private ClusterInvoker thirdInvoker = mock(ClusterInvoker.class);
+    private Invocation invocation = mock(Invocation.class);
+
+    private ZoneAwareClusterInvoker<ZoneAwareClusterInvokerTest> zoneAwareClusterInvoker;
+
+    private URL url = URL.valueOf("test://test");
+    private URL registryUrl = URL.valueOf("localhost://test");
+
+    String expectedValue = "expected";
+    String unexpectedValue = "unexpected";
+
+    @Test
+    public void testPreferredStrategy() {
+        given(invocation.getParameterTypes()).willReturn(new Class<?>[]{});
+        given(invocation.getArguments()).willReturn(new Object[]{});
+        given(invocation.getObjectAttachments()).willReturn(new HashMap<>());
+
+        firstInvoker = newUnexpectedInvoker();
+        thirdInvoker = newUnexpectedInvoker();
+
+        secondInvoker = (ClusterInvoker) Proxy.newProxyInstance(getClass().getClassLoader(), new Class<?>[]{ClusterInvoker.class}, (proxy, method, args) -> {
+            if ("getUrl".equals(method.getName())) {
+                return url;
+            }
+            if ("getRegistryUrl".equals(method.getName())) {
+                return registryUrl.addParameter(PREFERRED_KEY, true);
+            }
+            if ("isAvailable".equals(method.getName())) {
+                return true;
+            }
+            if ("invoke".equals(method.getName())) {
+                return new AppResponse(expectedValue);
+            }
+            return null;
+        });
+
+        given(directory.list(invocation)).willReturn(new ArrayList() {
+            {
+                add(firstInvoker);
+                add(secondInvoker);
+                add(thirdInvoker);
+            }
+        });
+
+        given(directory.getUrl()).willReturn(url);
+        given(directory.getConsumerUrl()).willReturn(url);
+
+        zoneAwareClusterInvoker = new ZoneAwareClusterInvoker<>(directory);
+        AppResponse response = (AppResponse) zoneAwareClusterInvoker.invoke(invocation);
+        Assertions.assertEquals(expectedValue, response.getValue());
+    }
+
+    @Test
+    public void testRegistryZoneStrategy() {
+        String zoneKey = "zone";
+
+        given(invocation.getParameterTypes()).willReturn(new Class<?>[]{});
+        given(invocation.getArguments()).willReturn(new Object[]{});
+        given(invocation.getObjectAttachments()).willReturn(new HashMap<>());
+        given(invocation.getAttachment(REGISTRY_ZONE)).willReturn(zoneKey);
+
+        firstInvoker = newUnexpectedInvoker();
+        thirdInvoker = newUnexpectedInvoker();
+
+        secondInvoker = (ClusterInvoker) Proxy.newProxyInstance(getClass().getClassLoader(), new Class<?>[]{ClusterInvoker.class}, (proxy, method, args) -> {
+            if ("getUrl".equals(method.getName())) {
+                return url;
+            }
+            if ("getRegistryUrl".equals(method.getName())) {
+                return registryUrl.addParameter(ZONE_KEY, zoneKey);
+            }
+            if ("isAvailable".equals(method.getName())) {
+                return true;
+            }
+            if ("invoke".equals(method.getName())) {
+                return new AppResponse(expectedValue);
+            }
+            return null;
+        });
+
+        given(directory.list(invocation)).willReturn(new ArrayList() {
+            {
+                add(firstInvoker);
+                add(secondInvoker);
+                add(thirdInvoker);
+            }
+        });
+
+        given(directory.getUrl()).willReturn(url);
+        given(directory.getConsumerUrl()).willReturn(url);
+
+        zoneAwareClusterInvoker = new ZoneAwareClusterInvoker<>(directory);
+        AppResponse response = (AppResponse) zoneAwareClusterInvoker.invoke(invocation);
+        Assertions.assertEquals(expectedValue, response.getValue());
+    }
+
+    @Test
+    public void testRegistryZoneForceStrategy() {
+        String zoneKey = "zone";
+
+        given(invocation.getParameterTypes()).willReturn(new Class<?>[]{});
+        given(invocation.getArguments()).willReturn(new Object[]{});
+        given(invocation.getObjectAttachments()).willReturn(new HashMap<>());
+        given(invocation.getAttachment(REGISTRY_ZONE)).willReturn(zoneKey);
+        given(invocation.getAttachment(REGISTRY_ZONE_FORCE)).willReturn("true");
+
+        firstInvoker = newUnexpectedInvoker();
+        secondInvoker = newUnexpectedInvoker();
+        thirdInvoker = newUnexpectedInvoker();
+
+        given(directory.list(invocation)).willReturn(new ArrayList() {
+            {
+                add(firstInvoker);
+                add(secondInvoker);
+                add(thirdInvoker);
+            }
+        });
+
+        given(directory.getUrl()).willReturn(url);
+        given(directory.getConsumerUrl()).willReturn(url);
+
+        zoneAwareClusterInvoker = new ZoneAwareClusterInvoker<>(directory);
+        Assertions.assertThrows(IllegalStateException.class,
+            () -> zoneAwareClusterInvoker.invoke(invocation));
+    }
+
+    private ClusterInvoker newUnexpectedInvoker() {
+        return  (ClusterInvoker) Proxy.newProxyInstance(getClass().getClassLoader(), new Class<?>[]{ClusterInvoker.class}, (proxy, method, args) -> {
+            if ("getUrl".equals(method.getName())) {
+                return url;
+            }
+            if ("getRegistryUrl".equals(method.getName())) {
+                return registryUrl;
+            }
+            if ("isAvailable".equals(method.getName())) {
+                return true;
+            }
+            if ("invoke".equals(method.getName())) {
+                return new AppResponse(unexpectedValue);
+            }
+            return null;
+        });
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

- Add unit test for class ZoneAwareClusterInvoker
- Fix class cast error when throw IllegalStateException in ZoneAwareClusterInvoker.java line 80

## Brief changelog

- Add unit test for class ZoneAwareClusterInvoker
- Fix class cast error when throw IllegalStateException in class ZoneAwareClusterInvoker

## Verifying this change


<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [x] Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [x] GitHub Actions works fine on your own branch.
- [x] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
