### PR TITLE
add peakEwmaLoadBalance

### DIFF
--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/Constants.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/Constants.java
@@ -139,4 +139,9 @@ public interface Constants {
      * The key of shortestResponseSlidePeriod
      */
     String SHORTEST_RESPONSE_SLIDE_PERIOD = "shortestResponseSlidePeriod";
+
+    /**
+     * The key of peakEwmaDecayTime
+     */
+    String PEAK_EWMA_DECAY_TIME = "peakEwmaDecayTime";
 }

--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/loadbalance/PeakEwmaLoadBalance.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/loadbalance/PeakEwmaLoadBalance.java
@@ -1,0 +1,142 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.rpc.cluster.loadbalance;
+
+import org.apache.dubbo.common.URL;
+import org.apache.dubbo.rpc.Invocation;
+import org.apache.dubbo.rpc.Invoker;
+import org.apache.dubbo.rpc.RpcStatus;
+import org.apache.dubbo.rpc.cluster.Constants;
+import org.apache.dubbo.rpc.model.ApplicationModel;
+import org.apache.dubbo.rpc.model.ScopeModelAware;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.locks.ReentrantLock;
+
+/**
+ * <p>
+ * PeakEwmaLoadBalance is designed to converge quickly when encountering slow endpoints.
+ * It is quick to react to latency spikes recovering only cautiously.Peak EWMA takes
+ * history into account,so that slow behavior is penalized relative to the
+ * supplied `decayTime`.
+ * if there are multiple invokers and the same cost,then randomly called,which doesn't care
+ * about weight.
+ * <p>
+ * Inspiration drawn from:
+ * https://github.com/twitter/finagle/blob/1bc837c4feafc0096e43c0e98516a8e1c50c4421
+ * /finagle-core/src/main/scala/com/twitter/finagle/loadbalancer/PeakEwma.scala
+ */
+public class PeakEwmaLoadBalance extends AbstractLoadBalance implements ScopeModelAware {
+
+    public static final String NAME = "peakewma";
+
+    private static final double PENALTY = Long.MAX_VALUE >> 16;
+
+    // The mean lifetime of `cost`, it reaches its half-life after decayTime*ln(2).
+    private static double decayTime = 10_000;
+
+    private ConcurrentMap<RpcStatus, Metric> methodMap = new ConcurrentHashMap<>();
+
+    @Override
+    public void setApplicationModel(ApplicationModel applicationModel) {
+        decayTime = 1.0 * applicationModel.getApplicationEnvironment().getConfiguration().getInt(Constants.PEAK_EWMA_DECAY_TIME, 10_000);
+    }
+
+    protected static class Metric {
+        // last timestamp in Millis we observed an runningTime
+        private volatile long lastUpdateTime;
+
+        // ewma of rtt, sensitive to peaks.
+        private volatile double cost;
+
+        // calculate running time And active num
+        private RpcStatus rpcStatus;
+        private long succeededOffset;
+        private long succeededElapsedOffset;
+
+        //lock for get and set cost
+        ReentrantLock ewmaLock = new ReentrantLock();
+
+        public Metric(RpcStatus rpcStatus) {
+            this.rpcStatus = rpcStatus;
+            this.lastUpdateTime = System.currentTimeMillis();
+            this.cost = 0.0;
+            this.succeededOffset = 0;
+            this.succeededElapsedOffset = 0;
+        }
+
+        private void observe() {
+            double rtt = 0;
+            long succeed = this.rpcStatus.getSucceeded() - this.succeededOffset;
+            if (succeed != 0) {
+                rtt = (this.rpcStatus.getSucceededElapsed() * 1.0 - this.succeededElapsedOffset) / succeed;
+            }
+
+            final long currentTime = System.currentTimeMillis();
+            long td = Math.max(currentTime - lastUpdateTime, 0);
+            double w = Math.exp(-td / decayTime);
+            if (rtt > cost) {
+                cost = rtt;
+            } else {
+                cost = cost * w + rtt * (1.0 - w);
+            }
+
+            lastUpdateTime = currentTime;
+            succeededOffset = rpcStatus.getSucceeded();
+            succeededElapsedOffset = rpcStatus.getSucceededElapsed();
+        }
+
+        private double getCost() {
+            ewmaLock.lock();
+            observe();
+            int active = rpcStatus.getActive();
+            ewmaLock.unlock();
+
+            //If we don't have any latency history, we penalize the host on the first probe.
+            return (cost == 0.0 && active != 0) ? PENALTY + active : cost * (active + 1);
+        }
+    }
+
+    @Override
+    protected <T> Invoker<T> doSelect(List<Invoker<T>> invokers, URL url, Invocation invocation) {
+        int length = invokers.size();
+        double minResponse = Double.MAX_VALUE;
+
+        List<Integer> selectInvokerIndexList = new ArrayList<>(invokers.size());
+        for (int i = 0; i < length; i++) {
+            Invoker<T> invoker = invokers.get(i);
+            RpcStatus rpcStatus = RpcStatus.getStatus(invoker.getUrl(), invocation.getMethodName());
+            Metric metric = methodMap.computeIfAbsent(rpcStatus, Metric::new);
+
+            // calculate the estimated response time from the product of active connections and succeeded average elapsed time.
+            double estimateResponse = metric.getCost();
+            if (estimateResponse < minResponse) {
+                selectInvokerIndexList.clear();
+                selectInvokerIndexList.add(i);
+                minResponse = estimateResponse;
+            } else if (estimateResponse == minResponse) {
+                selectInvokerIndexList.add(i);
+            }
+        }
+
+        return invokers.get(selectInvokerIndexList.get(ThreadLocalRandom.current().nextInt(selectInvokerIndexList.size())));
+    }
+}

