### PR TITLE
fixes: Try to reduce the time consuming in UT

### DIFF
--- a/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/support/AbstractClusterInvokerTest.java
+++ b/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/support/AbstractClusterInvokerTest.java
@@ -386,7 +386,7 @@ public class AbstractClusterInvokerTest {
 
     public void testSelect_multiInvokers(String lbname) throws Exception {
 
-        int min = 1000, max = 5000;
+        int min = 100, max = 500;
         Double d = (Math.random() * (max - min + 1) + min);
         int runs = d.intValue();
         Assertions.assertTrue(runs > min);

--- a/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/ReferenceConfigTest.java
+++ b/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/ReferenceConfigTest.java
@@ -29,6 +29,8 @@ import org.apache.dubbo.config.api.DemoService;
 import org.apache.dubbo.config.bootstrap.DubboBootstrap;
 import org.apache.dubbo.config.provider.impl.DemoServiceImpl;
 import org.apache.dubbo.registry.client.migration.MigrationInvoker;
+import org.apache.dubbo.registrycenter.RegistryCenter;
+import org.apache.dubbo.registrycenter.ZookeeperSingleRegistryCenter;
 import org.apache.dubbo.rpc.Exporter;
 import org.apache.dubbo.rpc.ProxyFactory;
 import org.apache.dubbo.rpc.listener.ListenerInvokerWrapper;
@@ -38,7 +40,6 @@ import org.apache.dubbo.rpc.model.ServiceMetadata;
 import org.apache.dubbo.rpc.protocol.injvm.InjvmInvoker;
 import org.apache.dubbo.rpc.protocol.injvm.InjvmProtocol;
 
-import org.apache.curator.test.TestingServer;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -100,16 +101,16 @@ import static org.apache.dubbo.rpc.Constants.SCOPE_LOCAL;
 import static org.apache.dubbo.rpc.Constants.SCOPE_REMOTE;
 
 public class ReferenceConfigTest {
-    private TestingServer zkServer;
     private String zkUrl;
     private String registryUrl;
+    private RegistryCenter registryCenter;
 
     @BeforeEach
     public void setUp() throws Exception {
         DubboBootstrap.reset();
         int zkServerPort = NetUtils.getAvailablePort(NetUtils.getRandomPort());
-        this.zkServer = new TestingServer(zkServerPort, true);
-        this.zkServer.start();
+        registryCenter = new ZookeeperSingleRegistryCenter(zkServerPort);
+        registryCenter.startup();
         this.zkUrl = "zookeeper://localhost:" + zkServerPort;
         this.registryUrl = "registry://localhost:" + zkServerPort+"?registry=zookeeper";
 
@@ -122,7 +123,7 @@ public class ReferenceConfigTest {
     @AfterEach
     public void tearDown() throws IOException {
         DubboBootstrap.reset();
-        zkServer.stop();
+        registryCenter.shutdown();
         Mockito.framework().clearInlineMocks();
 
     }

--- a/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/registrycenter/AbstractRegistryCenter.java
+++ b/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/registrycenter/AbstractRegistryCenter.java
@@ -60,7 +60,7 @@ abstract class AbstractRegistryCenter implements RegistryCenter {
     /**
      * The default value is -1.
      */
-    private static final int DEFAULT_MAX_CLIENT_CNXNS = -1;
+    private static final int DEFAULT_MAX_CLIENT_CNXNS = 60;
 
     /**
      * The minimum session timeout.

--- a/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/propertyconfigurer/consumer/PropertyConfigurerTest.java
+++ b/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/propertyconfigurer/consumer/PropertyConfigurerTest.java
@@ -59,11 +59,6 @@ public class PropertyConfigurerTest {
             // reset ConfigManager of provider context
             DubboBootstrap.reset(false);
 
-            try {
-                Thread.sleep(1000);
-            } catch (InterruptedException e) {
-            }
-
             // Resolve placeholder by PropertyPlaceholderConfigurer in dubbo-consumer.xml, without import property source.
             AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(ConsumerConfiguration.class);
             context.start();

--- a/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/propertyconfigurer/consumer2/PropertySourcesConfigurerTest.java
+++ b/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/propertyconfigurer/consumer2/PropertySourcesConfigurerTest.java
@@ -57,11 +57,6 @@ public class PropertySourcesConfigurerTest {
         try {
             providerContext.start();
 
-            try {
-                Thread.sleep(1000);
-            } catch (InterruptedException e) {
-            }
-
             // reset ConfigManager of provider context
             DubboBootstrap.reset(false);
 

--- a/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/propertyconfigurer/consumer3/PropertySourcesInJavaConfigTest.java
+++ b/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/propertyconfigurer/consumer3/PropertySourcesInJavaConfigTest.java
@@ -70,11 +70,6 @@ public class PropertySourcesInJavaConfigTest {
         try {
             providerContext.start();
 
-            try {
-                Thread.sleep(1000);
-            } catch (InterruptedException e) {
-            }
-
             // reset ConfigManager of provider context
             DubboBootstrap.reset(false);
             //ApplicationModel.defaultModel().getApplicationServiceRepository().setProviderUrlsWithoutGroup(tmp);
@@ -106,11 +101,6 @@ public class PropertySourcesInJavaConfigTest {
         ClassPathXmlApplicationContext providerContext = new ClassPathXmlApplicationContext(PROVIDER_CONFIG_PATH);
         try {
             providerContext.start();
-
-            try {
-                Thread.sleep(1000);
-            } catch (InterruptedException e) {
-            }
 
             // reset ConfigManager of provider context
             DubboBootstrap.reset(false);

--- a/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/reference/localcall/LocalCallTest.java
+++ b/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/reference/localcall/LocalCallTest.java
@@ -61,9 +61,6 @@ public class LocalCallTest {
     //@Qualifier("localHelloService")
     private HelloService localHelloService;
 
-    @Autowired
-    private ApplicationContext applicationContext;
-
     @Test
     public void testLocalCall() {
         // see also: org.apache.dubbo.rpc.protocol.injvm.InjvmInvoker.doInvoke

--- a/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/reference/localcallam/LocalCallMultipleReferenceAnnotationsTest.java
+++ b/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/reference/localcallam/LocalCallMultipleReferenceAnnotationsTest.java
@@ -22,6 +22,7 @@ import org.apache.dubbo.config.bootstrap.DubboBootstrap;
 import org.apache.dubbo.config.spring.ReferenceBean;
 import org.apache.dubbo.config.spring.api.HelloService;
 import org.apache.dubbo.config.spring.context.annotation.EnableDubbo;
+import org.apache.dubbo.config.spring.registrycenter.RegistryCenter;
 import org.apache.dubbo.config.spring.registrycenter.ZookeeperSingleRegistryCenter;
 import org.apache.dubbo.rpc.RpcContext;
 import org.junit.jupiter.api.AfterAll;
@@ -48,7 +49,7 @@ import static org.springframework.test.annotation.DirtiesContext.ClassMode.AFTER
 @DirtiesContext(classMode = AFTER_EACH_TEST_METHOD)
 public class LocalCallMultipleReferenceAnnotationsTest {
 
-    private static ZookeeperSingleRegistryCenter registryCenter;
+    private static RegistryCenter registryCenter;
 
     @BeforeAll
     public static void setUp() {

--- a/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/registrycenter/AbstractRegistryCenter.java
+++ b/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/registrycenter/AbstractRegistryCenter.java
@@ -53,14 +53,14 @@ abstract class AbstractRegistryCenter implements RegistryCenter {
     private static final int DEFAULT_SERVER_ID = -1;
 
     /**
-     * The default tick time is 10000
+     * The default tick time is 5000
      */
-    private static final int DEFAULT_TICK_TIME = 10 * 1000;
+    private static final int DEFAULT_TICK_TIME = 5 * 1000;
 
     /**
-     * The default value is -1.
+     * The default value is 60.
      */
-    private static final int DEFAULT_MAX_CLIENT_CNXNS = -1;
+    private static final int DEFAULT_MAX_CLIENT_CNXNS = 60;
 
     /**
      * The minimum session timeout.

--- a/dubbo-config/dubbo-config-spring/src/test/resources/META-INF/spring/dubbo-generic-consumer-without-interface.xml
+++ b/dubbo-config/dubbo-config-spring/src/test/resources/META-INF/spring/dubbo-generic-consumer-without-interface.xml
@@ -22,15 +22,15 @@
        http://dubbo.apache.org/schema/dubbo http://dubbo.apache.org/schema/dubbo/dubbo.xsd">
 
     <!-- 当前应用信息配置 -->
-    <dubbo:application name="dubbo-generic-consumer"/>
+    <dubbo:application name="dubbo-generic-consumer-without-interface"/>
 
     <!-- 连接注册中心配置 -->
     <dubbo:registry address="zookeeper://127.0.0.1:2181"/>
 
-    <dubbo:reference id="demoServiceRef" interface="org.apache.dubbo.config.spring.api.DemoService" generic="true" init="false"/>
-
     <bean id="genericService" class="org.apache.dubbo.config.spring.schema.MyGenericService"/>
 
-    <dubbo:service id="demoService" interface="org.apache.dubbo.config.spring.api.DemoService" generic="true"
+    <!-- generic service without interface class -->
+    <dubbo:reference id="genericServiceWithoutInterfaceRef" interface="org.apache.dubbo.config.spring.api.LocalMissClass" generic="true" init="false"/>
+    <dubbo:service id="genericServiceWithoutInterface" interface="org.apache.dubbo.config.spring.api.LocalMissClass" generic="true"
                    ref="genericService"/>
 </beans>

--- a/dubbo-dependencies-bom/pom.xml
+++ b/dubbo-dependencies-bom/pom.xml
@@ -100,7 +100,7 @@
         <httpcore_version>4.4.6</httpcore_version>
         <fastjson_version>1.2.70</fastjson_version>
         <zookeeper_version>3.4.13</zookeeper_version>
-        <curator_version>4.0.1</curator_version>
+        <curator_version>4.1.0</curator_version>
         <curator_test_version>2.12.0</curator_test_version>
         <jedis_version>3.6.0</jedis_version>
         <consul_version>1.4.2</consul_version>

--- a/dubbo-plugin/dubbo-qos/src/test/java/org/apache/dubbo/qos/command/impl/PortTelnetTest.java
+++ b/dubbo-plugin/dubbo-qos/src/test/java/org/apache/dubbo/qos/command/impl/PortTelnetTest.java
@@ -73,7 +73,7 @@ public class PortTelnetTest {
     public void testListClient() throws Exception {
         ExchangeClient client1 = Exchangers.connect("dubbo://127.0.0.1:" + availablePort + "/demo");
         ExchangeClient client2 = Exchangers.connect("dubbo://127.0.0.1:" + availablePort + "/demo");
-        Thread.sleep(5000);
+        Thread.sleep(100);
         String result = port.execute(mockCommandContext, new String[]{"-l", availablePort + ""});
         String client1Addr = client1.getLocalAddress().toString();
         String client2Addr = client2.getLocalAddress().toString();

--- a/dubbo-rpc/dubbo-rpc-dubbo/src/test/java/org/apache/dubbo/rpc/protocol/dubbo/ArgumentCallbackTest.java
+++ b/dubbo-rpc/dubbo-rpc-dubbo/src/test/java/org/apache/dubbo/rpc/protocol/dubbo/ArgumentCallbackTest.java
@@ -113,7 +113,7 @@ public class ArgumentCallbackTest {
     
     @Test
     public void TestCallbackNormalWithBindPort() throws Exception {
-        initOrResetUrl(1, 1000);
+        initOrResetUrl(1, 10000000);
         consumerUrl = serviceURL.addParameter(Constants.BIND_PORT_KEY,"7653");
         initOrResetService();
        
@@ -125,9 +125,9 @@ public class ArgumentCallbackTest {
                 count.incrementAndGet();
                 return "ok";
             }
-        }, "other custom args", 10, 10);
+        }, "other custom args", 10, 100);
         System.out.println("Async...");
-        assertCallbackCount(10, 10, count);
+        assertCallbackCount(10, 100, count);
         destroyService();
 
     }

--- a/dubbo-rpc/dubbo-rpc-dubbo/src/test/java/org/apache/dubbo/rpc/protocol/dubbo/ArgumentCallbackTest.java
+++ b/dubbo-rpc/dubbo-rpc-dubbo/src/test/java/org/apache/dubbo/rpc/protocol/dubbo/ArgumentCallbackTest.java
@@ -113,7 +113,7 @@ public class ArgumentCallbackTest {
     
     @Test
     public void TestCallbackNormalWithBindPort() throws Exception {
-        initOrResetUrl(1, 10000000);
+        initOrResetUrl(1, 1000);
         consumerUrl = serviceURL.addParameter(Constants.BIND_PORT_KEY,"7653");
         initOrResetService();
        
@@ -125,9 +125,9 @@ public class ArgumentCallbackTest {
                 count.incrementAndGet();
                 return "ok";
             }
-        }, "other custom args", 10, 100);
+        }, "other custom args", 10, 10);
         System.out.println("Async...");
-        assertCallbackCount(10, 100, count);
+        assertCallbackCount(10, 10, count);
         destroyService();
 
     }
@@ -174,18 +174,18 @@ public class ArgumentCallbackTest {
         {
             demoProxy.xxx2(callback);
             Assertions.assertEquals(1, demoProxy.getCallbackCount());
-            Thread.sleep(500);
+            //Thread.sleep(500);
             demoProxy.unxxx2(callback);
             Assertions.assertEquals(0, demoProxy.getCallbackCount());
 
             demoProxy.xxx2(callback2);
             Assertions.assertEquals(1, demoProxy.getCallbackCount());
-            Thread.sleep(500);
+            //Thread.sleep(500);
             demoProxy.unxxx2(callback2);
             Assertions.assertEquals(0, demoProxy.getCallbackCount());
 
             demoProxy.xxx2(callback);
-            Thread.sleep(500);
+            //Thread.sleep(500);
             Assertions.assertEquals(1, demoProxy.getCallbackCount());
             demoProxy.unxxx2(callback);
             Assertions.assertEquals(0, demoProxy.getCallbackCount());
@@ -364,7 +364,7 @@ public class ArgumentCallbackTest {
                                             callbacks.remove(callback);
                                         }
                                     }
-                                    Thread.sleep(100);
+                                    Thread.sleep(10);
                                 } catch (InterruptedException e) {
                                     e.printStackTrace();
                                 }

--- a/dubbo-rpc/dubbo-rpc-dubbo/src/test/java/org/apache/dubbo/rpc/protocol/dubbo/ArgumentCallbackTest.java
+++ b/dubbo-rpc/dubbo-rpc-dubbo/src/test/java/org/apache/dubbo/rpc/protocol/dubbo/ArgumentCallbackTest.java
@@ -174,18 +174,18 @@ public class ArgumentCallbackTest {
         {
             demoProxy.xxx2(callback);
             Assertions.assertEquals(1, demoProxy.getCallbackCount());
-            //Thread.sleep(500);
+            Thread.sleep(500);
             demoProxy.unxxx2(callback);
             Assertions.assertEquals(0, demoProxy.getCallbackCount());
 
             demoProxy.xxx2(callback2);
             Assertions.assertEquals(1, demoProxy.getCallbackCount());
-            //Thread.sleep(500);
+            Thread.sleep(500);
             demoProxy.unxxx2(callback2);
             Assertions.assertEquals(0, demoProxy.getCallbackCount());
 
             demoProxy.xxx2(callback);
-            //Thread.sleep(500);
+            Thread.sleep(500);
             Assertions.assertEquals(1, demoProxy.getCallbackCount());
             demoProxy.unxxx2(callback);
             Assertions.assertEquals(0, demoProxy.getCallbackCount());
@@ -364,7 +364,7 @@ public class ArgumentCallbackTest {
                                             callbacks.remove(callback);
                                         }
                                     }
-                                    Thread.sleep(10);
+                                    Thread.sleep(100);
                                 } catch (InterruptedException e) {
                                     e.printStackTrace();
                                 }

--- a/dubbo-rpc/dubbo-rpc-dubbo/src/test/java/org/apache/dubbo/rpc/protocol/dubbo/DubboProtocolTest.java
+++ b/dubbo-rpc/dubbo-rpc-dubbo/src/test/java/org/apache/dubbo/rpc/protocol/dubbo/DubboProtocolTest.java
@@ -190,7 +190,7 @@ public class DubboProtocolTest {
         service = proxy.getProxy(protocol.refer(DemoService.class, URL.valueOf("dubbo://127.0.0.1:" + port + "/" + DemoService.class.getName() + "?codec=exchange").addParameter("timeout",
                 3000L)));
         long start = System.currentTimeMillis();
-        for (int i = 0; i < 1000; i++)
+        for (int i = 0; i < 100; i++)
             service.getSize(new String[]{"", "", ""});
         System.out.println("take:" + (System.currentTimeMillis() - start));
     }

--- a/dubbo-test/dubbo-test-common/pom.xml
+++ b/dubbo-test/dubbo-test-common/pom.xml
@@ -60,7 +60,7 @@
         <dependency>
             <groupId>org.apache.curator</groupId>
             <artifactId>curator-test</artifactId>
-            <scope>test</scope>
+            <scope>compile</scope>
             <exclusions>
                 <exclusion>
                     <groupId>com.google.guava</groupId>

--- a/dubbo-test/dubbo-test-common/pom.xml
+++ b/dubbo-test/dubbo-test-common/pom.xml
@@ -57,5 +57,16 @@
             <groupId>org.apache.dubbo</groupId>
             <artifactId>dubbo-rpc-rest</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.apache.curator</groupId>
+            <artifactId>curator-test</artifactId>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>guava</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
     </dependencies>
 </project>

--- a/dubbo-test/dubbo-test-common/src/main/java/org/apache/dubbo/test/common/EmbeddedZooKeeper.java
+++ b/dubbo-test/dubbo-test-common/src/main/java/org/apache/dubbo/test/common/EmbeddedZooKeeper.java
@@ -39,7 +39,11 @@ import java.util.UUID;
  * @author Patrick Peralta
  * @author Mark Fisher
  * @author David Turanski
+ * @deprecated
+ * @see org.apache.dubbo.test.common.registrycenter.ZookeeperSingleRegistryCenter
+ * @see org.apache.dubbo.test.common.registrycenter.ZookeeperMultipleRegistryCenter
  */
+@Deprecated
 public class EmbeddedZooKeeper {
 
     /**

--- a/dubbo-test/dubbo-test-common/src/main/java/org/apache/dubbo/test/common/ZooKeeperServer.java
+++ b/dubbo-test/dubbo-test-common/src/main/java/org/apache/dubbo/test/common/ZooKeeperServer.java
@@ -16,6 +16,15 @@
  */
 package org.apache.dubbo.test.common;
 
+/**
+ * Using this class as registry center is not very well because of time-consuming.
+ * <p>The alternative is to use {@link org.apache.dubbo.test.common.registrycenter.ZookeeperSingleRegistryCenter}</p> or
+ * {@link org.apache.dubbo.test.common.registrycenter.ZookeeperMultipleRegistryCenter}
+ * @deprecated
+ * @see org.apache.dubbo.test.common.registrycenter.ZookeeperSingleRegistryCenter
+ * @see org.apache.dubbo.test.common.registrycenter.ZookeeperMultipleRegistryCenter
+ */
+@Deprecated
 public class ZooKeeperServer {
 
     private static EmbeddedZooKeeper zookeeper1;

--- a/dubbo-test/dubbo-test-common/src/main/java/org/apache/dubbo/test/common/registrycenter/AbstractRegistryCenter.java
+++ b/dubbo-test/dubbo-test-common/src/main/java/org/apache/dubbo/test/common/registrycenter/AbstractRegistryCenter.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.test.common.registrycenter;
+
+import org.apache.curator.test.InstanceSpec;
+
+import java.io.File;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * The abstraction of {@link RegistryCenter} implements the basic methods.
+ */
+abstract class AbstractRegistryCenter implements RegistryCenter {
+
+    /**
+     * The default data directory is null
+     */
+    private static final File DEFAULT_DATA_DIRECTORY = null;
+
+    /**
+     * The default election port is -1.
+     */
+    private static final int DEFAULT_ELECTION_PORT = -1;
+
+    /**
+     * The default quorum port is -1.
+     */
+    private static final int DEFAULT_QUORUM_PORT = -1;
+
+    /**
+     * The default value is true.
+     */
+    private static final boolean DEFAULT_DELETE_DATA_DIRECTORY_ON_CLOSE = true;
+
+    /**
+     * The default service id is -1.
+     */
+    private static final int DEFAULT_SERVER_ID = -1;
+
+    /**
+     * The default tick time is 10000
+     */
+    private static final int DEFAULT_TICK_TIME = 10 * 1000;
+
+    /**
+     * The default value is -1.
+     */
+    private static final int DEFAULT_MAX_CLIENT_CNXNS = -1;
+
+    /**
+     * The minimum session timeout.
+     */
+    private static final int DEFAULT_MINIMUM_SESSION_TIMEOUT = DEFAULT_TICK_TIME * 2;
+
+    /**
+     * The maximum session timeout.
+     */
+    private static final int DEFAULT_MAXIMUM_SESSION_TIMEOUT = 60 * 1000;
+
+    /**
+     * The default customer properties.
+     */
+    private static final Map<String, Object> DEFAULT_CUSTOM_PROPERTIES = new HashMap<>(2);
+
+    /**
+     * The default hostname.
+     */
+    private static final String DEFAULT_HOSTNAME = "127.0.0.1";
+
+    static {
+        DEFAULT_CUSTOM_PROPERTIES.put("minSessionTimeout", DEFAULT_MINIMUM_SESSION_TIMEOUT);
+        DEFAULT_CUSTOM_PROPERTIES.put("maxSessionTimeout", DEFAULT_MAXIMUM_SESSION_TIMEOUT);
+    }
+
+    /**
+     * Create an {@link InstanceSpec} instance to initialize {@link org.apache.curator.test.TestingServer}
+     *
+     * @param port the zookeeper server's port.
+     */
+    protected InstanceSpec createInstanceSpec(int port) {
+        return new InstanceSpec(DEFAULT_DATA_DIRECTORY,
+            port,
+            DEFAULT_ELECTION_PORT,
+            DEFAULT_QUORUM_PORT,
+            DEFAULT_DELETE_DATA_DIRECTORY_ON_CLOSE,
+            DEFAULT_SERVER_ID,
+            DEFAULT_TICK_TIME,
+            DEFAULT_MAX_CLIENT_CNXNS,
+            DEFAULT_CUSTOM_PROPERTIES,
+            DEFAULT_HOSTNAME);
+    }
+}

--- a/dubbo-test/dubbo-test-common/src/main/java/org/apache/dubbo/test/common/registrycenter/AbstractRegistryCenter.java
+++ b/dubbo-test/dubbo-test-common/src/main/java/org/apache/dubbo/test/common/registrycenter/AbstractRegistryCenter.java
@@ -53,14 +53,14 @@ abstract class AbstractRegistryCenter implements RegistryCenter {
     private static final int DEFAULT_SERVER_ID = -1;
 
     /**
-     * The default tick time is 10000
+     * The default tick time is 5000
      */
-    private static final int DEFAULT_TICK_TIME = 10 * 1000;
+    private static final int DEFAULT_TICK_TIME = 5 * 1000;
 
     /**
-     * The default value is -1.
+     * The default value is 60.
      */
-    private static final int DEFAULT_MAX_CLIENT_CNXNS = -1;
+    private static final int DEFAULT_MAX_CLIENT_CNXNS = 60;
 
     /**
      * The minimum session timeout.

--- a/dubbo-test/dubbo-test-common/src/main/java/org/apache/dubbo/test/common/registrycenter/RegistryCenter.java
+++ b/dubbo-test/dubbo-test-common/src/main/java/org/apache/dubbo/test/common/registrycenter/RegistryCenter.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.test.common.registrycenter;
+
+import org.apache.dubbo.rpc.RpcException;
+
+import java.util.List;
+
+/**
+ * The mock registry center.
+ */
+public interface RegistryCenter {
+
+    /**
+     * Start the registry center.
+     *
+     * @throws RpcException when an exception occurred
+     */
+    void startup() throws RpcException;
+
+    /**
+     * Returns the registry center instance.
+     * <p>This method can be called only after {@link #startup()} is called</p>
+     *
+     * @throws RpcException when an exception occurred
+     */
+    List<Instance> getRegistryCenterInstance() throws RpcException;
+
+    /**
+     * Stop the registry center.
+     *
+     * @throws RpcException when an exception occurred
+     */
+    void shutdown() throws RpcException;
+
+    /**
+     * The registry center instance.
+     */
+    interface Instance {
+
+        /**
+         * Returns the registry center type.
+         */
+        String getType();
+
+        /**
+         * Returns the hostname of registry center.
+         */
+        String getHostname();
+
+        /**
+         * Returns the port of registry center.
+         */
+        int getPort();
+    }
+}

--- a/dubbo-test/dubbo-test-common/src/main/java/org/apache/dubbo/test/common/registrycenter/ZookeeperMultipleRegistryCenter.java
+++ b/dubbo-test/dubbo-test-common/src/main/java/org/apache/dubbo/test/common/registrycenter/ZookeeperMultipleRegistryCenter.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.test.common.registrycenter;
+
+/**
+ * The default zookeeper multiple registry center.
+ */
+public class ZookeeperMultipleRegistryCenter extends ZookeeperRegistryCenter {
+
+    /**
+     * Initialize {@link ZookeeperMultipleRegistryCenter} instance.
+     *
+     * @param port1 the zookeeper server's port.
+     * @param port2 the zookeeper server's port.
+     */
+    public ZookeeperMultipleRegistryCenter(int port1, int port2) {
+        super(port1, port2);
+    }
+
+    /**
+     * Initialize {@link ZookeeperMultipleRegistryCenter} instance.
+     */
+    public ZookeeperMultipleRegistryCenter() {
+        this(DEFAULT_PORT1, DEFAULT_PORT2);
+    }
+
+    private static final int DEFAULT_PORT1 = 2181;
+    private static final int DEFAULT_PORT2 = 2182;
+}

--- a/dubbo-test/dubbo-test-common/src/main/java/org/apache/dubbo/test/common/registrycenter/ZookeeperRegistryCenter.java
+++ b/dubbo-test/dubbo-test-common/src/main/java/org/apache/dubbo/test/common/registrycenter/ZookeeperRegistryCenter.java
@@ -1,0 +1,142 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.test.common.registrycenter;
+
+import org.apache.curator.test.InstanceSpec;
+import org.apache.curator.test.TestingServer;
+import org.apache.dubbo.common.logger.Logger;
+import org.apache.dubbo.common.logger.LoggerFactory;
+import org.apache.dubbo.rpc.RpcException;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * The default implementation of registry center can support single and multiple registry center.
+ * <p>Each port represents an instance. You can provide multiple ports to build multiple registry center,
+ * if you want to create multiple registry center
+ */
+class ZookeeperRegistryCenter extends AbstractRegistryCenter {
+
+    /**
+     * Initialize the default registry center.
+     *
+     * @param ports the registry center's ports.
+     */
+    public ZookeeperRegistryCenter(int... ports) {
+        this.ports = ports;
+        this.instanceSpecs = new ArrayList<>(this.ports.length);
+        this.zookeeperServers = new ArrayList<>(this.ports.length);
+    }
+
+    private static final Logger logger = LoggerFactory.getLogger(ZookeeperRegistryCenter.class);
+
+    /**
+     * The type of the registry center.
+     */
+    private static final String DEFAULT_REGISTRY_CENTER_TYPE = "zookeeper";
+
+    private int[] ports;
+
+    private List<InstanceSpec> instanceSpecs;
+
+    private List<TestingServer> zookeeperServers;
+
+    private AtomicBoolean started = new AtomicBoolean(false);
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void startup() throws RpcException {
+        try {
+            if (started.compareAndSet(false, true)) {
+                logger.info("The ZookeeperRegistryCenter is starting...");
+                for (int port : this.ports) {
+                    InstanceSpec instanceSpec = this.createInstanceSpec(port);
+                    this.instanceSpecs.add(instanceSpec);
+                    this.zookeeperServers.add(new TestingServer(instanceSpec, true));
+                }
+                logger.info("The ZookeeperRegistryCenter is started successfully");
+            }
+        } catch (Exception exception) {
+            started.set(false);
+            throw new RpcException("Failed to initialize ZookeeperRegistryCenter instance", exception);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public List<Instance> getRegistryCenterInstance() throws RpcException {
+        this.startup();
+        List<Instance> instances = new ArrayList<>(this.instanceSpecs.size());
+        for (InstanceSpec instanceSpec : this.instanceSpecs) {
+            instances.add(new Instance() {
+                @Override
+                public String getType() {
+                    return DEFAULT_REGISTRY_CENTER_TYPE;
+                }
+
+                @Override
+                public String getHostname() {
+                    return instanceSpec.getHostname();
+                }
+
+                @Override
+                public int getPort() {
+                    return instanceSpec.getPort();
+                }
+            });
+        }
+        return instances;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void shutdown() throws RpcException {
+        logger.info("The ZookeeperRegistryCenter is stopping...");
+        List<RpcException> exceptions = new ArrayList<>(this.zookeeperServers.size());
+        for (TestingServer testingServer : this.zookeeperServers) {
+            try {
+                testingServer.close();
+                logger.info(String.format("The zookeeper instance of %s is shutdown successfully",
+                    testingServer.getConnectString()));
+            } catch (IOException exception) {
+                RpcException rpcException = new RpcException(String.format("Failed to close zookeeper instance of %s",
+                    testingServer.getConnectString()),
+                    exception);
+                exceptions.add(rpcException);
+                logger.error(rpcException);
+            }
+        }
+        this.instanceSpecs.clear();
+        this.zookeeperServers.clear();
+        if (!exceptions.isEmpty()) {
+            logger.info("The ZookeeperRegistryCenter failed to close.");
+            // throw any one of exceptions
+            throw exceptions.get(0);
+        } else {
+            logger.info("The ZookeeperRegistryCenter close successfully.");
+        }
+    }
+}

--- a/dubbo-test/dubbo-test-common/src/main/java/org/apache/dubbo/test/common/registrycenter/ZookeeperSingleRegistryCenter.java
+++ b/dubbo-test/dubbo-test-common/src/main/java/org/apache/dubbo/test/common/registrycenter/ZookeeperSingleRegistryCenter.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.test.common.registrycenter;
+
+/**
+ * The default zookeeper single registry center.
+ */
+public class ZookeeperSingleRegistryCenter extends ZookeeperRegistryCenter {
+
+    /**
+     * Initialize {@link ZookeeperSingleRegistryCenter} instance.
+     */
+    public ZookeeperSingleRegistryCenter() {
+        this(DEFAULT_PORT);
+    }
+
+    /**
+     * Initialize {@link RegistryCenter} instance.
+     *
+     * @param port the zookeeper server's port.
+     */
+    public ZookeeperSingleRegistryCenter(int port) {
+        super(port);
+    }
+
+    /**
+     * The zookeeper server's default port.
+     */
+    private static final int DEFAULT_PORT = 2181;
+}

--- a/dubbo-test/dubbo-test-spring/src/main/java/org/apache/dubbo/test/spring/SpringAnnotationBeanTest.java
+++ b/dubbo-test/dubbo-test-spring/src/main/java/org/apache/dubbo/test/spring/SpringAnnotationBeanTest.java
@@ -19,11 +19,13 @@ package org.apache.dubbo.test.spring;
 import org.apache.dubbo.config.annotation.DubboReference;
 import org.apache.dubbo.config.bootstrap.DubboBootstrap;
 import org.apache.dubbo.config.spring.context.annotation.EnableDubbo;
-import org.apache.dubbo.test.common.ZooKeeperServer;
 import org.apache.dubbo.test.common.api.DemoService;
+import org.apache.dubbo.test.common.registrycenter.RegistryCenter;
+import org.apache.dubbo.test.common.registrycenter.ZookeeperSingleRegistryCenter;
 import org.apache.dubbo.test.spring.context.MockSpringInitializationCustomizer;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
@@ -31,10 +33,20 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.PropertySource;
 
 public class SpringAnnotationBeanTest {
+
+    private static RegistryCenter registryCenter;
+
     @BeforeAll
     public static void beforeAll() {
-        ZooKeeperServer.start();
+        registryCenter = new ZookeeperSingleRegistryCenter();
+        registryCenter.startup();
         DubboBootstrap.reset();
+    }
+
+    @AfterAll
+    public static void afterAll(){
+        DubboBootstrap.reset();
+        registryCenter.shutdown();
     }
 
     @Test

--- a/dubbo-test/dubbo-test-spring/src/main/java/org/apache/dubbo/test/spring/SpringJavaConfigBeanTest.java
+++ b/dubbo-test/dubbo-test-spring/src/main/java/org/apache/dubbo/test/spring/SpringJavaConfigBeanTest.java
@@ -30,15 +30,17 @@ import org.apache.dubbo.config.spring.context.annotation.EnableDubbo;
 import org.apache.dubbo.rpc.Constants;
 import org.apache.dubbo.rpc.model.ApplicationModel;
 import org.apache.dubbo.test.common.SysProps;
-import org.apache.dubbo.test.common.ZooKeeperServer;
 import org.apache.dubbo.test.common.api.DemoService;
 import org.apache.dubbo.test.common.impl.DemoServiceImpl;
+import org.apache.dubbo.test.common.registrycenter.RegistryCenter;
+import org.apache.dubbo.test.common.registrycenter.ZookeeperSingleRegistryCenter;
 import org.apache.dubbo.test.spring.context.MockSpringInitializationCustomizer;
 
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
@@ -52,10 +54,19 @@ public class SpringJavaConfigBeanTest {
     private static final String MY_PROTOCOL_ID = "myProtocol";
     private static final String MY_REGISTRY_ID = "my-registry";
 
+    private static RegistryCenter registryCenter;
+
     @BeforeAll
     public static void beforeAll() {
-        ZooKeeperServer.start();
+        registryCenter = new ZookeeperSingleRegistryCenter();
+        registryCenter.startup();
         DubboBootstrap.reset();
+    }
+
+    @AfterAll
+    public static void afterAll(){
+        DubboBootstrap.reset();
+        registryCenter.shutdown();
     }
 
     @BeforeEach

--- a/dubbo-test/dubbo-test-spring/src/main/java/org/apache/dubbo/test/spring/SpringXmlConfigTest.java
+++ b/dubbo-test/dubbo-test-spring/src/main/java/org/apache/dubbo/test/spring/SpringXmlConfigTest.java
@@ -18,11 +18,13 @@ package org.apache.dubbo.test.spring;
 
 import org.apache.dubbo.config.bootstrap.DubboBootstrap;
 import org.apache.dubbo.test.common.SysProps;
-import org.apache.dubbo.test.common.ZooKeeperServer;
 import org.apache.dubbo.test.common.api.DemoService;
 import org.apache.dubbo.test.common.api.GreetingService;
 import org.apache.dubbo.test.common.api.RestDemoService;
+import org.apache.dubbo.test.common.registrycenter.RegistryCenter;
+import org.apache.dubbo.test.common.registrycenter.ZookeeperSingleRegistryCenter;
 import org.apache.dubbo.test.spring.context.MockSpringInitializationCustomizer;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -32,10 +34,19 @@ import static org.apache.dubbo.common.constants.CommonConstants.SHUTDOWN_WAIT_KE
 
 public class SpringXmlConfigTest {
 
+    private static RegistryCenter registryCenter;
+
     @BeforeAll
     public static void beforeAll() {
-        ZooKeeperServer.start();
+        registryCenter = new ZookeeperSingleRegistryCenter();
+        registryCenter.startup();
         DubboBootstrap.reset();
+    }
+
+    @AfterAll
+    public static void afterAll(){
+        DubboBootstrap.reset();
+        registryCenter.shutdown();
     }
 
     @Test


### PR DESCRIPTION
## What is the purpose of the change

Try to fix zookeeper timeout when run UT

```java
Error:  Errors: 
Error:    GenericServiceTest.testGeneric:97 � IllegalState Failed to check the status of...
[INFO] 
Error:  Tests run: 127, Failures: 0, Errors: 1, Skipped: 26
```

## Brief changelog

1. Replace ZookeeperServer with ZookeeperSingleRegistryCenter
2. Split the testcase of GenericServiceTest#testGeneric

## Verifying this change


<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [x] Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [x] GitHub Actions works fine on your own branch.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
