### PR TITLE
[master] support different method callback for each dubbo reference

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/constants/CommonConstants.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/constants/CommonConstants.java
@@ -416,5 +416,5 @@ public interface CommonConstants {
 
     String SERVICE_NAME_MAPPING_KEY = "service-name-mapping";
     
-    String ASYNC_METHODS_HASHCODE_KEY = "async-methods-hashcode";
+    String METHOD_CONFIGS_HASHCODE_KEY = "method-configs-hashcode";
 }

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/constants/CommonConstants.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/constants/CommonConstants.java
@@ -415,4 +415,6 @@ public interface CommonConstants {
     String DISPATHER = "dispather";
 
     String SERVICE_NAME_MAPPING_KEY = "service-name-mapping";
+    
+    String ASYNC_METHODS_HASHCODE_KEY = "async-methods-hashcode";
 }

--- a/dubbo-common/src/main/java/org/apache/dubbo/rpc/model/ApplicationModel.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/rpc/model/ApplicationModel.java
@@ -71,8 +71,8 @@ public class ApplicationModel {
         return getServiceRepository().lookupExportedService(serviceKey);
     }
 
-    public static ConsumerModel getConsumerModel(String serviceKey) {
-        return getServiceRepository().lookupReferredService(serviceKey);
+    public static ConsumerModel getConsumerModel(String consumerModelKey) {
+        return getServiceRepository().lookupReferredService(consumerModelKey);
     }
 
     private static final ExtensionLoader<FrameworkExt> LOADER = ExtensionLoader.getExtensionLoader(FrameworkExt.class);

--- a/dubbo-common/src/main/java/org/apache/dubbo/rpc/model/ConsumerModel.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/rpc/model/ConsumerModel.java
@@ -18,6 +18,7 @@ package org.apache.dubbo.rpc.model;
 
 import org.apache.dubbo.common.BaseServiceMetadata;
 import org.apache.dubbo.common.utils.Assert;
+import org.apache.dubbo.common.utils.CollectionUtils;
 import org.apache.dubbo.config.ReferenceConfigBase;
 
 import java.lang.reflect.Method;
@@ -64,7 +65,7 @@ public class ConsumerModel {
     }
 
     public void init(Map<String, AsyncMethodInfo> attributes) {
-        if (attributes != null) {
+        if (!CollectionUtils.isEmptyMap(attributes)) {
             this.methodConfigs = attributes;
         }
 

--- a/dubbo-common/src/main/java/org/apache/dubbo/rpc/model/ServiceRepository.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/rpc/model/ServiceRepository.java
@@ -93,21 +93,22 @@ public class ServiceRepository extends LifecycleAdapter implements FrameworkExt 
         services.remove(path);
     }
 
-    public void registerConsumer(String serviceKey,
+    public void registerConsumer(String consumerModelKey,
                                  ServiceDescriptor serviceDescriptor,
                                  ReferenceConfigBase<?> rc,
                                  Object proxy,
                                  ServiceMetadata serviceMetadata) {
         ConsumerModel consumerModel = new ConsumerModel(serviceMetadata.getServiceKey(), proxy, serviceDescriptor, rc,
                 serviceMetadata);
-        consumers.putIfAbsent(serviceKey, consumerModel);
+        consumers.putIfAbsent(consumerModelKey, consumerModel);
     }
 
-    public void reRegisterConsumer(String newServiceKey, String serviceKey) {
-        ConsumerModel consumerModel = consumers.get(serviceKey);
+    public void reRegisterConsumer(String newServiceKey, String serviceKey,
+            String newConsumerModelKey, String consumerModelKey) {
+        ConsumerModel consumerModel = consumers.get(consumerModelKey);
         consumerModel.setServiceKey(newServiceKey);
-        consumers.putIfAbsent(newServiceKey, consumerModel);
-        consumers.remove(serviceKey);
+        consumers.putIfAbsent(newConsumerModelKey, consumerModel);
+        consumers.remove(consumerModelKey);
 
     }
 
@@ -170,8 +171,8 @@ public class ServiceRepository extends LifecycleAdapter implements FrameworkExt 
         return Collections.unmodifiableList(new ArrayList<>(consumers.values()));
     }
 
-    public ConsumerModel lookupReferredService(String serviceKey) {
-        return consumers.get(serviceKey);
+    public ConsumerModel lookupReferredService(String consumerModelKey) {
+        return consumers.get(consumerModelKey);
     }
 
     @Override

--- a/dubbo-compatible/src/test/java/org/apache/dubbo/generic/GenericServiceTest.java
+++ b/dubbo-compatible/src/test/java/org/apache/dubbo/generic/GenericServiceTest.java
@@ -101,7 +101,7 @@ public class GenericServiceTest {
         ReferenceConfig<com.alibaba.dubbo.rpc.service.GenericService> oldReferenceConfig = new ReferenceConfig<>();
         oldReferenceConfig.setGeneric(true);
         oldReferenceConfig.setInterface(DemoService.class.getName());
-        oldReferenceConfig.checkAndUpdateSubConfigs();
+        oldReferenceConfig.checkAndUpdateSubConfigs(null);
         Invoker invoker = protocol.refer(oldReferenceConfig.getInterfaceClass(), url);
         com.alibaba.dubbo.rpc.service.GenericService client = (com.alibaba.dubbo.rpc.service.GenericService) proxyFactory.getProxy(invoker, true);
 

--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/ReferenceConfig.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/ReferenceConfig.java
@@ -64,7 +64,7 @@ import java.util.Map;
 import java.util.Set;
 
 import static org.apache.dubbo.common.constants.CommonConstants.ANY_VALUE;
-import static org.apache.dubbo.common.constants.CommonConstants.ASYNC_METHODS_HASHCODE_KEY;
+import static org.apache.dubbo.common.constants.CommonConstants.METHOD_CONFIGS_HASHCODE_KEY;
 import static org.apache.dubbo.common.constants.CommonConstants.CLUSTER_KEY;
 import static org.apache.dubbo.common.constants.CommonConstants.COMMA_SEPARATOR;
 import static org.apache.dubbo.common.constants.CommonConstants.COMMA_SEPARATOR_CHAR;
@@ -268,12 +268,12 @@ public class ReferenceConfig<T> extends ReferenceConfigBase<T> {
             }
         }
 
-        String asyncMethodsJsonHashcode = null;
+        String methodConfigsHashcode = null;
         if (!CollectionUtils.isEmptyMap(attributes)) {
-            asyncMethodsJsonHashcode = String.valueOf(JSON.toJSONString(attributes).hashCode());
-            map.put(ASYNC_METHODS_HASHCODE_KEY, asyncMethodsJsonHashcode);
+            methodConfigsHashcode = String.valueOf(attributes.hashCode());
+            map.put(METHOD_CONFIGS_HASHCODE_KEY, methodConfigsHashcode);
         }
-        checkAndUpdateSubConfigs(asyncMethodsJsonHashcode);
+        checkAndUpdateSubConfigs(methodConfigsHashcode);
 
         checkStubAndLocal(interfaceClass);
         ConfigValidationUtils.checkMock(interfaceClass, this);
@@ -324,10 +324,10 @@ public class ReferenceConfig<T> extends ReferenceConfigBase<T> {
         serviceMetadata.setTarget(ref);
         serviceMetadata.addAttribute(PROXY_CLASS_REF, ref);
         String consumerModelKey = null;
-        if (asyncMethodsJsonHashcode == null) {
+        if (methodConfigsHashcode == null) {
             consumerModelKey = serviceMetadata.getServiceKey();
         } else {
-            consumerModelKey = serviceMetadata.getServiceKey() +  asyncMethodsJsonHashcode;
+            consumerModelKey = serviceMetadata.getServiceKey() + methodConfigsHashcode;
         }
         ConsumerModel consumerModel = repository.lookupReferredService(consumerModelKey);
         consumerModel.setProxyObject(ref);
@@ -451,7 +451,7 @@ public class ReferenceConfig<T> extends ReferenceConfigBase<T> {
      * This method should be called right after the creation of this class's instance, before any property in other config modules is used.
      * Check each config modules are created properly and override their properties if necessary.
      */
-    public void checkAndUpdateSubConfigs(String asyncMethodsJsonHashcode) {
+    public void checkAndUpdateSubConfigs(String methodConfigsHashcode) {
         if (StringUtils.isEmpty(interfaceName)) {
             throw new IllegalStateException("<dubbo:reference interface=\"\" /> interface not allow null!");
         }
@@ -488,10 +488,10 @@ public class ReferenceConfig<T> extends ReferenceConfigBase<T> {
         ServiceRepository repository = ApplicationModel.getServiceRepository();
         ServiceDescriptor serviceDescriptor = repository.registerService(interfaceClass);
         String consumerModelKey = null;
-        if (asyncMethodsJsonHashcode == null) {
+        if (methodConfigsHashcode == null) {
             consumerModelKey = serviceMetadata.getServiceKey();
         } else {
-            consumerModelKey = serviceMetadata.getServiceKey() +  asyncMethodsJsonHashcode;
+            consumerModelKey = serviceMetadata.getServiceKey() + methodConfigsHashcode;
         }
         repository.registerConsumer(
                 consumerModelKey,

--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/ReferenceConfig.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/ReferenceConfig.java
@@ -53,8 +53,6 @@ import org.apache.dubbo.rpc.protocol.injvm.InjvmProtocol;
 import org.apache.dubbo.rpc.service.GenericService;
 import org.apache.dubbo.rpc.support.ProtocolUtils;
 
-import com.alibaba.fastjson.JSON;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;

--- a/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/beans/factory/annotation/MethodConfigCallbackTest.java
+++ b/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/beans/factory/annotation/MethodConfigCallbackTest.java
@@ -23,6 +23,7 @@ import org.apache.dubbo.config.spring.api.HelloService;
 import org.apache.dubbo.config.spring.api.MethodCallback;
 import org.apache.dubbo.config.spring.context.annotation.provider.ProviderConfiguration;
 import org.apache.dubbo.config.spring.impl.MethodCallbackImpl;
+import org.apache.dubbo.config.spring.impl.MethodCallbackImpl2;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -67,12 +68,23 @@ public class MethodConfigCallbackTest {
                     onthrow = "methodCallback.onthrow")})
     private HelloService helloServiceMethodCallBack;
 
+    @DubboReference(check = false,
+            methods = {@Method(name = "sayHello",
+                    oninvoke = "methodCallback2.oninvoke",
+                    onreturn = "methodCallback2.onreturn",
+                    onthrow = "methodCallback2.onthrow")})
+    private HelloService helloServiceMethodCallBack2;
+    
     @Test
     public void testMethodAnnotationCallBack() {
         helloServiceMethodCallBack.sayHello("dubbo");
+        helloServiceMethodCallBack2.sayHello("dubbo(2)");
         MethodCallback notify = (MethodCallback) context.getBean("methodCallback");
         Assertions.assertEquals("dubbo invoke success", notify.getOnInvoke());
         Assertions.assertEquals("dubbo return success", notify.getOnReturn());
+        MethodCallback notify2 = (MethodCallback) context.getBean("methodCallback2");
+        Assertions.assertEquals("dubbo invoke success(2)", notify2.getOnInvoke());
+        Assertions.assertEquals("dubbo return success(2)", notify2.getOnReturn());
     }
 
     @Configuration
@@ -81,6 +93,11 @@ public class MethodConfigCallbackTest {
         @Bean("methodCallback")
         public MethodCallback methodCallback() {
             return new MethodCallbackImpl();
+        }
+
+        @Bean("methodCallback2")
+        public MethodCallback methodCallback2() {
+            return new MethodCallbackImpl2();
         }
 
     }

--- a/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/impl/MethodCallbackImpl2.java
+++ b/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/impl/MethodCallbackImpl2.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.config.spring.impl;
+
+import org.apache.dubbo.config.spring.api.MethodCallback;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import org.springframework.core.env.Environment;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+import javax.annotation.PostConstruct;
+
+public class MethodCallbackImpl2 implements MethodCallback {
+    private String onInvoke;
+    private String onReturn;
+    private String onThrow;
+
+    @Autowired
+    private Environment environment;
+
+    @Autowired
+    private ApplicationContext context;
+
+    @PostConstruct
+    protected void init() {
+        checkInjection();
+    }
+
+    @Transactional(rollbackFor = Exception.class)
+    @Override
+    public void oninvoke(String request) {
+        try {
+            checkInjection();
+            checkTranscation();
+            this.onInvoke = "dubbo invoke success(2)";
+        } catch (Exception e) {
+            this.onInvoke = e.toString();
+            throw e;
+        }
+    }
+
+    @Override
+    @Transactional(rollbackFor = Exception.class)
+    public void onreturn(String response, String request) {
+        try {
+            checkInjection();
+            checkTranscation();
+            this.onReturn = "dubbo return success(2)";
+        } catch (Exception e) {
+            this.onReturn = e.toString();
+            throw e;
+        }
+    }
+
+    @Override
+    @Transactional(rollbackFor = Exception.class)
+    public void onthrow(Throwable ex, String request) {
+        try {
+            checkInjection();
+            checkTranscation();
+            this.onThrow = "dubbo throw exception(2)";
+        } catch (Exception e) {
+            this.onThrow = e.toString();
+            throw e;
+        }
+    }
+
+    public String getOnInvoke() {
+        return this.onInvoke;
+    }
+
+    public String getOnReturn() {
+        return this.onReturn;
+    }
+
+    public String getOnThrow() {
+        return this.onThrow;
+    }
+
+    private void checkInjection() {
+        if (environment == null) {
+            throw new IllegalStateException("environment is null(2)");
+        }
+        if (context == null) {
+            throw new IllegalStateException("application context is null(2)");
+        }
+    }
+
+    private void checkTranscation() {
+        if (!TransactionSynchronizationManager.isActualTransactionActive()) {
+            throw new IllegalStateException("No active transaction(2)");
+        }
+    }
+
+}

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/proxy/InvokerInvocationHandler.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/proxy/InvokerInvocationHandler.java
@@ -17,6 +17,7 @@
 package org.apache.dubbo.rpc.proxy;
 
 import org.apache.dubbo.common.URL;
+import org.apache.dubbo.common.constants.CommonConstants;
 import org.apache.dubbo.common.logger.Logger;
 import org.apache.dubbo.common.logger.LoggerFactory;
 import org.apache.dubbo.common.utils.ReflectUtils;
@@ -58,7 +59,13 @@ public class InvokerInvocationHandler implements InvocationHandler {
         String serviceKey = this.url.getServiceKey();
         this.protocolServiceKey = this.url.getProtocolServiceKey();
         if (serviceKey != null) {
-            this.consumerModel = ApplicationModel.getConsumerModel(serviceKey);
+            String consumerModelKey = null;
+            if (this.url.getParameter(CommonConstants.ASYNC_METHODS_HASHCODE_KEY) == null) {
+                consumerModelKey = serviceKey;
+            } else {
+                consumerModelKey = serviceKey + this.url.getParameter(CommonConstants.ASYNC_METHODS_HASHCODE_KEY);
+            }
+            this.consumerModel = ApplicationModel.getConsumerModel(consumerModelKey);
         }
     }
 

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/proxy/InvokerInvocationHandler.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/proxy/InvokerInvocationHandler.java
@@ -60,10 +60,10 @@ public class InvokerInvocationHandler implements InvocationHandler {
         this.protocolServiceKey = this.url.getProtocolServiceKey();
         if (serviceKey != null) {
             String consumerModelKey = null;
-            if (this.url.getParameter(CommonConstants.ASYNC_METHODS_HASHCODE_KEY) == null) {
+            if (this.url.getParameter(CommonConstants.METHOD_CONFIGS_HASHCODE_KEY) == null) {
                 consumerModelKey = serviceKey;
             } else {
-                consumerModelKey = serviceKey + this.url.getParameter(CommonConstants.ASYNC_METHODS_HASHCODE_KEY);
+                consumerModelKey = serviceKey + this.url.getParameter(CommonConstants.METHOD_CONFIGS_HASHCODE_KEY);
             }
             this.consumerModel = ApplicationModel.getConsumerModel(consumerModelKey);
         }

--- a/dubbo-rpc/dubbo-rpc-dubbo/src/main/java/org/apache/dubbo/rpc/protocol/dubbo/filter/FutureFilter.java
+++ b/dubbo-rpc/dubbo-rpc-dubbo/src/main/java/org/apache/dubbo/rpc/protocol/dubbo/filter/FutureFilter.java
@@ -188,11 +188,11 @@ public class FutureFilter implements Filter, Filter.Listener {
         }
 
         String consumerModelKey = null;
-        if (invoker.getUrl().getParameter(CommonConstants.ASYNC_METHODS_HASHCODE_KEY) == null) {
+        if (invoker.getUrl().getParameter(CommonConstants.METHOD_CONFIGS_HASHCODE_KEY) == null) {
             consumerModelKey = invoker.getUrl().getServiceKey();
         } else {
             consumerModelKey = invoker.getUrl().getServiceKey() 
-                    + invoker.getUrl().getParameter(CommonConstants.ASYNC_METHODS_HASHCODE_KEY);
+                    + invoker.getUrl().getParameter(CommonConstants.METHOD_CONFIGS_HASHCODE_KEY);
         }
         ConsumerModel consumerModel = ApplicationModel.getConsumerModel(consumerModelKey);
         if (consumerModel == null) {

--- a/dubbo-rpc/dubbo-rpc-dubbo/src/main/java/org/apache/dubbo/rpc/protocol/dubbo/filter/FutureFilter.java
+++ b/dubbo-rpc/dubbo-rpc-dubbo/src/main/java/org/apache/dubbo/rpc/protocol/dubbo/filter/FutureFilter.java
@@ -187,7 +187,14 @@ public class FutureFilter implements Filter, Filter.Listener {
             return asyncMethodInfo;
         }
 
-        ConsumerModel consumerModel = ApplicationModel.getConsumerModel(invoker.getUrl().getServiceKey());
+        String consumerModelKey = null;
+        if (invoker.getUrl().getParameter(CommonConstants.ASYNC_METHODS_HASHCODE_KEY) == null) {
+            consumerModelKey = invoker.getUrl().getServiceKey();
+        } else {
+            consumerModelKey = invoker.getUrl().getServiceKey() 
+                    + invoker.getUrl().getParameter(CommonConstants.ASYNC_METHODS_HASHCODE_KEY);
+        }
+        ConsumerModel consumerModel = ApplicationModel.getConsumerModel(consumerModelKey);
         if (consumerModel == null) {
             return null;
         }

--- a/dubbo-rpc/dubbo-rpc-grpc/src/main/java/org/apache/dubbo/rpc/protocol/grpc/GrpcProtocol.java
+++ b/dubbo-rpc/dubbo-rpc-grpc/src/main/java/org/apache/dubbo/rpc/protocol/grpc/GrpcProtocol.java
@@ -17,6 +17,7 @@
 package org.apache.dubbo.rpc.protocol.grpc;
 
 import org.apache.dubbo.common.URL;
+import org.apache.dubbo.common.constants.CommonConstants;
 import org.apache.dubbo.config.ReferenceConfigBase;
 import org.apache.dubbo.rpc.Invoker;
 import org.apache.dubbo.rpc.ProtocolServer;
@@ -115,11 +116,17 @@ public class GrpcProtocol extends AbstractProxyProtocol {
 
         // CallOptions
         try {
+            String consumerModelKey = null;
+            if (url.getParameter(CommonConstants.ASYNC_METHODS_HASHCODE_KEY) == null) {
+                consumerModelKey = url.getServiceKey();
+            } else {
+                consumerModelKey = url.getServiceKey() + url.getParameter(CommonConstants.ASYNC_METHODS_HASHCODE_KEY);
+            }
             @SuppressWarnings("unchecked") final T stub = (T) dubboStubMethod.invoke(null,
                     channel,
                     GrpcOptionsUtils.buildCallOptions(url),
                     url,
-                    ApplicationModel.getConsumerModel(url.getServiceKey()).getReferenceConfig()
+                    ApplicationModel.getConsumerModel(consumerModelKey).getReferenceConfig()
             );
             final Invoker<T> target = proxyFactory.getInvoker(stub, type, url);
             GrpcInvoker<T> grpcInvoker = new GrpcInvoker<>(type, url, target, channel);

--- a/dubbo-rpc/dubbo-rpc-grpc/src/main/java/org/apache/dubbo/rpc/protocol/grpc/GrpcProtocol.java
+++ b/dubbo-rpc/dubbo-rpc-grpc/src/main/java/org/apache/dubbo/rpc/protocol/grpc/GrpcProtocol.java
@@ -117,10 +117,10 @@ public class GrpcProtocol extends AbstractProxyProtocol {
         // CallOptions
         try {
             String consumerModelKey = null;
-            if (url.getParameter(CommonConstants.ASYNC_METHODS_HASHCODE_KEY) == null) {
+            if (url.getParameter(CommonConstants.METHOD_CONFIGS_HASHCODE_KEY) == null) {
                 consumerModelKey = url.getServiceKey();
             } else {
-                consumerModelKey = url.getServiceKey() + url.getParameter(CommonConstants.ASYNC_METHODS_HASHCODE_KEY);
+                consumerModelKey = url.getServiceKey() + url.getParameter(CommonConstants.METHOD_CONFIGS_HASHCODE_KEY);
             }
             @SuppressWarnings("unchecked") final T stub = (T) dubboStubMethod.invoke(null,
                     channel,


### PR DESCRIPTION
## What is the purpose of the change
fix #8567
support setting different method callback for each dubbo reference that refer the same dubbo service.

## Brief changelog
Change the entry key of ServiceRepository consumers from serviceKey to serviceKey + asyncMethodInfos hashcode.
asyncMethodInfos are the Method annotations of  ```@DubboReference```.