### PR TITLE
[3.0] Avoid blocking `ApplicationModel.defaultModel()` during destroying

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/rpc/model/FrameworkModel.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/rpc/model/FrameworkModel.java
@@ -103,27 +103,25 @@ public class FrameworkModel extends ScopeModel {
                 LOGGER.info("Destroying default framework model: " + getDesc());
             }
         }
-        synchronized (instLock) {
-            if (LOGGER.isInfoEnabled()) {
-                LOGGER.info(getDesc() + " is destroying ...");
-            }
 
-            // destroy all application model
-            for (ApplicationModel applicationModel : new ArrayList<>(applicationModels)) {
-                applicationModel.destroy();
-            }
+        if (LOGGER.isInfoEnabled()) {
+            LOGGER.info(getDesc() + " is destroying ...");
+        }
 
-            // check whether all application models are destroyed
-            checkApplicationDestroy();
+        // destroy all application model
+        for (ApplicationModel applicationModel : new ArrayList<>(applicationModels)) {
+            applicationModel.destroy();
+        }
+        // check whether all application models are destroyed
+        checkApplicationDestroy();
 
-            // notify destroy and clean framework resources
-            // see org.apache.dubbo.config.deploy.FrameworkModelCleaner
-            notifyDestroy();
-            checkApplicationDestroy();
+        // notify destroy and clean framework resources
+        // see org.apache.dubbo.config.deploy.FrameworkModelCleaner
+        notifyDestroy();
+        checkApplicationDestroy();
 
-            if (LOGGER.isInfoEnabled()) {
-                LOGGER.info(getDesc() + " is destroyed");
-            }
+        if (LOGGER.isInfoEnabled()) {
+            LOGGER.info(getDesc() + " is destroyed");
         }
 
         // remove from allInstances and reset default FrameworkModel
@@ -169,9 +167,9 @@ public class FrameworkModel extends ScopeModel {
                     defaultInstance = new FrameworkModel();
                 }
                 instance = defaultInstance;
-                Assert.notNull(instance, "Default FrameworkModel is null");
             }
         }
+        Assert.notNull(instance, "Default FrameworkModel is null");
         return instance;
     }
 
@@ -203,15 +201,19 @@ public class FrameworkModel extends ScopeModel {
     public ApplicationModel defaultApplication() {
         ApplicationModel appModel = this.defaultAppModel;
         if (appModel == null) {
-            synchronized (instLock) {
-                resetDefaultAppModel();
-                if (this.defaultAppModel == null) {
-                    this.defaultAppModel = newApplication();
+            // check destroyed before acquire inst lock, avoid blocking during destroying
+            checkDestroyed();
+            resetDefaultAppModel();
+            if ((appModel = this.defaultAppModel) == null) {
+                synchronized (instLock) {
+                    if (this.defaultAppModel == null) {
+                        this.defaultAppModel = newApplication();
+                    }
+                    appModel = this.defaultAppModel;
                 }
-                appModel = this.defaultAppModel;
-                Assert.notNull(appModel, "Default ApplicationModel is null");
             }
         }
+        Assert.notNull(appModel, "Default ApplicationModel is null");
         return appModel;
     }
 
@@ -222,7 +224,7 @@ public class FrameworkModel extends ScopeModel {
     void addApplication(ApplicationModel applicationModel) {
         // can not add new application if it's destroying
         checkDestroyed();
-        synchronized (instLock){
+        synchronized (instLock) {
             if (!this.applicationModels.contains(applicationModel)) {
                 applicationModel.setInternalId(buildInternalId(getInternalId(), appIndex.getAndIncrement()));
                 this.applicationModels.add(applicationModel);


### PR DESCRIPTION
## What is the purpose of the change

Avoid blocking `ApplicationModel.defaultModel()` calls during FrameworkModel destruction