### PR TITLE
Remove connections config of method level

### DIFF
--- a/dubbo-config/dubbo-config-spring/src/main/resources/META-INF/compat/dubbo.xsd
+++ b/dubbo-config/dubbo-config-spring/src/main/resources/META-INF/compat/dubbo.xsd
@@ -6,7 +6,8 @@
             targetNamespace="http://code.alibabatech.com/schema/dubbo">
 
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace"/>
-    <xsd:import namespace="http://www.springframework.org/schema/beans" schemaLocation="http://www.springframework.org/schema/beans/spring-beans.xsd"/>
+    <xsd:import namespace="http://www.springframework.org/schema/beans"
+                schemaLocation="http://www.springframework.org/schema/beans/spring-beans.xsd"/>
     <xsd:import namespace="http://www.springframework.org/schema/tool"/>
 
     <xsd:annotation>
@@ -170,6 +171,12 @@
                     <xsd:annotation>
                         <xsd:documentation>
                             <![CDATA[ Defines the service tag]]></xsd:documentation>
+                    </xsd:annotation>
+                </xsd:attribute>
+                <xsd:attribute name="connections" type="xsd:string">
+                    <xsd:annotation>
+                        <xsd:documentation>
+                            <![CDATA[ The exclusive connections. default share one connection. ]]></xsd:documentation>
                     </xsd:annotation>
                 </xsd:attribute>
             </xsd:extension>
@@ -393,7 +400,7 @@
                 <xsd:documentation><![CDATA[ The application monitor. ]]></xsd:documentation>
             </xsd:annotation>
         </xsd:attribute>
-        <xsd:attribute name="shutwait" type="xsd:string" >
+        <xsd:attribute name="shutwait" type="xsd:string">
             <xsd:annotation>
                 <xsd:documentation><![CDATA[ The application shutDown-wait time. ]]></xsd:documentation>
             </xsd:annotation>
@@ -415,7 +422,8 @@
         </xsd:attribute>
         <xsd:attribute name="publish-interface" type="xsd:boolean">
             <xsd:annotation>
-                <xsd:documentation><![CDATA[ Publish interface level url to registry, default false. ]]></xsd:documentation>
+                <xsd:documentation>
+                    <![CDATA[ Publish interface level url to registry, default false. ]]></xsd:documentation>
             </xsd:annotation>
         </xsd:attribute>
         <xsd:attribute name="protocol" type="xsd:string">
@@ -716,7 +724,8 @@
         </xsd:attribute>
         <xsd:attribute name="cluster" type="xsd:string" use="optional">
             <xsd:annotation>
