### PR TITLE
[3.0] fix Corrupted STDOUT issue of maven-surefire-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -113,6 +113,7 @@
         <!-- Maven plugins -->
         <maven_jar_version>3.2.0</maven_jar_version>
         <maven_surefire_version>3.0.0-M5</maven_surefire_version>
+        <maven_failsafe_version>3.0.0-M5</maven_failsafe_version>
         <maven_deploy_version>2.8.2</maven_deploy_version>
         <maven_compiler_version>3.8.1</maven_compiler_version>
         <maven_source_version>3.2.1</maven_source_version>
@@ -707,7 +708,7 @@
                 <!-- keep surefire and failsafe in sync -->
                 <plugin>
                     <artifactId>maven-failsafe-plugin</artifactId>
-                    <version>2.22.2</version>
+                    <version>${maven_failsafe_version}</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-clean-plugin</artifactId>


### PR DESCRIPTION
## What is the purpose of the change
Fix #9088
* update maven-surefire-plugin version to 3.0.0-M5 and configure forkNode implementation of it