### PR TITLE
[3.0] Support destroy scope bean and spi extension instance

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/context/Lifecycle.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/context/Lifecycle.java
@@ -16,12 +16,14 @@
  */
 package org.apache.dubbo.common.context;
 
+import org.apache.dubbo.common.resource.Disposable;
+
 /**
  * The Lifecycle of Dubbo component
  *
  * @since 2.7.5
  */
-public interface Lifecycle {
+public interface Lifecycle extends Disposable {
 
     /**
      * Initialize the component before {@link #start() start}

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/extension/ExtensionDirector.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/extension/ExtensionDirector.java
@@ -132,4 +132,11 @@ public class ExtensionDirector implements ExtensionAccessor {
     public void removeAllCachedLoader() {
         // extensionLoadersMap.clear();
     }
+
+    public void destroy() {
+        for (ExtensionLoader<?> extensionLoader : extensionLoadersMap.values()) {
+            extensionLoader.destroy();
+        }
+        extensionLoadersMap.clear();
+    }
 }

--- a/dubbo-common/src/main/java/org/apache/dubbo/rpc/model/ScopeModel.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/rpc/model/ScopeModel.java
@@ -107,6 +107,12 @@ public abstract class ScopeModel implements ExtensionAccessor {
                 for (ClassLoader classLoader : copyOfClassLoaders) {
                     removeClassLoader(classLoader);
                 }
+                if (beanFactory != null) {
+                    beanFactory.destroy();
+                }
+                if (extensionDirector != null) {
+                    extensionDirector.destroy();
+                }
             } catch (Throwable t) {
                 LOGGER.error("Error happened when destroying ScopeModel.", t);
             }

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/beans/ScopeBeanFactoryTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/beans/ScopeBeanFactoryTest.java
@@ -44,5 +44,13 @@ public class ScopeBeanFactoryTest {
 
         Object objectBean = applicationModel.getBeanFactory().getBean(Object.class);
         Assertions.assertNull(objectBean);
+
+        Assertions.assertFalse(beanWithApplicationModel.isDestroyed());
+        Assertions.assertFalse(beanWithFrameworkModel.isDestroyed());
+
+        // destroy
+        frameworkModel.destroy();
+        Assertions.assertTrue(beanWithApplicationModel.isDestroyed());
+        Assertions.assertTrue(beanWithFrameworkModel.isDestroyed());
     }
 }

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/beans/model/FooBeanWithApplicationModel.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/beans/model/FooBeanWithApplicationModel.java
@@ -16,10 +16,12 @@
  */
 package org.apache.dubbo.common.beans.model;
 
+import org.apache.dubbo.common.resource.Disposable;
 import org.apache.dubbo.rpc.model.ApplicationModel;
 
-public class FooBeanWithApplicationModel {
+public class FooBeanWithApplicationModel implements Disposable {
     private ApplicationModel applicationModel;
+    private boolean destroyed;
 
     public FooBeanWithApplicationModel(ApplicationModel applicationModel) {
         this.applicationModel = applicationModel;
@@ -27,5 +29,14 @@ public class FooBeanWithApplicationModel {
 
     public ApplicationModel getApplicationModel() {
         return applicationModel;
+    }
+
+    @Override
+    public void destroy() {
+        this.destroyed = true;
+    }
+
+    public boolean isDestroyed() {
+        return destroyed;
     }
 }

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/beans/model/FooBeanWithFrameworkModel.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/beans/model/FooBeanWithFrameworkModel.java
@@ -16,10 +16,12 @@
  */
 package org.apache.dubbo.common.beans.model;
 
+import org.apache.dubbo.common.resource.Disposable;
 import org.apache.dubbo.rpc.model.FrameworkModel;
 
-public class FooBeanWithFrameworkModel {
+public class FooBeanWithFrameworkModel implements Disposable {
     private FrameworkModel frameworkModel;
+    private boolean destroyed;
 
     public FooBeanWithFrameworkModel(FrameworkModel frameworkModel) {
         this.frameworkModel = frameworkModel;
@@ -27,5 +29,14 @@ public class FooBeanWithFrameworkModel {
 
     public FrameworkModel getFrameworkModel() {
         return frameworkModel;
+    }
+
+    @Override
+    public void destroy() {
+        this.destroyed = true;
+    }
+
+    public boolean isDestroyed() {
+        return destroyed;
     }
 }

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/extension/ExtensionDirectorTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/extension/ExtensionDirectorTest.java
@@ -265,5 +265,14 @@ public class ExtensionDirectorTest {
         Assertions.assertNull(frameworkService.getAppProvider());
         Assertions.assertNull(frameworkService.getModuleProvider());
 
+        Assertions.assertFalse(moduleService.isDestroyed());
+        Assertions.assertFalse(appService.isDestroyed());
+        Assertions.assertFalse(frameworkService.isDestroyed());
+
+        // destroy
+        frameworkModel.destroy();
+        Assertions.assertTrue(moduleService.isDestroyed());
+        Assertions.assertTrue(appService.isDestroyed());
+        Assertions.assertTrue(frameworkService.isDestroyed());
     }
 }

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/extension/director/impl/BaseTestService.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/extension/director/impl/BaseTestService.java
@@ -16,15 +16,17 @@
  */
 package org.apache.dubbo.common.extension.director.impl;
 
+import org.apache.dubbo.common.resource.Disposable;
 import org.apache.dubbo.rpc.model.ApplicationModel;
 import org.apache.dubbo.rpc.model.FrameworkModel;
-import org.apache.dubbo.rpc.model.ScopeModelAware;
 import org.apache.dubbo.rpc.model.ModuleModel;
+import org.apache.dubbo.rpc.model.ScopeModelAware;
 
-public class BaseTestService implements ScopeModelAware {
+public class BaseTestService implements ScopeModelAware, Disposable {
     private FrameworkModel frameworkModel;
     private ApplicationModel applicationModel;
     private ModuleModel moduleModel;
+    private volatile boolean destroyed;
 
     @Override
     public void setFrameworkModel(FrameworkModel frameworkModel) {
@@ -51,5 +53,14 @@ public class BaseTestService implements ScopeModelAware {
 
     public ModuleModel getModuleModel() {
         return moduleModel;
+    }
+
+    @Override
+    public void destroy() {
+        this.destroyed = true;
+    }
+
+    public boolean isDestroyed() {
+        return destroyed;
     }
 }


### PR DESCRIPTION
## What is the purpose of the change
Support destroy scope bean and spi extension instance

## Usage

Scope bean and SPI extension can implement `org.apache.dubbo.common.resource.Disposable`, then will be call `destroy()` method when scope model is destroyed.

```java
public class FooBean implement Disposable {
   public void destroy() {
      ....
   }
}
```

```java
public class MyFooSPI implement FooSPI, Disposable {
   public void destroy() {
      ....
   }
}
```