-                <xsd:documentation><![CDATA[ The config center cluster, it's real meaning may very on different Config Center products. ]]></xsd:documentation>
+                <xsd:documentation>
+                    <![CDATA[ The config center cluster, it's real meaning may very on different Config Center products. ]]></xsd:documentation>
             </xsd:annotation>
         </xsd:attribute>
         <xsd:attribute name="namespace" type="xsd:string" use="optional">
@@ -959,7 +968,8 @@
                 </xsd:attribute>
                 <xsd:attribute name="threadpool" type="xsd:string">
                     <xsd:annotation>
-                        <xsd:documentation><![CDATA[ Consumer threadpool: cached, fixed, limited, eager]]></xsd:documentation>
+                        <xsd:documentation>
+                            <![CDATA[ Consumer threadpool: cached, fixed, limited, eager]]></xsd:documentation>
                     </xsd:annotation>
                 </xsd:attribute>
                 <xsd:attribute name="corethreads" type="xsd:string">

--- a/dubbo-config/dubbo-config-spring/src/main/resources/META-INF/dubbo.xsd
+++ b/dubbo-config/dubbo-config-spring/src/main/resources/META-INF/dubbo.xsd
@@ -173,6 +173,12 @@
                             <![CDATA[ Defines the service tag]]></xsd:documentation>
                     </xsd:annotation>
                 </xsd:attribute>
+                <xsd:attribute name="connections" type="xsd:string">
+                    <xsd:annotation>
+                        <xsd:documentation>
+                            <![CDATA[ The exclusive connections. default share one connection. ]]></xsd:documentation>
+                    </xsd:annotation>
+                </xsd:attribute>
             </xsd:extension>
         </xsd:complexContent>
     </xsd:complexType>
@@ -336,7 +342,7 @@
                         <xsd:documentation><![CDATA[ The serialization protocol of service. ]]></xsd:documentation>
                     </xsd:annotation>
                 </xsd:attribute>
-                <xsd:attribute name="export-async" type="xsd:boolean" >
+                <xsd:attribute name="export-async" type="xsd:boolean">
                     <xsd:annotation>
                         <xsd:documentation>
                             <![CDATA[ Weather the service is export asynchronously, default false. ]]></xsd:documentation>
@@ -423,7 +429,8 @@
         </xsd:attribute>
         <xsd:attribute name="publish-interface" type="xsd:boolean">
             <xsd:annotation>
-                <xsd:documentation><![CDATA[ Publish interface level url to registry, default true. ]]></xsd:documentation>
+                <xsd:documentation>
+                    <![CDATA[ Publish interface level url to registry, default true. ]]></xsd:documentation>
             </xsd:annotation>
         </xsd:attribute>
         <xsd:attribute name="protocol" type="xsd:string">
@@ -476,12 +483,14 @@
         </xsd:attribute>
         <xsd:attribute name="background" type="xsd:boolean">
             <xsd:annotation>
-                <xsd:documentation><![CDATA[ Whether start module in background, if true do not await finish. ]]></xsd:documentation>
+                <xsd:documentation>
+                    <![CDATA[ Whether start module in background, if true do not await finish. ]]></xsd:documentation>
             </xsd:annotation>
         </xsd:attribute>
         <xsd:attribute name="refer-async" type="xsd:boolean">
             <xsd:annotation>
-                <xsd:documentation><![CDATA[ Weather the reference is refer asynchronously, default false.  ]]></xsd:documentation>
+                <xsd:documentation>
+                    <![CDATA[ Weather the reference is refer asynchronously, default false.  ]]></xsd:documentation>
             </xsd:annotation>
         </xsd:attribute>
         <xsd:attribute name="refer-thread-num" type="xsd:boolean">
@@ -491,7 +500,8 @@
         </xsd:attribute>
         <xsd:attribute name="export-async" type="xsd:boolean">
             <xsd:annotation>
-                <xsd:documentation><![CDATA[ Weather the service is export asynchronously, default false. ]]></xsd:documentation>
+                <xsd:documentation>
+                    <![CDATA[ Weather the service is export asynchronously, default false. ]]></xsd:documentation>
             </xsd:annotation>
         </xsd:attribute>
         <xsd:attribute name="export-thread-num" type="xsd:boolean">
@@ -666,12 +676,14 @@
         </xsd:attribute>
         <xsd:attribute name="publish-interface" type="xsd:boolean">
             <xsd:annotation>
-                <xsd:documentation><![CDATA[ Publish interface level url to registry, default true. ]]></xsd:documentation>
+                <xsd:documentation>
+                    <![CDATA[ Publish interface level url to registry, default true. ]]></xsd:documentation>
             </xsd:annotation>
         </xsd:attribute>
         <xsd:attribute name="publish-instance" type="xsd:boolean">
             <xsd:annotation>
-                <xsd:documentation><![CDATA[ Publish instance level url to registry, default true. ]]></xsd:documentation>
+                <xsd:documentation>
+                    <![CDATA[ Publish instance level url to registry, default true. ]]></xsd:documentation>
             </xsd:annotation>
         </xsd:attribute>
     </xsd:complexType>
@@ -907,9 +919,9 @@
 
     <xsd:complexType name="metricsType">
         <xsd:all>
-                <xsd:element ref="prometheus-exporter" minOccurs="0"/>
-                <xsd:element ref="prometheus-pushgateway" minOccurs="0"/>
-                <xsd:element ref="aggregation" minOccurs="0"/>
+            <xsd:element ref="prometheus-exporter" minOccurs="0"/>
+            <xsd:element ref="prometheus-pushgateway" minOccurs="0"/>
+            <xsd:element ref="aggregation" minOccurs="0"/>
         </xsd:all>
         <xsd:attribute name="protocol" type="xsd:string">
             <xsd:annotation>
@@ -1140,12 +1152,14 @@
                 </xsd:attribute>
                 <xsd:attribute name="refer-thread-num" type="xsd:integer">
                     <xsd:annotation>
-                        <xsd:documentation><![CDATA[ Thread num for asynchronous refer pool size. ]]></xsd:documentation>
+                        <xsd:documentation>
+                            <![CDATA[ Thread num for asynchronous refer pool size. ]]></xsd:documentation>
                     </xsd:annotation>
                 </xsd:attribute>
                 <xsd:attribute name="refer-background" type="xsd:boolean">
                     <xsd:annotation>
-                        <xsd:documentation><![CDATA[ Whether refer should run in background or not, default false. ]]></xsd:documentation>
+                        <xsd:documentation>
+                            <![CDATA[ Whether refer should run in background or not, default false. ]]></xsd:documentation>
                     </xsd:annotation>
                 </xsd:attribute>
                 <xsd:anyAttribute namespace="##other" processContents="lax"/>
@@ -1541,12 +1555,14 @@
                 </xsd:attribute>
                 <xsd:attribute name="export-thread-num" type="xsd:integer">
                     <xsd:annotation>
-                        <xsd:documentation><![CDATA[ Thread num for asynchronous export pool size. ]]></xsd:documentation>
+                        <xsd:documentation>
+                            <![CDATA[ Thread num for asynchronous export pool size. ]]></xsd:documentation>
                     </xsd:annotation>
                 </xsd:attribute>
                 <xsd:attribute name="export-background" type="xsd:boolean">
                     <xsd:annotation>
-                        <xsd:documentation><![CDATA[ Deprecated. Whether export should run in background or not, default false. ]]></xsd:documentation>
+                        <xsd:documentation>
+                            <![CDATA[ Deprecated. Whether export should run in background or not, default false. ]]></xsd:documentation>
                     </xsd:annotation>
                 </xsd:attribute>
                 <xsd:anyAttribute namespace="##other" processContents="lax"/>


### PR DESCRIPTION
## What is the purpose of the change

Method config can no longer set connections, the definition in xsd can be deleted directly.
Fix https://github.com/apache/dubbo/issues/2769

## Brief changelog


## Verifying this change


<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [ ] GitHub Actions works fine on your own branch.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
