### PR TITLE
fix issue-8741: consumer and provider have same tag, but no provider …

### DIFF
--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/router/tag/TagStaticStateRouter.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/router/tag/TagStaticStateRouter.java
@@ -55,7 +55,8 @@ public class TagStaticStateRouter extends AbstractStateRouter {
     public <T> BitList<Invoker<T>> route(BitList<Invoker<T>> invokers, RouterCache<T> routerCache, URL url, Invocation invocation)
         throws RpcException {
 
-        String tag = StringUtils.isEmpty(invocation.getAttachment(TAG_KEY)) ? url.getParameter(TAG_KEY) :
+        // TagDynamicStateRouter route first, add noTag into invocation.
+        String tag = isNoTag(invocation.getAttachment(TAG_KEY)) ? url.getParameter(TAG_KEY) :
             invocation.getAttachment(TAG_KEY);
         if (StringUtils.isEmpty(tag)) {
             tag = NO_TAG;
@@ -67,6 +68,10 @@ public class TagStaticStateRouter extends AbstractStateRouter {
             return invokers;
         }
         return invokers.intersect(res, invokers.getUnmodifiableList());
+    }
+
+    private boolean isNoTag(String tag) {
+        return StringUtils.isEmpty(tag) || NO_TAG.equals(tag);
     }
 
     @Override


### PR DESCRIPTION
…found

## What is the purpose of the change

fix #8741 

tagDynamicRouter run first and add "noTag" into invocation,
then tagStaticRouter check invocation tag not emtpy, so return wrong invoker.

I just change tagStaticRouter, check tag is not empty and not equals "noTag".
But tagDynamicRouter add "noTag" may be the root reason.

## Brief changelog


## Verifying this change


<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [ ] GitHub Actions works fine on your own branch.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
