### PR TITLE
[Master]Fix netty ssl file leak

### DIFF
--- a/dubbo-remoting/dubbo-remoting-netty4/src/main/java/org/apache/dubbo/remoting/transport/netty4/SslContexts.java
+++ b/dubbo-remoting/dubbo-remoting-netty4/src/main/java/org/apache/dubbo/remoting/transport/netty4/SslContexts.java
@@ -30,6 +30,7 @@ import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.SslProvider;
 
 import javax.net.ssl.SSLException;
+import java.io.IOException;
 import java.io.InputStream;
 import java.security.Provider;
 import java.security.Security;
@@ -43,14 +44,19 @@ public class SslContexts {
         SslConfig sslConfig = globalConfigManager.getSsl().orElseThrow(() -> new IllegalStateException("Ssl enabled, but no ssl cert information provided!"));
 
         SslContextBuilder sslClientContextBuilder = null;
+        InputStream serverKeyCertChainPathStream = null;
+        InputStream serverPrivateKeyPathStream = null;
         try {
+            serverKeyCertChainPathStream = sslConfig.getServerKeyCertChainPathStream();
+            serverPrivateKeyPathStream = sslConfig.getServerPrivateKeyPathStream();
+            sslConfig.getServerPrivateKeyPathStream();
             String password = sslConfig.getServerKeyPassword();
             if (password != null) {
-                sslClientContextBuilder = SslContextBuilder.forServer(sslConfig.getServerKeyCertChainPathStream(),
-                        sslConfig.getServerPrivateKeyPathStream(), password);
+                sslClientContextBuilder = SslContextBuilder.forServer(serverKeyCertChainPathStream,
+                        serverPrivateKeyPathStream, password);
             } else {
-                sslClientContextBuilder = SslContextBuilder.forServer(sslConfig.getServerKeyCertChainPathStream(),
-                        sslConfig.getServerPrivateKeyPathStream());
+                sslClientContextBuilder = SslContextBuilder.forServer(serverKeyCertChainPathStream,
+                        serverPrivateKeyPathStream);
             }
 
             if (sslConfig.getServerTrustCertCollectionPathStream() != null) {
@@ -66,6 +72,9 @@ public class SslContexts {
 
         } catch (Exception e) {
             throw new IllegalArgumentException("Could not find certificate file or the certificate is invalid.", e);
+        }finally {
+            safeCloseStream(serverKeyCertChainPathStream);
+            safeCloseStream(serverPrivateKeyPathStream);
         }
         try {
             return sslClientContextBuilder.sslProvider(findSslProvider()).build();
@@ -79,13 +88,17 @@ public class SslContexts {
         SslConfig sslConfig = globalConfigManager.getSsl().orElseThrow(() -> new IllegalStateException("Ssl enabled, but no ssl cert information provided!"));
 
         SslContextBuilder builder = SslContextBuilder.forClient();
+        InputStream clientTrustCertCollectionPath = null;
+        InputStream clientCertChainFilePath = null;
+        InputStream clientPrivateKeyFilePath = null;
         try {
-            if (sslConfig.getClientTrustCertCollectionPathStream() != null) {
-                builder.trustManager(sslConfig.getClientTrustCertCollectionPathStream());
+            clientTrustCertCollectionPath = sslConfig.getClientTrustCertCollectionPathStream();
+            if (clientTrustCertCollectionPath != null) {
+                builder.trustManager(clientTrustCertCollectionPath);
             }
 
-            InputStream clientCertChainFilePath = sslConfig.getClientKeyCertChainPathStream();
-            InputStream clientPrivateKeyFilePath = sslConfig.getClientPrivateKeyPathStream();
+            clientCertChainFilePath = sslConfig.getClientKeyCertChainPathStream();
+            clientPrivateKeyFilePath = sslConfig.getClientPrivateKeyPathStream();
             if (clientCertChainFilePath != null && clientPrivateKeyFilePath != null) {
                 String password = sslConfig.getClientKeyPassword();
                 if (password != null) {
@@ -102,6 +115,10 @@ public class SslContexts {
             }
         } catch (Exception e) {
             throw new IllegalArgumentException("Could not find certificate file or find invalid certificate.", e);
+        } finally {
+            safeCloseStream(clientTrustCertCollectionPath);
+            safeCloseStream(clientCertChainFilePath);
+            safeCloseStream(clientPrivateKeyFilePath);
         }
         try {
             return builder.sslProvider(findSslProvider()).build();
@@ -129,6 +146,17 @@ public class SslContexts {
     private static boolean checkJdkProvider() {
         Provider[] jdkProviders = Security.getProviders("SSLContext.TLS");
         return (jdkProviders != null && jdkProviders.length > 0);
+    }
+
+    private static void safeCloseStream(InputStream stream) {
+        if (stream == null) {
+            return;
+        }
+        try {
+            stream.close();
+        } catch (IOException e) {
+            logger.warn("Failed to close a stream.", e);
+        }
     }
 
 }

--- a/dubbo-remoting/dubbo-remoting-netty4/src/main/java/org/apache/dubbo/remoting/transport/netty4/SslContexts.java
+++ b/dubbo-remoting/dubbo-remoting-netty4/src/main/java/org/apache/dubbo/remoting/transport/netty4/SslContexts.java
@@ -49,7 +49,6 @@ public class SslContexts {
         try {
             serverKeyCertChainPathStream = sslConfig.getServerKeyCertChainPathStream();
             serverPrivateKeyPathStream = sslConfig.getServerPrivateKeyPathStream();
-            sslConfig.getServerPrivateKeyPathStream();
             String password = sslConfig.getServerKeyPassword();
             if (password != null) {
                 sslClientContextBuilder = SslContextBuilder.forServer(serverKeyCertChainPathStream,

--- a/dubbo-rpc/dubbo-rpc-grpc/src/main/java/org/apache/dubbo/rpc/protocol/grpc/GrpcOptionsUtils.java
+++ b/dubbo-rpc/dubbo-rpc-grpc/src/main/java/org/apache/dubbo/rpc/protocol/grpc/GrpcOptionsUtils.java
@@ -18,6 +18,8 @@ package org.apache.dubbo.rpc.protocol.grpc;
 
 import org.apache.dubbo.common.URL;
 import org.apache.dubbo.common.extension.ExtensionLoader;
+import org.apache.dubbo.common.logger.Logger;
+import org.apache.dubbo.common.logger.LoggerFactory;
 import org.apache.dubbo.common.threadpool.ThreadPool;
 import org.apache.dubbo.common.utils.CollectionUtils;
 import org.apache.dubbo.config.SslConfig;
@@ -39,6 +41,7 @@ import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslContextBuilder;
 
 import javax.net.ssl.SSLException;
+import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
@@ -62,6 +65,8 @@ import static org.apache.dubbo.rpc.protocol.grpc.GrpcConstants.TRANSPORT_FILTERS
  * Support gRPC configs in a Dubbo specific way.
  */
 public class GrpcOptionsUtils {
+
+    private static final Logger logger = LoggerFactory.getLogger(GrpcOptionsUtils.class);
 
     static ServerBuilder buildServerBuilder(URL url, NettyServerBuilder builder) {
 
@@ -157,14 +162,18 @@ public class GrpcOptionsUtils {
         SslConfig sslConfig = globalConfigManager.getSsl().orElseThrow(() -> new IllegalStateException("Ssl enabled, but no ssl cert information provided!"));
 
         SslContextBuilder sslClientContextBuilder = null;
+        InputStream serverKeyCertChainPathStream = null;
+        InputStream serverPrivateKeyPathStream = null;
         try {
+            serverKeyCertChainPathStream = sslConfig.getServerKeyCertChainPathStream();
+            serverPrivateKeyPathStream = sslConfig.getServerPrivateKeyPathStream();
             String password = sslConfig.getServerKeyPassword();
             if (password != null) {
-                sslClientContextBuilder = GrpcSslContexts.forServer(sslConfig.getServerKeyCertChainPathStream(),
-                        sslConfig.getServerPrivateKeyPathStream(), password);
+                sslClientContextBuilder = GrpcSslContexts.forServer(serverKeyCertChainPathStream,
+                        serverPrivateKeyPathStream, password);
             } else {
-                sslClientContextBuilder = GrpcSslContexts.forServer(sslConfig.getServerKeyCertChainPathStream(),
-                        sslConfig.getServerPrivateKeyPathStream());
+                sslClientContextBuilder = GrpcSslContexts.forServer(serverKeyCertChainPathStream,
+                        serverPrivateKeyPathStream);
             }
 
             InputStream trustCertCollectionFilePath = sslConfig.getServerTrustCertCollectionPathStream();
@@ -174,6 +183,9 @@ public class GrpcOptionsUtils {
             }
         } catch (Exception e) {
             throw new IllegalArgumentException("Could not find certificate file or the certificate is invalid.", e);
+        }finally {
+            safeCloseStream(serverKeyCertChainPathStream);
+            safeCloseStream(serverPrivateKeyPathStream);
         }
         try {
             return sslClientContextBuilder.build();
@@ -188,13 +200,16 @@ public class GrpcOptionsUtils {
 
 
         SslContextBuilder builder = GrpcSslContexts.forClient();
+        InputStream trustCertCollectionFilePath = null;
+        InputStream clientCertChainFilePath = null;
+        InputStream clientPrivateKeyFilePath = null;
         try {
-            InputStream trustCertCollectionFilePath = sslConfig.getClientTrustCertCollectionPathStream();
+            trustCertCollectionFilePath = sslConfig.getClientTrustCertCollectionPathStream();
             if (trustCertCollectionFilePath != null) {
                 builder.trustManager(trustCertCollectionFilePath);
             }
-            InputStream clientCertChainFilePath = sslConfig.getClientKeyCertChainPathStream();
-            InputStream clientPrivateKeyFilePath = sslConfig.getClientPrivateKeyPathStream();
+            clientCertChainFilePath = sslConfig.getClientKeyCertChainPathStream();
+            clientPrivateKeyFilePath = sslConfig.getClientPrivateKeyPathStream();
             if (clientCertChainFilePath != null && clientPrivateKeyFilePath != null) {
                 String password = sslConfig.getClientKeyPassword();
                 if (password != null) {
@@ -205,6 +220,10 @@ public class GrpcOptionsUtils {
             }
         } catch (Exception e) {
             throw new IllegalArgumentException("Could not find certificate file or find invalid certificate.", e);
+        } finally {
+            safeCloseStream(trustCertCollectionFilePath);
+            safeCloseStream(clientCertChainFilePath);
+            safeCloseStream(clientPrivateKeyFilePath);
         }
         try {
             return builder.build();
@@ -221,5 +240,16 @@ public class GrpcOptionsUtils {
             return Optional.of(configurators.iterator().next());
         }
         return Optional.empty();
+    }
+
+    private static void safeCloseStream(InputStream stream) {
+        if (stream == null) {
+            return;
+        }
+        try {
+            stream.close();
+        } catch (IOException e) {
+            logger.warn("Failed to close a stream.", e);
+        }
     }
 }


### PR DESCRIPTION
## What is the purpose of the change
fix #7161

`org.apache.dubbo.config.SslConfig#getServerKeyCertChainPathStream`  each call will create a new stream,should be closed after use.
```
    public InputStream getServerKeyCertChainPathStream() throws IOException {
        if (serverKeyCertChainPath != null) {
            serverKeyCertChainPathStream = IOUtils.getURL(serverKeyCertChainPath).openStream();
        }
        return serverKeyCertChainPathStream;
    }
```


## Brief changelog


## Verifying this change


<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [ ] GitHub Actions works fine on your own branch.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
