### PR TITLE
[master] Fix #8240, on branch master, when provider and consumer stop cause NPE

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/rpc/model/ApplicationModel.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/rpc/model/ApplicationModel.java
@@ -118,8 +118,7 @@ public class ApplicationModel {
         if (application != null) {
             return application;
         }
-        Optional<ApplicationConfig> appCfgOptional = getConfigManager().getApplication();
-        return appCfgOptional.map(ApplicationConfig::getName).orElse(null);
+        return getConfigManager().getApplication().map(ApplicationConfig::getName).orElse(null);
     }
 
     // Currently used by UT.

--- a/dubbo-common/src/main/java/org/apache/dubbo/rpc/model/ApplicationModel.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/rpc/model/ApplicationModel.java
@@ -119,7 +119,7 @@ public class ApplicationModel {
             return application;
         }
         Optional<ApplicationConfig> appCfgOptional = getConfigManager().getApplication();
-        return appCfgOptional.isPresent() ? appCfgOptional.get().getName() : null;
+        return appCfgOptional.map(ApplicationConfig::getName).orElse(null);
     }
 
     // Currently used by UT.

--- a/dubbo-common/src/main/java/org/apache/dubbo/rpc/model/ApplicationModel.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/rpc/model/ApplicationModel.java
@@ -118,7 +118,8 @@ public class ApplicationModel {
         if (application != null) {
             return application;
         }
-        return getConfigManager().getApplication().map(ApplicationConfig::getName).orElse(null);
+        return getConfigManager().getApplication()
+                .map(ApplicationConfig::getName).orElse(null);
     }
 
     // Currently used by UT.

--- a/dubbo-common/src/main/java/org/apache/dubbo/rpc/model/ApplicationModel.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/rpc/model/ApplicationModel.java
@@ -25,7 +25,6 @@ import org.apache.dubbo.config.ApplicationConfig;
 import org.apache.dubbo.config.context.ConfigManager;
 
 import java.util.Collection;
-import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 

--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/DubboShutdownHook.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/DubboShutdownHook.java
@@ -115,7 +115,6 @@ public class DubboShutdownHook extends Thread {
         dispatch(new DubboServiceDestroyedEvent(this));
         if (destroyed.compareAndSet(false, true)) {
             AbstractRegistryFactory.destroyAll();
-            destroyProtocols();
         }
     }
 

--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/DubboShutdownHook.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/DubboShutdownHook.java
@@ -115,6 +115,7 @@ public class DubboShutdownHook extends Thread {
         dispatch(new DubboServiceDestroyedEvent(this));
         if (destroyed.compareAndSet(false, true)) {
             AbstractRegistryFactory.destroyAll();
+            destroyProtocols();
         }
     }
 

--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/bootstrap/DubboBootstrap.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/bootstrap/DubboBootstrap.java
@@ -1260,7 +1260,6 @@ public class DubboBootstrap {
     public void destroy() {
         if (destroyLock.tryLock()) {
             try {
-                destroyProtocols();
                 if (destroyed.compareAndSet(false, true)) {
                     if (started.compareAndSet(true, false)) {
                         unregisterServiceInstance();
@@ -1268,17 +1267,16 @@ public class DubboBootstrap {
                         unexportServices();
                         unreferServices();
                     }
-
                     destroyRegistries();
                     destroyServiceDiscoveries();
                     destroyExecutorRepository();
+                    DubboShutdownHook.destroyAll();
                     clearConfigManager();
                     shutdownExecutor();
                     release();
                     ExtensionLoader<DubboBootstrapStartStopListener> exts = getExtensionLoader(DubboBootstrapStartStopListener.class);
                     exts.getSupportedExtensionInstances().forEach(ext -> ext.onStop(this));
                 }
-                DubboShutdownHook.destroyAll();
             } finally {
                 initialized.set(false);
                 destroyLock.unlock();

--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/bootstrap/DubboBootstrap.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/bootstrap/DubboBootstrap.java
@@ -105,7 +105,6 @@ import static org.apache.dubbo.common.extension.ExtensionLoader.getExtensionLoad
 import static org.apache.dubbo.common.function.ThrowableAction.execute;
 import static org.apache.dubbo.common.utils.StringUtils.isEmpty;
 import static org.apache.dubbo.common.utils.StringUtils.isNotEmpty;
-import static org.apache.dubbo.config.DubboShutdownHook.destroyProtocols;
 import static org.apache.dubbo.metadata.MetadataConstants.DEFAULT_METADATA_PUBLISH_DELAY;
 import static org.apache.dubbo.metadata.MetadataConstants.METADATA_PUBLISH_DELAY_KEY;
 import static org.apache.dubbo.metadata.WritableMetadataService.getDefaultExtension;


### PR DESCRIPTION
issue #8240

这个bug可能是因为这个PR引起的：#7965

当执行`DubboBootstrap#destroy()`的时候，`clear()`方法清除了`ConfigManager`的缓存
https://github1s.com/apache/dubbo/blob/master/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/bootstrap/DubboBootstrap.java#L1273-L1274

然后`DubboShutdownHook.destroyAll();`中去销毁`protocol`的时候去拿了`ApplicationConfig`，因为上面已经在缓存中清除了，所以报了NPE。
https://github1s.com/apache/dubbo/blob/master/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/integration/RegistryProtocol.java#L575-L576

另外`clear();`、`shutdown();`名字起的不是很好，我一并修改了。
