### PR TITLE
[3.0] Fix default ApplicationModel NPE

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/rpc/model/ApplicationModel.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/rpc/model/ApplicationModel.java
@@ -83,8 +83,8 @@ public class ApplicationModel extends ScopeModel {
     }
 
     /**
-     * During destroying the default FrameworkModel, FrameworkModel.defaultModel() or ApplicationModel.defaultModel()
-     * will get an broken model, maybe cause unpredictable problem.
+     * During destroying the default FrameworkModel, the FrameworkModel.defaultModel() or ApplicationModel.defaultModel()
+     * will return a broken model, maybe cause unpredictable problem.
      * Recommendation: Avoid using the default model as much as possible.
      * @return the global default ApplicationModel
      */


### PR DESCRIPTION
## What is the purpose of the change

Fix default ApplicationModel/FrameworkModel NPE

## Exception

see https://github.com/apache/dubbo/runs/4042205535?check_suite_focus=true

```
[INFO] [29/10/21 03:20:24:347 UTC] ERROR listener.ServiceInstancesChangedListener:  [DUBBO] Failed to load service metadata, meta type is local, dubbo version: 3.0.5-SNAPSHOT, current host: 10.1.0.14
[INFO] java.lang.NullPointerException
[INFO] 	at org.apache.dubbo.registry.client.metadata.MetadataUtils.referProxy(MetadataUtils.java:82)
[INFO] 	at org.apache.dubbo.registry.client.metadata.MetadataUtils.lambda$getMetadataServiceProxy$0(MetadataUtils.java:67)
[INFO] 	at java.base/java.util.concurrent.ConcurrentHashMap.computeIfAbsent(ConcurrentHashMap.java:1705)
[INFO] 	at org.apache.dubbo.registry.client.metadata.MetadataUtils.getMetadataServiceProxy(MetadataUtils.java:67)
[INFO] 	at org.apache.dubbo.registry.client.event.listener.ServiceInstancesChangedListener.doGetMetadataInfo(ServiceInstancesChangedListener.java:379)
[INFO] 	at org.apache.dubbo.registry.client.event.listener.ServiceInstancesChangedListener.getRemoteMetadata(ServiceInstancesChangedListener.java:330)
[INFO] 	at org.apache.dubbo.registry.client.event.listener.ServiceInstancesChangedListener.onEvent(ServiceInstancesChangedListener.java:143)
[INFO] 	at org.apache.dubbo.registry.client.event.listener.ServiceInstancesChangedListener$AddressRefreshRetryTask.run(ServiceInstancesChangedListener.java:493)
[INFO] 	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
[INFO] 	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
[INFO] 	at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:304)
[INFO] 	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
[INFO] 	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
[INFO] 	at java.base/java.lang.Thread.run(Thread.java:829)
```
