### PR TITLE
Fix process can't stop when tomcat port already in use.

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/threadpool/manager/DefaultExecutorRepository.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/threadpool/manager/DefaultExecutorRepository.java
@@ -353,13 +353,12 @@ public class DefaultExecutorRepository implements ExecutorRepository {
             }
         });
 
-        // TODO shutdown all executor services
-//        for (ScheduledExecutorService executorService : scheduledExecutors.listItems()) {
-//            executorService.shutdown();
-//        }
-//
-//        for (ExecutorService executorService : executorServiceRing.listItems()) {
-//            executorService.shutdown();
-//        }
+        for (ScheduledExecutorService executorService : scheduledExecutors.listItems()) {
+            executorService.shutdown();
+        }
+
+        for (ExecutorService executorService : executorServiceRing.listItems()) {
+            executorService.shutdown();
+        }
     }
 }

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/threadpool/manager/DefaultExecutorRepository.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/threadpool/manager/DefaultExecutorRepository.java
@@ -83,7 +83,7 @@ public class DefaultExecutorRepository implements ExecutorRepository {
     public DefaultExecutorRepository() {
         for (int i = 0; i < DEFAULT_SCHEDULER_SIZE; i++) {
             ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor(
-                new NamedThreadFactory("Dubbo-framework-scheduler"));
+                new NamedThreadFactory("Dubbo-framework-scheduler", true));
             scheduledExecutors.addItem(scheduler);
 
             executorServiceRing.addItem(new ThreadPoolExecutor(1, 1,


### PR DESCRIPTION
## What is the purpose of the change
https://github.com/apache/dubbo/blob/873937453b41374d58421f977b4eca5ee1ca4730/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/bootstrap/DubboBootstrap.java#L1507

when tomcat port conflict, the process can't exit. 