--- a/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/loadbalance/PeakEwmaLoadBalanceTest.java
+++ b/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/loadbalance/PeakEwmaLoadBalanceTest.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License")); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.rpc.cluster.loadbalance;
+
+import org.apache.dubbo.rpc.Invoker;
+import org.apache.dubbo.rpc.RpcStatus;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.IntStream;
+
+/**
+ * PeakEwmaLoadBalanceTest
+ */
+public class PeakEwmaLoadBalanceTest extends LoadBalanceBaseTest {
+
+    private static final int THREAD_NUM = 4;
+
+    private static final int INVOKE_NUM = 2_000;
+
+    private static final long SHAKE_TIME = 50;
+
+    private AtomicInteger sumInvoker1 = new AtomicInteger(0);
+    private AtomicInteger sumInvoker2 = new AtomicInteger(0);
+    private AtomicInteger sumInvoker5 = new AtomicInteger(0);
+
+    @Test
+    public void testWithoutShake() throws InterruptedException {
+        //active -> 0
+        RpcStatus.endCount(weightInvoker5.getUrl(), weightTestInvocation.getMethodName(), 0L, true);
+
+        List<Callable<Boolean>> tasks = new ArrayList<>();
+        IntStream.range(0, THREAD_NUM).forEach(e -> tasks.add(getTask(false)));
+
+        ExecutorService executorService = Executors.newFixedThreadPool(THREAD_NUM);
+        executorService.invokeAll(tasks);
+
+        Assertions.assertTrue(Math.abs(sumInvoker2.get() - sumInvoker1.get()) <= INVOKE_NUM);
+    }
+
+    @Test
+    public void testWithShake() throws InterruptedException {
+        //active -> 0
+        RpcStatus.endCount(weightInvoker5.getUrl(), weightTestInvocation.getMethodName(), 0L, true);
+
+        List<Callable<Boolean>> tasks = new ArrayList<>();
+        IntStream.range(0, THREAD_NUM).forEach(e -> tasks.add(getTask(true)));
+
+        ExecutorService executorService = Executors.newFixedThreadPool(THREAD_NUM);
+        executorService.invokeAll(tasks);
+
+        Assertions.assertTrue(sumInvoker1.get() <= INVOKE_NUM);
+    }
+
+    private Callable<Boolean> getTask(boolean needShake) {
+        PeakEwmaLoadBalance lb = new PeakEwmaLoadBalance();
+        return () -> {
+            boolean needShakeTemp = needShake;
+            for (int i = 0; i < INVOKE_NUM; i++) {
+                Invoker selected = lb.select(weightInvokersSR, null, weightTestInvocation);
+                RpcStatus rpcStatus = RpcStatus.getStatus(selected.getUrl(), weightTestInvocation.getMethodName());
+
+                if (i > 100 && needShakeTemp && selected.getUrl().getProtocol().equals("test1")) {
+                    //invoker1 shake
+                    needShakeTemp = false;
+                    rpcStatus.beginCount(selected.getUrl(), weightTestInvocation.getMethodName());
+                    TimeUnit.MICROSECONDS.sleep(SHAKE_TIME);
+                    rpcStatus.endCount(selected.getUrl(), weightTestInvocation.getMethodName(), SHAKE_TIME, true);
+                } else {
+                    rpcStatus.beginCount(selected.getUrl(), weightTestInvocation.getMethodName());
+                    long time = ThreadLocalRandom.current().nextLong(5, 10);
+                    TimeUnit.MICROSECONDS.sleep(time);
+                    rpcStatus.endCount(selected.getUrl(), weightTestInvocation.getMethodName(), time, true);
+                }
+
+                if (selected.getUrl().getProtocol().equals("test1")) {
+                    sumInvoker1.incrementAndGet();
+                }
+
+                if (selected.getUrl().getProtocol().equals("test2")) {
+                    sumInvoker2.incrementAndGet();
+                }
+
+                if (selected.getUrl().getProtocol().equals("test5")) {
+                    sumInvoker5.incrementAndGet();
+                }
+            }
+            return true;
+        };
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change
I am disappointment with shortestResponseLoadBalance，though  it  is better than others in latency spike. However, it’s slow for it  depends on average.I am looking forwad to a sensitive loadbance.

PeakEwmaLoadBalance is designed to converge quickly when encountering slow endpoints.
It is quick to react to latency spikes recovering only cautiously.Peak EWMA takes history into account,so that slow behavior is penalized relative to the supplied `decayTime`.

Inspiration drawn from:[finagle](https://github.com/twitter/finagle/blob/1bc837c4feafc0096e43c0e98516a8e1c50c4421/finagle-core/src/main/scala/com/twitter/finagle/loadbalancer/PeakEwma.scala)

## note
We will have a try first and  feed back to the community in time.

## Brief changelog
-  calculate cost by exponential moving averages
-  add decayTime
-  ignore invoker‘s weight

## Reference
[finagle](https://github.com/twitter/finagle/blob/1bc837c4feafc0096e43c0e98516a8e1c50c4421/finagle-core/src/main/scala/com/twitter/finagle/loadbalancer/PeakEwma.scala)
[apisix](https://github.com/apache/apisix/blob/131998df4f44720b7ddf0424f4d381efb689d4ce/apisix/balancer/ewma.lua
)
[paper](http://www.eckner.com/papers/Algorithms%20for%20Unevenly%20Spaced%20Time%20Series.pdf)







