### PR TITLE
 [3.0] Support start module in background

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/deploy/ApplicationDeployer.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/deploy/ApplicationDeployer.java
@@ -47,7 +47,6 @@ public interface ApplicationDeployer extends Deployer<ApplicationModel> {
 
     /**
      * Indicates that the Application is initialized or not.
-     * @return
      */
     boolean isInitialized();
 
@@ -55,7 +54,10 @@ public interface ApplicationDeployer extends Deployer<ApplicationModel> {
 
     ReferenceCache getReferenceCache();
 
-    boolean isAsync();
+    /**
+     * Whether start in background, do not await finish
+     */
+    boolean isBackground();
 
     void checkStarting();
 

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/deploy/ModuleDeployer.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/deploy/ModuleDeployer.java
@@ -43,5 +43,8 @@ public interface ModuleDeployer extends Deployer<ModuleModel> {
 
     void notifyExportService(ServiceConfigBase<?> sc);
 
-    boolean isAsync();
+    /**
+     * Whether start in background, do not await finish
+     */
+    boolean isBackground();
 }

--- a/dubbo-common/src/main/java/org/apache/dubbo/config/AbstractConfig.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/config/AbstractConfig.java
@@ -395,12 +395,6 @@ public abstract class AbstractConfig implements Serializable {
         this.id = id;
     }
 
-    public void updateIdIfAbsent(String value) {
-        if (StringUtils.isNotEmpty(value) && StringUtils.isEmpty(id)) {
-            this.id = value;
-        }
-    }
-
     /**
      * Copy attributes from annotation
      *

--- a/dubbo-common/src/main/java/org/apache/dubbo/config/AbstractInterfaceConfig.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/config/AbstractInterfaceConfig.java
@@ -624,14 +624,14 @@ public abstract class AbstractInterfaceConfig extends AbstractMethodConfig {
         if (module != null) {
             return module;
         }
-        return getConfigManager().getModule().orElse(null);
+        return getModuleConfigManager().getModule().orElse(null);
     }
 
     @Deprecated
     public void setModule(ModuleConfig module) {
         this.module = module;
         if (module != null) {
-            getConfigManager().setModule(module);
+            getModuleConfigManager().setModule(module);
         }
     }
 

--- a/dubbo-common/src/main/java/org/apache/dubbo/config/AbstractReferenceConfig.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/config/AbstractReferenceConfig.java
@@ -83,7 +83,10 @@ public abstract class AbstractReferenceConfig extends AbstractInterfaceConfig {
 
     /**
      * Weather the reference is refer asynchronously
+     * @deprecated
+     * @see ModuleConfig#referAsync
      */
+    @Deprecated
     private Boolean referAsync;
 
     @Override
@@ -238,11 +241,13 @@ public abstract class AbstractReferenceConfig extends AbstractInterfaceConfig {
         this.router = router;
     }
 
+    @Deprecated
     @Parameter(key = REFER_ASYNC_KEY)
     public Boolean getReferAsync() {
         return referAsync;
     }
 
+    @Deprecated
     public void setReferAsync(Boolean referAsync) {
         this.referAsync = referAsync;
     }

--- a/dubbo-common/src/main/java/org/apache/dubbo/config/AbstractServiceConfig.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/config/AbstractServiceConfig.java
@@ -120,7 +120,10 @@ public abstract class AbstractServiceConfig extends AbstractInterfaceConfig {
 
     /**
      * Weather the service is export asynchronously
+     * @deprecated
+     * @see ModuleConfig#exportAsync
      */
+    @Deprecated
     private Boolean exportAsync;
 
     @Override
@@ -310,11 +313,13 @@ public abstract class AbstractServiceConfig extends AbstractInterfaceConfig {
         this.serialization = serialization;
     }
 
+    @Deprecated
     @Parameter(key = EXPORT_ASYNC_KEY)
     public Boolean getExportAsync() {
         return exportAsync;
     }
 
+    @Deprecated
     public void setExportAsync(Boolean exportAsync) {
         this.exportAsync = exportAsync;
     }

--- a/dubbo-common/src/main/java/org/apache/dubbo/config/ApplicationConfig.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/config/ApplicationConfig.java
@@ -219,7 +219,6 @@ public class ApplicationConfig extends AbstractConfig {
 
     public void setName(String name) {
         this.name = name;
-        //this.updateIdIfAbsent(name);
     }
 
     @Parameter(key = APPLICATION_VERSION_KEY)

--- a/dubbo-common/src/main/java/org/apache/dubbo/config/ConsumerConfig.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/config/ConsumerConfig.java
@@ -75,7 +75,10 @@ public class ConsumerConfig extends AbstractReferenceConfig {
     private Integer referThreadNum;
 
     /**
-     * Whether refer should run in background or not
+     * Whether refer should run in background or not.
+     *
+     * @deprecated replace with {@link ModuleConfig#setBackground(Boolean)}
+     * @see ModuleConfig#setBackground(Boolean)
      */
     private Boolean referBackground;
 
@@ -155,11 +158,19 @@ public class ConsumerConfig extends AbstractReferenceConfig {
         this.referThreadNum = referThreadNum;
     }
 
+    @Deprecated
     @Parameter(key = REFER_BACKGROUND_KEY, excluded = true)
     public Boolean getReferBackground() {
         return referBackground;
     }
 
+    /**
+     * Whether refer should run in background or not.
+     *
+     * @deprecated replace with {@link ModuleConfig#setBackground(Boolean)}
+     * @see ModuleConfig#setBackground(Boolean)
+     */
+    @Deprecated
     public void setReferBackground(Boolean referBackground) {
         this.referBackground = referBackground;
     }

--- a/dubbo-common/src/main/java/org/apache/dubbo/config/ModuleConfig.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/config/ModuleConfig.java
@@ -71,9 +71,19 @@ public class ModuleConfig extends AbstractConfig {
     private Boolean background;
 
     /**
+     * Weather the reference is refer asynchronously
+     */
+    private Boolean referAsync;
+
+    /**
      * Thread num for asynchronous refer pool size
      */
     private Integer referThreadNum;
+
+    /**
+     * Weather the service is export asynchronously
+     */
+    private Boolean exportAsync;
 
     /**
      * Thread num for asynchronous export pool size
@@ -85,7 +95,7 @@ public class ModuleConfig extends AbstractConfig {
     }
 
     public ModuleConfig(String name) {
-        super(ApplicationModel.defaultModel().getDefaultModule());
+        this();
         setName(name);
     }
 
@@ -193,5 +203,21 @@ public class ModuleConfig extends AbstractConfig {
 
     public void setExportThreadNum(Integer exportThreadNum) {
         this.exportThreadNum = exportThreadNum;
+    }
+
+    public Boolean getReferAsync() {
+        return referAsync;
+    }
+
+    public void setReferAsync(Boolean referAsync) {
+        this.referAsync = referAsync;
+    }
+
+    public Boolean getExportAsync() {
+        return exportAsync;
+    }
+
+    public void setExportAsync(Boolean exportAsync) {
+        this.exportAsync = exportAsync;
     }
 }

--- a/dubbo-common/src/main/java/org/apache/dubbo/config/ModuleConfig.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/config/ModuleConfig.java
@@ -18,6 +18,7 @@ package org.apache.dubbo.config;
 
 import org.apache.dubbo.common.utils.CollectionUtils;
 import org.apache.dubbo.config.support.Parameter;
+import org.apache.dubbo.rpc.model.ApplicationModel;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -61,11 +62,40 @@ public class ModuleConfig extends AbstractConfig {
      */
     private MonitorConfig monitor;
 
+    /**
+     * Whether start module in background.
+     * If start in backgound, do not await finish on Spring ContextRefreshedEvent.
+     *
+     * @see org.apache.dubbo.config.spring.context.DubboDeployApplicationListener
+     */
+    private Boolean background;
+
+    /**
+     * Thread num for asynchronous refer pool size
+     */
+    private Integer referThreadNum;
+
+    /**
+     * Thread num for asynchronous export pool size
+     */
+    private Integer exportThreadNum;
+
     public ModuleConfig() {
+        super(ApplicationModel.defaultModel().getDefaultModule());
     }
 
     public ModuleConfig(String name) {
+        super(ApplicationModel.defaultModel().getDefaultModule());
         setName(name);
+    }
+
+    @Override
+    protected void checkDefault() {
+        super.checkDefault();
+        // default is false
+        if (background == null) {
+            background = false;
+        }
     }
 
     @Parameter(key = "module")
@@ -75,7 +105,6 @@ public class ModuleConfig extends AbstractConfig {
 
     public void setName(String name) {
         this.name = name;
-        //this.updateIdIfAbsent(name);
     }
 
     @Parameter(key = "module.version")
@@ -136,4 +165,33 @@ public class ModuleConfig extends AbstractConfig {
         this.monitor = new MonitorConfig(monitor);
     }
 
+    public Boolean getBackground() {
+        return background;
+    }
+
+    /**
+     * Whether start module in background.
+     * If start in backgound, do not await finish on Spring ContextRefreshedEvent.
+     *
+     * @see org.apache.dubbo.config.spring.context.DubboDeployApplicationListener
+     */
+    public void setBackground(Boolean background) {
+        this.background = background;
+    }
+
+    public Integer getReferThreadNum() {
+        return referThreadNum;
+    }
+
+    public void setReferThreadNum(Integer referThreadNum) {
+        this.referThreadNum = referThreadNum;
+    }
+
+    public Integer getExportThreadNum() {
+        return exportThreadNum;
+    }
+
+    public void setExportThreadNum(Integer exportThreadNum) {
+        this.exportThreadNum = exportThreadNum;
+    }
 }

--- a/dubbo-common/src/main/java/org/apache/dubbo/config/ModuleConfig.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/config/ModuleConfig.java
@@ -19,6 +19,8 @@ package org.apache.dubbo.config;
 import org.apache.dubbo.common.utils.CollectionUtils;
 import org.apache.dubbo.config.support.Parameter;
 import org.apache.dubbo.rpc.model.ApplicationModel;
+import org.apache.dubbo.rpc.model.ModuleModel;
+import org.apache.dubbo.rpc.model.ScopeModel;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -105,6 +107,16 @@ public class ModuleConfig extends AbstractConfig {
         // default is false
         if (background == null) {
             background = false;
+        }
+    }
+
+    @Override
+    protected void checkScopeModel(ScopeModel scopeModel) {
+        if (scopeModel == null) {
+            throw new IllegalArgumentException("scopeModel cannot be null");
+        }
+        if (!(scopeModel instanceof ModuleModel)) {
+            throw new IllegalArgumentException("Invalid scope model, expect to be a ModuleModel but got: " + scopeModel);
         }
     }
 

--- a/dubbo-common/src/main/java/org/apache/dubbo/config/ProtocolConfig.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/config/ProtocolConfig.java
@@ -241,7 +241,6 @@ public class ProtocolConfig extends AbstractConfig {
 
     public final void setName(String name) {
         this.name = name;
-        //this.updateIdIfAbsent(name);
     }
 
     @Parameter(excluded = true)

--- a/dubbo-common/src/main/java/org/apache/dubbo/config/ProviderConfig.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/config/ProviderConfig.java
@@ -163,7 +163,10 @@ public class ProviderConfig extends AbstractServiceConfig {
     private Integer exportThreadNum;
 
     /**
-     * Whether export should run in background or not
+     * Whether export should run in background or not.
+     *
+     * @deprecated replace with {@link ModuleConfig#setBackground(Boolean)}
+     * @see ModuleConfig#setBackground(Boolean)
      */
     private Boolean exportBackground;
 
@@ -436,20 +439,34 @@ public class ProviderConfig extends AbstractServiceConfig {
         this.wait = wait;
     }
 
+    @Deprecated
     @Parameter(key = EXPORT_THREAD_NUM_KEY, excluded = true)
     public Integer getExportThreadNum() {
         return exportThreadNum;
     }
 
+    @Deprecated
     public void setExportThreadNum(Integer exportThreadNum) {
         this.exportThreadNum = exportThreadNum;
     }
 
+    /**
+     * @deprecated replace with {@link ModuleConfig#getBackground()}
+     * @see ModuleConfig#getBackground()
+     */
+    @Deprecated
     @Parameter(key = EXPORT_BACKGROUND_KEY, excluded = true)
     public Boolean getExportBackground() {
         return exportBackground;
     }
 
+    /**
+     * Whether export should run in background or not.
+     *
+     * @deprecated replace with {@link ModuleConfig#setBackground(Boolean)}
+     * @see ModuleConfig#setBackground(Boolean)
+     */
+    @Deprecated
     public void setExportBackground(Boolean exportBackground) {
         this.exportBackground = exportBackground;
     }

--- a/dubbo-common/src/main/java/org/apache/dubbo/config/ReferenceConfigBase.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/config/ReferenceConfigBase.java
@@ -117,7 +117,7 @@ public abstract class ReferenceConfigBase<T> extends AbstractReferenceConfig {
         if (consumer == null) {
             consumer = getModuleConfigManager()
                     .getDefaultConsumer()
-                    .orElseThrow(() -> new IllegalArgumentException("Default consumer is not initialized"));
+                    .orElseThrow(() -> new IllegalStateException("Default consumer is not initialized"));
         }
     }
 

--- a/dubbo-common/src/main/java/org/apache/dubbo/config/RegistryConfig.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/config/RegistryConfig.java
@@ -207,8 +207,6 @@ public class RegistryConfig extends AbstractConfig {
 
     public void setProtocol(String protocol) {
         this.protocol = protocol;
-        // protocol as id is inappropriate, registries's protocol may be duplicated
-//        this.updateIdIfAbsent(protocol);
     }
 
     @Parameter(excluded = true)

--- a/dubbo-common/src/main/java/org/apache/dubbo/config/ServiceConfigBase.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/config/ServiceConfigBase.java
@@ -213,7 +213,7 @@ public abstract class ServiceConfigBase<T> extends AbstractServiceConfig {
         if (provider == null) {
             provider = getModuleConfigManager()
                     .getDefaultProvider()
-                    .orElseThrow(() -> new IllegalArgumentException("Default provider is not initialized"));
+                    .orElseThrow(() -> new IllegalStateException("Default provider is not initialized"));
         }
     }
 

--- a/dubbo-common/src/main/java/org/apache/dubbo/config/context/AbstractConfigManager.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/config/context/AbstractConfigManager.java
@@ -554,8 +554,10 @@ public abstract class AbstractConfigManager extends LifecycleAdapter {
 
         //validate configs
         Collection<T> configs = this.getConfigs(configType);
-        for (T config : configs) {
-            getConfigValidator().validate(config);
+        if (getConfigValidator() != null) {
+            for (T config : configs) {
+                getConfigValidator().validate(config);
+            }
         }
 
         // check required default

--- a/dubbo-common/src/main/java/org/apache/dubbo/config/context/AbstractConfigManager.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/config/context/AbstractConfigManager.java
@@ -85,11 +85,14 @@ public abstract class AbstractConfigManager extends LifecycleAdapter {
 
     static {
         // init unique config types
+        // unique config in application
         uniqueConfigTypes.add(ApplicationConfig.class);
-        uniqueConfigTypes.add(ModuleConfig.class);
         uniqueConfigTypes.add(MonitorConfig.class);
         uniqueConfigTypes.add(MetricsConfig.class);
         uniqueConfigTypes.add(SslConfig.class);
+
+        // unique config in each module
+        uniqueConfigTypes.add(ModuleConfig.class);
     }
 
 

--- a/dubbo-common/src/main/java/org/apache/dubbo/config/context/ConfigManager.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/config/context/ConfigManager.java
@@ -16,21 +16,17 @@
  */
 package org.apache.dubbo.config.context;
 
-import org.apache.dubbo.common.config.CompositeConfiguration;
 import org.apache.dubbo.common.context.ApplicationExt;
 import org.apache.dubbo.common.extension.DisableInject;
 import org.apache.dubbo.common.logger.Logger;
 import org.apache.dubbo.common.logger.LoggerFactory;
 import org.apache.dubbo.common.utils.CollectionUtils;
-import org.apache.dubbo.common.utils.ConcurrentHashSet;
-import org.apache.dubbo.common.utils.StringUtils;
 import org.apache.dubbo.config.AbstractConfig;
 import org.apache.dubbo.config.ApplicationConfig;
 import org.apache.dubbo.config.ConfigCenterConfig;
 import org.apache.dubbo.config.ConfigKeys;
 import org.apache.dubbo.config.MetadataReportConfig;
 import org.apache.dubbo.config.MetricsConfig;
-import org.apache.dubbo.config.ModuleConfig;
 import org.apache.dubbo.config.MonitorConfig;
 import org.apache.dubbo.config.ProtocolConfig;
 import org.apache.dubbo.config.RegistryConfig;
@@ -43,8 +39,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 import static java.util.Optional.ofNullable;
 import static org.apache.dubbo.config.AbstractConfig.getTagName;
@@ -61,48 +55,11 @@ public class ConfigManager extends AbstractConfigManager implements ApplicationE
     public static final String BEAN_NAME = "dubboConfigManager";
     public static final String DUBBO_CONFIG_MODE = ConfigKeys.DUBBO_CONFIG_MODE;
 
-    private ConfigMode configMode = ConfigMode.STRICT;
-
-    private ApplicationModel applicationModel;
-
-    private AtomicBoolean inited = new AtomicBoolean(false);
-
-    private static Set<Class<? extends AbstractConfig>> uniqueConfigTypes = new ConcurrentHashSet<>();
-
-    static {
-        // init unique config types
-        uniqueConfigTypes.add(ApplicationConfig.class);
-        uniqueConfigTypes.add(ModuleConfig.class);
-        uniqueConfigTypes.add(MonitorConfig.class);
-        uniqueConfigTypes.add(MetricsConfig.class);
-        uniqueConfigTypes.add(SslConfig.class);
-    }
 
     public ConfigManager(ApplicationModel applicationModel) {
-        super(applicationModel, Arrays.asList(ApplicationConfig.class, ModuleConfig.class, MonitorConfig.class,
+        super(applicationModel, Arrays.asList(ApplicationConfig.class, MonitorConfig.class,
             MetricsConfig.class, SslConfig.class, ProtocolConfig.class, RegistryConfig.class, ConfigCenterConfig.class,
             MetadataReportConfig.class));
-        this.applicationModel = applicationModel;
-    }
-
-    @Override
-    public void initialize() throws IllegalStateException {
-        if (!inited.compareAndSet(false, true)) {
-            return;
-        }
-        CompositeConfiguration configuration = applicationModel.getModelEnvironment().getConfiguration();
-        String configModeStr = (String) configuration.getProperty(DUBBO_CONFIG_MODE);
-        try {
-            if (StringUtils.hasText(configModeStr)) {
-                this.configMode = ConfigMode.valueOf(configModeStr.toUpperCase());
-            }
-        } catch (Exception e) {
-            String msg = "Illegal '" + DUBBO_CONFIG_MODE + "' config value [" + configModeStr + "], available values " + Arrays.toString(ConfigMode.values());
-            logger.error(msg, e);
-            throw new IllegalArgumentException(msg, e);
-        }
-
-        logger.info("Config settings - config mode: " + configMode);
     }
 
 
@@ -136,17 +93,6 @@ public class ConfigManager extends AbstractConfigManager implements ApplicationE
 
     public Optional<MonitorConfig> getMonitor() {
         return ofNullable(getSingleConfig(getTagName(MonitorConfig.class)));
-    }
-
-    // ModuleConfig correlative methods
-
-    @DisableInject
-    public void setModule(ModuleConfig module) {
-        addConfig(module);
-    }
-
-    public Optional<ModuleConfig> getModule() {
-        return ofNullable(getSingleConfig(getTagName(ModuleConfig.class)));
     }
 
     @DisableInject
@@ -273,7 +219,6 @@ public class ConfigManager extends AbstractConfigManager implements ApplicationE
         // refresh all configs here,
         getApplication().ifPresent(ApplicationConfig::refresh);
         getMonitor().ifPresent(MonitorConfig::refresh);
-        getModule().ifPresent(ModuleConfig::refresh);
         getMetrics().ifPresent(MetricsConfig::refresh);
         getSsl().ifPresent(SslConfig::refresh);
 
@@ -283,90 +228,11 @@ public class ConfigManager extends AbstractConfigManager implements ApplicationE
         getMetadataConfigs().forEach(MetadataReportConfig::refresh);
     }
 
-    private boolean isUniqueConfig(AbstractConfig config) {
-        if (uniqueConfigTypes.contains(config.getClass())) {
-            return true;
-        }
-        for (Class<? extends AbstractConfig> uniqueConfigType : uniqueConfigTypes) {
-            if (uniqueConfigType.isAssignableFrom(config.getClass())) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    protected <C extends AbstractConfig> C getSingleConfig(String configType) throws IllegalStateException {
-        Map<String, AbstractConfig> configsMap = getConfigsMap(configType);
-        int size = configsMap.size();
-        if (size < 1) {
-//                throw new IllegalStateException("No such " + configType.getName() + " is found");
-            return null;
-        } else if (size > 1) {
-            throw new IllegalStateException("Expected single instance of " + configType + ", but found " + size +
-                " instances, please remove redundant configs. instances: " + configsMap.values());
-        }
-        return (C) configsMap.values().iterator().next();
-    }
-
-    @Override
-    protected <C extends AbstractConfig> Optional<C> findDuplicatedConfig(Map<String, C> configsMap, C config) {
-
-        // find by value
-        Optional<C> prevConfig = findConfigByValue(configsMap.values(), config);
-        if (prevConfig.isPresent()) {
-            if (prevConfig.get() == config) {
-                // the new one is same as existing one
-                return prevConfig;
-            }
-
-            // ignore duplicated equivalent config
-            if (logger.isInfoEnabled() && duplicatedConfigs.add(config)) {
-                logger.info("Ignore duplicated config: " + config);
-            }
-            return prevConfig;
-        }
-
-        // check unique config
-        if (configsMap.size() > 0 && isUniqueConfig(config)) {
-            C oldOne = configsMap.values().iterator().next();
-            String configName = oldOne.getClass().getSimpleName();
-            String msgPrefix = "Duplicate Configs found for " + configName + ", only one unique " + configName +
-                " is allowed for one application. previous: " + oldOne + ", later: " + config + ". According to config mode [" + configMode + "], ";
-            switch (configMode) {
-                case STRICT: {
-                    if (!isEquals(oldOne, config)) {
-                        throw new IllegalStateException(msgPrefix + "please remove redundant configs and keep only one.");
-                    }
-                    break;
-                }
-                case IGNORE: {
-                    // ignore later config
-                    if (logger.isWarnEnabled() && duplicatedConfigs.add(config)) {
-                        logger.warn(msgPrefix + "keep previous config and ignore later config");
-                    }
-                    return Optional.of(oldOne);
-                }
-                case OVERRIDE: {
-                    // clear previous config, add new config
-                    configsMap.clear();
-                    if (logger.isWarnEnabled() && duplicatedConfigs.add(config)) {
-                        logger.warn(msgPrefix + "override previous config with later config");
-                    }
-                    break;
-                }
-            }
-        }
-        return Optional.empty();
-    }
-
     @Override
     public void loadConfigs() {
         // application config has load before starting config center
         // load dubbo.applications.xxx
         loadConfigsOfTypeFromProps(ApplicationConfig.class);
-
-        // load dubbo.modules.xxx
-        loadConfigsOfTypeFromProps(ModuleConfig.class);
 
         // load dubbo.monitors.xxx
         loadConfigsOfTypeFromProps(MonitorConfig.class);
@@ -398,7 +264,6 @@ public class ConfigManager extends AbstractConfigManager implements ApplicationE
             RegistryConfig.class,
             MetadataReportConfig.class,
             MonitorConfig.class,
-            ModuleConfig.class,
             MetricsConfig.class,
             SslConfig.class);
 

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/threadpool/manager/ExecutorRepositoryTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/threadpool/manager/ExecutorRepositoryTest.java
@@ -17,8 +17,7 @@
 package org.apache.dubbo.common.threadpool.manager;
 
 import org.apache.dubbo.common.URL;
-import org.apache.dubbo.common.extension.ExtensionLoader;
-
+import org.apache.dubbo.rpc.model.ApplicationModel;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -26,9 +25,14 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ThreadPoolExecutor;
 
 public class ExecutorRepositoryTest {
-    private ExecutorRepository executorRepository = ExtensionLoader.getExtensionLoader(ExecutorRepository.class).getDefaultExtension();
+    private ExecutorRepository executorRepository = ApplicationModel.defaultModel().getExtensionLoader(ExecutorRepository.class).getDefaultExtension();
 
     @Test
+    public void test() {
+        testGetExecutor();
+        testUpdateExecutor();
+    }
+
     public void testGetExecutor() {
         testGet(URL.valueOf("dubbo://127.0.0.1:23456"));
         testGet(URL.valueOf("dubbo://127.0.0.1:23456?side=consumer"));
@@ -50,7 +54,6 @@ public class ExecutorRepositoryTest {
         Assertions.assertNotEquals(executorService, executorRepository.getExecutor(url));
     }
 
-    @Test
     public void testUpdateExecutor() {
         URL url = URL.valueOf("dubbo://127.0.0.1:23456?threads=5");
         ThreadPoolExecutor executorService = (ThreadPoolExecutor) executorRepository.createExecutorIfAbsent(url);

--- a/dubbo-common/src/test/java/org/apache/dubbo/config/context/ConfigManagerTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/config/context/ConfigManagerTest.java
@@ -66,7 +66,6 @@ public class ConfigManagerTest {
         // assert single
         assertFalse(configManager.getApplication().isPresent());
         assertFalse(configManager.getMonitor().isPresent());
-        assertFalse(configManager.getModule().isPresent());
         assertFalse(configManager.getMetrics().isPresent());
 
         // protocols
@@ -88,6 +87,7 @@ public class ConfigManagerTest {
         assertTrue(moduleConfigManager.getReferences().isEmpty());
 
         // providers and consumers
+        assertFalse(moduleConfigManager.getModule().isPresent());
         assertFalse(moduleConfigManager.getDefaultProvider().isPresent());
         assertFalse(moduleConfigManager.getDefaultConsumer().isPresent());
         assertTrue(moduleConfigManager.getProviders().isEmpty());
@@ -117,9 +117,9 @@ public class ConfigManagerTest {
     @Test
     public void tesModuleConfig() {
         ModuleConfig config = new ModuleConfig();
-        configManager.setModule(config);
-        assertTrue(configManager.getModule().isPresent());
-        assertEquals(config, configManager.getModule().get());
+        moduleConfigManager.setModule(config);
+        assertTrue(moduleConfigManager.getModule().isPresent());
+        assertEquals(config, moduleConfigManager.getModule().get());
     }
 
     // Test MetricsConfig correlative methods

--- a/dubbo-common/src/test/java/org/apache/dubbo/config/context/ConfigManagerTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/config/context/ConfigManagerTest.java
@@ -48,12 +48,15 @@ import static org.junit.jupiter.api.Assertions.fail;
  */
 public class ConfigManagerTest {
 
-    private ConfigManager configManager = ApplicationModel.defaultModel().getApplicationConfigManager();
-    private ModuleConfigManager moduleConfigManager = ApplicationModel.defaultModel().getDefaultModule().getConfigManager();
+    private ConfigManager configManager;
+    private ModuleConfigManager moduleConfigManager;
 
     @BeforeEach
     public void init() {
-        configManager.destroy();
+        ApplicationModel.defaultModel().destroy();
+        ApplicationModel applicationModel = ApplicationModel.defaultModel();
+        configManager = applicationModel.getApplicationConfigManager();
+        moduleConfigManager = applicationModel.getDefaultModule().getConfigManager();
     }
 
     @Test

--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/bootstrap/DubboBootstrap.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/bootstrap/DubboBootstrap.java
@@ -659,6 +659,17 @@ public final class DubboBootstrap {
         moduleModel.getConfigManager().addConsumer(consumerConfig);
         return this;
     }
+
+    public DubboBootstrap module(ModuleConfig moduleConfig) {
+        this.module(moduleConfig, applicationModel.getDefaultModule());
+        return this;
+    }
+
+    public DubboBootstrap module(ModuleConfig moduleConfig, ModuleModel moduleModel) {
+        moduleConfig.setScopeModel(moduleModel);
+        moduleModel.getConfigManager().setModule(moduleConfig);
+        return this;
+    }
     // module configs end
 
     // {@link ConfigCenterConfig} correlative methods
@@ -687,12 +698,6 @@ public final class DubboBootstrap {
     public DubboBootstrap metrics(MetricsConfig metrics) {
         metrics.setScopeModel(applicationModel);
         configManager.setMetrics(metrics);
-        return this;
-    }
-
-    public DubboBootstrap module(ModuleConfig module) {
-        module.setScopeModel(applicationModel);
-        configManager.setModule(module);
         return this;
     }
 
@@ -737,6 +742,13 @@ public final class DubboBootstrap {
         return new Module(applicationModel.newModule());
     }
 
+    public Module newModule(ModuleConfig moduleConfig) {
+        ModuleModel moduleModel = applicationModel.newModule();
+        moduleConfig.setScopeModel(moduleModel);
+        moduleModel.getConfigManager().setModule(moduleConfig);
+        return new Module(moduleModel);
+    }
+
     public DubboBootstrap endModule() {
         return this;
     }
@@ -757,6 +769,11 @@ public final class DubboBootstrap {
 
         public ModuleModel getModuleModel() {
             return moduleModel;
+        }
+
+        public Module config(ModuleConfig moduleConfig) {
+            this.moduleModel.getConfigManager().setModule(moduleConfig);
+            return this;
         }
 
         // {@link ServiceConfig} correlative methods

--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/deploy/DefaultApplicationDeployer.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/deploy/DefaultApplicationDeployer.java
@@ -610,9 +610,9 @@ public class DefaultApplicationDeployer extends AbstractDeployer<ApplicationMode
     }
 
     @Override
-    public boolean isAsync() {
+    public boolean isBackground() {
         for (ModuleModel moduleModel : applicationModel.getModuleModels()) {
-            if (moduleModel.getDeployer().isAsync()) {
+            if (moduleModel.getDeployer().isBackground()) {
                 return true;
             }
         }

--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/deploy/DefaultModuleDeployer.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/deploy/DefaultModuleDeployer.java
@@ -26,6 +26,7 @@ import org.apache.dubbo.common.logger.LoggerFactory;
 import org.apache.dubbo.common.threadpool.manager.ExecutorRepository;
 import org.apache.dubbo.common.utils.StringUtils;
 import org.apache.dubbo.config.ConsumerConfig;
+import org.apache.dubbo.config.ModuleConfig;
 import org.apache.dubbo.config.ProviderConfig;
 import org.apache.dubbo.config.ReferenceConfig;
 import org.apache.dubbo.config.ServiceConfig;
@@ -67,7 +68,7 @@ public class DefaultModuleDeployer extends AbstractDeployer<ModuleModel> impleme
 
     private ApplicationDeployer applicationDeployer;
     private CompletableFuture startFuture;
-    private Boolean async;
+    private Boolean background;
 
 
     public DefaultModuleDeployer(ModuleModel moduleModel) {
@@ -353,11 +354,17 @@ public class DefaultModuleDeployer extends AbstractDeployer<ModuleModel> impleme
     }
 
     @Override
-    public boolean isAsync() {
-        if (async == null) {
-            async = isExportBackground() || isReferBackground();
+    public boolean isBackground() {
+        if (background == null) {
+            ModuleConfig moduleConfig = moduleModel.getConfigManager().getModule()
+                .orElseThrow(() -> new IllegalStateException("Default module config is not initialized"));
+            background = moduleConfig.getBackground();
+            if (background == null) {
+                // compatible with old usages
+                background = isExportBackground() || isReferBackground();
+            }
         }
-        return async;
+        return background;
     }
 
     private boolean isExportBackground() {

--- a/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/context/DubboConfigBeanInitializer.java
+++ b/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/context/DubboConfigBeanInitializer.java
@@ -99,7 +99,6 @@ public class DubboConfigBeanInitializer implements BeanFactoryAware, Initializin
         //Make sure all these config beans are inited and registered to ConfigManager
         // load application configs
         loadConfigBeansOfType(ApplicationConfig.class, configManager);
-        loadConfigBeansOfType(ModuleConfig.class, configManager);
         loadConfigBeansOfType(RegistryConfig.class, configManager);
         loadConfigBeansOfType(ProtocolConfig.class, configManager);
         loadConfigBeansOfType(MonitorConfig.class, configManager);
@@ -109,6 +108,7 @@ public class DubboConfigBeanInitializer implements BeanFactoryAware, Initializin
         loadConfigBeansOfType(SslConfig.class, configManager);
 
         // load module configs
+        loadConfigBeansOfType(ModuleConfig.class, moduleModel.getConfigManager());
         loadConfigBeansOfType(ProviderConfig.class, moduleModel.getConfigManager());
         loadConfigBeansOfType(ConsumerConfig.class, moduleModel.getConfigManager());
 

--- a/dubbo-config/dubbo-config-spring/src/main/resources/META-INF/dubbo.xsd
+++ b/dubbo-config/dubbo-config-spring/src/main/resources/META-INF/dubbo.xsd
@@ -485,6 +485,26 @@
                 <xsd:documentation><![CDATA[ Whether start module in background, if true do not await finish. ]]></xsd:documentation>
             </xsd:annotation>
         </xsd:attribute>
+        <xsd:attribute name="refer-async" type="xsd:boolean">
+            <xsd:annotation>
+                <xsd:documentation><![CDATA[ Weather the reference is refer asynchronously, default false.  ]]></xsd:documentation>
+            </xsd:annotation>
+        </xsd:attribute>
+        <xsd:attribute name="refer-thread-num" type="xsd:boolean">
+            <xsd:annotation>
+                <xsd:documentation><![CDATA[ Thread num for asynchronous refer pool size. ]]></xsd:documentation>
+            </xsd:annotation>
+        </xsd:attribute>
+        <xsd:attribute name="export-async" type="xsd:boolean">
+            <xsd:annotation>
+                <xsd:documentation><![CDATA[ Weather the service is export asynchronously, default false. ]]></xsd:documentation>
+            </xsd:annotation>
+        </xsd:attribute>
+        <xsd:attribute name="export-thread-num" type="xsd:boolean">
+            <xsd:annotation>
+                <xsd:documentation><![CDATA[ Thread num for asynchronous export pool size. ]]></xsd:documentation>
+            </xsd:annotation>
+        </xsd:attribute>
     </xsd:complexType>
 
     <xsd:complexType name="registryType">

--- a/dubbo-config/dubbo-config-spring/src/main/resources/META-INF/dubbo.xsd
+++ b/dubbo-config/dubbo-config-spring/src/main/resources/META-INF/dubbo.xsd
@@ -342,7 +342,7 @@
                         <xsd:documentation><![CDATA[ The serialization protocol of service. ]]></xsd:documentation>
                     </xsd:annotation>
                 </xsd:attribute>
-                <xsd:attribute name="export-async" type="xsd:boolean">
+                <xsd:attribute name="export-async" type="xsd:boolean" >
                     <xsd:annotation>
                         <xsd:documentation>
                             <![CDATA[ Weather the service is export asynchronously, default false. ]]></xsd:documentation>
@@ -478,6 +478,11 @@
         <xsd:attribute name="default" type="xsd:string">
             <xsd:annotation>
                 <xsd:documentation><![CDATA[ Is default. ]]></xsd:documentation>
+            </xsd:annotation>
+        </xsd:attribute>
+        <xsd:attribute name="background" type="xsd:boolean">
+            <xsd:annotation>
+                <xsd:documentation><![CDATA[ Whether start module in background, if true do not await finish. ]]></xsd:documentation>
             </xsd:annotation>
         </xsd:attribute>
     </xsd:complexType>
@@ -1443,7 +1448,7 @@
                 </xsd:attribute>
                 <xsd:attribute name="export-background" type="xsd:boolean">
                     <xsd:annotation>
-                        <xsd:documentation><![CDATA[ Whether export should run in background or not, default false. ]]></xsd:documentation>
+                        <xsd:documentation><![CDATA[ Deprecated. Whether export should run in background or not, default false. ]]></xsd:documentation>
                     </xsd:annotation>
                 </xsd:attribute>
                 <xsd:anyAttribute namespace="##other" processContents="lax"/>

--- a/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/boot/configprops/SpringBootConfigPropsTest.java
+++ b/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/boot/configprops/SpringBootConfigPropsTest.java
@@ -98,9 +98,6 @@ public class SpringBootConfigPropsTest {
         ApplicationConfig applicationConfig = configManager.getApplicationOrElseThrow();
         Assertions.assertEquals("dubbo-demo-application", applicationConfig.getName());
 
-        ModuleConfig moduleConfig = configManager.getModule().get();
-        Assertions.assertEquals("dubbo-demo-module", moduleConfig.getName());
-
         MonitorConfig monitorConfig = configManager.getMonitor().get();
         Assertions.assertEquals("zookeeper://127.0.0.1:32770", monitorConfig.getAddress());
 
@@ -131,7 +128,11 @@ public class SpringBootConfigPropsTest {
         Assertions.assertEquals("zookeeper://127.0.0.1:2182", reportConfig.getAddress());
         Assertions.assertEquals("User", reportConfig.getUsername());
 
+        // module configs
         ModuleConfigManager moduleConfigManager = moduleModel.getConfigManager();
+        ModuleConfig moduleConfig = moduleConfigManager.getModule().get();
+        Assertions.assertEquals("dubbo-demo-module", moduleConfig.getName());
+
         ProviderConfig providerConfig = moduleConfigManager.getDefaultProvider().get();
         Assertions.assertEquals("127.0.0.1", providerConfig.getHost());
 

--- a/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/boot/configprops/SpringBootMultipleConfigPropsTest.java
+++ b/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/boot/configprops/SpringBootMultipleConfigPropsTest.java
@@ -97,9 +97,6 @@ public class SpringBootMultipleConfigPropsTest {
         ApplicationConfig applicationConfig = configManager.getApplicationOrElseThrow();
         Assertions.assertEquals("dubbo-demo-application", applicationConfig.getName());
 
-        ModuleConfig moduleConfig = configManager.getModule().get();
-        Assertions.assertEquals("dubbo-demo-module", moduleConfig.getName());
-
         MonitorConfig monitorConfig = configManager.getMonitor().get();
         Assertions.assertEquals("zookeeper://127.0.0.1:32770", monitorConfig.getAddress());
 
@@ -130,7 +127,12 @@ public class SpringBootMultipleConfigPropsTest {
         Assertions.assertEquals("zookeeper://127.0.0.1:2182", reportConfig.getAddress());
         Assertions.assertEquals("User", reportConfig.getUsername());
 
+        // module configs
         ModuleConfigManager moduleConfigManager = moduleModel.getConfigManager();
+
+        ModuleConfig moduleConfig = moduleConfigManager.getModule().get();
+        Assertions.assertEquals("dubbo-demo-module", moduleConfig.getName());
+
         ProviderConfig providerConfig = moduleConfigManager.getDefaultProvider().get();
         Assertions.assertEquals("127.0.0.1", providerConfig.getHost());
 


### PR DESCRIPTION
## What is the purpose of the change

* move ModuleConfig to ModuleConfigManager
* copy some config options to  ModuleConfig from ProviderConfig/ConsumerConfig, such as  `background` , `exportThreadNum`, `referThreadNum`
* support start module in background, do not await module start finish in Spring application

