### PR TITLE
[master] update curator version to 4.2.0 for zk 3.4.13

### DIFF
--- a/dubbo-dependencies-bom/pom.xml
+++ b/dubbo-dependencies-bom/pom.xml
@@ -100,7 +100,7 @@
         <httpcore_version>4.4.6</httpcore_version>
         <fastjson_version>1.2.70</fastjson_version>
         <zookeeper_version>3.4.13</zookeeper_version>
-        <curator_version>4.0.1</curator_version>
+        <curator_version>4.2.0</curator_version>
         <curator_test_version>2.12.0</curator_test_version>
         <jedis_version>3.6.0</jedis_version>
         <consul_version>1.4.2</consul_version>

--- a/dubbo-remoting/dubbo-remoting-netty/src/test/java/org/apache/dubbo/remoting/transport/netty/ThreadNameTest.java
+++ b/dubbo-remoting/dubbo-remoting-netty/src/test/java/org/apache/dubbo/remoting/transport/netty/ThreadNameTest.java
@@ -124,26 +124,26 @@ public class ThreadNameTest {
 
         @Override
         public void disconnected(Channel channel) throws RemotingException {
+            // client: DubboClientHandler thread, server: DubboServerHandler or DubboSharedHandler thread.
             output("disconnected");
-            checkThreadName();
         }
 
         @Override
         public void sent(Channel channel, Object message) throws RemotingException {
+            // main thread.
             output("sent");
-            checkThreadName();
         }
 
         @Override
         public void received(Channel channel, Object message) throws RemotingException {
+            // server: DubboServerHandler or DubboSharedHandler thread.
             output("received");
-            checkThreadName();
         }
 
         @Override
         public void caught(Channel channel, Throwable exception) throws RemotingException {
+            // client: DubboClientHandler thread, server: ?
             output("caught");
-            checkThreadName();
         }
     }
 


### PR DESCRIPTION
## What is the purpose of the change
* update curator version to 4.2.0 for zookeeper 3.4.x compatibility ( https://curator.apache.org/zk-compatibility-34.html )
* only test thread name for connected event ( fixes #8988 )