### PR TITLE
[3.0] Patch DefaultApplicationDeployer for delay exporting

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/threadpool/manager/DefaultExecutorRepository.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/threadpool/manager/DefaultExecutorRepository.java
@@ -212,13 +212,11 @@ public class DefaultExecutorRepository implements ExecutorRepository, ExtensionA
 
     @Override
     public ScheduledExecutorService getServiceExportExecutor() {
+        synchronized (LOCK) {
         if (serviceExportExecutor == null) {
-            synchronized (LOCK) {
-                if (serviceExportExecutor == null) {
-                    int coreSize = getExportThreadNum();
-                    serviceExportExecutor = Executors.newScheduledThreadPool(coreSize,
+                int coreSize = getExportThreadNum();
+                serviceExportExecutor = Executors.newScheduledThreadPool(coreSize,
                         new NamedThreadFactory("Dubbo-service-export", true));
-                }
             }
         }
         return serviceExportExecutor;

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/threadpool/manager/DefaultExecutorRepository.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/threadpool/manager/DefaultExecutorRepository.java
@@ -210,7 +210,7 @@ public class DefaultExecutorRepository implements ExecutorRepository, ExtensionA
     @Override
     public ScheduledExecutorService getServiceExportExecutor() {
         synchronized (LOCK) {
-        if (serviceExportExecutor == null) {
+            if (serviceExportExecutor == null) {
                 int coreSize = getExportThreadNum();
                 serviceExportExecutor = Executors.newScheduledThreadPool(coreSize,
                         new NamedThreadFactory("Dubbo-service-export", true));

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/threadpool/manager/DefaultExecutorRepository.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/threadpool/manager/DefaultExecutorRepository.java
@@ -68,8 +68,6 @@ public class DefaultExecutorRepository implements ExecutorRepository, ExtensionA
 
     private volatile ExecutorService serviceReferExecutor;
 
-    private ScheduledExecutorService reconnectScheduledExecutor;
-
     public Ring<ScheduledExecutorService> registryNotificationExecutorRing = new Ring<>();
 
     private Ring<ScheduledExecutorService> serviceDiscoveryAddressNotificationExecutorRing = new Ring<>();
@@ -102,7 +100,6 @@ public class DefaultExecutorRepository implements ExecutorRepository, ExtensionA
                 , new ThreadPoolExecutor.AbortPolicy()));
         }
 
-//        reconnectScheduledExecutor = Executors.newSingleThreadScheduledExecutor(new NamedThreadFactory("Dubbo-reconnect-scheduler"));
         poolRouterExecutor = new ThreadPoolExecutor(1, 10, 0L, TimeUnit.MILLISECONDS, new LinkedBlockingQueue<Runnable>(1024),
             new NamedInternalThreadFactory("Dubbo-state-router-pool-router", true), new ThreadPoolExecutor.AbortPolicy());
 

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/threadpool/manager/DefaultExecutorRepository.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/threadpool/manager/DefaultExecutorRepository.java
@@ -239,13 +239,11 @@ public class DefaultExecutorRepository implements ExecutorRepository, ExtensionA
 
     @Override
     public ExecutorService getServiceReferExecutor() {
-        if (serviceReferExecutor == null) {
-            synchronized (LOCK) {
-                if (serviceReferExecutor == null) {
-                    int coreSize = getReferThreadNum();
-                    serviceReferExecutor = Executors.newFixedThreadPool(coreSize,
+        synchronized (LOCK) {
+            if (serviceReferExecutor == null) {
+                int coreSize = getReferThreadNum();
+                serviceReferExecutor = Executors.newFixedThreadPool(coreSize,
                         new NamedThreadFactory("Dubbo-service-refer", true));
-                }
             }
         }
         return serviceReferExecutor;

--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/deploy/DefaultApplicationDeployer.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/deploy/DefaultApplicationDeployer.java
@@ -1007,9 +1007,6 @@ public class DefaultApplicationDeployer extends AbstractDeployer<ApplicationMode
             } catch (Exception e) {
                 logger.error("refresh metadata failed: " + e.getMessage(), e);
             }
-            // shutdown export/refer executor after started
-            executorRepository.shutdownServiceExportExecutor();
-            executorRepository.shutdownServiceReferExecutor();
         } finally {
             // complete future
             completeStartFuture(true);
@@ -1051,6 +1048,9 @@ public class DefaultApplicationDeployer extends AbstractDeployer<ApplicationMode
     }
 
     private void destroyExecutorRepository() {
+        // shutdown export/refer executor
+        executorRepository.shutdownServiceExportExecutor();
+        executorRepository.shutdownServiceReferExecutor();
         getExtensionLoader(ExecutorRepository.class).getDefaultExtension().destroyAll();
     }
 


### PR DESCRIPTION
## What is the purpose of the change
#9168 
* shutdown export,refer executor at destroyExecutorRepository instead of onStarted