### PR TITLE
Fix nacos group inviable in consumer side

### DIFF
--- a/dubbo-registry/dubbo-registry-nacos/src/main/java/org/apache/dubbo/registry/nacos/NacosNamingServiceWrapper.java
+++ b/dubbo-registry/dubbo-registry-nacos/src/main/java/org/apache/dubbo/registry/nacos/NacosNamingServiceWrapper.java
@@ -74,6 +74,10 @@ public class NacosNamingServiceWrapper {
         return namingService.selectInstances(handleInnerSymbol(serviceName), healthy);
     }
 
+    public List<Instance> selectInstances(String serviceName, String group, boolean healthy) throws NacosException {
+        return namingService.selectInstances(handleInnerSymbol(serviceName), group, healthy);
+    }
+
     public void shutdown() throws NacosException {
         this.namingService.shutDown();
     }

--- a/dubbo-registry/dubbo-registry-nacos/src/main/java/org/apache/dubbo/registry/nacos/NacosServiceDiscovery.java
+++ b/dubbo-registry/dubbo-registry-nacos/src/main/java/org/apache/dubbo/registry/nacos/NacosServiceDiscovery.java
@@ -27,6 +27,7 @@ import org.apache.dubbo.registry.client.event.ServiceInstancesChangedEvent;
 import org.apache.dubbo.registry.client.event.listener.ServiceInstancesChangedListener;
 import org.apache.dubbo.registry.nacos.util.NacosNamingServiceUtils;
 
+import com.alibaba.nacos.api.common.Constants;
 import com.alibaba.nacos.api.exception.NacosException;
 import com.alibaba.nacos.api.naming.listener.NamingEvent;
 import com.alibaba.nacos.api.naming.pojo.Instance;
@@ -39,7 +40,6 @@ import java.util.stream.Collectors;
 
 import static org.apache.dubbo.common.function.ThrowableConsumer.execute;
 import static org.apache.dubbo.registry.nacos.util.NacosNamingServiceUtils.createNamingService;
