### PR TITLE
[master] set client to null at LazyConnectExchangeClient close methods

### DIFF
--- a/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/exchange/support/header/HeaderExchangeChannel.java
+++ b/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/exchange/support/header/HeaderExchangeChannel.java
@@ -153,6 +153,7 @@ final class HeaderExchangeChannel implements ExchangeChannel {
         if (closed) {
             return;
         }
+        closed = true;
         try {
             // graceful close
             DefaultFuture.closeChannel(channel);
@@ -168,7 +169,6 @@ final class HeaderExchangeChannel implements ExchangeChannel {
         if (closed) {
             return;
         }
-        closed = true;
         if (timeout > 0) {
             long start = System.currentTimeMillis();
             while (DefaultFuture.hasFuture(channel)

--- a/dubbo-rpc/dubbo-rpc-dubbo/src/main/java/org/apache/dubbo/rpc/protocol/dubbo/LazyConnectExchangeClient.java
+++ b/dubbo-rpc/dubbo-rpc-dubbo/src/main/java/org/apache/dubbo/rpc/protocol/dubbo/LazyConnectExchangeClient.java
@@ -193,6 +193,7 @@ final class LazyConnectExchangeClient implements ExchangeClient {
     public void close() {
         if (client != null) {
             client.close();
+            client = null;
         }
     }
 
@@ -200,6 +201,7 @@ final class LazyConnectExchangeClient implements ExchangeClient {
     public void close(int timeout) {
         if (client != null) {
             client.close(timeout);
+            client = null;
         }
     }
 

--- a/dubbo-rpc/dubbo-rpc-dubbo/src/main/java/org/apache/dubbo/rpc/protocol/dubbo/ReferenceCountExchangeClient.java
+++ b/dubbo-rpc/dubbo-rpc-dubbo/src/main/java/org/apache/dubbo/rpc/protocol/dubbo/ReferenceCountExchangeClient.java
@@ -205,7 +205,7 @@ final class ReferenceCountExchangeClient implements ExchangeClient {
         /**
          * the order of judgment in the if statement cannot be changed.
          */
-        if (!(client instanceof LazyConnectExchangeClient) || client.isClosed()) {
+        if (!(client instanceof LazyConnectExchangeClient)) {
             // this is a defensive operation to avoid client is closed by accident, the initial state of the client is false
             URL lazyUrl = url.addParameter(LAZY_CONNECT_INITIAL_STATE_KEY, Boolean.TRUE)
                     //.addParameter(RECONNECT_KEY, Boolean.FALSE)

--- a/dubbo-rpc/dubbo-rpc-dubbo/src/test/java/org/apache/dubbo/rpc/protocol/dubbo/ReferenceCountExchangeClientTest.java
+++ b/dubbo-rpc/dubbo-rpc-dubbo/src/test/java/org/apache/dubbo/rpc/protocol/dubbo/ReferenceCountExchangeClientTest.java
@@ -177,6 +177,11 @@ public class ReferenceCountExchangeClientTest {
             Assertions.fail();
         }
 
+        // client has been replaced with lazy client, close status is false because a new lazy client's exchange client is null.
+        Assertions.assertFalse(client.isClosed(), "client status close");
+        // invoker status is available because the default value of associated lazy client's initial state is true.
+        Assertions.assertTrue(helloServiceInvoker.isAvailable(), "invoker status unavailable");
+
         // due to the effect of LazyConnectExchangeClient, the client will be "revived" whenever there is a call.
         Assertions.assertEquals("hello", helloService.hello());
         Assertions.assertEquals(1, LogUtil.findMessage(errorMsg), "should warning message");
@@ -186,9 +191,6 @@ public class ReferenceCountExchangeClientTest {
         Assertions.assertEquals(1, LogUtil.findMessage(errorMsg), "should warning message");
 
         DubboAppender.doStop();
-
-        // status switch to available once invoke again
-        Assertions.assertTrue(helloServiceInvoker.isAvailable(), "client status available");
 
         /**
          * This is the third time to close the same client. Under normal circumstances,
@@ -201,10 +203,14 @@ public class ReferenceCountExchangeClientTest {
          */
         client.close();
 
-        // client has been replaced with lazy client. lazy client is fetched from referenceclientmap, and since it's
-        // been invoked once, it's close status is false
+        // close status is false because the lazy client's exchange client is null again after close().
         Assertions.assertFalse(client.isClosed(), "client status close");
-        Assertions.assertFalse(helloServiceInvoker.isAvailable(), "client status close");
+        // invoker status is available because the default value of associated lazy client's initial state is true.
+        Assertions.assertTrue(helloServiceInvoker.isAvailable(), "invoker status unavailable");
+
+        // revive: initial the lazy client's exchange client again.  
+        Assertions.assertEquals("hello", helloService.hello());
+
         destoy();
     }
 


### PR DESCRIPTION
## What is the purpose of the change
fix #8880 on master
* set the client field of LazyConnectExchangeClient  to null at the end of close() and close(int timeout) methods
* move close status setting from HeaderExchangeChannel close(timeout) to close()