### PR TITLE
[3.0-Triple] fix tri stream method can not find methodDescriptor

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/rpc/model/MethodDescriptor.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/rpc/model/MethodDescriptor.java
@@ -62,10 +62,17 @@ public class MethodDescriptor {
     private final RpcType rpcType;
     private final ConcurrentMap<String, Object> attributeMap = new ConcurrentHashMap<>();
 
+    // only for tri protocol
+    // support StreamObserver ...
+    private final Class<?>[] realParameterClasses;
+    private final Class<?> realReturnClass;
+
     public MethodDescriptor(Method method) {
         this.method = method;
         this.methodName = method.getName();
         Class<?>[] parameterTypes = method.getParameterTypes();
+        realParameterClasses = parameterTypes;
+        realReturnClass = method.getReturnType();
         // bidirectional-stream: StreamObserver<Request> foo(StreamObserver<Response>)
         if (parameterTypes.length == 1 && isStreamType(parameterTypes[0])) {
             this.parameterClasses = new Class<?>[]{
@@ -317,6 +324,15 @@ public class MethodDescriptor {
 
     public Object getAttribute(String key) {
         return this.attributeMap.get(key);
+    }
+
+
+    public Class<?>[] getRealParameterClasses() {
+        return realParameterClasses;
+    }
+
+    public Class<?> getRealReturnClass() {
+        return realReturnClass;
     }
 
     public enum RpcType {

--- a/dubbo-common/src/main/java/org/apache/dubbo/rpc/model/ServiceDescriptor.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/rpc/model/ServiceDescriptor.java
@@ -102,8 +102,12 @@ public class ServiceDescriptor {
     public MethodDescriptor getMethod(String methodName, Class<?>[] paramTypes) {
         List<MethodDescriptor> methodModels = methods.get(methodName);
         if (CollectionUtils.isNotEmpty(methodModels)) {
-            for (int i = 0; i < methodModels.size(); i++) {
-                MethodDescriptor descriptor = methodModels.get(i);
+            // fix tri stream mode can not find md
+            // todo change methods map key
+            if (methodModels.size() == 1) {
+                return methodModels.get(0);
+            }
+            for (MethodDescriptor descriptor : methodModels) {
                 if (Arrays.equals(paramTypes, descriptor.getParameterClasses())) {
                     return descriptor;
                 }

--- a/dubbo-common/src/main/java/org/apache/dubbo/rpc/model/ServiceDescriptor.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/rpc/model/ServiceDescriptor.java
@@ -112,19 +112,6 @@ public class ServiceDescriptor {
         return null;
     }
 
-
-    // public MethodDescriptor getMethodByMethodParams(String methodParamsName) {
-    //     return methodWithParams.get(methodParamsName);
-    // }
-    //
-    // public MethodDescriptor getMethodByMethodParams(Method method) {
-    //     return methodWithParams.get(getMethodWithParamName(method));
-    // }
-    //
-    // public MethodDescriptor getMethodByMethodParams(String methodName, Class<?>[] paramTypes) {
-    //     return methodWithParams.get(getMethodWithParamName(methodName,paramTypes));
-    // }
-
     public List<MethodDescriptor> getMethods(String methodName) {
         return methods.get(methodName);
     }

--- a/dubbo-common/src/main/java/org/apache/dubbo/rpc/model/ServiceDescriptor.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/rpc/model/ServiceDescriptor.java
@@ -110,11 +110,6 @@ public class ServiceDescriptor {
     public MethodDescriptor getMethod(String methodName, Class<?>[] paramTypes) {
         List<MethodDescriptor> methodModels = methods.get(methodName);
         if (CollectionUtils.isNotEmpty(methodModels)) {
-            // fix tri stream mode can not find md
-            // todo change methods map key
-            if (methodModels.size() == 1) {
-                return methodModels.get(0);
-            }
             for (MethodDescriptor descriptor : methodModels) {
                 if (Arrays.equals(paramTypes, descriptor.getParameterClasses())) {
                     return descriptor;

--- a/dubbo-common/src/main/java/org/apache/dubbo/rpc/model/ServiceDescriptor.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/rpc/model/ServiceDescriptor.java
@@ -16,7 +16,6 @@
  */
 package org.apache.dubbo.rpc.model;
 
-import org.apache.dubbo.common.utils.ArrayUtils;
 import org.apache.dubbo.common.utils.CollectionUtils;
 
 import java.lang.reflect.Method;
@@ -39,11 +38,6 @@ public class ServiceDescriptor {
     private final Map<String, List<MethodDescriptor>> methods = new HashMap<>();
     private final Map<String, Map<String, MethodDescriptor>> descToMethods = new HashMap<>();
 
-    // method#params#params2
-    private final Map<String, MethodDescriptor> methodWithParams = new HashMap<>();
-
-    public static final String METHOD_PARAMS_SEPARATOR = "#";
-
     public ServiceDescriptor(Class<?> interfaceClass) {
         this.serviceInterfaceClass = interfaceClass;
         this.serviceName = interfaceClass.getName();
@@ -56,7 +50,6 @@ public class ServiceDescriptor {
             method.setAccessible(true);
 
             MethodDescriptor methodDescriptor = new MethodDescriptor(method);
-            methodWithParams.put(getMethodWithParamName(method), methodDescriptor);
 
             List<MethodDescriptor> methodModels = methods.computeIfAbsent(method.getName(), (k) -> new ArrayList<>(1));
             methodModels.add(methodDescriptor);
@@ -120,17 +113,17 @@ public class ServiceDescriptor {
     }
 
 
-    public MethodDescriptor getMethodByMethodParams(String methodParamsName) {
-        return methodWithParams.get(methodParamsName);
-    }
-
-    public MethodDescriptor getMethodByMethodParams(Method method) {
-        return methodWithParams.get(getMethodWithParamName(method));
-    }
-
-    public MethodDescriptor getMethodByMethodParams(String methodName, Class<?>[] paramTypes) {
-        return methodWithParams.get(getMethodWithParamName(methodName,paramTypes));
-    }
+    // public MethodDescriptor getMethodByMethodParams(String methodParamsName) {
+    //     return methodWithParams.get(methodParamsName);
+    // }
+    //
+    // public MethodDescriptor getMethodByMethodParams(Method method) {
+    //     return methodWithParams.get(getMethodWithParamName(method));
+    // }
+    //
+    // public MethodDescriptor getMethodByMethodParams(String methodName, Class<?>[] paramTypes) {
+    //     return methodWithParams.get(getMethodWithParamName(methodName,paramTypes));
+    // }
 
     public List<MethodDescriptor> getMethods(String methodName) {
         return methods.get(methodName);
@@ -154,23 +147,5 @@ public class ServiceDescriptor {
     @Override
     public int hashCode() {
         return Objects.hash(serviceName, serviceInterfaceClass, methods, descToMethods);
-    }
-
-    public static String getMethodWithParamName(Method method) {
-        return getMethodWithParamName(method.getName(), method.getParameterTypes());
-    }
-
-    public static String getMethodWithParamName(String methodName, Class<?>[] paramsClass) {
-        StringBuilder sb = new StringBuilder();
-        sb.append(methodName);
-        sb.append(METHOD_PARAMS_SEPARATOR);
-        if (ArrayUtils.isEmpty(paramsClass)) {
-            return sb.deleteCharAt(sb.length() - 1).toString();
-        }
-        for (Class<?> aClass : paramsClass) {
-            sb.append(aClass.getName());
-            sb.append(METHOD_PARAMS_SEPARATOR);
-        }
-        return sb.deleteCharAt(sb.length() - 1).toString();
     }
 }

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/RpcInvocation.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/RpcInvocation.java
@@ -58,13 +58,7 @@ public class RpcInvocation implements Invocation, Serializable {
 
     private ServiceModel serviceModel;
 
-    // Convenient for subsequent use
-    private MethodDescriptor methodDescriptor;
-
     private String methodName;
-
-    // the same as ServiceDescriptor methodWithParams
-    private String methodWithParamsName;
 
     private String serviceName;
 
@@ -177,8 +171,6 @@ public class RpcInvocation implements Invocation, Serializable {
                          Map<String, Object> attachments, Invoker<?> invoker, Map<Object, Object> attributes) {
         this.serviceModel = serviceModel;
         this.methodName = methodName;
-        String methodWithParamsName = ServiceDescriptor.getMethodWithParamName(methodName, parameterTypes);
-        this.methodWithParamsName = methodWithParamsName;
         this.serviceName = serviceName;
         this.protocolServiceKey = protocolServiceKey;
         this.parameterTypes = parameterTypes == null ? new Class<?>[0] : parameterTypes;
@@ -206,13 +198,12 @@ public class RpcInvocation implements Invocation, Serializable {
         }
 
         if (serviceDescriptor.get() != null) {
-            MethodDescriptor methodDescriptor = serviceDescriptor.get().getMethodByMethodParams(methodWithParamsName);
+            MethodDescriptor methodDescriptor = serviceDescriptor.get().getMethod(methodName, parameterTypes);
             if (methodDescriptor != null) {
                 this.parameterTypesDesc = methodDescriptor.getParamDesc();
                 this.compatibleParamSignatures = methodDescriptor.getCompatibleParamSignatures();
                 this.returnTypes = methodDescriptor.getReturnTypes();
                 this.returnType = methodDescriptor.getReturnClass();
-                this.methodDescriptor = methodDescriptor;
             }
         }
 
@@ -478,14 +469,6 @@ public class RpcInvocation implements Invocation, Serializable {
             return null;
         }
         return attachments.get(key);
-    }
-
-    public String getMethodWithParamsName() {
-        return methodWithParamsName;
-    }
-
-    public MethodDescriptor getMethodDescriptor() {
-        return methodDescriptor;
     }
 
     public Class<?> getReturnType() {

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/RpcInvocation.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/RpcInvocation.java
@@ -57,7 +57,12 @@ public class RpcInvocation implements Invocation, Serializable {
     private String protocolServiceKey;
 
     private ServiceModel serviceModel;
+
     private String methodName;
+
+    // the same as ServiceDescriptor methodWithParams
+    private String methodWithParamsName;
+
     private String serviceName;
 
     private transient Class<?>[] parameterTypes;
@@ -169,6 +174,7 @@ public class RpcInvocation implements Invocation, Serializable {
                          Map<String, Object> attachments, Invoker<?> invoker, Map<Object, Object> attributes) {
         this.serviceModel = serviceModel;
         this.methodName = methodName;
+        this.methodWithParamsName = ServiceDescriptor.getMethodWithParamName(methodName, parameterTypes);
         this.serviceName = serviceName;
         this.protocolServiceKey = protocolServiceKey;
         this.parameterTypes = parameterTypes == null ? new Class<?>[0] : parameterTypes;
@@ -467,6 +473,10 @@ public class RpcInvocation implements Invocation, Serializable {
             return null;
         }
         return attachments.get(key);
+    }
+
+    public String getMethodWithParamsName() {
+        return methodWithParamsName;
     }
 
     public Class<?> getReturnType() {

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/RpcInvocation.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/RpcInvocation.java
@@ -58,6 +58,9 @@ public class RpcInvocation implements Invocation, Serializable {
 
     private ServiceModel serviceModel;
 
+    // Convenient for subsequent use
+    private MethodDescriptor methodDescriptor;
+
     private String methodName;
 
     // the same as ServiceDescriptor methodWithParams
@@ -174,7 +177,8 @@ public class RpcInvocation implements Invocation, Serializable {
                          Map<String, Object> attachments, Invoker<?> invoker, Map<Object, Object> attributes) {
         this.serviceModel = serviceModel;
         this.methodName = methodName;
-        this.methodWithParamsName = ServiceDescriptor.getMethodWithParamName(methodName, parameterTypes);
+        String methodWithParamsName = ServiceDescriptor.getMethodWithParamName(methodName, parameterTypes);
+        this.methodWithParamsName = methodWithParamsName;
         this.serviceName = serviceName;
         this.protocolServiceKey = protocolServiceKey;
         this.parameterTypes = parameterTypes == null ? new Class<?>[0] : parameterTypes;
@@ -202,12 +206,13 @@ public class RpcInvocation implements Invocation, Serializable {
         }
 
         if (serviceDescriptor.get() != null) {
-            MethodDescriptor methodDescriptor = serviceDescriptor.get().getMethod(methodName, parameterTypes);
+            MethodDescriptor methodDescriptor = serviceDescriptor.get().getMethodByMethodParams(methodWithParamsName);
             if (methodDescriptor != null) {
                 this.parameterTypesDesc = methodDescriptor.getParamDesc();
                 this.compatibleParamSignatures = methodDescriptor.getCompatibleParamSignatures();
                 this.returnTypes = methodDescriptor.getReturnTypes();
                 this.returnType = methodDescriptor.getReturnClass();
+                this.methodDescriptor = methodDescriptor;
             }
         }
 
@@ -477,6 +482,10 @@ public class RpcInvocation implements Invocation, Serializable {
 
     public String getMethodWithParamsName() {
         return methodWithParamsName;
+    }
+
+    public MethodDescriptor getMethodDescriptor() {
+        return methodDescriptor;
     }
 
     public Class<?> getReturnType() {

--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/AbstractServerStream.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/AbstractServerStream.java
@@ -154,8 +154,9 @@ public abstract class AbstractServerStream extends AbstractStream implements Str
                 }
                 if (getMethodDescriptor() == null) {
                     final String[] paramTypes = wrapper.getArgTypesList().toArray(new String[wrapper.getArgsCount()]);
-
+                    // wrapper mode the method can overload so maybe list
                     for (MethodDescriptor descriptor : getMethodDescriptors()) {
+                        // params type is array
                         if (Arrays.equals(descriptor.getCompatibleParamSignatures(), paramTypes)) {
                             method(descriptor);
                             break;

--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/TripleClientHandler.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/TripleClientHandler.java
@@ -75,11 +75,7 @@ public class TripleClientHandler extends ChannelDuplexHandler {
         ConsumerModel consumerModel = (ConsumerModel) url.getServiceModel();
 
         MethodDescriptor methodDescriptor = inv.getMethodDescriptor();
-        // String serviceKey = url.getServiceKey();
-        // // If it is InstanceAddressURL, the serviceKey may not be obtained.
-        // if (null == serviceKey) {
-        //     serviceKey = inv.getTargetServiceUniqueName();
-        // }
+
         ClassLoadUtil.switchContextLoader(consumerModel.getServiceInterfaceClass().getClassLoader());
         AbstractClientStream stream;
         if (methodDescriptor.isUnary()) {

--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/TripleClientHandler.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/TripleClientHandler.java
@@ -74,7 +74,7 @@ public class TripleClientHandler extends ChannelDuplexHandler {
         final URL url = inv.getInvoker().getUrl();
         ConsumerModel consumerModel = (ConsumerModel) url.getServiceModel();
 
-        MethodDescriptor methodDescriptor = consumerModel.getServiceModel().getMethodByMethodParams(inv.getMethodWithParamsName());
+        MethodDescriptor methodDescriptor = inv.getMethodDescriptor();
         // String serviceKey = url.getServiceKey();
         // // If it is InstanceAddressURL, the serviceKey may not be obtained.
         // if (null == serviceKey) {

--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/TripleClientHandler.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/TripleClientHandler.java
@@ -74,12 +74,12 @@ public class TripleClientHandler extends ChannelDuplexHandler {
         final URL url = inv.getInvoker().getUrl();
         ConsumerModel consumerModel = (ConsumerModel) url.getServiceModel();
 
-        MethodDescriptor methodDescriptor = consumerModel.getServiceModel().getMethod(inv.getMethodName(), inv.getParameterTypes());
-        String serviceKey = url.getServiceKey();
-        // If it is InstanceAddressURL, the serviceKey may not be obtained.
-        if (null == serviceKey) {
-            serviceKey = inv.getTargetServiceUniqueName();
-        }
+        MethodDescriptor methodDescriptor = consumerModel.getServiceModel().getMethodByMethodParams(inv.getMethodWithParamsName());
+        // String serviceKey = url.getServiceKey();
+        // // If it is InstanceAddressURL, the serviceKey may not be obtained.
+        // if (null == serviceKey) {
+        //     serviceKey = inv.getTargetServiceUniqueName();
+        // }
         ClassLoadUtil.switchContextLoader(consumerModel.getServiceInterfaceClass().getClassLoader());
         AbstractClientStream stream;
         if (methodDescriptor.isUnary()) {

--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/TripleHttp2FrameServerHandler.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/TripleHttp2FrameServerHandler.java
@@ -173,7 +173,7 @@ public class TripleHttp2FrameServerHandler extends ChannelDuplexHandler {
         MethodDescriptor methodDescriptor = null;
         List<MethodDescriptor> methodDescriptors = null;
 
-        if (isINVOKE(methodName)) {
+        if (isGeneric(methodName)) {
             // There should be one and only one
             methodDescriptor = ServiceDescriptorInternalCache.genericService().getMethods(methodName).get(0);
         } else if (isEcho(methodName)) {
@@ -221,7 +221,7 @@ public class TripleHttp2FrameServerHandler extends ChannelDuplexHandler {
         return CommonConstants.$ECHO.equals(methodName);
     }
 
-    private boolean isINVOKE(String methodName) {
+    private boolean isGeneric(String methodName) {
         return CommonConstants.$INVOKE.equals(methodName) || CommonConstants.$INVOKE_ASYNC.equals(methodName);
     }
 

--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/TripleHttp2FrameServerHandler.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/TripleHttp2FrameServerHandler.java
@@ -20,6 +20,7 @@ import org.apache.dubbo.common.URL;
 import org.apache.dubbo.common.constants.CommonConstants;
 import org.apache.dubbo.common.logger.Logger;
 import org.apache.dubbo.common.logger.LoggerFactory;
+import org.apache.dubbo.common.utils.CollectionUtils;
 import org.apache.dubbo.rpc.Invoker;
 import org.apache.dubbo.rpc.model.FrameworkModel;
 import org.apache.dubbo.rpc.model.FrameworkServiceRepository;
@@ -172,17 +173,20 @@ public class TripleHttp2FrameServerHandler extends ChannelDuplexHandler {
         MethodDescriptor methodDescriptor = null;
         List<MethodDescriptor> methodDescriptors = null;
 
-        if (CommonConstants.$INVOKE.equals(methodName) || CommonConstants.$INVOKE_ASYNC.equals(methodName)) {
+        if (isINVOKE(methodName)) {
+            // There should be one and only one
             methodDescriptor = ServiceDescriptorInternalCache.genericService().getMethods(methodName).get(0);
-        } else if (CommonConstants.$ECHO.equals(methodName)) {
+        } else if (isEcho(methodName)) {
+            // There should be one and only one
             methodDescriptor = ServiceDescriptorInternalCache.echoService().getMethods(methodName).get(0);
         } else {
             methodDescriptors = providerModel.getServiceModel().getMethods(methodName);
-            if (methodDescriptors == null || methodDescriptors.isEmpty()) {
+            if (CollectionUtils.isEmpty(methodDescriptors)) {
                 responseErr(ctx, GrpcStatus.fromCode(Code.UNIMPLEMENTED)
                         .withDescription("Method :" + methodName + " not found of service:" + serviceName));
                 return;
             }
+            // In most cases there is only one method
             if (methodDescriptors.size() == 1) {
                 methodDescriptor = methodDescriptors.get(0);
             }
@@ -200,6 +204,7 @@ public class TripleHttp2FrameServerHandler extends ChannelDuplexHandler {
         if (methodDescriptor != null) {
             stream.method(methodDescriptor);
         } else {
+            // Then you need to find the corresponding parameter according to the request body
             stream.methods(methodDescriptors);
         }
         final TransportObserver observer = stream.asTransportObserver();
@@ -210,4 +215,14 @@ public class TripleHttp2FrameServerHandler extends ChannelDuplexHandler {
 
         ctx.channel().attr(TripleUtil.SERVER_STREAM_KEY).set(stream);
     }
+
+
+    private boolean isEcho(String methodName) {
+        return CommonConstants.$ECHO.equals(methodName);
+    }
+
+    private boolean isINVOKE(String methodName) {
+        return CommonConstants.$INVOKE.equals(methodName) || CommonConstants.$INVOKE_ASYNC.equals(methodName);
+    }
+
 }


### PR DESCRIPTION
## What is the purpose of the change

- fix tri stream method can not find methodDescriptor (Because of multiple instances)

## Brief changelog


## Verifying this change


<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [ ] GitHub Actions works fine on your own branch.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
