### PR TITLE
Catch deploy error, improve module start waiting

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/deploy/AbstractDeployer.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/deploy/AbstractDeployer.java
@@ -37,6 +37,8 @@ public abstract class AbstractDeployer<E extends ScopeModel> implements Deployer
 
     private volatile DeployState state = PENDING;
 
+    private volatile Throwable lastError;
+
     protected AtomicBoolean initialized = new AtomicBoolean(false);
 
     private List<DeployListener<E>> listeners = new ArrayList<>();
@@ -144,15 +146,21 @@ public abstract class AbstractDeployer<E extends ScopeModel> implements Deployer
         }
     }
 
-    protected void setFailed(Throwable cause) {
+    protected void setFailed(Throwable error) {
         this.state = FAILED;
+        this.lastError = error;
         for (DeployListener<E> listener : listeners) {
             try {
-                listener.onFailure(scopeModel, cause);
+                listener.onFailure(scopeModel, error);
             } catch (Throwable e) {
                 logger.error(getIdentifier() + " an exception occurred when handle failed event", e);
             }
         }
+    }
+
+    @Override
+    public Throwable getError() {
+        return lastError;
     }
 
     public boolean isInitialized() {

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/deploy/Deployer.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/deploy/Deployer.java
@@ -89,4 +89,5 @@ public interface Deployer<E extends ScopeModel> {
 
     void removeDeployListener(DeployListener<E> listener);
 
+    Throwable getError();
 }

--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/deploy/DefaultApplicationDeployer.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/deploy/DefaultApplicationDeployer.java
@@ -582,27 +582,28 @@ public class DefaultApplicationDeployer extends AbstractDeployer<ApplicationMode
         // prepare application instance
         prepareApplicationInstance();
 
-        executorRepository.getSharedExecutor().submit(() -> {
-            try {
-                while (isStarting()) {
-                    // notify when any module state changed
-                    synchronized (stateLock) {
-                        try {
-                            stateLock.wait(500);
-                        } catch (InterruptedException e) {
-                            // ignore
-                        }
-                    }
-
-                    // if has new module, do start again
-                    if (hasPendingModule()) {
-                        startModules();
-                    }
-                }
-            } catch (Exception e) {
-                logger.warn("waiting for application startup occurred an exception", e);
-            }
-        });
+        // Ignore checking new module after start
+//        executorRepository.getSharedExecutor().submit(() -> {
+//            try {
+//                while (isStarting()) {
+//                    // notify when any module state changed
+//                    synchronized (stateLock) {
+//                        try {
+//                            stateLock.wait(500);
+//                        } catch (InterruptedException e) {
+//                            // ignore
+//                        }
+//                    }
+//
+//                    // if has new module, do start again
+//                    if (hasPendingModule()) {
+//                        startModules();
+//                    }
+//                }
+//            } catch (Throwable e) {
+//                onFailed(getIdentifier() + " check start occurred an exception", e);
+//            }
+//        });
     }
 
     private void startModules() {

--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/deploy/DefaultApplicationDeployer.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/deploy/DefaultApplicationDeployer.java
@@ -554,6 +554,7 @@ public class DefaultApplicationDeployer extends AbstractDeployer<ApplicationMode
                 doStart();
             } catch (Throwable e) {
                 onFailed(getIdentifier() + " start failure", e);
+                throw e;
             }
 
             return startFuture;

--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/deploy/DefaultApplicationDeployer.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/deploy/DefaultApplicationDeployer.java
@@ -609,10 +609,12 @@ public class DefaultApplicationDeployer extends AbstractDeployer<ApplicationMode
         // ensure init and start internal module first
         prepareInternalModule();
 
-        // filter and start pending modules, ignore new module during starting
-        applicationModel.getModuleModels().stream()
-            .filter(moduleModel -> moduleModel.getDeployer().isPending())
-            .forEach(moduleModel -> moduleModel.getDeployer().start());
+        // filter and start pending modules, ignore new module during starting, throw exception of module start
+        for (ModuleModel moduleModel : new ArrayList<>(applicationModel.getModuleModels())) {
+            if (moduleModel.getDeployer().isPending()) {
+                moduleModel.getDeployer().start();
+            }
+        }
     }
 
     @Override

--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/deploy/DefaultModuleDeployer.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/deploy/DefaultModuleDeployer.java
@@ -169,6 +169,7 @@ public class DefaultModuleDeployer extends AbstractDeployer<ModuleModel> impleme
             }
         } catch (Throwable e) {
             onModuleFailed(getIdentifier() + " start failed: " + e.toString(), e);
+            throw e;
         }
         return startFuture;
     }

--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/deploy/DefaultModuleDeployer.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/deploy/DefaultModuleDeployer.java
@@ -127,41 +127,49 @@ public class DefaultModuleDeployer extends AbstractDeployer<ModuleModel> impleme
             throw new IllegalStateException(getIdentifier() + " is stopping or stopped, can not start again");
         }
 
-        if (isStarting() || isStarted()) {
-            return startFuture;
-        }
-
-        onModuleStarting();
-
-        // initialize
-        applicationDeployer.initialize();
-        initialize();
-
-        // export services
-        exportServices();
-
-        // prepare application instance
-        // exclude internal module to avoid wait itself
-        if (moduleModel != moduleModel.getApplicationModel().getInternalModule()) {
-            applicationDeployer.prepareApplicationInstance();
-        }
-
-        // refer services
-        referServices();
-
-        executorRepository.getSharedExecutor().submit(() -> {
-            try {
-                // wait for export finish
-                waitExportFinish();
-                // wait for refer finish
-                waitReferFinish();
-            } catch (Throwable e) {
-                logger.warn("wait for export/refer services occurred an exception", e);
-            } finally {
-                onModuleStarted();
+        try {
+            if (isStarting() || isStarted()) {
+                return startFuture;
             }
-        });
 
+            onModuleStarting();
+
+            // initialize
+            applicationDeployer.initialize();
+            initialize();
+
+            // export services
+            exportServices();
+
+            // prepare application instance
+            // exclude internal module to avoid wait itself
+            if (moduleModel != moduleModel.getApplicationModel().getInternalModule()) {
+                applicationDeployer.prepareApplicationInstance();
+            }
+
+            // refer services
+            referServices();
+
+            // if no async export/refer services, just set started
+            if (asyncExportingFutures.isEmpty() && asyncReferringFutures.isEmpty()) {
+                onModuleStarted();
+            } else {
+                executorRepository.getSharedExecutor().submit(() -> {
+                    try {
+                        // wait for export finish
+                        waitExportFinish();
+                        // wait for refer finish
+                        waitReferFinish();
+                    } catch (Throwable e) {
+                        logger.warn("wait for export/refer services occurred an exception", e);
+                    } finally {
+                        onModuleStarted();
+                    }
+                });
+            }
+        } catch (Throwable e) {
+            onModuleFailed(getIdentifier() + " start failed: " + e.toString(), e);
+        }
         return startFuture;
     }
 
@@ -245,6 +253,16 @@ public class DefaultModuleDeployer extends AbstractDeployer<ModuleModel> impleme
         } finally {
             // complete module start future after application state changed
             completeStartFuture(true);
+        }
+    }
+
+    private void onModuleFailed(String msg, Throwable ex) {
+        try {
+            setFailed(ex);
+            logger.error(msg, ex);
+            applicationDeployer.notifyModuleChanged(moduleModel, DeployState.STARTED);
+        } finally {
+            completeStartFuture(false);
         }
     }
 


### PR DESCRIPTION
## What is the purpose of the change

* Catch deploy error
* Improve module start waiting, if no async export/refer services, do not wait for started on new thread.

