### PR TITLE
[master] add destroy() calling to close tomcat server port

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/utils/NetUtils.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/utils/NetUtils.java
@@ -118,6 +118,20 @@ public class NetUtils {
         return port;
     }
 
+    /**
+     * Check the port whether is in use in os
+     * @param port
+     * @return
+     */
+    public static boolean isPortInUsed(int port) {
+        try (ServerSocket ignored = new ServerSocket(port)) {
+            return false;
+        } catch (IOException e) {
+            // continue
+        }
+        return true;
+    }
+
     public static boolean isInvalidPort(int port) {
         return port < MIN_PORT || port > MAX_PORT;
     }

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/utils/NetUtils.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/utils/NetUtils.java
@@ -120,8 +120,9 @@ public class NetUtils {
 
     /**
      * Check the port whether is in use in os
-     * @param port
-     * @return
+     * 
+     * @param port the port to check if in use
+     * @return is the given port in use or not
      */
     public static boolean isPortInUsed(int port) {
         try (ServerSocket ignored = new ServerSocket(port)) {

--- a/dubbo-remoting/dubbo-remoting-http/src/main/java/org/apache/dubbo/remoting/http/tomcat/TomcatHttpServer.java
+++ b/dubbo-remoting/dubbo-remoting-http/src/main/java/org/apache/dubbo/remoting/http/tomcat/TomcatHttpServer.java
@@ -88,6 +88,8 @@ public class TomcatHttpServer extends AbstractHttpServer {
 
         try {
             tomcat.stop();
+            // close port by destroy()
+            tomcat.destroy();
         } catch (Exception e) {
             logger.warn(e.getMessage(), e);
         }

--- a/dubbo-remoting/dubbo-remoting-http/src/test/java/org/apache/dubbo/remoting/http/tomcat/TomcatHttpBinderTest.java
+++ b/dubbo-remoting/dubbo-remoting-http/src/test/java/org/apache/dubbo/remoting/http/tomcat/TomcatHttpBinderTest.java
@@ -51,5 +51,6 @@ public class TomcatHttpBinderTest {
         assertThat(response, is("Tomcat"));
 
         httpServer.close();
+        assertThat(NetUtils.isPortInUsed(port), is(false));
     }
 }


### PR DESCRIPTION
## What is the purpose of the change
fix #8919 on master
* add destroy() calling to close tomcat server port
* add NetUtils.isPortInUsed() from branch 3.0