### PR TITLE
#8685 supported to configure HTTP2 settings

### DIFF
--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/Constants.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/Constants.java
@@ -94,4 +94,11 @@ public interface Constants {
     String SERIALIZATION_SECURITY_CHECK_KEY = "serialization.security.check";
     String INVOCATION_KEY = "invocation";
     String SERIALIZATION_ID_KEY = "serialization_id";
+
+    String H2_SETTINGS_HEADER_TABLE_SIZE_KEY = "h2.settings.header-table-size";
+    String H2_SETTINGS_ENABLE_PUSH_KEY = "h2.settings.enable-push";
+    String H2_SETTINGS_MAX_CONCURRENT_STREAMS_KEY = "h2.settings.max-concurrent-streams";
+    String H2_SETTINGS_INITIAL_WINDOW_SIZE_KEY = "h2.settings.initial-window-size";
+    String H2_SETTINGS_MAX_FRAME_SIZE_KEY = "h2.settings.max-frame-size";
+    String H2_SETTINGS_MAX_HEADER_LIST_SIZE_KEY = "h2.settings.max-header-list-size";
 }

--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/TripleHttp2Protocol.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/TripleHttp2Protocol.java
@@ -16,6 +16,8 @@
  */
 package org.apache.dubbo.rpc.protocol.tri;
 
+import org.apache.dubbo.common.config.Configuration;
+import org.apache.dubbo.common.config.ConfigurationUtils;
 import org.apache.dubbo.common.extension.Activate;
 import org.apache.dubbo.remoting.api.Http2WireProtocol;
 import org.apache.dubbo.rpc.model.FrameworkModel;
@@ -29,6 +31,13 @@ import io.netty.handler.codec.http2.Http2FrameCodecBuilder;
 import io.netty.handler.codec.http2.Http2MultiplexHandler;
 import io.netty.handler.codec.http2.Http2Settings;
 import io.netty.handler.ssl.SslContext;
+
+import static org.apache.dubbo.rpc.Constants.H2_SETTINGS_ENABLE_PUSH_KEY;
+import static org.apache.dubbo.rpc.Constants.H2_SETTINGS_HEADER_TABLE_SIZE_KEY;
+import static org.apache.dubbo.rpc.Constants.H2_SETTINGS_INITIAL_WINDOW_SIZE_KEY;
+import static org.apache.dubbo.rpc.Constants.H2_SETTINGS_MAX_CONCURRENT_STREAMS_KEY;
+import static org.apache.dubbo.rpc.Constants.H2_SETTINGS_MAX_FRAME_SIZE_KEY;
+import static org.apache.dubbo.rpc.Constants.H2_SETTINGS_MAX_HEADER_LIST_SIZE_KEY;
 
 @Activate
 public class TripleHttp2Protocol extends Http2WireProtocol implements ScopeModelAware {
@@ -46,13 +55,15 @@ public class TripleHttp2Protocol extends Http2WireProtocol implements ScopeModel
 
     @Override
     public void configServerPipeline(ChannelPipeline pipeline, SslContext sslContext) {
+        final Configuration config = ConfigurationUtils.getGlobalConfiguration();
         final Http2FrameCodec codec = Http2FrameCodecBuilder.forServer()
                 .gracefulShutdownTimeoutMillis(10000)
                 .initialSettings(new Http2Settings()
-                        .maxHeaderListSize(8192)
-                        .maxFrameSize(2 << 16)
-                        .maxConcurrentStreams(Integer.MAX_VALUE)
-                        .initialWindowSize(1048576))
+                    .headerTableSize(config.getInt(H2_SETTINGS_HEADER_TABLE_SIZE_KEY, 4096))
+                    .maxConcurrentStreams(config.getInt(H2_SETTINGS_MAX_CONCURRENT_STREAMS_KEY, Integer.MAX_VALUE))
+                    .initialWindowSize(config.getInt(H2_SETTINGS_INITIAL_WINDOW_SIZE_KEY, 1 << 20))
+                    .maxFrameSize(config.getInt(H2_SETTINGS_MAX_FRAME_SIZE_KEY, 2 << 14))
+                    .maxHeaderListSize(config.getInt(H2_SETTINGS_MAX_HEADER_LIST_SIZE_KEY, 8192)))
                 .frameLogger(SERVER_LOGGER)
                 .build();
         final Http2MultiplexHandler handler = new Http2MultiplexHandler(new TripleServerInitializer(frameworkModel));
@@ -67,13 +78,16 @@ public class TripleHttp2Protocol extends Http2WireProtocol implements ScopeModel
 
     @Override
     public void configClientPipeline(ChannelPipeline pipeline, SslContext sslContext) {
+        final Configuration config = ConfigurationUtils.getGlobalConfiguration();
         final Http2FrameCodec codec = Http2FrameCodecBuilder.forClient()
-                .initialSettings(new Http2Settings()
-                        .maxHeaderListSize(8192)
-                        .maxFrameSize(2 << 16)
-                        .maxConcurrentStreams(Integer.MAX_VALUE)
-                        .initialWindowSize(1048576))
                 .gracefulShutdownTimeoutMillis(10000)
+                .initialSettings(new Http2Settings()
+                    .headerTableSize(config.getInt(H2_SETTINGS_HEADER_TABLE_SIZE_KEY, 4096))
+                    .pushEnabled(config.getBoolean(H2_SETTINGS_ENABLE_PUSH_KEY, false))
+                    .maxConcurrentStreams(config.getInt(H2_SETTINGS_MAX_CONCURRENT_STREAMS_KEY, Integer.MAX_VALUE))
+                    .initialWindowSize(config.getInt(H2_SETTINGS_INITIAL_WINDOW_SIZE_KEY, 1 << 20))
+                    .maxFrameSize(config.getInt(H2_SETTINGS_MAX_FRAME_SIZE_KEY, 2 << 14))
+                    .maxHeaderListSize(config.getInt(H2_SETTINGS_MAX_HEADER_LIST_SIZE_KEY, 8192)))
                 .frameLogger(CLIENT_LOGGER)
                 .build();
         final Http2MultiplexHandler handler = new Http2MultiplexHandler(new SimpleChannelInboundHandler<Object>() {


### PR DESCRIPTION
## What is the purpose of the change
HTTP2 Settings should be able to configured by user in different sences. Hard code in current code should be substituted.

## Brief changelog
supported to configure all HTTP2 settings: SETTINGS_HEADER_TABLE_SIZE, SETTINGS_ENABLE_PUSH, SETTINGS_MAX_CONCURRENT_STREAMS, SETTINGS_INITIAL_WINDOW_SIZE, SETTINGS_MAX_FRAME_SIZE, SETTINGS_MAX_HEADER_LIST_SIZE 

## Verifying this change
yes


<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [ ] GitHub Actions works fine on your own branch.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
