### PR TITLE
Netty4 netty channel changeto public

### DIFF
--- a/dubbo-remoting/dubbo-remoting-netty4/src/main/java/org/apache/dubbo/remoting/transport/netty4/NettyChannel.java
+++ b/dubbo-remoting/dubbo-remoting-netty4/src/main/java/org/apache/dubbo/remoting/transport/netty4/NettyChannel.java
@@ -39,7 +39,7 @@ import static org.apache.dubbo.common.constants.CommonConstants.TIMEOUT_KEY;
 /**
  * NettyChannel maintains the cache of channel.
  */
-final class NettyChannel extends AbstractChannel {
+public final class NettyChannel extends AbstractChannel {
 
     private static final Logger logger = LoggerFactory.getLogger(NettyChannel.class);
     /**


### PR DESCRIPTION
## What is the purpose of the change
we want to add self define pipeline to netty channel
but we do not want to copy too much code, reuse the NettyChannel is good way
so we want to change this class to public