### PR TITLE
Use MapUtils instead of AttachmentsAdapter

### DIFF
--- a/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/directory/MockDirInvocation.java
+++ b/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/directory/MockDirInvocation.java
@@ -16,19 +16,17 @@
  */
 package org.apache.dubbo.rpc.cluster.directory;
 
-import org.apache.dubbo.rpc.AttachmentsAdapter;
-import org.apache.dubbo.rpc.Invocation;
-import org.apache.dubbo.rpc.Invoker;
-
 import java.util.HashMap;
 import java.util.Map;
-
 import static org.apache.dubbo.common.constants.CommonConstants.DUBBO_VERSION_KEY;
 import static org.apache.dubbo.common.constants.CommonConstants.GROUP_KEY;
 import static org.apache.dubbo.common.constants.CommonConstants.PATH_KEY;
 import static org.apache.dubbo.common.constants.CommonConstants.TIMEOUT_KEY;
 import static org.apache.dubbo.common.constants.CommonConstants.VERSION_KEY;
+import org.apache.dubbo.common.utils.MapUtils;
 import static org.apache.dubbo.rpc.Constants.TOKEN_KEY;
+import org.apache.dubbo.rpc.Invocation;
+import org.apache.dubbo.rpc.Invoker;
 
 /**
  * MockInvocation.java
@@ -75,7 +73,7 @@ public class MockDirInvocation implements Invocation {
     }
 
     public Map<String, String> getAttachments() {
-        return new AttachmentsAdapter.ObjectToStringMap(attachments);
+        return MapUtils.objectToStringMap(attachments);
     }
 
     @Override
@@ -90,7 +88,7 @@ public class MockDirInvocation implements Invocation {
 
     @Override
     public void setAttachment(String key, Object value) {
-       setObjectAttachment(key, value);
+        setObjectAttachment(key, value);
     }
 
     @Override

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/utils/MapUtils.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/utils/MapUtils.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.dubbo.common.utils;
 
 import java.util.HashMap;

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/utils/MapUtils.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/utils/MapUtils.java
@@ -51,6 +51,7 @@ public class MapUtils {
 
     /**
      * use {@link Object#toString()} switch Obj to String
+     *
      * @param obj
      * @return
      */

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/utils/MapUtils.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/utils/MapUtils.java
@@ -11,9 +11,10 @@ public class MapUtils {
     /**
      * switch Map<String, Object> to Map<String, String>
      *
+     * If the value of the original Map is not of type String, then toString() of value will be called
+     *
      * @param originMap
      * @return
-     * @apiNote If the value of the original Map is not of type String, then toString() of value will be called
      */
     public static Map<String, String> objectToStringMap(Map<String, Object> originMap) {
         Map<String, String> newStrMap = new HashMap<>();

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/utils/MapUtils.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/utils/MapUtils.java
@@ -33,6 +33,11 @@ public class MapUtils {
         return newStrMap;
     }
 
+    /**
+     * use {@link Object#toString()} switch Obj to String
+     * @param obj
+     * @return
+     */
     private static String convertToString(Object obj) {
         if (obj == null) {
             return null;

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/utils/MapUtils.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/utils/MapUtils.java
@@ -1,0 +1,42 @@
+package org.apache.dubbo.common.utils;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Map tools
+ */
+public class MapUtils {
+
+    /**
+     * switch Map<String, Object> to Map<String, String>
+     *
+     * @param originMap
+     * @return
+     * @apiNote If the value of the original Map is not of type String, then toString() of value will be called
+     */
+    public static Map<String, String> objectToStringMap(Map<String, Object> originMap) {
+        Map<String, String> newStrMap = new HashMap<>();
+
+        if (originMap == null) {
+            return newStrMap;
+        }
+
+        for (Map.Entry<String, Object> entry : originMap.entrySet()) {
+            String stringValue = convertToString(entry.getValue());
+            if (stringValue != null) {
+                newStrMap.put(entry.getKey(), stringValue);
+            }
+        }
+
+        return newStrMap;
+    }
+
+    private static String convertToString(Object obj) {
+        if (obj == null) {
+            return null;
+        } else {
+            return obj.toString();
+        }
+    }
+}

--- a/dubbo-compatible/src/test/java/org/apache/dubbo/service/MockInvocation.java
+++ b/dubbo-compatible/src/test/java/org/apache/dubbo/service/MockInvocation.java
@@ -16,7 +16,7 @@
  */
 package org.apache.dubbo.service;
 
-import org.apache.dubbo.rpc.AttachmentsAdapter;
+import org.apache.dubbo.common.utils.MapUtils;
 import org.apache.dubbo.rpc.Invocation;
 import org.apache.dubbo.rpc.Invoker;
 
@@ -79,7 +79,7 @@ public class MockInvocation implements Invocation {
     }
 
     public Map<String, String> getAttachments() {
-        return new AttachmentsAdapter.ObjectToStringMap(attachments);
+        return MapUtils.objectToStringMap(attachments);
     }
 
     @Override

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/AppResponse.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/AppResponse.java
@@ -17,6 +17,7 @@
 package org.apache.dubbo.rpc;
 
 
+import org.apache.dubbo.common.utils.MapUtils;
 import org.apache.dubbo.rpc.proxy.InvokerInvocationHandler;
 
 import java.util.HashMap;
@@ -121,7 +122,7 @@ public class AppResponse implements Result {
     @Override
     @Deprecated
     public Map<String, String> getAttachments() {
-        return new AttachmentsAdapter.ObjectToStringMap(attachments);
+        return MapUtils.objectToStringMap(attachments);
     }
 
     @Override

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/AttachmentsAdapter.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/AttachmentsAdapter.java
@@ -57,10 +57,11 @@ public class AttachmentsAdapter {
         }
 
         private String convert(Object obj) {
-            if (obj instanceof String) {
-                return (String) obj;
+            if (obj == null) {
+                return null;
+            } else {
+                return obj.toString();
             }
-            return null; // or JSON.toString(obj);
         }
 
         @Override

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/AttachmentsAdapter.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/AttachmentsAdapter.java
@@ -22,12 +22,18 @@ import java.util.Map;
 /**
  * This class provides map adapters to support attachments in RpcContext, Invocation and Result switch from
  * <String, String> to <String, Object>
+ *
+ * please use {@link org.apache.dubbo.common.utils.MapUtils}
+ *
  */
+@Deprecated
 public class AttachmentsAdapter {
 
+    @Deprecated
     public static class ObjectToStringMap extends HashMap<String, String> {
         private Map<String, Object> attachments;
 
+        @Deprecated
         public ObjectToStringMap(Map<String, Object> attachments) {
             for (Entry<String, Object> entry : attachments.entrySet()) {
                 String convertResult = convert(entry.getValue());

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/RpcContext.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/RpcContext.java
@@ -20,6 +20,7 @@ import org.apache.dubbo.common.Experimental;
 import org.apache.dubbo.common.URL;
 import org.apache.dubbo.common.threadlocal.InternalThreadLocal;
 import org.apache.dubbo.common.utils.CollectionUtils;
+import org.apache.dubbo.common.utils.MapUtils;
 import org.apache.dubbo.common.utils.NetUtils;
 import org.apache.dubbo.common.utils.StringUtils;
 
@@ -552,7 +553,7 @@ public class RpcContext {
      */
     @Deprecated
     public Map<String, String> getAttachments() {
-        return new AttachmentsAdapter.ObjectToStringMap(this.getObjectAttachments());
+        return MapUtils.objectToStringMap(this.getObjectAttachments());
     }
 
     /**

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/RpcContext.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/RpcContext.java
@@ -798,7 +798,7 @@ public class RpcContext {
         return asyncContext.stop();
     }
 
-    public AsyncContext getcontgetAsyncContext() {
+    public AsyncContext getAsyncContext() {
         return asyncContext;
     }
 

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/RpcContext.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/RpcContext.java
@@ -549,7 +549,8 @@ public class RpcContext {
     /**
      * get String type attachments.
      *
-     * @apiNote Best to use {{@link #getObjectAttachments()}}
+     * Best to use {{@link #getObjectAttachments()}}
+     *
      * @return attachments
      */
     @Deprecated
@@ -797,7 +798,7 @@ public class RpcContext {
         return asyncContext.stop();
     }
 
-    public AsyncContext getAsyncContext() {
+    public AsyncContext getcontgetAsyncContext() {
         return asyncContext;
     }
 

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/RpcContext.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/RpcContext.java
@@ -547,8 +547,9 @@ public class RpcContext {
     }
 
     /**
-     * get attachments.
+     * get String type attachments.
      *
+     * @apiNote Best to use {{@link #getObjectAttachments()}}
      * @return attachments
      */
     @Deprecated

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/RpcInvocation.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/RpcInvocation.java
@@ -17,6 +17,7 @@
 package org.apache.dubbo.rpc;
 
 import org.apache.dubbo.common.URL;
+import org.apache.dubbo.common.utils.MapUtils;
 import org.apache.dubbo.common.utils.ReflectUtils;
 import org.apache.dubbo.common.utils.StringUtils;
 import org.apache.dubbo.rpc.model.ApplicationModel;
@@ -277,7 +278,7 @@ public class RpcInvocation implements Invocation, Serializable {
     @Deprecated
     @Override
     public Map<String, String> getAttachments() {
-        return new AttachmentsAdapter.ObjectToStringMap(attachments);
+        return MapUtils.objectToStringMap(attachments);
     }
 
     @Deprecated

--- a/dubbo-rpc/dubbo-rpc-api/src/test/java/org/apache/dubbo/rpc/support/MockInvocation.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/test/java/org/apache/dubbo/rpc/support/MockInvocation.java
@@ -16,7 +16,7 @@
  */
 package org.apache.dubbo.rpc.support;
 
-import org.apache.dubbo.rpc.AttachmentsAdapter;
+import org.apache.dubbo.common.utils.MapUtils;
 import org.apache.dubbo.rpc.Invocation;
 import org.apache.dubbo.rpc.Invoker;
 
@@ -75,7 +75,7 @@ public class MockInvocation implements Invocation {
     }
 
     public Map<String, String> getAttachments() {
-        return new AttachmentsAdapter.ObjectToStringMap(attachments);
+        return MapUtils.objectToStringMap(attachments);
     }
 
     @Override


### PR DESCRIPTION
## What is the purpose of the change
In order to realize the conversion from Map<String, Object> to Map<String, String>, the implementation of AttachmentsAdapter is too complicated, and the inner class of the class is also used. For the sake of simplicity, the tool class MapUtils with less code is used to achieve the same function.

为了实现Map<String, Object>到Map<String, String>的转换，AttachmentsAdapter实现的太复杂，还使用类内部类。为了简单起见，使用更少代码的工具类MapUtils来实现一样的功能。




## Brief changelog


## Verifying this change


<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [ ] GitHub Actions works fine on your own branch.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
