### PR TITLE
[3.0] Fix duplicated ApplicationConfig error

### DIFF
--- a/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/ConfigTest.java
+++ b/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/ConfigTest.java
@@ -108,6 +108,7 @@ public class ConfigTest {
     @AfterEach
     public void tearDown() {
         SysProps.clear();
+        DubboBootstrap.reset();
     }
 
 
@@ -145,6 +146,7 @@ public class ConfigTest {
     @Test
     @Disabled("waiting-to-fix")
     public void testServiceAnnotation() {
+        DubboBootstrap consumerBootstrap = null;
         AnnotationConfigApplicationContext providerContext = new AnnotationConfigApplicationContext();
         try {
             providerContext.register(ProviderConfiguration.class);
@@ -155,16 +157,19 @@ public class ConfigTest {
             reference.setInterface(HelloService.class);
             reference.setUrl("dubbo://127.0.0.1:12345");
 
-            DubboBootstrap bootstrap = DubboBootstrap.newInstance()
+            consumerBootstrap = DubboBootstrap.newInstance()
                     .application(new ApplicationConfig("consumer"))
                     .reference(reference)
                     .start();
-            HelloService helloService = bootstrap.getCache().get(reference);
+            HelloService helloService = consumerBootstrap.getCache().get(reference);
 
             String hello = helloService.sayHello("hello");
             assertEquals("Hello, hello", hello);
         } finally {
             providerContext.close();
+            if (consumerBootstrap != null) {
+                consumerBootstrap.stop();
+            }
         }
 
     }
@@ -443,14 +448,15 @@ public class ConfigTest {
         reference.setInterface(DemoService.class);
         reference.setUrl("dubbo://" + NetUtils.getLocalHost() + ":20880?" + DemoService.class.getName() + "?check=false");
 
-        DubboBootstrap bootstrap = DubboBootstrap.getInstance()
+
+        try {
+            DubboBootstrap.getInstance()
                 .application(application)
                 .provider(provider)
                 .service(service)
                 .reference(reference)
                 .start();
 
-        try {
             List<URL> urls = service.getExportedUrls();
             assertNotNull(urls);
             assertEquals(1, urls.size());
@@ -462,7 +468,7 @@ public class ConfigTest {
             assertEquals("classloader,monitor,accesslog,trace", urls.get(0).getParameter("reference.filter"));
 
         } finally {
-            bootstrap.stop();
+            DubboBootstrap.getInstance().stop();
         }
     }
 
@@ -695,7 +701,8 @@ public class ConfigTest {
         reference.setInterface(DemoService.class);
         reference.setUrl("dubbo://127.0.0.1:13123");
 
-        DubboBootstrap bootstrap = DubboBootstrap.getInstance()
+        try {
+            DubboBootstrap.getInstance()
                 .application(application)
                 .registry(registry)
                 .protocol(protocol)
@@ -703,7 +710,6 @@ public class ConfigTest {
                 .reference(reference)
                 .start();
 
-        try {
             URL url = service.getExportedUrls().get(0);
             assertEquals("api-override-properties", url.getParameter("application"));
             assertEquals("world", url.getParameter("owner"));
@@ -712,7 +718,7 @@ public class ConfigTest {
             url = reference.getExportedUrls().get(0);
             assertEquals("2000", url.getParameter("timeout"));
         } finally {
-            bootstrap.stop();
+            DubboBootstrap.getInstance().stop();
         }
     }
 
@@ -828,6 +834,7 @@ public class ConfigTest {
                     .service(service)
                     .reference(reference)
                     .start();
+
             // override retries
             assertEquals(Integer.valueOf(5), reference.getRetries());
             // set default value of check
@@ -838,6 +845,7 @@ public class ConfigTest {
             assertEquals(1234, defaultConsumer.getTimeout());
             assertEquals(false, defaultConsumer.isCheck());
         } finally {
+            DubboBootstrap.getInstance().stop();
         }
     }
 
@@ -849,24 +857,23 @@ public class ConfigTest {
         SysProps.setProperty("dubbo.registry.address", "N/A");
         SysProps.setProperty("dubbo.protocol.name", "dubbo");
         SysProps.setProperty("dubbo.protocol.port", "20834");
+
         try {
             ServiceConfig<DemoService> serviceConfig = new ServiceConfig<DemoService>();
             serviceConfig.setInterface(DemoService.class);
             serviceConfig.setRef(new DemoServiceImpl());
 
-            DubboBootstrap bootstrap = DubboBootstrap.getInstance()
-                    .service(serviceConfig)
-                    .start();
-            try {
-                assertEquals("sysover", serviceConfig.getApplication().getName());
-                assertEquals("sysowner", serviceConfig.getApplication().getOwner());
-                assertEquals("N/A", serviceConfig.getRegistry().getAddress());
-                assertEquals("dubbo", serviceConfig.getProtocol().getName());
-                assertEquals(20834, serviceConfig.getProtocol().getPort().intValue());
-            } finally {
-                bootstrap.stop();
-            }
+            DubboBootstrap.getInstance()
+                .service(serviceConfig)
+                .start();
+
+            assertEquals("sysover", serviceConfig.getApplication().getName());
+            assertEquals("sysowner", serviceConfig.getApplication().getOwner());
+            assertEquals("N/A", serviceConfig.getRegistry().getAddress());
+            assertEquals("dubbo", serviceConfig.getProtocol().getName());
+            assertEquals(20834, serviceConfig.getProtocol().getPort().intValue());
         } finally {
+            DubboBootstrap.getInstance().stop();
         }
     }
 
@@ -896,23 +903,20 @@ public class ConfigTest {
             service.setRegistry(registry);
             service.setProtocol(protocol);
 
-            DubboBootstrap bootstrap = DubboBootstrap.getInstance()
+            DubboBootstrap.getInstance()
                     .application(application)
                     .registry(registry)
                     .protocol(protocol)
                     .service(service)
                     .start();
 
-            try {
-                URL url = service.getExportedUrls().get(0);
-                assertEquals("sysover", url.getParameter("application"));
-                assertEquals("sysowner", url.getParameter("owner"));
-                assertEquals("dubbo", url.getProtocol());
-                assertEquals(20834, url.getPort());
-            } finally {
-                bootstrap.stop();
-            }
+            URL url = service.getExportedUrls().get(0);
+            assertEquals("sysover", url.getParameter("application"));
+            assertEquals("sysowner", url.getParameter("owner"));
+            assertEquals("dubbo", url.getProtocol());
+            assertEquals(20834, url.getPort());
         } finally {
+            DubboBootstrap.getInstance().stop();
         }
     }
 
@@ -938,26 +942,23 @@ public class ConfigTest {
             service.setRegistry(registry);
             service.setProtocol(protocol);
 
-            DubboBootstrap bootstrap = DubboBootstrap.getInstance()
+            DubboBootstrap.getInstance()
                     .application(application)
                     .registry(registry)
                     .protocol(protocol)
                     .service(service)
                     .start();
 
-            try {
-                URL url = service.getExportedUrls().get(0);
-                // from api
-                assertEquals("aaa", url.getParameter("application"));
-                // from dubbo-binder.properties
-                assertEquals("world", url.getParameter("owner"));
-                // from system property
-                assertEquals(1234, url.getPort());
-            } finally {
-                bootstrap.stop();
-            }
+            URL url = service.getExportedUrls().get(0);
+            // from api
+            assertEquals("aaa", url.getParameter("application"));
+            // from dubbo-binder.properties
+            assertEquals("world", url.getParameter("owner"));
+            // from system property
+            assertEquals(1234, url.getPort());
         } finally {
             System.clearProperty("dubbo.protocol.port");
+            DubboBootstrap.getInstance().stop();
         }
     }
 
@@ -1027,7 +1028,6 @@ public class ConfigTest {
         int port = NetUtils.getAvailablePort();
         SysProps.setProperty("dubbo.protocol.port", String.valueOf(port));
         ServiceConfig<DemoService> service = null;
-        DubboBootstrap bootstrap = null;
         try {
             ApplicationConfig application = new ApplicationConfig();
             application.setName("dubbo-protocol-port-override");
@@ -1054,9 +1054,7 @@ public class ConfigTest {
 
             assertEquals(port, service.getExportedUrls().get(0).getPort());
         } finally {
-            if (bootstrap != null) {
-                bootstrap.stop();
-            }
+            DubboBootstrap.getInstance().stop();
         }
     }
 
@@ -1090,19 +1088,19 @@ public class ConfigTest {
         helloService.setRegistry(registry);
         helloService.setProtocol(protocol);
 
-        DubboBootstrap bootstrap = DubboBootstrap.getInstance()
+        try {
+            DubboBootstrap.getInstance()
                 .application(application)
                 .registry(registry)
                 .protocol(protocol)
                 .service(demoService)
-                .service(helloService);
-        try {
-            bootstrap.start();
+                .service(helloService)
+                .start();
 
             assertEquals(demoService.getExportedUrls().get(0).getPort(),
                     helloService.getExportedUrls().get(0).getPort());
         } finally {
-            bootstrap.stop();
+            DubboBootstrap.getInstance().stop();
         }
     }
 
@@ -1121,17 +1119,17 @@ public class ConfigTest {
         ref.setRegistry(rc);
         ref.setInterface(DemoService.class.getName());
 
-        DubboBootstrap bootstrap = DubboBootstrap.getInstance()
+        try {
+            DubboBootstrap.getInstance()
                 .application(new ApplicationConfig("test-refer-generic-export"))
                 .service(sc)
-                .reference(ref);
-        try {
-            bootstrap.start();
+                .reference(ref)
+                .start();
             fail();
         } catch (Exception e) {
             e.printStackTrace();
         } finally {
-            bootstrap.stop();
+            DubboBootstrap.getInstance().stop();
         }
     }
 
@@ -1143,18 +1141,19 @@ public class ConfigTest {
         service.setGeneric(GENERIC_SERIALIZATION_BEAN);
         service.setRef((method, parameterTypes, args) -> null);
 
-        DubboBootstrap bootstrap = DubboBootstrap.getInstance()
+        try {
+            DubboBootstrap.getInstance()
                 .application(new ApplicationConfig("test"))
                 .service(service)
                 .start();
-        try {
+
             Collection<Registry> collection = MockRegistryFactory.getCachedRegistry();
             MockRegistry registry = (MockRegistry) collection.iterator().next();
             URL url = registry.getRegistered().get(0);
             assertEquals(GENERIC_SERIALIZATION_BEAN, url.getParameter(GENERIC_KEY));
         } finally {
             MockRegistryFactory.cleanCachedRegistry();
-            bootstrap.stop();
+            DubboBootstrap.getInstance().stop();
         }
     }
 


### PR DESCRIPTION
## What is the purpose of the change

Fix duplicated `ApplicationConfig` of  `testSystemPropertyOverrideReferenceConfig`

## Unit Tests Logs
```
Error:  Tests run: 1, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 0.05 s <<< FAILURE! - in org.apache.dubbo.config.spring.ShutdownHookTest
Error:  testDisableShutdownHook  Time elapsed: 0.05 s  <<< ERROR!
org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'dubboConfigBeanInitializer': Invocation of init method failed; nested exception is org.springframework.beans.FatalBeanException: Initialization dubbo config beans failed; nested exception is java.lang.IllegalStateException: Duplicate Configs found for ApplicationConfig, only one unique ApplicationConfig is allowed for one application. previous: <dubbo:application enableFileCache="false" name="testSystemPropertyOverrideReferenceConfig" protocol="dubbo" />, later: <dubbo:application enableFileCache="false" name="demo-provider" id="demo-provider" protocol="dubbo" />. According to config mode [STRICT], please remove redundant configs and keep only one.
	at org.apache.dubbo.config.spring.ShutdownHookTest.testDisableShutdownHook(ShutdownHookTest.java:40)
Caused by: org.springframework.beans.FatalBeanException: Initialization dubbo config beans failed; nested exception is java.lang.IllegalStateException: Duplicate Configs found for ApplicationConfig, only one unique ApplicationConfig is allowed for one application. previous: <dubbo:application enableFileCache="false" name="testSystemPropertyOverrideReferenceConfig" protocol="dubbo" />, later: <dubbo:application enableFileCache="false" name="demo-provider" id="demo-provider" protocol="dubbo" />. According to config mode [STRICT], please remove redundant configs and keep only one.
	at org.apache.dubbo.config.spring.ShutdownHookTest.testDisableShutdownHook(ShutdownHookTest.java:40)
Caused by: java.lang.IllegalStateException: Duplicate Configs found for ApplicationConfig, only one unique ApplicationConfig is allowed for one application. previous: <dubbo:application enableFileCache="false" name="testSystemPropertyOverrideReferenceConfig" protocol="dubbo" />, later: <dubbo:application enableFileCache="false" name="demo-provider" id="demo-provider" protocol="dubbo" />. According to config mode [STRICT], please remove redundant configs and keep only one.
	at org.apache.dubbo.config.spring.ShutdownHookTest.testDisableShutdownHook(ShutdownHookTest.java:40)
```


