### PR TITLE
[3.0] Fix @DubboReference.consumer() lookup error

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/config/annotation/DubboReference.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/config/annotation/DubboReference.java
@@ -269,8 +269,8 @@ public @interface DubboReference {
     String[] parameters() default {};
 
     /**
-     * Application associated name
-     * @deprecated Do not set it and use the global Application Config
+     * Application name
+     * @deprecated This attribute was deprecated, use bind application/module of spring ApplicationContext
      */
     @Deprecated
     String application() default "";

--- a/dubbo-common/src/main/java/org/apache/dubbo/config/annotation/DubboService.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/config/annotation/DubboService.java
@@ -263,7 +263,7 @@ public @interface DubboService {
 
     /**
      * Application spring bean name
-     * @deprecated Do not set it and use the global Application Config
+     * @deprecated This attribute was deprecated, use bind application/module of spring ApplicationContext
      */
     @Deprecated
     String application() default "";

--- a/dubbo-common/src/main/java/org/apache/dubbo/config/context/ModuleConfigManager.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/config/context/ModuleConfigManager.java
@@ -22,11 +22,19 @@ import org.apache.dubbo.common.logger.LoggerFactory;
 import org.apache.dubbo.common.utils.CollectionUtils;
 import org.apache.dubbo.config.AbstractConfig;
 import org.apache.dubbo.config.AbstractInterfaceConfig;
+import org.apache.dubbo.config.ApplicationConfig;
+import org.apache.dubbo.config.ConfigCenterConfig;
 import org.apache.dubbo.config.ConsumerConfig;
+import org.apache.dubbo.config.MetadataReportConfig;
+import org.apache.dubbo.config.MetricsConfig;
 import org.apache.dubbo.config.ModuleConfig;
+import org.apache.dubbo.config.MonitorConfig;
+import org.apache.dubbo.config.ProtocolConfig;
 import org.apache.dubbo.config.ProviderConfig;
 import org.apache.dubbo.config.ReferenceConfigBase;
+import org.apache.dubbo.config.RegistryConfig;
 import org.apache.dubbo.config.ServiceConfigBase;
+import org.apache.dubbo.config.SslConfig;
 import org.apache.dubbo.rpc.model.ModuleModel;
 
 import java.util.Arrays;
@@ -47,10 +55,12 @@ public class ModuleConfigManager extends AbstractConfigManager {
     private static final Logger logger = LoggerFactory.getLogger(ModuleConfigManager.class);
 
     private Map<String, AbstractInterfaceConfig> serviceConfigCache = new ConcurrentHashMap<>();
+    private final ConfigManager applicationConfigManager;
 
 
     public ModuleConfigManager(ModuleModel moduleModel) {
         super(moduleModel, Arrays.asList(ModuleConfig.class, ServiceConfigBase.class, ReferenceConfigBase.class, ProviderConfig.class, ConsumerConfig.class));
+        applicationConfigManager = moduleModel.getApplicationModel().getApplicationConfigManager();
     }
 
     // ModuleConfig correlative methods
@@ -259,4 +269,109 @@ public class ModuleConfigManager extends AbstractConfigManager {
         checkDefaultAndValidateConfigs(ModuleConfig.class);
     }
 
+
+    //
+    // Delegate read application configs
+    //
+
+    public ConfigManager getApplicationConfigManager() {
+        return applicationConfigManager;
+    }
+
+    @Override
+    public <C extends AbstractConfig> Map<String, C> getConfigsMap(Class<C> cls) {
+        if (isSupportConfigType(cls)) {
+            return super.getConfigsMap(cls);
+        } else {
+            // redirect to application ConfigManager
+            return applicationConfigManager.getConfigsMap(cls);
+        }
+    }
+
+    @Override
+    public <C extends AbstractConfig> Collection<C> getConfigs(Class<C> configType) {
+        if (isSupportConfigType(configType)) {
+            return super.getConfigs(configType);
+        } else {
+            return applicationConfigManager.getConfigs(configType);
+        }
+    }
+
+    @Override
+    public <T extends AbstractConfig> Optional<T> getConfig(Class<T> cls, String idOrName) {
+        if (isSupportConfigType(cls)) {
+            return super.getConfig(cls, idOrName);
+        } else {
+            return applicationConfigManager.getConfig(cls, idOrName);
+        }
+    }
+
+    @Override
+    public <C extends AbstractConfig> List<C> getDefaultConfigs(Class<C> cls) {
+        if (isSupportConfigType(cls)) {
+            return super.getDefaultConfigs(cls);
+        } else {
+            return applicationConfigManager.getDefaultConfigs(cls);
+        }
+    }
+
+    public Optional<ApplicationConfig> getApplication() {
+        return applicationConfigManager.getApplication();
+    }
+
+    public Optional<MonitorConfig> getMonitor() {
+        return applicationConfigManager.getMonitor();
+    }
+
+    public Optional<MetricsConfig> getMetrics() {
+        return applicationConfigManager.getMetrics();
+    }
+
+    public Optional<SslConfig> getSsl() {
+        return applicationConfigManager.getSsl();
+    }
+
+    public Optional<Collection<ConfigCenterConfig>> getDefaultConfigCenter() {
+        return applicationConfigManager.getDefaultConfigCenter();
+    }
+
+    public Optional<ConfigCenterConfig> getConfigCenter(String id) {
+        return applicationConfigManager.getConfigCenter(id);
+    }
+
+    public Collection<ConfigCenterConfig> getConfigCenters() {
+        return applicationConfigManager.getConfigCenters();
+    }
+
+    public Collection<MetadataReportConfig> getMetadataConfigs() {
+        return applicationConfigManager.getMetadataConfigs();
+    }
+
+    public Collection<MetadataReportConfig> getDefaultMetadataConfigs() {
+        return applicationConfigManager.getDefaultMetadataConfigs();
+    }
+
+    public Optional<ProtocolConfig> getProtocol(String idOrName) {
+        return applicationConfigManager.getProtocol(idOrName);
+    }
+
+    public List<ProtocolConfig> getDefaultProtocols() {
+        return applicationConfigManager.getDefaultProtocols();
+    }
+
+    public Collection<ProtocolConfig> getProtocols() {
+        return applicationConfigManager.getProtocols();
+    }
+
+    public Optional<RegistryConfig> getRegistry(String id) {
+        return applicationConfigManager.getRegistry(id);
+    }
+
+    public List<RegistryConfig> getDefaultRegistries() {
+        return applicationConfigManager.getDefaultRegistries();
+    }
+
+    public Collection<RegistryConfig> getRegistries() {
+        return applicationConfigManager.getRegistries();
+    }
 }

--- a/dubbo-common/src/test/java/org/apache/dubbo/config/context/ConfigManagerTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/config/context/ConfigManagerTest.java
@@ -105,6 +105,7 @@ public class ConfigManagerTest {
         configManager.setApplication(config);
         assertTrue(configManager.getApplication().isPresent());
         assertEquals(config, configManager.getApplication().get());
+        assertEquals(config, moduleConfigManager.getApplication().get());
     }
 
     // Test MonitorConfig correlative methods
@@ -115,6 +116,7 @@ public class ConfigManagerTest {
         configManager.setMonitor(monitorConfig);
         assertTrue(configManager.getMonitor().isPresent());
         assertEquals(monitorConfig, configManager.getMonitor().get());
+        assertEquals(monitorConfig, moduleConfigManager.getMonitor().get());
     }
 
     // Test MonitorConfig correlative methods
@@ -134,6 +136,7 @@ public class ConfigManagerTest {
         configManager.setMetrics(config);
         assertTrue(configManager.getMetrics().isPresent());
         assertEquals(config, configManager.getMetrics().get());
+        assertEquals(config, moduleConfigManager.getMetrics().get());
     }
 
     // Test ProviderConfig correlative methods
@@ -183,6 +186,7 @@ public class ConfigManagerTest {
         assertEquals(1, configs.size());
         assertEquals(config, configs.iterator().next());
         assertFalse(configManager.getDefaultProtocols().isEmpty());
+        assertEquals(configs, moduleConfigManager.getProtocols());
     }
 
     // Test RegistryConfig correlative methods
@@ -194,6 +198,7 @@ public class ConfigManagerTest {
         assertEquals(1, configs.size());
         assertEquals(config, configs.iterator().next());
         assertFalse(configManager.getDefaultRegistries().isEmpty());
+        assertEquals(configs, moduleConfigManager.getRegistries());
     }
 
     // Test ConfigCenterConfig correlative methods
@@ -215,7 +220,7 @@ public class ConfigManagerTest {
         configs = configManager.getConfigCenters();
         assertEquals(1, configs.size());
         assertEquals(config, configs.iterator().next());
-
+        assertEquals(configs, moduleConfigManager.getConfigCenters());
     }
 
     @Test
@@ -232,6 +237,7 @@ public class ConfigManagerTest {
     @Test
     public void testRefreshAll() {
         configManager.refreshAll();
+        moduleConfigManager.refreshAll();
     }
 
     @Test

--- a/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/beans/factory/annotation/ServiceAnnotationPostProcessor.java
+++ b/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/beans/factory/annotation/ServiceAnnotationPostProcessor.java
@@ -470,11 +470,11 @@ public class ServiceAnnotationPostProcessor implements BeanDefinitionRegistryPos
             addPropertyReference(builder, "monitor", monitorConfigId);
         }
 
-        // application reference
-        String applicationConfigId = (String) serviceAnnotationAttributes.get("application");
-        if (StringUtils.hasText(applicationConfigId)) {
-            addPropertyReference(builder, "application", applicationConfigId);
-        }
+        // deprecate application reference
+//        String applicationConfigId = (String) serviceAnnotationAttributes.get("application");
+//        if (StringUtils.hasText(applicationConfigId)) {
+//            addPropertyReference(builder, "application", applicationConfigId);
+//        }
 
         // module reference
         String moduleConfigId = (String) serviceAnnotationAttributes.get("module");

--- a/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/reference/ReferenceCreator.java
+++ b/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/reference/ReferenceCreator.java
@@ -19,19 +19,20 @@ package org.apache.dubbo.config.spring.reference;
 import com.alibaba.spring.util.AnnotationUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.apache.dubbo.config.ApplicationConfig;
+import org.apache.dubbo.config.AbstractConfig;
 import org.apache.dubbo.config.ArgumentConfig;
 import org.apache.dubbo.config.ConsumerConfig;
 import org.apache.dubbo.config.MethodConfig;
 import org.apache.dubbo.config.ModuleConfig;
 import org.apache.dubbo.config.MonitorConfig;
 import org.apache.dubbo.config.ReferenceConfig;
-import org.apache.dubbo.config.RegistryConfig;
 import org.apache.dubbo.config.annotation.Argument;
 import org.apache.dubbo.config.annotation.DubboReference;
 import org.apache.dubbo.config.annotation.Method;
 import org.apache.dubbo.config.spring.beans.factory.annotation.AnnotationPropertyValuesAdapter;
 import org.apache.dubbo.config.spring.util.DubboAnnotationUtils;
+import org.apache.dubbo.config.spring.util.DubboBeanUtils;
+import org.apache.dubbo.rpc.model.ModuleModel;
 import org.springframework.beans.propertyeditors.StringTrimmerEditor;
 import org.springframework.context.ApplicationContext;
 import org.springframework.core.convert.support.DefaultConversionService;
@@ -39,13 +40,9 @@ import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 import org.springframework.validation.DataBinder;
 
-import java.util.Arrays;
-import java.util.List;
 import java.util.Map;
 
 import static com.alibaba.spring.util.AnnotationUtils.getAttribute;
-import static com.alibaba.spring.util.BeanFactoryUtils.getBeans;
-import static com.alibaba.spring.util.BeanFactoryUtils.getOptionalBean;
 import static com.alibaba.spring.util.ObjectUtils.of;
 
 /**
@@ -72,6 +69,7 @@ public class ReferenceCreator {
     protected final ClassLoader classLoader;
 
     protected Class<?> defaultInterfaceClass;
+    private final ModuleModel moduleModel;
 
     private ReferenceCreator(Map<String, Object> attributes, ApplicationContext applicationContext) {
         Assert.notNull(attributes, "The Annotation attributes must not be null!");
@@ -80,6 +78,8 @@ public class ReferenceCreator {
         this.applicationContext = applicationContext;
         this.classLoader = applicationContext.getClassLoader() != null ?
                 applicationContext.getClassLoader() : Thread.currentThread().getContextClassLoader();
+        moduleModel = DubboBeanUtils.getModuleModel(applicationContext);
+        Assert.notNull(moduleModel, "ModuleModel not found in Spring ApplicationContext");
     }
 
     public final ReferenceConfig build() throws Exception {
@@ -98,108 +98,49 @@ public class ReferenceCreator {
 
     protected void configureBean(ReferenceConfig configBean) throws Exception {
 
-        populateBean(attributes, configBean);
+        populateBean(configBean);
 
-        //configureRegistryConfigs(configBean);
+        // deprecate application reference
+        //configureApplicationConfig(configBean);
 
         configureMonitorConfig(configBean);
 
-        configureApplicationConfig(configBean);
-
         configureModuleConfig(configBean);
 
-        //interfaceClass
-        //configureInterface(attributes, configBean);
-
-        configureConsumerConfig(attributes, configBean);
-
-        //configureMethodConfig(attributes, configBean);
-
-        //bean.setApplicationContext(applicationContext);
-        //bean.afterPropertiesSet();
-
-    }
-
-    private void configureRegistryConfigs(ReferenceConfig configBean) {
-
-        String[] registryConfigBeanIds = getAttribute(attributes, "registry");
-        if (registryConfigBeanIds != null) {
-            List<RegistryConfig> registryConfigs = getBeans(applicationContext, registryConfigBeanIds, RegistryConfig.class);
-            configBean.setRegistries(registryConfigs);
-        }
+        configureConsumerConfig(configBean);
 
     }
 
     private void configureMonitorConfig(ReferenceConfig configBean) {
-
-        String monitorBeanName = getAttribute(attributes, "monitor");
-
-        MonitorConfig monitorConfig = getOptionalBean(applicationContext, monitorBeanName, MonitorConfig.class);
-
-        configBean.setMonitor(monitorConfig);
-
-    }
-
-    private void configureApplicationConfig(ReferenceConfig configBean) {
-
-        String applicationConfigBeanName = getAttribute(attributes, "application");
-
-        ApplicationConfig applicationConfig =
-                getOptionalBean(applicationContext, applicationConfigBeanName, ApplicationConfig.class);
-
-        configBean.setApplication(applicationConfig);
-
-    }
-
-    private void configureModuleConfig(ReferenceConfig configBean) {
-
-        String moduleConfigBeanName = getAttribute(attributes, "module");
-
-        ModuleConfig moduleConfig =
-                getOptionalBean(applicationContext, moduleConfigBeanName, ModuleConfig.class);
-
-        configBean.setModule(moduleConfig);
-
-    }
-
-    private void configureInterface(Map<String, Object> attributes, ReferenceConfig referenceBean) {
-        if (referenceBean.getInterface() == null) {
-
-            Object genericValue = getAttribute(attributes, "generic");
-            String generic = (genericValue != null) ? genericValue.toString() : null;
-            referenceBean.setGeneric(generic);
-
-            String interfaceClassName = getAttribute(attributes, "interfaceName");
-            if (StringUtils.hasText(interfaceClassName)) {
-                referenceBean.setInterface(interfaceClassName);
-            } else {
-                Class<?> interfaceClass = getAttribute(attributes, "interfaceClass");
-                if (void.class.equals(interfaceClass)) { // default or set void.class for purpose.
-                    interfaceClass = null;
-                }
-                if (interfaceClass != null) {
-                    Assert.isTrue(interfaceClass.isInterface(),
-                            "The interfaceClass of @DubboReference is not an interface: "+interfaceClass.getName());
-                }
-                // Not present 'interfaceClass' attribute, use default injection type of annotated
-                if (interfaceClass == null && defaultInterfaceClass != null) {
-                    interfaceClass = defaultInterfaceClass;
-                    Assert.isTrue(interfaceClass.isInterface(),
-                            "The class of field or method that was annotated @DubboReference is not an interface!");
-                }
-                // Convert to interface class name, InterfaceClass will be determined later
-                referenceBean.setInterface(interfaceClass.getName());
-            }
+        String monitorConfigId = getAttribute(attributes, "monitor");
+        if (StringUtils.hasText(monitorConfigId)) {
+            MonitorConfig monitorConfig = getConfig(monitorConfigId, MonitorConfig.class);
+            configBean.setMonitor(monitorConfig);
         }
     }
 
+//    private void configureApplicationConfig(ReferenceConfig configBean) {
+//        String applicationConfigId = getAttribute(attributes, "application");
+//        if (StringUtils.hasText(applicationConfigId)) {
+//            ApplicationConfig applicationConfig = getConfig(applicationConfigId, ApplicationConfig.class);
+//            configBean.setApplication(applicationConfig);
+//        }
+//    }
 
-    private void configureConsumerConfig(Map<String, Object> attributes, ReferenceConfig<?> referenceBean) {
+    private void configureModuleConfig(ReferenceConfig configBean) {
+        String moduleConfigId = getAttribute(attributes, "module");
+        if (StringUtils.hasText(moduleConfigId)) {
+            ModuleConfig moduleConfig = getConfig(moduleConfigId, ModuleConfig.class);
+            configBean.setModule(moduleConfig);
+        }
+    }
+
+    private void configureConsumerConfig(ReferenceConfig<?> referenceBean) {
         ConsumerConfig consumerConfig = null;
         Object consumer = getAttribute(attributes, "consumer");
         if (consumer != null) {
             if (consumer instanceof String) {
-                consumerConfig = getOptionalBean(applicationContext, (String) consumer, ConsumerConfig.class);
+                consumerConfig = getConfig((String) consumer, ConsumerConfig.class);
             } else if (consumer instanceof ConsumerConfig) {
                 consumerConfig = (ConsumerConfig) consumer;
             } else {
@@ -209,22 +150,24 @@ public class ReferenceCreator {
         }
     }
 
-    void configureMethodConfig(Map<String, Object> attributes, ReferenceConfig<?> referenceBean) {
-        Object value = attributes.get("methods");
-        if (value instanceof Method[]) {
-            Method[] methods = (Method[]) value;
-            List<MethodConfig> methodConfigs = MethodConfig.constructMethodConfig(methods);
-            if (!methodConfigs.isEmpty()) {
-                referenceBean.setMethods(methodConfigs);
+    private <T extends AbstractConfig> T getConfig(String configIdOrName, Class<T> configType) {
+        // 1. find in ModuleConfigManager
+        T config = moduleModel.getConfigManager().getConfig(configType, configIdOrName).orElse(null);
+        if (config == null) {
+            // 2. find in Spring ApplicationContext
+            if (applicationContext.containsBean(configIdOrName)) {
+                config = applicationContext.getBean(configIdOrName, configType);
             }
-        } else if (value instanceof MethodConfig[]) {
-            MethodConfig[] methodConfigs = (MethodConfig[]) value;
-            referenceBean.setMethods(Arrays.asList(methodConfigs));
         }
+        if (config == null) {
+            throw new IllegalArgumentException(configType.getSimpleName() + " not found: " + configIdOrName);
+        }
+        return config;
     }
 
-    protected void populateBean(Map<String, Object> attributes, ReferenceConfig referenceBean) {
+    protected void populateBean(ReferenceConfig referenceBean) {
         Assert.notNull(defaultInterfaceClass, "The default interface class cannot be empty!");
+        // convert attributes, e.g. interface, registry
         ReferenceBeanSupport.convertReferenceProps(attributes, defaultInterfaceClass);
 
         DataBinder dataBinder = new DataBinder(referenceBean);

--- a/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/beans/factory/annotation/ReferenceCreatorTest.java
+++ b/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/beans/factory/annotation/ReferenceCreatorTest.java
@@ -19,7 +19,10 @@ package org.apache.dubbo.config.spring.beans.factory.annotation;
 
 import com.alibaba.spring.util.AnnotationUtils;
 import org.apache.dubbo.config.ArgumentConfig;
+import org.apache.dubbo.config.ConsumerConfig;
 import org.apache.dubbo.config.MethodConfig;
+import org.apache.dubbo.config.ModuleConfig;
+import org.apache.dubbo.config.MonitorConfig;
 import org.apache.dubbo.config.ReferenceConfig;
 import org.apache.dubbo.config.annotation.Argument;
 import org.apache.dubbo.config.annotation.DubboReference;
@@ -29,6 +32,8 @@ import org.apache.dubbo.config.bootstrap.DubboBootstrap;
 import org.apache.dubbo.config.spring.api.HelloService;
 import org.apache.dubbo.config.spring.impl.NotifyService;
 import org.apache.dubbo.config.spring.reference.ReferenceCreator;
+import org.apache.dubbo.rpc.model.ApplicationModel;
+import org.apache.dubbo.rpc.model.ModuleModel;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -65,6 +70,11 @@ import static org.springframework.util.ReflectionUtils.findField;
 @DirtiesContext(classMode = AFTER_EACH_TEST_METHOD)
 public class ReferenceCreatorTest {
 
+    private static final String MODULE_CONFIG_ID = "mymodule";
+    private static final String CONSUMER_CONFIG_ID = "myconsumer";
+    private static final String MONITOR_CONFIG_ID = "mymonitor";
+    private static final String REGISTRY_CONFIG_ID = "myregistry";
+
     @DubboReference(
             //interfaceClass = HelloService.class,
             version = "1.0.0", group = "TEST_GROUP", url = "dubbo://localhost:12345",
@@ -79,7 +89,7 @@ public class ReferenceCreatorTest {
             timeout = 3, cache = "cache", filter = {"echo", "generic", "accesslog"},
             listener = {"deprecated"}, parameters = {"n1=v1  ", "n2 = v2 ", "  n3 =   v3  "},
             application = "application",
-            module = "module", consumer = "consumer", monitor = "monitor", registry = {"myregistry"},
+            module = MODULE_CONFIG_ID, consumer = CONSUMER_CONFIG_ID, monitor = MONITOR_CONFIG_ID, registry = {REGISTRY_CONFIG_ID},
             // @since 2.7.3
             id = "reference",
             // @since 2.7.8
@@ -156,7 +166,7 @@ public class ReferenceCreatorTest {
         Assertions.assertEquals("reference", referenceBean.getId());
         Assertions.assertEquals(ofSet("service1", "service2", "service3"), referenceBean.getSubscribedServices());
         Assertions.assertEquals("service1,service2,service3", referenceBean.getProvidedBy());
-        Assertions.assertEquals("myregistry", referenceBean.getRegistryIds());
+        Assertions.assertEquals(REGISTRY_CONFIG_ID, referenceBean.getRegistryIds());
 
         // parameters
         Map<String, String> parameters = new HashMap<String, String>();
@@ -195,9 +205,9 @@ public class ReferenceCreatorTest {
 
         // Asserts Null fields
         Assertions.assertThrows(IllegalStateException.class, () -> referenceBean.getApplication());
-        Assertions.assertNull(referenceBean.getModule());
-        Assertions.assertNull(referenceBean.getConsumer());
-        Assertions.assertNull(referenceBean.getMonitor());
+        Assertions.assertNotNull(referenceBean.getModule());
+        Assertions.assertNotNull(referenceBean.getConsumer());
+        Assertions.assertNotNull(referenceBean.getMonitor());
     }
 
 
@@ -207,6 +217,26 @@ public class ReferenceCreatorTest {
         @Bean
         public NotifyService notifyService() {
             return new NotifyService();
+        }
+
+        @Bean("org.apache.dubbo.rpc.model.ModuleModel")
+        public ModuleModel moduleModel() {
+            return ApplicationModel.defaultModel().getDefaultModule();
+        }
+
+        @Bean(CONSUMER_CONFIG_ID)
+        public ConsumerConfig consumerConfig() {
+            return new ConsumerConfig();
+        }
+
+        @Bean(MONITOR_CONFIG_ID)
+        public MonitorConfig monitorConfig(){
+            return new MonitorConfig();
+        }
+
+        @Bean(MODULE_CONFIG_ID)
+        public ModuleConfig moduleConfig(){
+            return new ModuleConfig();
         }
 
     }

--- a/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/issues/issue9172/MultipleConsumerAndProviderTest.java
+++ b/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/issues/issue9172/MultipleConsumerAndProviderTest.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.config.spring.issues.issue9172;
+
+import org.apache.dubbo.config.ReferenceConfigBase;
+import org.apache.dubbo.config.annotation.DubboReference;
+import org.apache.dubbo.config.annotation.DubboService;
+import org.apache.dubbo.config.context.ModuleConfigManager;
+import org.apache.dubbo.config.spring.api.DemoService;
+import org.apache.dubbo.config.spring.api.HelloService;
+import org.apache.dubbo.config.spring.context.annotation.EnableDubbo;
+import org.apache.dubbo.config.spring.impl.DemoServiceImpl;
+import org.apache.dubbo.config.spring.impl.HelloServiceImpl;
+import org.apache.dubbo.config.spring.registrycenter.ZookeeperMultipleRegistryCenter;
+import org.apache.dubbo.config.spring.util.DubboBeanUtils;
+import org.apache.dubbo.rpc.model.ModuleModel;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.PropertySource;
+
+/**
+ * Test for issue 9172
+ */
+public class MultipleConsumerAndProviderTest {
+
+    private static ZookeeperMultipleRegistryCenter registryCenter;
+
+    @BeforeAll
+    public static void setUp() {
+        registryCenter = new ZookeeperMultipleRegistryCenter();
+        registryCenter.startup();
+    }
+
+    @AfterAll
+    public static void tearDown() {
+        if (registryCenter != null) {
+            registryCenter.shutdown();
+        }
+    }
+
+    @Test
+    public void test() {
+
+        AnnotationConfigApplicationContext providerContext = null;
+        AnnotationConfigApplicationContext consumerContext = null;
+
+        try {
+            providerContext = new AnnotationConfigApplicationContext(ProviderConfiguration.class);
+            consumerContext = new AnnotationConfigApplicationContext(ConsumerConfiguration.class);
+
+            ModuleModel consumerModuleModel = DubboBeanUtils.getModuleModel(consumerContext);
+            ModuleConfigManager consumerConfigManager = consumerModuleModel.getConfigManager();
+            ReferenceConfigBase helloServiceOneConfig = consumerConfigManager.getReference("helloServiceOne");
+            ReferenceConfigBase demoServiceTwoConfig = consumerConfigManager.getReference("demoServiceTwo");
+            Assertions.assertEquals(consumerConfigManager.getConsumer("consumer-one").get(), helloServiceOneConfig.getConsumer());
+            Assertions.assertEquals(consumerConfigManager.getConsumer("consumer-two").get(), demoServiceTwoConfig.getConsumer());
+            Assertions.assertEquals(consumerConfigManager.getRegistry("registry-one").get(), helloServiceOneConfig.getRegistry());
+            Assertions.assertEquals(consumerConfigManager.getRegistry("registry-two").get(), demoServiceTwoConfig.getRegistry());
+
+            HelloService helloServiceOne = consumerContext.getBean("helloServiceOne", HelloService.class);
+            DemoService demoServiceTwo = consumerContext.getBean("demoServiceTwo", DemoService.class);
+            String sayHello = helloServiceOne.sayHello("dubbo");
+            String sayName = demoServiceTwo.sayName("dubbo");
+            Assertions.assertEquals("Hello, dubbo", sayHello);
+            Assertions.assertEquals("say:dubbo", sayName);
+        } finally {
+            if (providerContext != null) {
+                providerContext.close();
+            }
+            if (consumerContext != null) {
+                consumerContext.close();
+            }
+        }
+    }
+
+
+    @EnableDubbo(scanBasePackages = "")
+    @PropertySource("classpath:/META-INF/issues/issue9172/consumer.properties")
+    static class ConsumerConfiguration {
+
+        @DubboReference(consumer = "consumer-one")
+        private HelloService helloServiceOne;
+
+        @DubboReference(consumer = "consumer-two")
+        private DemoService demoServiceTwo;
+
+    }
+
+    @EnableDubbo(scanBasePackages = "")
+    @PropertySource("classpath:/META-INF/issues/issue9172/provider.properties")
+    static class ProviderConfiguration {
+
+        @Bean
+        @DubboService(provider = "provider-one")
+        public HelloService helloServiceOne() {
+            return new HelloServiceImpl();
+        }
+
+        @Bean
+        @DubboService(provider = "provider-two")
+        public DemoService demoServiceTwo() {
+            return new DemoServiceImpl();
+        }
+    }
+}

--- a/dubbo-config/dubbo-config-spring/src/test/resources/META-INF/issues/issue9172/consumer.properties
+++ b/dubbo-config/dubbo-config-spring/src/test/resources/META-INF/issues/issue9172/consumer.properties
@@ -1,0 +1,30 @@
+dubbo.application.name=consumer-app
+dubbo.application.owner=com.test
+dubbo.application.organization=test
+dubbo.application.logger=slf4j
+dubbo.application.compiler=javassist
+dubbo.application.qosEnable=false
+
+# registry-one
+dubbo.registries.registry-one.id=registry-one
+dubbo.registries.registry-one.protocol=zookeeper
+dubbo.registries.registry-one.client=curator
+dubbo.registries.registry-one.address=localhost:2181
+
+dubbo.consumers.consumer-one.registryIds=registry-one
+dubbo.consumers.consumer-one.check=true
+dubbo.consumers.consumer-one.timeout=15000
+dubbo.consumers.consumer-one.injvm=false
+dubbo.consumers.consumer-one.group=group-one
+
+# registry-two
+dubbo.registries.registry-two.id=registry-two
+dubbo.registries.registry-two.protocol=zookeeper
+dubbo.registries.registry-two.client=curator
+dubbo.registries.registry-two.address=localhost:2182
+
+dubbo.consumers.consumer-two.registryIds=registry-two
+dubbo.consumers.consumer-two.check=true
+dubbo.consumers.consumer-two.timeout=15000
+dubbo.consumers.consumer-two.injvm=false
+dubbo.consumers.consumer-two.group=group-two

--- a/dubbo-config/dubbo-config-spring/src/test/resources/META-INF/issues/issue9172/provider.properties
+++ b/dubbo-config/dubbo-config-spring/src/test/resources/META-INF/issues/issue9172/provider.properties
@@ -1,0 +1,24 @@
+dubbo.application.name=provider-app
+dubbo.application.owner=com.test
+dubbo.application.organization=test
+dubbo.application.logger=slf4j
+dubbo.application.compiler=javassist
+dubbo.application.qosEnable=false
+
+# registry-one
+dubbo.registries.registry-one.id=registry-one
+dubbo.registries.registry-one.protocol=zookeeper
+dubbo.registries.registry-one.client=curator
+dubbo.registries.registry-one.address=localhost:2181
+
+dubbo.providers.provider-one.registryIds=registry-one
+dubbo.providers.provider-one.group=group-one
+
+# registry-two
+dubbo.registries.registry-two.id=registry-two
+dubbo.registries.registry-two.protocol=zookeeper
+dubbo.registries.registry-two.client=curator
+dubbo.registries.registry-two.address=localhost:2182
+
+dubbo.providers.provider-two.registryIds=registry-two
+dubbo.providers.provider-two.group=group-two


### PR DESCRIPTION
## What is the purpose of the change
* Lookup consumer config of `@DubboReference.consumer()` from `ModuleConfigManager`,  fix #9172
* Deprecate `@DubboReference.application()` and `@DubboService.application()`
* ModuleConfigManager delegates read methods of application ConfigManager 

## Verifying this change
* org.apache.dubbo.config.spring.issues.issue9172.MultipleConsumerAndProviderTest

