### PR TITLE
Fix the problem of StatItem#isAllowable under multi-threading

### DIFF
--- a/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/zookeeper/AbstractZookeeperTransporter.java
+++ b/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/zookeeper/AbstractZookeeperTransporter.java
@@ -35,7 +35,7 @@ import static org.apache.dubbo.common.constants.CommonConstants.TIMEOUT_KEY;
 /**
  * AbstractZookeeperTransporter is abstract implements of ZookeeperTransporter.
  * <p>
- * If you want to extends this, implements createZookeeperClient.
+ * If you want to extend this, implements createZookeeperClient.
  */
 public abstract class AbstractZookeeperTransporter implements ZookeeperTransporter {
     private static final Logger logger = LoggerFactory.getLogger(ZookeeperTransporter.class);

--- a/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/zookeeper/ZookeeperClient.java
+++ b/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/zookeeper/ZookeeperClient.java
@@ -33,13 +33,13 @@ public interface ZookeeperClient {
     List<String> addChildListener(String path, ChildListener listener);
 
     /**
-     * @param path:    directory. All of child of path will be listened.
+     * @param path:    directory. All child of path will be listened.
      * @param listener
      */
     void addDataListener(String path, DataListener listener);
 
     /**
-     * @param path:    directory. All of child of path will be listened.
+     * @param path:    directory. All child of path will be listened.
      * @param listener
      * @param executor another thread
      */

--- a/dubbo-remoting/dubbo-remoting-api/src/test/java/org/apache/dubbo/remoting/transport/CodecSupportTest.java
+++ b/dubbo-remoting/dubbo-remoting-api/src/test/java/org/apache/dubbo/remoting/transport/CodecSupportTest.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.remoting.transport;
+
+import org.apache.dubbo.common.serialize.ObjectOutput;
+import org.apache.dubbo.common.serialize.Serialization;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+
+
+public class CodecSupportTest {
+
+    @Test
+    public void testHeartbeat() throws Exception {
+        Byte proto = CodecSupport.getIDByName("hessian2");
+        Serialization serialization = CodecSupport.getSerializationById(proto);
+        byte[] nullBytes = CodecSupport.getNullBytesOf(serialization);
+
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        ObjectOutput out = serialization.serialize(null, baos);
+        out.writeObject(null);
+        out.flushBuffer();
+        InputStream is = new ByteArrayInputStream(baos.toByteArray());
+        baos.close();
+        byte[] payload = CodecSupport.getPayload(is);
+
+        Assertions.assertArrayEquals(nullBytes, payload);
+        Assertions.assertTrue(CodecSupport.isHeartBeat(payload, proto));
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

The logic of the original code, assuming token=2, there are 10 threads that are not satisfied when executing if (token.sum() <= 0), that is, token.sum()> 0, at this time all execute token.decrement At this time, the value of token.sum() becomes a negative number, which is obviously wrong. The judgment +decrement is not turned into an atomic operation. Here I reverted to the original AtomicInteger to solve this problem.

原有代码的逻辑，假设token=2，有10个线程在执行if (token.sum() <= 0) 的时候都不满足，即token.sum() > 0，此时都执行token.decrement，token.sum()的值成了负数，显然是不对的，没有将判断+decrement变成原子操作，这里我还原成了原先使用的AtomicInteger来解决这个问题。