### PR TITLE
[Master]Fix netty server ssl context file leak

### DIFF
--- a/dubbo-remoting/dubbo-remoting-netty4/src/main/java/org/apache/dubbo/remoting/transport/netty4/SslContexts.java
+++ b/dubbo-remoting/dubbo-remoting-netty4/src/main/java/org/apache/dubbo/remoting/transport/netty4/SslContexts.java
@@ -46,9 +46,11 @@ public class SslContexts {
         SslContextBuilder sslClientContextBuilder = null;
         InputStream serverKeyCertChainPathStream = null;
         InputStream serverPrivateKeyPathStream = null;
+        InputStream serverTrustCertStream = null;
         try {
             serverKeyCertChainPathStream = sslConfig.getServerKeyCertChainPathStream();
             serverPrivateKeyPathStream = sslConfig.getServerPrivateKeyPathStream();
+            serverTrustCertStream = sslConfig.getServerTrustCertCollectionPathStream();
             String password = sslConfig.getServerKeyPassword();
             if (password != null) {
                 sslClientContextBuilder = SslContextBuilder.forServer(serverKeyCertChainPathStream,
@@ -58,8 +60,8 @@ public class SslContexts {
                         serverPrivateKeyPathStream);
             }
 
-            if (sslConfig.getServerTrustCertCollectionPathStream() != null) {
-                sslClientContextBuilder.trustManager(sslConfig.getServerTrustCertCollectionPathStream());
+            if (serverTrustCertStream != null) {
+                sslClientContextBuilder.trustManager(serverTrustCertStream);
                 sslClientContextBuilder.clientAuth(ClientAuth.REQUIRE);
             }
             if (sslConfig.getCiphers() != null) {
@@ -74,6 +76,7 @@ public class SslContexts {
         }finally {
             safeCloseStream(serverKeyCertChainPathStream);
             safeCloseStream(serverPrivateKeyPathStream);
+            safeCloseStream(serverTrustCertStream);
         }
         try {
             return sslClientContextBuilder.sslProvider(findSslProvider()).build();

--- a/dubbo-rpc/dubbo-rpc-grpc/src/main/java/org/apache/dubbo/rpc/protocol/grpc/GrpcOptionsUtils.java
+++ b/dubbo-rpc/dubbo-rpc-grpc/src/main/java/org/apache/dubbo/rpc/protocol/grpc/GrpcOptionsUtils.java
@@ -164,6 +164,7 @@ public class GrpcOptionsUtils {
         SslContextBuilder sslClientContextBuilder = null;
         InputStream serverKeyCertChainPathStream = null;
         InputStream serverPrivateKeyPathStream = null;
+        InputStream trustCertCollectionFilePath = null;
         try {
             serverKeyCertChainPathStream = sslConfig.getServerKeyCertChainPathStream();
             serverPrivateKeyPathStream = sslConfig.getServerPrivateKeyPathStream();
@@ -176,7 +177,7 @@ public class GrpcOptionsUtils {
                         serverPrivateKeyPathStream);
             }
 
-            InputStream trustCertCollectionFilePath = sslConfig.getServerTrustCertCollectionPathStream();
+            trustCertCollectionFilePath = sslConfig.getServerTrustCertCollectionPathStream();
             if (trustCertCollectionFilePath != null) {
                 sslClientContextBuilder.trustManager(trustCertCollectionFilePath);
                 sslClientContextBuilder.clientAuth(ClientAuth.REQUIRE);
@@ -186,6 +187,7 @@ public class GrpcOptionsUtils {
         }finally {
             safeCloseStream(serverKeyCertChainPathStream);
             safeCloseStream(serverPrivateKeyPathStream);
+            safeCloseStream(trustCertCollectionFilePath);
         }
         try {
             return sslClientContextBuilder.build();


### PR DESCRIPTION
## What is the purpose of the change
For #9197 change forget close `serverTrustCertCollectionPathStream`.

## Brief changelog


## Verifying this change


<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [ ] GitHub Actions works fine on your own branch.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