-import static org.apache.dubbo.registry.nacos.util.NacosNamingServiceUtils.getGroup;
 import static org.apache.dubbo.registry.nacos.util.NacosNamingServiceUtils.toInstance;
 
 /**
@@ -52,8 +52,6 @@ public class NacosServiceDiscovery extends AbstractServiceDiscovery {
 
     private final Logger logger = LoggerFactory.getLogger(getClass());
 
-    private String group;
-
     private NacosNamingServiceWrapper namingService;
 
     private URL registryURL;
@@ -61,7 +59,6 @@ public class NacosServiceDiscovery extends AbstractServiceDiscovery {
     @Override
     public void doInitialize(URL registryURL) throws Exception {
         this.namingService = createNamingService(registryURL);
-        this.group = getGroup(registryURL);
         this.registryURL = registryURL;
     }
 
@@ -74,7 +71,10 @@ public class NacosServiceDiscovery extends AbstractServiceDiscovery {
     public void doRegister(ServiceInstance serviceInstance) {
         execute(namingService, service -> {
             Instance instance = toInstance(serviceInstance);
-            service.registerInstance(instance.getServiceName(), group, instance);
+            // Should not register real group for ServiceInstance
+            // Or will cause consumer unable to fetch all of the providers from every group
+            // Provider's group is invisible for consumer
+            service.registerInstance(instance.getServiceName(), Constants.DEFAULT_GROUP, instance);
         });
     }
 
@@ -89,14 +89,20 @@ public class NacosServiceDiscovery extends AbstractServiceDiscovery {
     public void doUnregister(ServiceInstance serviceInstance) throws RuntimeException {
         execute(namingService, service -> {
             Instance instance = toInstance(serviceInstance);
-            service.deregisterInstance(instance.getServiceName(), group, instance);
+            // Should not register real group for ServiceInstance
+            // Or will cause consumer unable to fetch all of the providers from every group
+            // Provider's group is invisible for consumer
+            service.deregisterInstance(instance.getServiceName(), Constants.DEFAULT_GROUP, instance);
         });
     }
 
     @Override
     public Set<String> getServices() {
         return ThrowableFunction.execute(namingService, service -> {
-            ListView<String> view = service.getServicesOfServer(0, Integer.MAX_VALUE, group);
+            // Should not register real group for ServiceInstance
+            // Or will cause consumer unable to fetch all of the providers from every group
+            // Provider's group is invisible for consumer
+            ListView<String> view = service.getServicesOfServer(0, Integer.MAX_VALUE, Constants.DEFAULT_GROUP);
             return new LinkedHashSet<>(view.getData());
         });
     }
@@ -104,7 +110,7 @@ public class NacosServiceDiscovery extends AbstractServiceDiscovery {
     @Override
     public List<ServiceInstance> getInstances(String serviceName) throws NullPointerException {
         return ThrowableFunction.execute(namingService, service ->
-                service.selectInstances(serviceName, true)
+                service.selectInstances(serviceName, Constants.DEFAULT_GROUP, true)
                         .stream().map(NacosNamingServiceUtils::toServiceInstance)
                         .collect(Collectors.toList())
         );
@@ -116,7 +122,7 @@ public class NacosServiceDiscovery extends AbstractServiceDiscovery {
         execute(namingService, service -> {
             listener.getServiceNames().forEach(serviceName -> {
                 try {
-                    service.subscribe(serviceName, e -> { // Register Nacos EventListener
+                    service.subscribe(serviceName, Constants.DEFAULT_GROUP, e -> { // Register Nacos EventListener
                         if (e instanceof NamingEvent) {
                             NamingEvent event = (NamingEvent) e;
                             handleEvent(event, listener);

--- a/dubbo-registry/dubbo-registry-nacos/src/main/java/org/apache/dubbo/registry/nacos/util/NacosNamingServiceUtils.java
+++ b/dubbo-registry/dubbo-registry-nacos/src/main/java/org/apache/dubbo/registry/nacos/util/NacosNamingServiceUtils.java
@@ -36,9 +36,7 @@ import java.util.Properties;
 
 import static com.alibaba.nacos.api.PropertyKeyConst.NAMING_LOAD_CACHE_AT_START;
 import static com.alibaba.nacos.api.PropertyKeyConst.SERVER_ADDR;
-import static com.alibaba.nacos.api.common.Constants.DEFAULT_GROUP;
 import static com.alibaba.nacos.client.naming.utils.UtilAndComs.NACOS_NAMING_LOG_NAME;
-import static org.apache.dubbo.common.constants.CommonConstants.GROUP_KEY;
 import static org.apache.dubbo.common.constants.RemotingConstants.BACKUP_KEY;
 import static org.apache.dubbo.common.utils.StringConstantFieldValuePredicate.of;
 
@@ -83,19 +81,6 @@ public class NacosNamingServiceUtils {
         serviceInstance.setEnabled(instance.isEnabled());
         serviceInstance.setHealthy(instance.isHealthy());
         return serviceInstance;
-    }
-
-    /**
-     * The group of {@link NamingService} to register
-     *
-     * @param connectionURL {@link URL connection url}
-     * @return non-null, "default" as default
-     * @since 2.7.5
-     */
-    public static String getGroup(URL connectionURL) {
-        // Compatible with nacos grouping via group.
-        String group = connectionURL.getParameter(GROUP_KEY, DEFAULT_GROUP);
-        return connectionURL.getParameter(NACOS_GROUP_KEY, group);
     }
 
     /**


### PR DESCRIPTION
## What is the purpose of the change

Fix #8527
Should not register real group for ServiceInstance, or this will cause consumer unable to fetch all of the providers from every group. Provider's group is invisible for consumer.

## Brief changelog


## Verifying this change


<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [ ] GitHub Actions works fine on your own branch.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
