### PR TITLE
[3.0-Triple] Remove throwable tw-bin header and truncate exception 

### DIFF
--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/AbstractStream.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/AbstractStream.java
@@ -252,10 +252,6 @@ public abstract class AbstractStream implements Stream {
         Status status = builder.build();
         metadata.put(TripleHeaderEnum.STATUS_DETAIL_KEY.getHeader(),
                 TripleUtil.encodeBase64ASCII(status.toByteArray()));
-        // only wrapper mode support exception serialization
-        if (getMethodDescriptor() != null && !getMethodDescriptor().isNeedWrap()) {
-            return metadata;
-        }
         return metadata;
     }
 

--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/AbstractStream.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/AbstractStream.java
@@ -29,7 +29,6 @@ import org.apache.dubbo.remoting.exchange.Request;
 import org.apache.dubbo.rpc.model.MethodDescriptor;
 import org.apache.dubbo.rpc.model.ServiceDescriptor;
 import org.apache.dubbo.rpc.protocol.tri.GrpcStatus.Code;
-import org.apache.dubbo.triple.TripleWrapper;
 
 import com.google.protobuf.Any;
 import com.google.rpc.DebugInfo;
@@ -245,7 +244,7 @@ public abstract class AbstractStream implements Stream {
             return metadata;
         }
         DebugInfo debugInfo = DebugInfo.newBuilder()
-                .addAllStackEntries(ExceptionUtils.getStackFrameList(throwable))
+                .addAllStackEntries(ExceptionUtils.getStackFrameList(throwable,10))
                 // can not use now
                 // .setDetail(throwable.getMessage())
                 .build();
@@ -257,17 +256,6 @@ public abstract class AbstractStream implements Stream {
         if (getMethodDescriptor() != null && !getMethodDescriptor().isNeedWrap()) {
             return metadata;
         }
-        try {
-            TripleWrapper.TripleExceptionWrapper exceptionWrapper = TripleUtil.wrapException(getUrl(), throwable,
-                    getSerializeType(), getMultipleSerialization());
-            String exceptionStr = TripleUtil.encodeBase64ASCII(exceptionWrapper.toByteArray());
-            if (!TripleUtil.overEachHeaderListSize(exceptionStr)) {
-                metadata.put(TripleHeaderEnum.EXCEPTION_TW_BIN.getHeader(), exceptionStr);
-            }
-        } catch (Throwable t) {
-            LOGGER.warn("Encode triple exception to trailers failed", t);
-        }
-
         return metadata;
     }
 

--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/ExceptionUtils.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/ExceptionUtils.java
@@ -64,14 +64,18 @@ public class ExceptionUtils {
         return list.toArray(new String[0]);
     }
 
