### PR TITLE
[master] catch handler.caught() throwable of MultiMessageHandler

### DIFF
--- a/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/transport/MultiMessageHandler.java
+++ b/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/transport/MultiMessageHandler.java
@@ -20,7 +20,6 @@ import org.apache.dubbo.common.logger.Logger;
 import org.apache.dubbo.common.logger.LoggerFactory;
 import org.apache.dubbo.remoting.Channel;
 import org.apache.dubbo.remoting.ChannelHandler;
-import org.apache.dubbo.remoting.ExecutionException;
 import org.apache.dubbo.remoting.RemotingException;
 import org.apache.dubbo.remoting.exchange.support.MultiMessage;
 
@@ -43,9 +42,13 @@ public class MultiMessageHandler extends AbstractChannelHandlerDelegate {
             for (Object obj : list) {
                 try {
                     handler.received(channel, obj);
-                } catch (ExecutionException e) {
-                    logger.error("MultiMessageHandler received fail.", e);
-                    handler.caught(channel, e);
+                } catch (Throwable t) {
+                    logger.error("MultiMessageHandler received fail.", t);
+                    try {
+                        handler.caught(channel, t);
+                    } catch (Throwable t1) {
+                        logger.error("MultiMessageHandler caught fail.", t1);
+                    }
                 }
             }
         } else {

--- a/dubbo-remoting/dubbo-remoting-netty/src/test/java/org/apache/dubbo/remoting/exchange/support/header/HeartbeatHandlerTest.java
+++ b/dubbo-remoting/dubbo-remoting-netty/src/test/java/org/apache/dubbo/remoting/exchange/support/header/HeartbeatHandlerTest.java
@@ -57,12 +57,15 @@ public class HeartbeatHandlerTest {
             server = null;
         }
 
+        FakeChannelHandlers.resetChannelHandlers();
+
         // wait for timer to finish
         Thread.sleep(2000);
     }
 
     @Test
     public void testServerHeartbeat() throws Exception {
+        FakeChannelHandlers.resetChannelHandlers();
         URL serverURL = URL.valueOf("telnet://localhost:" + NetUtils.getAvailablePort(56780))
                 .addParameter(Constants.EXCHANGER_KEY, HeaderExchanger.NAME)
                 .addParameter(Constants.TRANSPORTER_KEY, "netty3")


### PR DESCRIPTION
## What is the purpose of the change
#8929
* catch handler.caught() throwable of MultiMessageHandler
* reset ChannelHandlers after each testing of HeartbeatHandlerTest