### PR TITLE
ignore MetadataService destroy

### DIFF
--- a/dubbo-rpc/dubbo-rpc-dubbo/src/main/java/org/apache/dubbo/rpc/protocol/dubbo/ReferenceCountExchangeClient.java
+++ b/dubbo-rpc/dubbo-rpc-dubbo/src/main/java/org/apache/dubbo/rpc/protocol/dubbo/ReferenceCountExchangeClient.java
@@ -158,7 +158,8 @@ final class ReferenceCountExchangeClient implements ExchangeClient {
 
     @Override
     public void close(int timeout) {
-        if (referenceCount.decrementAndGet() <= 0) {
+        // ignore MetadataService destroy
+        if (referenceCount.decrementAndGet() <= 1) {
             if (timeout == 0) {
                 client.close();
 


### PR DESCRIPTION
## What is the purpose of the change
临时解决 #6404 问题。
Temporary solution for #6404 issue.

Provider优雅停机时，Consumer中MetadataService的DubboInvoder没有销毁，导致ReferenceCountExchangeClient.referenceCount没有正常-1的问题。
然后导致ReconnectTimerTask重连异常日志。

When the Provider shuts down gracefully, the DubboInvoder of the MetadataService in the Consumer is not destroyed, resulting in the problem of ReferenceCountExchangeClient.referenceCount not being normal -1.
Then cause the ReconnectTimerTask to reconnect to the abnormal log.

## Brief changelog
ignore MetadataService destroy

## Verifying this change
a temp pull request to solve  ReconnectTimerTask reconnect error log。Please help me to check，thx.

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [ ] GitHub Actions works fine on your own branch.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
