### PR TITLE
[WIP][3.0] Fix #8985, add destroy check when refreshMetadata

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/rpc/model/ScopeModel.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/rpc/model/ScopeModel.java
@@ -69,6 +69,7 @@ public abstract class ScopeModel implements ExtensionAccessor {
 
     private Map<String, Object> attributes;
     private AtomicBoolean destroyed = new AtomicBoolean(false);
+    private AtomicBoolean isShutdown = new AtomicBoolean(false);
     private volatile boolean stopping;
 
     public ScopeModel(ScopeModel parent, ExtensionScope scope) {
@@ -229,5 +230,14 @@ public abstract class ScopeModel implements ExtensionAccessor {
 
     public void setModelName(String modelName) {
         this.modelName = modelName;
+    }
+
+    public boolean isShutdown() {
+        return isShutdown.get();
+    }
+
+    public void shutdown() {
+        isShutdown.compareAndSet(false, true);
+        destroy();
     }
 }

--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/DubboShutdownHook.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/DubboShutdownHook.java
@@ -64,7 +64,7 @@ public class DubboShutdownHook extends Thread {
     }
 
     private void doDestroy() {
-        applicationModel.destroy();
+        applicationModel.shutdown();
     }
 
     /**

--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/deploy/DefaultApplicationDeployer.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/deploy/DefaultApplicationDeployer.java
@@ -714,7 +714,7 @@ public class DefaultApplicationDeployer extends AbstractDeployer<ApplicationMode
                 }
                 try {
                     // when jvm exit, the refreshMetadata is not required.
-                    if (!applicationModel.isDestroyed()) {
+                    if (!applicationModel.isShutdown()) {
                         ServiceInstanceMetadataUtils.refreshMetadataAndInstance(serviceInstance);
                     }
                 } catch (Exception e) {


### PR DESCRIPTION
fix #8985 ,
jvm退出时，localMetadataService.blockUntilUpdated被释放，此时可使用applicationModel.isDestroyed()判断是否继续处理ServiceInstanceMetadataUtils.refreshMetadataAndInstance()


<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [x] Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [x] GitHub Actions works fine on your own branch.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
