### PR TITLE
[3.0] destroy executor and improve tests 0926

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/threadpool/manager/DefaultExecutorRepository.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/threadpool/manager/DefaultExecutorRepository.java
@@ -387,14 +387,22 @@ public class DefaultExecutorRepository implements ExecutorRepository, ExtensionA
             }
         });
 
-        // TODO shutdown all executor services
-//        for (ScheduledExecutorService executorService : scheduledExecutors.listItems()) {
-//            executorService.shutdown();
-//        }
-//
-//        for (ExecutorService executorService : executorServiceRing.listItems()) {
-//            executorService.shutdown();
-//        }
+        // shutdown all executor services
+        for (ScheduledExecutorService executorService : scheduledExecutors.listItems()) {
+            try {
+                executorService.shutdown();
+            } catch (Exception e) {
+                logger.warn("shutdown scheduledExecutors failed: " + e.getMessage(), e);
+            }
+        }
+
+        for (ExecutorService executorService : executorServiceRing.listItems()) {
+            try {
+                executorService.shutdown();
+            } catch (Exception e) {
+                logger.warn("shutdown executorServiceRing failed: " + e.getMessage(), e);
+            }
+        }
     }
 
     @Override

--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/DubboShutdownHook.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/DubboShutdownHook.java
@@ -87,7 +87,7 @@ public class DubboShutdownHook extends Thread {
      */
     public void unregister() {
         if (registered.compareAndSet(true, false)) {
-            if (!this.isAlive()) {
+            if (this.isAlive() || destroyed.get()) {
                 // DubboShutdownHook is running
                 return;
             }

--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/DubboShutdownHook.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/DubboShutdownHook.java
@@ -74,6 +74,8 @@ public class DubboShutdownHook extends Thread {
         if (registered.compareAndSet(false, true)) {
             try {
                 Runtime.getRuntime().addShutdownHook(this);
+            } catch (IllegalStateException e) {
+                logger.warn("register shutdown hook failed: " + e.getMessage());
             } catch (Exception e) {
                 logger.warn("register shutdown hook failed: " + e.getMessage(), e);
             }
@@ -85,8 +87,14 @@ public class DubboShutdownHook extends Thread {
      */
     public void unregister() {
         if (registered.compareAndSet(true, false)) {
+            if (!this.isAlive()) {
+                // DubboShutdownHook is running
+                return;
+            }
             try {
                 Runtime.getRuntime().removeShutdownHook(this);
+            } catch (IllegalStateException e) {
+                logger.warn("unregister shutdown hook failed: " + e.getMessage());
             } catch (Exception e) {
                 logger.warn("unregister shutdown hook failed: " + e.getMessage(), e);
             }

--- a/dubbo-config/dubbo-config-spring/pom.xml
+++ b/dubbo-config/dubbo-config-spring/pom.xml
@@ -274,7 +274,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <configuration>
                     <forkCount>1</forkCount>
-                    <reuseForks>false</reuseForks>
+                    <!--<reuseForks>false</reuseForks>-->
                 </configuration>
             </plugin>
         </plugins>

--- a/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/propertyconfigurer/consumer3/PropertySourcesInJavaConfigTest.java
+++ b/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/propertyconfigurer/consumer3/PropertySourcesInJavaConfigTest.java
@@ -22,8 +22,10 @@ import org.apache.dubbo.config.spring.context.annotation.EnableDubbo;
 import org.apache.dubbo.config.spring.propertyconfigurer.consumer.DemoBeanFactoryPostProcessor;
 import org.apache.dubbo.config.spring.registrycenter.RegistryCenter;
 import org.apache.dubbo.config.spring.registrycenter.ZookeeperSingleRegistryCenter;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
@@ -43,19 +45,27 @@ public class PropertySourcesInJavaConfigTest {
     private static final String SCAN_PACKAGE_NAME = "org.apache.dubbo.config.spring.propertyconfigurer.consumer3.notexist";
     private static final String PACKAGE_PATH = "/org/apache/dubbo/config/spring/propertyconfigurer/consumer3";
     private static final String PROVIDER_CONFIG_PATH = "org/apache/dubbo/config/spring/propertyconfigurer/provider/dubbo-provider.xml";
-    private RegistryCenter singleRegistryCenter;
+    private static RegistryCenter singleRegistryCenter;
+
+    @BeforeAll
+    public static void beforeAll() {
+        singleRegistryCenter = new ZookeeperSingleRegistryCenter();
+        singleRegistryCenter.startup();
+    }
+
+    @AfterAll
+    public static void afterAll() {
+        singleRegistryCenter.shutdown();
+    }
 
     @BeforeEach
     public void setUp() throws Exception {
-        singleRegistryCenter = new ZookeeperSingleRegistryCenter();
-        singleRegistryCenter.startup();
         DubboBootstrap.reset();
     }
 
     @AfterEach
     public void tearDown() throws IOException {
         DubboBootstrap.reset();
-        singleRegistryCenter.shutdown();
     }
 
     @BeforeEach

--- a/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/reference/javaconfig/JavaConfigReferenceBeanTest.java
+++ b/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/reference/javaconfig/JavaConfigReferenceBeanTest.java
@@ -30,8 +30,10 @@ import org.apache.dubbo.config.spring.registrycenter.RegistryCenter;
 import org.apache.dubbo.config.spring.registrycenter.ZookeeperMultipleRegistryCenter;
 import org.apache.dubbo.rpc.service.GenericException;
 import org.apache.dubbo.rpc.service.GenericService;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -48,18 +50,26 @@ import java.util.Map;
 
 public class JavaConfigReferenceBeanTest {
 
-    private RegistryCenter multipleRegistryCenter;
+    private static RegistryCenter multipleRegistryCenter;
 
-    @BeforeEach
-    public void setUp() {
-        DubboBootstrap.reset();
+    @BeforeAll
+    public static void beforeAll() {
         multipleRegistryCenter = new ZookeeperMultipleRegistryCenter();
         multipleRegistryCenter.startup();
     }
 
+    @AfterAll
+    public static void afterAll() {
+        multipleRegistryCenter.shutdown();
+    }
+
+    @BeforeEach
+    public void setUp() {
+        DubboBootstrap.reset();
+    }
+
     @AfterEach
     public void tearDown() {
-        multipleRegistryCenter.shutdown();
         DubboBootstrap.reset();
     }
 


### PR DESCRIPTION
## What is the purpose of the change

* Destroy executor services
* `dubbo-config-spring`  surefire plugin  `reuseForks=true`
* Fix unregister `DubboShutdownHook` error
* Fix `DecodeableRpcResult`  read config NPE
* Improve registry center of tests: PropertySourcesInJavaConfigTest, JavaConfigReferenceBeanTest