-    public static List<String> getStackFrameList(final Throwable t) {
+    public static List<String> getStackFrameList(final Throwable t, int maxDepth) {
         final String stackTrace = getStackTrace(t);
         final String linebreak = System.lineSeparator();
         final StringTokenizer frames = new StringTokenizer(stackTrace, linebreak);
         final List<String> list = new ArrayList<>();
-        while (frames.hasMoreTokens()) {
+        for (int i = 0; i < maxDepth && frames.hasMoreTokens(); i++) {
             list.add(frames.nextToken());
         }
         return list;
+    }
+
+    public static List<String> getStackFrameList(final Throwable t) {
+        return getStackFrameList(t, Integer.MAX_VALUE);
     }
 }

--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/TripleHeaderEnum.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/TripleHeaderEnum.java
@@ -40,8 +40,7 @@ public enum TripleHeaderEnum {
     CONSUMER_APP_NAME_KEY("tri-consumer-appname"),
     UNIT_INFO_KEY("tri-unit-info"),
     SERVICE_VERSION("tri-service-version"),
-    SERVICE_GROUP("tri-service-group"),
-    EXCEPTION_TW_BIN("tri-exception-tw-bin");
+    SERVICE_GROUP("tri-service-group");
 
     static Map<String, TripleHeaderEnum> enumMap = new HashMap<>();
 

--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/UnaryClientStream.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/UnaryClientStream.java
@@ -22,7 +22,6 @@ import org.apache.dubbo.common.stream.StreamObserver;
 import org.apache.dubbo.remoting.exchange.Response;
 import org.apache.dubbo.remoting.exchange.support.DefaultFuture2;
 import org.apache.dubbo.rpc.AppResponse;
-import org.apache.dubbo.triple.TripleWrapper;
 
 import com.google.protobuf.Any;
 import com.google.rpc.DebugInfo;
@@ -90,50 +89,29 @@ public class UnaryClientStream extends AbstractClientStream implements Stream {
         }
 
         private Throwable getThrowable(Metadata metadata) {
-            // first get throwable from exception tw bin
-            try {
-                if (metadata.contains(TripleHeaderEnum.EXCEPTION_TW_BIN.getHeader())) {
-                    final CharSequence raw = metadata.get(TripleHeaderEnum.EXCEPTION_TW_BIN.getHeader());
-                    byte[] exceptionTwBin = TripleUtil.decodeASCIIByte(raw);
-                    ClassLoader tccl = Thread.currentThread().getContextClassLoader();
-                    try {
-                        TripleWrapper.TripleExceptionWrapper wrapper = TripleUtil.unpack(exceptionTwBin,
-                                TripleWrapper.TripleExceptionWrapper.class);
-                        Throwable throwable = TripleUtil.unWrapException(getUrl(), wrapper, getSerializeType(),
-                                getMultipleSerialization());
-                        if (throwable != null) {
-                            return throwable;
-                        }
-                    } finally {
-                        ClassLoadUtil.switchContextLoader(tccl);
-                    }
-                }
-            } catch (Throwable t) {
-                LOGGER.warn(String.format("Decode exception instance from triple trailers:%s failed", metadata), t);
-            }
             // second get status detail
-            if (metadata.contains(TripleHeaderEnum.STATUS_DETAIL_KEY.getHeader())) {
-                final CharSequence raw = metadata.get(TripleHeaderEnum.STATUS_DETAIL_KEY.getHeader());
-                byte[] statusDetailBin = TripleUtil.decodeASCIIByte(raw);
-                ClassLoader tccl = Thread.currentThread().getContextClassLoader();
-                try {
-                    final Status statusDetail = TripleUtil.unpack(statusDetailBin, Status.class);
-                    List<Any> detailList = statusDetail.getDetailsList();
-                    Map<Class<?>, Object> classObjectMap = TripleUtil.tranFromStatusDetails(detailList);
-
-                    // get common exception from DebugInfo
-                    DebugInfo debugInfo = (DebugInfo) classObjectMap.get(DebugInfo.class);
-                    if (debugInfo == null) {
-                        return new TripleRpcException(statusDetail.getCode(),
-                                statusDetail.getMessage(), metadata);
-                    }
-                    String msg = ExceptionUtils.getStackFrameString(debugInfo.getStackEntriesList());
-                    return new TripleRpcException(statusDetail.getCode(), msg, metadata);
-                } finally {
-                    ClassLoadUtil.switchContextLoader(tccl);
-                }
+            if (!metadata.contains(TripleHeaderEnum.STATUS_DETAIL_KEY.getHeader())) {
+                return null;
             }
-            return null;
+            final CharSequence raw = metadata.get(TripleHeaderEnum.STATUS_DETAIL_KEY.getHeader());
+            byte[] statusDetailBin = TripleUtil.decodeASCIIByte(raw);
+            ClassLoader tccl = Thread.currentThread().getContextClassLoader();
+            try {
+                final Status statusDetail = TripleUtil.unpack(statusDetailBin, Status.class);
+                List<Any> detailList = statusDetail.getDetailsList();
+                Map<Class<?>, Object> classObjectMap = TripleUtil.tranFromStatusDetails(detailList);
+
+                // get common exception from DebugInfo
+                DebugInfo debugInfo = (DebugInfo) classObjectMap.get(DebugInfo.class);
+                if (debugInfo == null) {
+                    return new TripleRpcException(statusDetail.getCode(),
+                            statusDetail.getMessage(), metadata);
+                }
+                String msg = ExceptionUtils.getStackFrameString(debugInfo.getStackEntriesList());
+                return new TripleRpcException(statusDetail.getCode(), msg, metadata);
+            } finally {
+                ClassLoadUtil.switchContextLoader(tccl);
+            }
         }
     }
 }


### PR DESCRIPTION
## What is the purpose of the change
Default h2 header list size is 8192 byte, exception's `tw-bin` header and detail status header is too large .


## Brief changelog

1. Remove throwable tw-bin
2. Truncate exception to 10 stacks

## Verifying this change


<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [ ] GitHub Actions works fine on your own branch.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
