### PR TITLE
fix duplicate config init

### DIFF
--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/ServiceConfig.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/ServiceConfig.java
@@ -199,8 +199,6 @@ public class ServiceConfig<T> extends ServiceConfigBase<T> {
             // load ServiceListeners from extension
             ExtensionLoader<ServiceListener> extensionLoader = ExtensionLoader.getExtensionLoader(ServiceListener.class);
             this.serviceListeners.addAll(extensionLoader.getSupportedExtensionInstances());
-
-            this.checkAndUpdateSubConfigs();
         }
 
         initServiceMetadata(provider);


### PR DESCRIPTION
`checkAndUpdateSubConfigs` was called twice from `init` and `refresh`, this patch tries to remove the `init` call.