### PR TITLE
change way to determine the port that metadata service will listen on

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/constants/CommonConstants.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/constants/CommonConstants.java
@@ -41,6 +41,8 @@ public interface CommonConstants {
 
     String METADATA_SERVICE_PORT_KEY = "metadata-service-port";
 
+    String METADATA_SERVICE_PROTOCOL_KEY = "metadata-service-protocol";
+
     String LIVENESS_PROBE_KEY = "liveness-probe";
 
     String READINESS_PROBE_KEY = "readiness-probe";

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/utils/NetUtils.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/utils/NetUtils.java
@@ -102,8 +102,8 @@ public class NetUtils {
     }
 
     public synchronized static int getAvailablePort(int port) {
-        if (port < MIN_PORT) {
-            return port = MIN_PORT;
+         if (port < MIN_PORT) {
+            return MIN_PORT;
         }
         for (int i = port; i < MAX_PORT; i++) {
             if (USED_PORT.get(i)) {
@@ -111,13 +111,15 @@ public class NetUtils {
             }
             try (ServerSocket ignored = new ServerSocket(i)) {
                 USED_PORT.set(i);
-                return i;
+                port = i;
+                break;
             } catch (IOException e) {
                 // continue
             }
         }
         return port;
     }
+
 
     /**
      * Check the port whether is in use in os

--- a/dubbo-common/src/main/java/org/apache/dubbo/config/ApplicationConfig.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/config/ApplicationConfig.java
@@ -177,6 +177,11 @@ public class ApplicationConfig extends AbstractConfig {
     private String protocol;
 
     /**
+     * The protocol used for peer-to-peer metadata transmission
+     */
+    private String metadataServiceProtocol;
+
+    /**
      * Metadata Service, used in Service Discovery
      */
     private Integer metadataServicePort;
@@ -521,6 +526,15 @@ public class ApplicationConfig extends AbstractConfig {
 
     public void setMetadataServicePort(Integer metadataServicePort) {
         this.metadataServicePort = metadataServicePort;
+    }
+
+    @Parameter(key = METADATA_SERVICE_PORT_KEY)
+    public String getMetadataServiceProtocol() {
+        return metadataServiceProtocol;
+    }
+
+    public void setMetadataServiceProtocol(String metadataServiceProtocol) {
+        this.metadataServiceProtocol = metadataServiceProtocol;
     }
 
     @Parameter(key = LIVENESS_PROBE_KEY)

--- a/dubbo-config/dubbo-config-api/pom.xml
+++ b/dubbo-config/dubbo-config-api/pom.xml
@@ -68,6 +68,11 @@
             <version>${project.parent.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.dubbo</groupId>
+            <artifactId>dubbo-rpc-triple</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
 
         <dependency>
             <groupId>org.apache.dubbo</groupId>

--- a/dubbo-config/dubbo-config-api/pom.xml
+++ b/dubbo-config/dubbo-config-api/pom.xml
@@ -72,6 +72,7 @@
             <groupId>org.apache.dubbo</groupId>
             <artifactId>dubbo-rpc-triple</artifactId>
             <version>${project.parent.version}</version>
+            <scope>test</scope>
         </dependency>
 
         <dependency>

--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/deploy/DefaultApplicationDeployer.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/deploy/DefaultApplicationDeployer.java
@@ -614,6 +614,10 @@ public class DefaultApplicationDeployer extends AbstractDeployer<ApplicationMode
         // ensure init and start internal module first
         prepareInternalModule();
 
+        // always start metadata service on application model start, so it's ready whenever a new module is started
+        // export MetadataService
+        exportMetadataService();
+
         if (hasPreparedApplicationInstance.get()) {
             return;
         }
@@ -631,8 +635,7 @@ public class DefaultApplicationDeployer extends AbstractDeployer<ApplicationMode
             if (!hasPreparedInternalModule.compareAndSet(false, true)) {
                 return;
             }
-            // export MetadataService
-            exportMetadataService();
+
             // start internal module
             ModuleDeployer internalModuleDeployer = applicationModel.getInternalModule().getDeployer();
             if (!internalModuleDeployer.isStarted()) {

--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/deploy/DefaultApplicationDeployer.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/deploy/DefaultApplicationDeployer.java
@@ -727,7 +727,10 @@ public class DefaultApplicationDeployer extends AbstractDeployer<ApplicationMode
      * export {@link MetadataService}
      */
     private void exportMetadataService() {
-        metadataServiceExporter.export();
+        // fixme, let's disable local metadata service export at this moment
+        if (!REMOTE_METADATA_STORAGE_TYPE.equals(getMetadataType())) {
+            metadataServiceExporter.export();
+        }
     }
 
     private void unexportMetadataService() {

--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/metadata/ConfigurableMetadataServiceExporter.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/metadata/ConfigurableMetadataServiceExporter.java
@@ -100,7 +100,7 @@ public class ConfigurableMetadataServiceExporter implements MetadataServiceExpor
             serviceConfig.setMethods(generateMethodConfig());
 
             // export
-            serviceConfig.exportOnly();
+            serviceConfig.export();
 
             if (logger.isInfoEnabled()) {
                 logger.info("The MetadataService exports urls : " + serviceConfig.getExportedUrls());

--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/metadata/ConfigurableMetadataServiceExporter.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/metadata/ConfigurableMetadataServiceExporter.java
@@ -178,7 +178,7 @@ public class ConfigurableMetadataServiceExporter implements MetadataServiceExpor
                 }
 
                 Protocol protocol = applicationModel.getExtensionLoader(Protocol.class).getExtension(specifiedProtocol);
-                if (protocol != null) {
+                if (protocol != null && protocol.getServers() != null) {
                     Iterator<ProtocolServer> it = protocol.getServers().iterator();
                     if (it.hasNext()) {
                         String addr = it.next().getAddress();
@@ -209,7 +209,9 @@ public class ConfigurableMetadataServiceExporter implements MetadataServiceExpor
             Map<String, String> params = getApplicationConfig().getParameters();
             if (isNotEmpty(params)) {
                 String rawPort = getApplicationConfig().getParameters().get(METADATA_SERVICE_PORT_KEY);
-                port = Integer.parseInt(rawPort);
+                if (StringUtils.isNotEmpty(rawPort)) {
+                    port = Integer.parseInt(rawPort);
+                }
             }
         }
         return port;

--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/metadata/ConfigurableMetadataServiceExporter.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/metadata/ConfigurableMetadataServiceExporter.java
@@ -19,6 +19,7 @@ package org.apache.dubbo.config.metadata;
 import org.apache.dubbo.common.URL;
 import org.apache.dubbo.common.logger.Logger;
 import org.apache.dubbo.common.logger.LoggerFactory;
+import org.apache.dubbo.common.utils.CollectionUtils;
 import org.apache.dubbo.common.utils.StringUtils;
 import org.apache.dubbo.config.ApplicationConfig;
 import org.apache.dubbo.config.ArgumentConfig;
@@ -40,7 +41,6 @@ import java.util.List;
 import java.util.Map;
 
 import static java.util.Collections.emptyList;
-import static org.apache.dubbo.common.compiler.support.ClassUtils.isNotEmpty;
 import static org.apache.dubbo.common.constants.CommonConstants.DUBBO_PROTOCOL;
 import static org.apache.dubbo.common.constants.CommonConstants.METADATA_SERVICE_PORT_KEY;
 import static org.apache.dubbo.common.constants.CommonConstants.METADATA_SERVICE_PROTOCOL_KEY;
@@ -207,7 +207,7 @@ public class ConfigurableMetadataServiceExporter implements MetadataServiceExpor
         Integer port = getApplicationConfig().getMetadataServicePort();
         if (port == null) {
             Map<String, String> params = getApplicationConfig().getParameters();
-            if (isNotEmpty(params)) {
+            if (CollectionUtils.isNotEmptyMap(params)) {
                 String rawPort = getApplicationConfig().getParameters().get(METADATA_SERVICE_PORT_KEY);
                 if (StringUtils.isNotEmpty(rawPort)) {
                     port = Integer.parseInt(rawPort);
@@ -221,11 +221,11 @@ public class ConfigurableMetadataServiceExporter implements MetadataServiceExpor
         String protocol = getApplicationConfig().getMetadataServiceProtocol();
         if (StringUtils.isEmpty(protocol)) {
             Map<String, String> params = getApplicationConfig().getParameters();
-            if (isNotEmpty(params)) {
+            if (CollectionUtils.isNotEmptyMap(params)) {
                 protocol = getApplicationConfig().getParameters().get(METADATA_SERVICE_PROTOCOL_KEY);
             }
         }
 
-        return isNotEmpty(protocol) ? protocol : DUBBO_PROTOCOL;
+        return StringUtils.isNotEmpty(protocol) ? protocol : DUBBO_PROTOCOL;
     }
 }

--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/metadata/ConfigurableMetadataServiceExporter.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/metadata/ConfigurableMetadataServiceExporter.java
@@ -29,15 +29,21 @@ import org.apache.dubbo.config.ServiceConfig;
 import org.apache.dubbo.config.context.ConfigManager;
 import org.apache.dubbo.metadata.MetadataService;
 import org.apache.dubbo.metadata.MetadataServiceExporter;
+import org.apache.dubbo.rpc.Protocol;
+import org.apache.dubbo.rpc.ProtocolServer;
 import org.apache.dubbo.rpc.model.ApplicationModel;
 import org.apache.dubbo.rpc.model.ScopeModelAware;
 
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
-import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.Map;
+import java.util.Set;
 
 import static java.util.Collections.emptyList;
+import static org.apache.dubbo.common.compiler.support.ClassUtils.isNotEmpty;
 import static org.apache.dubbo.common.constants.CommonConstants.DUBBO_PROTOCOL;
+import static org.apache.dubbo.common.constants.CommonConstants.METADATA_SERVICE_PORT_KEY;
 
 /**
  * {@link MetadataServiceExporter} implementation based on {@link ConfigManager Dubbo configurations}, the clients
@@ -62,7 +68,6 @@ public class ConfigurableMetadataServiceExporter implements MetadataServiceExpor
 
     private volatile ServiceConfig<MetadataService> serviceConfig;
     private ApplicationModel applicationModel;
-    private AtomicBoolean exported = new AtomicBoolean(false);
 
     public ConfigurableMetadataServiceExporter() {
     }
@@ -79,7 +84,7 @@ public class ConfigurableMetadataServiceExporter implements MetadataServiceExpor
     @Override
     public ConfigurableMetadataServiceExporter export() {
 
-        if (exported.compareAndSet(false, true)) {
+        if (!isExported()) {
 
             ApplicationConfig applicationConfig = getApplicationConfig();
             ServiceConfig<MetadataService> serviceConfig = new ServiceConfig<>();
@@ -94,8 +99,8 @@ public class ConfigurableMetadataServiceExporter implements MetadataServiceExpor
             serviceConfig.setVersion(metadataService.version());
             serviceConfig.setMethods(generateMethodConfig());
 
-            // add to internal module, do export later
-            applicationModel.getInternalModule().getConfigManager().addService(serviceConfig);
+            // export
+            serviceConfig.exportOnly();
 
             if (logger.isInfoEnabled()) {
                 logger.info("The MetadataService exports urls : " + serviceConfig.getExportedUrls());
@@ -139,7 +144,6 @@ public class ConfigurableMetadataServiceExporter implements MetadataServiceExpor
         if (isExported()) {
             serviceConfig.unexport();
         }
-        exported.set(false);
         return this;
     }
 
@@ -149,7 +153,7 @@ public class ConfigurableMetadataServiceExporter implements MetadataServiceExpor
     }
 
     public boolean isExported() {
-        return exported.get();
+        return serviceConfig != null && serviceConfig.isExported() && !serviceConfig.isUnexported();
     }
 
     private ApplicationConfig getApplicationConfig() {
@@ -157,42 +161,63 @@ public class ConfigurableMetadataServiceExporter implements MetadataServiceExpor
     }
 
     private ProtocolConfig generateMetadataProtocol() {
-        ProtocolConfig defaultProtocol = new ProtocolConfig();
-        Integer port = getApplicationConfig().getMetadataServicePort();
+        ProtocolConfig protocolConfig = new ProtocolConfig();
+        protocolConfig.setName(DUBBO_PROTOCOL);
+        Integer port = getSpecifiedPort();
 
         if (port == null || port < -1) {
-            if (logger.isInfoEnabled()) {
-                logger.info("Metadata Service Port hasn't been set will use default protocol defined in protocols.");
-            }
-            List<ProtocolConfig> defaultProtocols = applicationModel.getApplicationConfigManager().getDefaultProtocols();
+            try {
+                if (logger.isInfoEnabled()) {
+                    logger.info("Metadata Service Port hasn't been set will use default protocol defined in protocols.");
+                }
+                Set<Protocol> defaultProtocols = applicationModel.getExtensionLoader(Protocol.class).getSupportedExtensionInstances();
 
-            ProtocolConfig dubboProtocol = findDubboProtocol(defaultProtocols);
-            if (dubboProtocol != null) {
-                logger.info("Using dubbo protocol " + dubboProtocol + " to export MetadataService.");
-                return dubboProtocol;
-            } else {
-                defaultProtocol.setName(DUBBO_PROTOCOL);
-                defaultProtocol.setPort(-1);
+                Protocol protocol = findDubboProtocol(defaultProtocols);
+                if (protocol != null) {
+                    Iterator<ProtocolServer> it = protocol.getServers().iterator();
+                    if (it.hasNext()) {
+                        String addr = it.next().getAddress();
+                        String rawPort = addr.substring(addr.indexOf(":") + 1);
+                        logger.info("Using dubbo protocol to export MetadataService on port " + rawPort);
+                        protocolConfig.setPort(Integer.parseInt(rawPort));
+                    }
+                }
+            } catch (Exception e) {
+                logger.error("Failed to find any valid dubbo protocol, will use random port to export metadata service.");
             }
-
         } else {
-            defaultProtocol.setName(DUBBO_PROTOCOL);
-            defaultProtocol.setPort(port);
+            protocolConfig.setPort(port);
         }
 
-        logger.info("Using dubbo protocol " + defaultProtocol + " to export MetadataService.");
+        if (protocolConfig.getPort() == null) {
+            protocolConfig.setPort(-1);
+        }
 
-        return defaultProtocol;
+        logger.info("Using dubbo protocol to export metadata service on port " + protocolConfig.getPort());
+
+        return protocolConfig;
     }
 
-    private ProtocolConfig findDubboProtocol(List<ProtocolConfig> protocolConfigs) {
-        if (CollectionUtils.isEmpty(protocolConfigs)) {
+    private Integer getSpecifiedPort() {
+        Integer port = getApplicationConfig().getMetadataServicePort();
+        if (port == null) {
+            Map<String, String> params = getApplicationConfig().getParameters();
+            if (isNotEmpty(params)) {
+                String rawPort = getApplicationConfig().getParameters().get(METADATA_SERVICE_PORT_KEY);
+                port = Integer.parseInt(rawPort);
+            }
+        }
+        return port;
+    }
+
+    private Protocol findDubboProtocol(Set<Protocol> protocols) {
+        if (CollectionUtils.isEmpty(protocols)) {
             return null;
         }
 
-        for (ProtocolConfig protocolConfig : protocolConfigs) {
-            if (DUBBO_PROTOCOL.equalsIgnoreCase(protocolConfig.getName())) {
-                return protocolConfig;
+        for (Protocol p : protocols) {
+            if (p.getClass().getName().equals("org.apache.dubbo.rpc.protocol.dubbo.DubboProtocol")) {
+                return p;
             }
         }
 

--- a/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/metadata/MetadataServiceExporterTest.java
+++ b/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/metadata/MetadataServiceExporterTest.java
@@ -16,20 +16,36 @@
  */
 package org.apache.dubbo.metadata;
 
+import org.apache.dubbo.common.URL;
+import org.apache.dubbo.common.utils.NetUtils;
 import org.apache.dubbo.config.ApplicationConfig;
 import org.apache.dubbo.config.ProtocolConfig;
 import org.apache.dubbo.config.RegistryConfig;
+import org.apache.dubbo.config.ServiceConfig;
+import org.apache.dubbo.config.api.DemoService;
 import org.apache.dubbo.config.bootstrap.DubboBootstrap;
 import org.apache.dubbo.config.metadata.ConfigurableMetadataServiceExporter;
+import org.apache.dubbo.config.provider.impl.DemoServiceImpl;
+import org.apache.dubbo.registrycenter.RegistryCenter;
+import org.apache.dubbo.registrycenter.ZookeeperSingleRegistryCenter;
 import org.apache.dubbo.rpc.model.ApplicationModel;
+import org.apache.dubbo.rpc.model.FrameworkModel;
+
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
+import java.util.List;
+
 import static org.apache.dubbo.common.constants.CommonConstants.COMPOSITE_METADATA_STORAGE_TYPE;
 import static org.apache.dubbo.common.constants.CommonConstants.DEFAULT_METADATA_STORAGE_TYPE;
+import static org.apache.dubbo.common.constants.CommonConstants.DUBBO_PROTOCOL;
 import static org.apache.dubbo.common.constants.CommonConstants.REMOTE_METADATA_STORAGE_TYPE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -82,6 +98,165 @@ public class MetadataServiceExporterTest {
 
         applicationModel.getDeployer().stop();
         assertFalse(exporter.isExported());
+    }
+
+    /**
+     * test reuse of port started by normal service
+     */
+    @Test
+    public void testPortReuse() throws Exception {
+        DubboBootstrap providerBootstrap = DubboBootstrap.newInstance();
+        ServiceConfig<DemoService> serviceConfig = new ServiceConfig<>();
+        serviceConfig.setInterface(DemoService.class);
+        serviceConfig.setRef(new DemoServiceImpl());
+
+        ApplicationConfig applicationConfig = new ApplicationConfig("exporter-test");
+        applicationConfig.setMetadataType(DEFAULT_METADATA_STORAGE_TYPE);
+
+        providerBootstrap
+            .application(applicationConfig)
+            .registry(registryConfig)
+            .protocol(new ProtocolConfig("dubbo", 2002))
+            .service(serviceConfig);
+
+        // will start exporter
+        providerBootstrap.start();
+        ConfigurableMetadataServiceExporter exporter = (ConfigurableMetadataServiceExporter) providerBootstrap.getApplicationModel().getExtensionLoader(MetadataServiceExporter.class).getDefaultExtension();
+
+        try {
+            assertTrue(exporter.isExported());
+            List<URL> urls = exporter.getExportedURLs();
+            assertNotNull(urls);
+            assertEquals(2002, urls.get(0).getPort());
+            assertEquals(DUBBO_PROTOCOL, urls.get(0).getProtocol());
+        } finally {
+            providerBootstrap.stop();
+        }
+        assertFalse(exporter.isExported());
+    }
+
+    /**
+     * test user specified port and protocol
+     * @throws Exception
+     */
+    @Test
+    public void testSpecifiedPortAndProtocol() throws Exception {
+        DubboBootstrap providerBootstrap = DubboBootstrap.newInstance();
+        ServiceConfig<DemoService> serviceConfig = new ServiceConfig<>();
+        serviceConfig.setInterface(DemoService.class);
+        serviceConfig.setRef(new DemoServiceImpl());
+
+        ApplicationConfig applicationConfig = new ApplicationConfig("exporter-test");
+        applicationConfig.setMetadataType(DEFAULT_METADATA_STORAGE_TYPE);
+        applicationConfig.setMetadataServiceProtocol("tri");
+        applicationConfig.setMetadataServicePort(8089);
+
+        providerBootstrap
+            .application(applicationConfig)
+            .registry(registryConfig)
+            .protocol(new ProtocolConfig("dubbo", 2002))
+            .service(serviceConfig);
+
+        // will start exporter.export()
+        providerBootstrap.start();
+        ConfigurableMetadataServiceExporter exporter = (ConfigurableMetadataServiceExporter) providerBootstrap.getApplicationModel().getExtensionLoader(MetadataServiceExporter.class).getDefaultExtension();
+
+        try {
+            assertTrue(exporter.isExported());
+            List<URL> urls = exporter.getExportedURLs();
+            assertNotNull(urls);
+            assertEquals(8089, urls.get(0).getPort());
+            assertEquals("tri", urls.get(0).getProtocol());
+        } finally {
+            providerBootstrap.stop();
+        }
+        assertFalse(exporter.isExported());
+    }
+
+    @Test
+    public void testMetadataStartsBeforeNormalService() throws Exception {
+        DubboBootstrap providerBootstrap = DubboBootstrap.newInstance();
+        ServiceConfig<DemoService> serviceConfig = new ServiceConfig<>();
+        serviceConfig.setInterface(DemoService.class);
+        serviceConfig.setRef(new DemoServiceImpl());
+        serviceConfig.setDelay(1000);
+
+        ApplicationConfig applicationConfig = new ApplicationConfig("exporter-test");
+        applicationConfig.setMetadataType(DEFAULT_METADATA_STORAGE_TYPE);
+//        applicationConfig.setMetadataServiceProtocol("triple");
+//        applicationConfig.setMetadataServicePort(8089);
+
+        providerBootstrap
+            .application(applicationConfig)
+            .registry(registryConfig)
+            .protocol(new ProtocolConfig("dubbo", 2002))
+            .service(serviceConfig);
+
+        // will start exporter.export()
+        providerBootstrap.start();
+        ConfigurableMetadataServiceExporter exporter = (ConfigurableMetadataServiceExporter) providerBootstrap.getApplicationModel().getExtensionLoader(MetadataServiceExporter.class).getDefaultExtension();
+
+        try {
+            assertTrue(exporter.isExported());
+            List<URL> urls = exporter.getExportedURLs();
+            assertNotNull(urls);
+            assertNotEquals(2002, urls.get(0).getPort());
+            assertEquals("dubbo", urls.get(0).getProtocol());
+        } finally {
+            providerBootstrap.stop();
+        }
+        assertFalse(exporter.isExported());
+    }
+//
+//    /**
+//     * test multiple protocols
+//     * @throws Exception
+//     */
+//    @Test
+//    public void testMultiProtocols() throws Exception {
+//        DubboBootstrap providerBootstrap = DubboBootstrap.newInstance();
+//        ServiceConfig<DemoService> serviceConfig = new ServiceConfig<>();
+//        serviceConfig.setInterface(DemoService.class);
+//        serviceConfig.setRef(new DemoServiceImpl());
+//
+//        providerBootstrap
+//            .application("provider-app")
+//            .registry(registryConfig)
+//            .protocol(new ProtocolConfig("dubbo", 2002))
+//            .service(serviceConfig);
+//
+//        ConfigurableMetadataServiceExporter exporter = (ConfigurableMetadataServiceExporter) applicationModel.getExtensionLoader(MetadataServiceExporter.class).getDefaultExtension();
+//        MetadataService metadataService = Mockito.mock(MetadataService.class);
+//        exporter.setMetadataService(metadataService);
+//
+//        try {
+//            providerBootstrap.start();
+//            assertTrue(exporter.isExported());
+//            assertTrue(exporter.supports(DEFAULT_METADATA_STORAGE_TYPE));
+//            assertTrue(exporter.supports(REMOTE_METADATA_STORAGE_TYPE));
+//            assertTrue(exporter.supports(COMPOSITE_METADATA_STORAGE_TYPE));
+//        } finally {
+//            providerBootstrap.stop();
+//        }
+//        assertFalse(exporter.isExported());
+//    }
+
+    private static ZookeeperSingleRegistryCenter registryCenter;
+    private static RegistryConfig registryConfig;
+
+    @BeforeAll
+    public static void beforeAll() {
+        FrameworkModel.destroyAll();
+        registryCenter = new ZookeeperSingleRegistryCenter(NetUtils.getAvailablePort());
+        registryCenter.startup();
+        RegistryCenter.Instance instance = registryCenter.getRegistryCenterInstance().get(0);
+        registryConfig = new RegistryConfig(String.format("%s://%s:%s",
+            instance.getType(),
+            instance.getHostname(),
+            instance.getPort()));
+
+        // pre-check threads
+        //precheckUnclosedThreads();
     }
 
 }

--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/metadata/ServiceInstanceMetadataUtils.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/metadata/ServiceInstanceMetadataUtils.java
@@ -113,6 +113,9 @@ public class ServiceInstanceMetadataUtils {
     }
 
     public static String getMetadataServiceParameter(URL url) {
+        if (url == null) {
+            return "";
+        }
         url = url.removeParameter(APPLICATION_KEY);
         url = url.removeParameter(GROUP_KEY);
         url = url.removeParameter(DEPRECATED_KEY);

--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/metadata/store/InMemoryWritableMetadataService.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/metadata/store/InMemoryWritableMetadataService.java
@@ -16,7 +16,6 @@
  */
 package org.apache.dubbo.registry.client.metadata.store;
 
-import com.google.gson.Gson;
 import org.apache.dubbo.common.URL;
 import org.apache.dubbo.common.config.ConfigurationUtils;
 import org.apache.dubbo.common.logger.Logger;
@@ -36,6 +35,8 @@ import org.apache.dubbo.registry.client.RegistryClusterIdentifier;
 import org.apache.dubbo.rpc.model.ApplicationModel;
 import org.apache.dubbo.rpc.model.ScopeModelAware;
 import org.apache.dubbo.rpc.support.ProtocolUtils;
+
+import com.google.gson.Gson;
 
 import java.util.Collections;
 import java.util.Comparator;
@@ -209,7 +210,6 @@ public class InMemoryWritableMetadataService implements WritableMetadataService,
     @Override
     public boolean unexportURL(URL url) {
         if (MetadataService.class.getName().equals(url.getServiceInterface())) {
-            // TODO, metadata service need to be unexported.
             this.metadataServiceURL = null;
             return true;
         }


### PR DESCRIPTION
The protocol will always be Dubbo while the port is determined by following below steps:

1. Check explicitly specified port
2. Try to find currently working Dubbo protocol port by terating protocols 
3. use random port 