### PR TITLE
[3.0-Triple] Fix error in filters can not be returned to client

### DIFF
--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/UnaryServerStream.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/UnaryServerStream.java
@@ -61,16 +61,7 @@ public class UnaryServerStream extends AbstractServerStream implements Stream {
                         .withDescription("Missing request data"));
                 return;
             }
-            execute(()->{
-                try {
-                    this.invoke();
-                }catch (Throwable t){
-                    LOGGER.warn("Exception processing triple message", t);
-                    transportError(GrpcStatus.fromCode(GrpcStatus.Code.INTERNAL)
-                            .withDescription("Exception in invoker chain :" + t.getMessage())
-                            .withCause(t));
-                }
-            });
+            execute(this::invoke);
         }
 
         public void invoke() {

--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/UnaryServerStream.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/UnaryServerStream.java
@@ -61,7 +61,16 @@ public class UnaryServerStream extends AbstractServerStream implements Stream {
                         .withDescription("Missing request data"));
                 return;
             }
-            execute(this::invoke);
+            execute(()->{
+                try {
+                    this.invoke();
+                }catch (Throwable t){
+                    LOGGER.warn("Exception processing triple message", t);
+                    transportError(GrpcStatus.fromCode(GrpcStatus.Code.INTERNAL)
+                            .withDescription("Exception in invoker chain :" + t.getMessage())
+                            .withCause(t));
+                }
+            });
         }
 
         public void invoke() {


### PR DESCRIPTION
## What is the purpose of the change

Fix when exception occured in `invoker.invoke` , triple can not pass it to client.

## Brief changelog

Add `try-catch` in executor.

## Verifying this change

Run samples here
https://github.com/apache/dubbo-samples/pull/356

<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [ ] GitHub Actions works fine on your own branch.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
