### PR TITLE
[3.0-tri-compiler] dubbo compiler support stream

### DIFF
--- a/compiler/pom.xml
+++ b/compiler/pom.xml
@@ -26,7 +26,7 @@
 
     <groupId>org.apache.dubbo</groupId>
     <artifactId>dubbo-compiler</artifactId>
-    <version>0.0.2</version>
+    <version>0.0.3-SNAPSHOT</version>
 
     <packaging>jar</packaging>
 

--- a/compiler/src/main/resources/Dubbo3InterfaceStub.mustache
+++ b/compiler/src/main/resources/Dubbo3InterfaceStub.mustache
@@ -1,5 +1,5 @@
 {{#packageName}}
-    package {{packageName}};
+package {{packageName}};
 {{/packageName}}
 
 import java.util.concurrent.CompletableFuture;
@@ -18,11 +18,37 @@ static final String SERVICE_NAME = "{{commonPackageName}}.{{serviceName}}";
     // FIXME, initialize Dubbo3 stub when interface loaded, thinking of new ways doing this.
     static final boolean inited = {{className}}.init();
 
-{{#methods}}
+{{#unaryMethods}}
+    {{#javaDoc}}
+        {{{javaDoc}}}
+    {{/javaDoc}}
+    {{#deprecated}}
+        @java.lang.Deprecated
+    {{/deprecated}}
     {{outputType}} {{methodName}}({{inputType}} request);
 
     CompletableFuture<{{outputType}}> {{methodName}}Async({{inputType}} request);
 
-{{/methods}}
+{{/unaryMethods}}
+
+{{#serverStreamingMethods}}
+    {{#javaDoc}}
+        {{{javaDoc}}}
+    {{/javaDoc}}
+    {{#deprecated}}
+        @java.lang.Deprecated
+    {{/deprecated}}
+    void {{methodName}}({{inputType}} request, org.apache.dubbo.common.stream.StreamObserver<{{outputType}}> responseObserver);
+{{/serverStreamingMethods}}
+
+{{#biStreamingMethods}}
+    {{#javaDoc}}
+        {{{javaDoc}}}
+    {{/javaDoc}}
+    {{#deprecated}}
+        @java.lang.Deprecated
+    {{/deprecated}}
+    org.apache.dubbo.common.stream.StreamObserver<{{inputType}}> {{methodName}}(org.apache.dubbo.common.stream.StreamObserver<{{outputType}}> responseObserver);
+{{/biStreamingMethods}}
 
 }

--- a/compiler/src/main/resources/Dubbo3Stub.mustache
+++ b/compiler/src/main/resources/Dubbo3Stub.mustache
@@ -17,7 +17,7 @@ private static final AtomicBoolean registered = new AtomicBoolean();
 public static boolean init() {
     if (registered.compareAndSet(false, true)) {
         {{#methodTypes}}
-            org.apache.dubbo.common.serialize.protobuf.support.ProtobufUtils.marshaller(
+            org.apache.dubbo.rpc.protocol.tri.SingleProtobufUtils.marshaller(
             {{.}}.getDefaultInstance());
         {{/methodTypes}}
     }

--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/TripleUtil.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/TripleUtil.java
@@ -60,8 +60,6 @@ public class TripleUtil {
 
     public static final String LANGUAGE = "java";
 
-
-    private static final SingleProtobufSerialization pbSerialization = new SingleProtobufSerialization();
     private static final Base64.Decoder BASE64_DECODER = Base64.getDecoder();
     private static final Base64.Encoder BASE64_ENCODER = Base64.getEncoder().withoutPadding();
 
@@ -255,7 +253,7 @@ public class TripleUtil {
 
     public static <T> T unpack(InputStream is, Class<T> clz) {
         try {
-            final T req = (T) pbSerialization.deserialize(is, clz);
+            final T req = SingleProtobufUtils.deserialize(is, clz);
             is.close();
             return req;
         } catch (IOException e) {
@@ -278,7 +276,7 @@ public class TripleUtil {
     public static byte[] pack(Object obj) {
         final ByteArrayOutputStream baos = new ByteArrayOutputStream();
         try {
-            pbSerialization.serialize(obj, baos);
+            SingleProtobufUtils.serialize(obj, baos);
         } catch (IOException e) {
             throw new RuntimeException("Failed to pack protobuf object", e);
         }


### PR DESCRIPTION
## What is the purpose of the change

- change dubbo-compiler version to `0.0.3-SNAPSHOT`
- dubbo compiler support stream on dubbo3 gen
- drop compiler dependency `dubbo-serialization-protobuf`
- change TriUtils pbserialization to SingleProtobufUtils

## Brief changelog


## Verifying this change


<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [ ] GitHub Actions works fine on your own branch.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
