### PR TITLE
Fix Compressor's getCompressor method

### DIFF
--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/Compressor.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/Compressor.java
@@ -42,6 +42,9 @@ public interface Compressor {
         if (null == compressorStr) {
             return null;
         }
+        if (compressorStr.equals(DEFAULT_COMPRESSOR)) {
+            return NONE;
+        }
         return frameworkModel.getExtensionLoader(Compressor.class).getExtension(compressorStr);
     }
 


### PR DESCRIPTION
## What is the purpose of the change

IdentityCompressor and Compressor#NONE obtained through SPI are not the same object, causing OutboundTransportObserver#calcCompressFlag to perform IdentityCompressor.NONE.equals(compressor) to return false

![image](https://user-images.githubusercontent.com/43363120/140602145-bf47ae7b-09d1-4259-a2e3-82ce798bd292.png)
