### PR TITLE
[3.0] Judge whether success or not by user's perspective in interface-appName mapping.

### DIFF
--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/metadata/MetadataServiceNameMapping.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/metadata/MetadataServiceNameMapping.java
@@ -78,7 +78,7 @@ public class MetadataServiceNameMapping extends AbstractServiceNameMapping imple
             if (StringUtils.isNotEmpty(oldConfigContent)) {
                 boolean contains = StringUtils.isContains(oldConfigContent, appName);
                 if (contains) {
-                    // From user's perspective, it means successful when the oldConfigContent has contained the current appName. So we should not throw an Exception to user, it will confused user.
+                    // From the user's perspective, it means successful when the oldConfigContent has contained the current appName. So we should not throw an Exception to user, it will confuse the user.
                     succeeded = true;
                     break;
                 }

--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/metadata/MetadataServiceNameMapping.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/metadata/MetadataServiceNameMapping.java
@@ -53,38 +53,40 @@ public class MetadataServiceNameMapping extends AbstractServiceNameMapping imple
 
     @Override
     public boolean map(URL url) {
-            if (CollectionUtils.isEmpty(applicationModel.getApplicationConfigManager().getMetadataConfigs())) {
-                return false;
-            }
-            String serviceInterface = url.getServiceInterface();
-            if (IGNORED_SERVICE_INTERFACES.contains(serviceInterface)) {
-                return false;
-            }
-            String registryCluster = getRegistryCluster(url);
-            MetadataReport metadataReport = metadataReportInstance.getMetadataReport(registryCluster);
+        if (CollectionUtils.isEmpty(applicationModel.getApplicationConfigManager().getMetadataConfigs())) {
+            return false;
+        }
+        String serviceInterface = url.getServiceInterface();
+        if (IGNORED_SERVICE_INTERFACES.contains(serviceInterface)) {
+            return false;
+        }
+        String registryCluster = getRegistryCluster(url);
+        MetadataReport metadataReport = metadataReportInstance.getMetadataReport(registryCluster);
 
-            String appName = applicationModel.getApplicationName();
-            if (metadataReport.registerServiceAppMapping(serviceInterface, appName, url)) {
-                // MetadataReport support directly register service-app mapping
-                return true;
-            }
+        String appName = applicationModel.getApplicationName();
+        if (metadataReport.registerServiceAppMapping(serviceInterface, appName, url)) {
+            // MetadataReport support directly register service-app mapping
+            return true;
+        }
 
-            int currentRetryTimes = 1;
-            boolean succeeded = false;
-            String newConfigContent = appName;
-            do {
-                ConfigItem configItem = metadataReport.getConfigItem(serviceInterface, DEFAULT_MAPPING_GROUP);
-                String oldConfigContent = configItem.getContent();
-                if (StringUtils.isNotEmpty(oldConfigContent)) {
-                    boolean contains = StringUtils.isContains(oldConfigContent, appName);
-                    if (contains) {
-                        break;
-                    }
-                    newConfigContent = oldConfigContent + COMMA_SEPARATOR + appName;
+        int currentRetryTimes = 1;
+        boolean succeeded = false;
+        String newConfigContent = appName;
+        do {
+            ConfigItem configItem = metadataReport.getConfigItem(serviceInterface, DEFAULT_MAPPING_GROUP);
+            String oldConfigContent = configItem.getContent();
+            if (StringUtils.isNotEmpty(oldConfigContent)) {
+                boolean contains = StringUtils.isContains(oldConfigContent, appName);
+                if (contains) {
+                    // From user's perspective, it means successful when the oldConfigContent has contained the current appName. So we should not throw an Exception to user, it will confused user.
+                    succeeded = true;
+                    break;
                 }
-                succeeded = metadataReport.registerServiceAppMapping(serviceInterface, DEFAULT_MAPPING_GROUP, newConfigContent, configItem.getTicket());
-            } while (!succeeded && currentRetryTimes++ <= CAS_RETRY_TIMES);
-            if (!succeeded) {
+                newConfigContent = oldConfigContent + COMMA_SEPARATOR + appName;
+            }
+            succeeded = metadataReport.registerServiceAppMapping(serviceInterface, DEFAULT_MAPPING_GROUP, newConfigContent, configItem.getTicket());
+        } while (!succeeded && currentRetryTimes++ <= CAS_RETRY_TIMES);
+        if (!succeeded) {
             throw new RuntimeException();
         }
 


### PR DESCRIPTION
## What is the purpose of the change
* Judge whether success or not by user's perspective in interface-appName mapping.
* By the way, format the function `MetadataServiceNameMapping#map`: change the indent spaces from 8 to 4.

Fixes #8722 

## Brief changelog
Every time the provider restarted after the first start,  it would raise an error "Failed register interface application mapping......".
But from the user's perspective, it means successful when the oldConfigContent has contained the current appName. So we should not throw an Exception to the user, it will confuse the user.

Just change one line code：
```java
// => org.apache.dubbo.registry.client.metadata.MetadataServiceNameMapping#map
public boolean map(URL url) {
    // ......
    if (StringUtils.isNotEmpty(oldConfigContent)) {
        boolean contains = StringUtils.isContains(oldConfigContent, appName);
        if (contains) {
            // From user's perspective, it means successful when the oldConfigContent has contained the current appName. So we should not throw an Exception to user, it will confuse user.
            succeeded = true;   // <= The only changes for this function.
            break;
        }
        newConfigContent = oldConfigContent + COMMA_SEPARATOR + appName;
    }
    // ......
}
```


What's more, the `map` function is only called by `ServiceConfig#export`，the changes are safe.
```java
// => org.apache.dubbo.config.ServiceConfig#export
protected void exported() {
    exported = true;
    List<URL> exportedURLs = this.getExportedUrls();
    exportedURLs.forEach(url -> {
        if (url.getParameters().containsKey(SERVICE_NAME_MAPPING_KEY)) {
            ServiceNameMapping serviceNameMapping = ServiceNameMapping.getDefaultExtension(getScopeModel());
            try {
                // try to register
                boolean succeeded = serviceNameMapping.map(url);
                if (succeeded) {
                    logger.info("Successfully registered interface application mapping for service " + url.getServiceKey());
                }
            } catch (Exception e) {
                logger.error("Failed register interface application mapping for service " + url.getServiceKey(), e);
            }
        }
    });
    onExported();
}
```
