### PR TITLE
[3.0] fix dubbo:monitor protocol bug after 8477

### DIFF
--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/utils/ConfigValidationUtils.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/utils/ConfigValidationUtils.java
@@ -312,7 +312,7 @@ public class ConfigValidationUtils {
         } else if (monitor != null) {
             address = monitor.getAddress();
         }
-        String protocol = monitor == null ? DUBBO_PROTOCOL : monitor.getProtocol();
+        String protocol = monitor == null ? null : monitor.getProtocol();
         if (monitor != null &&
             (REGISTRY_PROTOCOL.equals(protocol) || SERVICE_REGISTRY_PROTOCOL.equals(protocol))
             && registryURL != null) {

--- a/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/bootstrap/DubboBootstrapTest.java
+++ b/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/bootstrap/DubboBootstrapTest.java
@@ -174,6 +174,12 @@ public class DubboBootstrapTest {
     }
 
     @Test
+    public void testLoadUserMonitor_no_monitor() {
+        URL url = ConfigValidationUtils.loadMonitor(getTestInterfaceConfig(null), URL.valueOf("zookeeper://127.0.0.1:2181"));
+        Assertions.assertNull(url);
+    }
+
+    @Test
     public void testLoadUserMonitor_user() {
         // dubbo.monitor.protocol=user
         MonitorConfig monitorConfig = new MonitorConfig();
@@ -197,7 +203,9 @@ public class DubboBootstrapTest {
     private AbstractInterfaceConfigTest.InterfaceConfig getTestInterfaceConfig(MonitorConfig monitorConfig) {
         AbstractInterfaceConfigTest.InterfaceConfig interfaceConfig = new AbstractInterfaceConfigTest.InterfaceConfig();
         interfaceConfig.setApplication(new ApplicationConfig("testLoadMonitor"));
-        interfaceConfig.setMonitor(monitorConfig);
+        if(monitorConfig!=null) {
+            interfaceConfig.setMonitor(monitorConfig);
+        }
         return interfaceConfig;
     }
 


### PR DESCRIPTION
## What is the purpose of the change

PR #8477 带来一个bug，即未配置dubbo:monitor，ConfigValidationUtils#loadMonitor返回了dubbo协议的URL的错误。
感谢 @guohao 

## Brief changelog

当未配置dubbo:monitor，monitorUrl返回null，也就不会触发monitorFilter

<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [ ] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [x] Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [ ] GitHub Actions works fine on your own branch.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
