### PR TITLE
[3.0] fix ignored interface name matches method

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/utils/NetUtils.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/utils/NetUtils.java
@@ -43,6 +43,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
 
 import static java.util.Collections.emptyList;
 import static org.apache.dubbo.common.constants.CommonConstants.ANYHOST_VALUE;
@@ -332,8 +333,20 @@ public class NetUtils {
         if (StringUtils.isNotEmpty(ignoredInterfaces)
             && StringUtils.isNotEmpty(networkInterfaceDisplayName = networkInterface.getDisplayName())) {
             for (String ignoredInterface : ignoredInterfaces.split(",")) {
-                if (networkInterfaceDisplayName.matches(ignoredInterface.trim())) {
-                    return true;
+                String trimIgnoredInterface = ignoredInterface.trim();
+                boolean matched = false;
+                try {                     
+                    matched = networkInterfaceDisplayName.matches(trimIgnoredInterface);
+                } catch (PatternSyntaxException e) {
+                    // if trimIgnoredInterface is a invalid regular expression, a PatternSyntaxException will be thrown out
+                    logger.warn("exception occurred: " + networkInterfaceDisplayName + " matches " + trimIgnoredInterface, e);
+                } finally {
+                    if (matched) {
+                        return true;
+                    }
+                    if (networkInterfaceDisplayName.equals(trimIgnoredInterface)) {
+                        return true;
+                    }
                 }
             }
         }

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/utils/NetUtilsInterfaceDisplayNameHasMetaCharactersTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/utils/NetUtilsInterfaceDisplayNameHasMetaCharactersTest.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.common.utils;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import java.util.Enumeration;
+import java.util.NoSuchElementException;
+import java.net.InetAddress;
+import java.net.NetworkInterface;
+
+import static org.apache.dubbo.common.constants.CommonConstants.DUBBO_NETWORK_IGNORED_INTERFACE;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class NetUtilsInterfaceDisplayNameHasMetaCharactersTest {
+    private static final String IGNORED_DISPLAY_NAME_HAS_METACHARACTERS = "Mock(R) ^$*+?.|-[0-9] Adapter";
+    private static final String SELECTED_DISPLAY_NAME = "Selected Adapter";
+    private static final String SELECTED_HOST_ADDR = "192.168.0.1";
+
+    @Test
+    public void testIgnoreGivenInterfaceNameWithMetaCharacters() throws Exception {
+        String originIgnoredInterfaces = this.getIgnoredInterfaces();
+        // mock static methods of final class NetworkInterface
+        try (MockedStatic<NetworkInterface> mockedStaticNetif = Mockito.mockStatic(NetworkInterface.class)) {
+            NetworkInterface mockIgnoredNetif = Mockito.mock(NetworkInterface.class);
+            NetworkInterface mockSelectedNetif = Mockito.mock(NetworkInterface.class);
+            NetworkInterface[] mockNetifs = { mockIgnoredNetif, mockSelectedNetif };
+            Enumeration<NetworkInterface> mockEnumIfs = new Enumeration<NetworkInterface>() {
+                private int i = 0;
+                public NetworkInterface nextElement() {
+                    if (mockNetifs != null && i < mockNetifs.length) {
+                        NetworkInterface netif = mockNetifs[i++];
+                        return netif;
+                    } else {
+                        throw new NoSuchElementException();
+                    }
+                }
+
+                public boolean hasMoreElements() {
+                    return (mockNetifs != null && i < mockNetifs.length);
+                }
+            };
+
+            InetAddress mockSelectedAddr = Mockito.mock(InetAddress.class);
+            InetAddress[] mockAddrs = { mockSelectedAddr };
+            Enumeration<InetAddress> mockEnumAddrs = new Enumeration<InetAddress>() {
+                private int i = 0;
+                public InetAddress nextElement() {
+                    if (mockAddrs != null && i < mockAddrs.length) {
+                        InetAddress addr = mockAddrs[i++];
+                        return addr;
+                    } else {
+                        throw new NoSuchElementException();
+                    }
+                }
+
+                public boolean hasMoreElements() {
+                    return (mockAddrs != null && i < mockAddrs.length);
+                }
+            };
+
+            // mock static method getNetworkInterfaces
+            mockedStaticNetif.when(() -> { NetworkInterface.getNetworkInterfaces(); }).thenReturn(mockEnumIfs);
+
+            Mockito.when(mockIgnoredNetif.isUp()).thenReturn(true);
+            Mockito.when(mockIgnoredNetif.getDisplayName()).thenReturn(IGNORED_DISPLAY_NAME_HAS_METACHARACTERS);
+
+            Mockito.when(mockSelectedNetif.isUp()).thenReturn(true);
+            Mockito.when(mockSelectedNetif.getDisplayName()).thenReturn(SELECTED_DISPLAY_NAME);
+            Mockito.when(mockSelectedNetif.getInetAddresses()).thenReturn(mockEnumAddrs);
+
+            Mockito.when(mockSelectedAddr.isLoopbackAddress()).thenReturn(false);
+            Mockito.when(mockSelectedAddr.getHostAddress()).thenReturn(SELECTED_HOST_ADDR);
+            Mockito.when(mockSelectedAddr.isReachable(Mockito.anyInt())).thenReturn(true);
+
+            this.setIgnoredInterfaces(IGNORED_DISPLAY_NAME_HAS_METACHARACTERS);
+            NetworkInterface newNetworkInterface = NetUtils.findNetworkInterface();
+            assertTrue(!IGNORED_DISPLAY_NAME_HAS_METACHARACTERS.equals(newNetworkInterface.getDisplayName()));
+        } finally {
+            // recover the origin ignored interfaces
+            this.setIgnoredInterfaces(originIgnoredInterfaces);
+        }
+    }
+
+    private String getIgnoredInterfaces(){
+        return System.getProperty(DUBBO_NETWORK_IGNORED_INTERFACE);
+    }
+
+    private void setIgnoredInterfaces(String ignoredInterfaces){
+        if(ignoredInterfaces!=null){
+            System.setProperty(DUBBO_NETWORK_IGNORED_INTERFACE,ignoredInterfaces);
+        }else{
+            System.setProperty(DUBBO_NETWORK_IGNORED_INTERFACE,"");
+        }
+    }
+
+}

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/utils/NetUtilsTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/utils/NetUtilsTest.java
@@ -25,6 +25,7 @@ import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.NetworkInterface;
 import java.net.UnknownHostException;
+import java.util.regex.Pattern;
 
 import static org.apache.dubbo.common.constants.CommonConstants.DUBBO_NETWORK_IGNORED_INTERFACE;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -336,7 +337,7 @@ public class NetUtilsTest {
         String originIgnoredInterfaces = this.getIgnoredInterfaces();
         try {
             // ignore all interfaces
-            this.setIgnoredInterfaces("*");
+            this.setIgnoredInterfaces(".*");
             assertNull(NetUtils.findNetworkInterface());
         } finally {
             // recover the origin ignored interfaces
@@ -352,7 +353,7 @@ public class NetUtilsTest {
             NetworkInterface networkInterface = NetUtils.findNetworkInterface();
             assertNotNull(networkInterface);
             // ignore the given network interface's display name
-            this.setIgnoredInterfaces(networkInterface.getDisplayName());
+            this.setIgnoredInterfaces(Pattern.quote(networkInterface.getDisplayName()));
             NetworkInterface newNetworkInterface = NetUtils.findNetworkInterface();
             if (newNetworkInterface != null) {
                 assertTrue(!networkInterface.getDisplayName().equals(newNetworkInterface.getDisplayName()));
@@ -373,7 +374,7 @@ public class NetUtilsTest {
             // ignore the given prefix network interface's display name
             String displayName = networkInterface.getDisplayName();
             if (StringUtils.isNotEmpty(displayName) && displayName.length() > 2) {
-                String ignoredInterfaces = displayName.substring(0, 1) + ".*";
+                String ignoredInterfaces = Pattern.quote(displayName.substring(0, 1)) + ".*";
                 this.setIgnoredInterfaces(ignoredInterfaces);
                 NetworkInterface newNetworkInterface = NetUtils.findNetworkInterface();
                 if (newNetworkInterface != null) {


### PR DESCRIPTION
## What is the purpose of the change
fix #8581 on  branch 3.0