### PR TITLE
Unify the constants into Constants class and abstract the statistical array into StatisticsItem

### DIFF
--- a/dubbo-monitor/dubbo-monitor-api/src/main/java/org/apache/dubbo/monitor/Constants.java
+++ b/dubbo-monitor/dubbo-monitor-api/src/main/java/org/apache/dubbo/monitor/Constants.java
@@ -16,15 +16,65 @@
  */
 package org.apache.dubbo.monitor;
 
+import static org.apache.dubbo.rpc.Constants.INPUT_KEY;
+import static org.apache.dubbo.rpc.Constants.OUTPUT_KEY;
+
 public interface Constants {
     String DUBBO_PROVIDER = "dubbo.provider";
+
     String DUBBO_CONSUMER = "dubbo.consumer";
+
     String DUBBO_PROVIDER_METHOD = "dubbo.provider.method";
+
     String DUBBO_CONSUMER_METHOD = "dubbo.consumer.method";
+
     String SERVICE = "service";
+
     String METHOD = "method";
+
     String DUBBO_GROUP = "dubbo";
+
     String METRICS_KEY = "metrics";
+
     String LOGSTAT_PROTOCOL = "logstat";
+
     String COUNT_PROTOCOL = "count";
+
+    String MONITOR_SEND_DATA_INTERVAL_KEY = "interval";
+
+    int DEFAULT_MONITOR_SEND_DATA_INTERVAL = 60000;
+
+    String APPLICATION = "application";
+
+    String INTERFACE = "interface";
+
+    String GROUP = "group";
+
+    String VERSION = "version";
+
+    String CONSUMER = "consumer";
+
+    String PROVIDER = "provider";
+
+    String TIMESTAMP = "timestamp";
+
+    String SUCCESS = "success";
+
+    String FAILURE = "failure";
+
+    String INPUT = INPUT_KEY;
+
+    String OUTPUT = OUTPUT_KEY;
+
+    String ELAPSED = "elapsed";
+
+    String CONCURRENT = "concurrent";
+
+    String MAX_INPUT = "max.input";
+
+    String MAX_OUTPUT = "max.output";
+
+    String MAX_ELAPSED = "max.elapsed";
+
+    String MAX_CONCURRENT = "max.concurrent";
 }

--- a/dubbo-monitor/dubbo-monitor-api/src/main/java/org/apache/dubbo/monitor/Constants.java
+++ b/dubbo-monitor/dubbo-monitor-api/src/main/java/org/apache/dubbo/monitor/Constants.java
@@ -30,11 +30,7 @@ public interface Constants {
 
     String SERVICE = "service";
 
-    String METHOD = "method";
-
     String DUBBO_GROUP = "dubbo";
-
-    String METRICS_KEY = "metrics";
 
     String LOGSTAT_PROTOCOL = "logstat";
 
@@ -44,37 +40,23 @@ public interface Constants {
 
     int DEFAULT_MONITOR_SEND_DATA_INTERVAL = 60000;
 
-    String APPLICATION = "application";
+    String SUCCESS_KEY = "success";
 
-    String INTERFACE = "interface";
+    String FAILURE_KEY = "failure";
 
-    String GROUP = "group";
+    String INPUT_KEY = "input";
 
-    String VERSION = "version";
+    String OUTPUT_KEY = "output";
 
-    String CONSUMER = "consumer";
+    String ELAPSED_KEY = "elapsed";
 
-    String PROVIDER = "provider";
+    String CONCURRENT_KEY = "concurrent";
 
-    String TIMESTAMP = "timestamp";
+    String MAX_INPUT_KEY = "max.input";
 
-    String SUCCESS = "success";
+    String MAX_OUTPUT_KEY = "max.output";
 
-    String FAILURE = "failure";
+    String MAX_ELAPSED_KEY = "max.elapsed";
 
-    String INPUT = INPUT_KEY;
-
-    String OUTPUT = OUTPUT_KEY;
-
-    String ELAPSED = "elapsed";
-
-    String CONCURRENT = "concurrent";
-
-    String MAX_INPUT = "max.input";
-
-    String MAX_OUTPUT = "max.output";
-
-    String MAX_ELAPSED = "max.elapsed";
-
-    String MAX_CONCURRENT = "max.concurrent";
+    String MAX_CONCURRENT_KEY = "max.concurrent";
 }

--- a/dubbo-monitor/dubbo-monitor-api/src/main/java/org/apache/dubbo/monitor/MonitorService.java
+++ b/dubbo-monitor/dubbo-monitor-api/src/main/java/org/apache/dubbo/monitor/MonitorService.java
@@ -21,48 +21,10 @@ import org.apache.dubbo.common.URL;
 
 import java.util.List;
 
-import static org.apache.dubbo.rpc.Constants.INPUT_KEY;
-import static org.apache.dubbo.rpc.Constants.OUTPUT_KEY;
 /**
  * MonitorService. (SPI, Prototype, ThreadSafe)
  */
 public interface MonitorService {
-
-    String APPLICATION = "application";
-
-    String INTERFACE = "interface";
-
-    String METHOD = "method";
-
-    String GROUP = "group";
-
-    String VERSION = "version";
-
-    String CONSUMER = "consumer";
-
-    String PROVIDER = "provider";
-
-    String TIMESTAMP = "timestamp";
-
-    String SUCCESS = "success";
-
-    String FAILURE = "failure";
-
-    String INPUT = INPUT_KEY;
-
-    String OUTPUT = OUTPUT_KEY;
-
-    String ELAPSED = "elapsed";
-
-    String CONCURRENT = "concurrent";
-
-    String MAX_INPUT = "max.input";
-
-    String MAX_OUTPUT = "max.output";
-
-    String MAX_ELAPSED = "max.elapsed";
-
-    String MAX_CONCURRENT = "max.concurrent";
 
     /**
      * Collect monitor data

--- a/dubbo-monitor/dubbo-monitor-api/src/main/java/org/apache/dubbo/monitor/support/MonitorFilter.java
+++ b/dubbo-monitor/dubbo-monitor-api/src/main/java/org/apache/dubbo/monitor/support/MonitorFilter.java
@@ -22,7 +22,6 @@ import org.apache.dubbo.common.logger.Logger;
 import org.apache.dubbo.common.logger.LoggerFactory;
 import org.apache.dubbo.common.url.component.ServiceConfigURL;
 import org.apache.dubbo.common.utils.NetUtils;
-import org.apache.dubbo.monitor.Constants;
 import org.apache.dubbo.monitor.Monitor;
 import org.apache.dubbo.monitor.MonitorFactory;
 import org.apache.dubbo.rpc.Filter;
@@ -37,13 +36,21 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import static org.apache.dubbo.common.constants.CommonConstants.APPLICATION_KEY;
+import static org.apache.dubbo.common.constants.CommonConstants.CONSUMER;
 import static org.apache.dubbo.common.constants.CommonConstants.CONSUMER_SIDE;
 import static org.apache.dubbo.common.constants.CommonConstants.GROUP_KEY;
+import static org.apache.dubbo.common.constants.CommonConstants.INTERFACE_KEY;
+import static org.apache.dubbo.common.constants.CommonConstants.METHOD_KEY;
 import static org.apache.dubbo.common.constants.CommonConstants.MONITOR_KEY;
 import static org.apache.dubbo.common.constants.CommonConstants.PATH_SEPARATOR;
 import static org.apache.dubbo.common.constants.CommonConstants.PROVIDER;
 import static org.apache.dubbo.common.constants.CommonConstants.VERSION_KEY;
+import static org.apache.dubbo.monitor.Constants.CONCURRENT_KEY;
 import static org.apache.dubbo.monitor.Constants.COUNT_PROTOCOL;
+import static org.apache.dubbo.monitor.Constants.ELAPSED_KEY;
+import static org.apache.dubbo.monitor.Constants.FAILURE_KEY;
+import static org.apache.dubbo.monitor.Constants.SUCCESS_KEY;
 import static org.apache.dubbo.rpc.Constants.INPUT_KEY;
 import static org.apache.dubbo.rpc.Constants.OUTPUT_KEY;
 
@@ -185,12 +192,12 @@ public class MonitorFilter implements Filter, Filter.Listener {
         if (CONSUMER_SIDE.equals(invoker.getUrl().getSide())) {
             // ---- for service consumer ----
             localPort = 0;
-            remoteKey = Constants.PROVIDER;
+            remoteKey = PROVIDER;
             remoteValue = invoker.getUrl().getAddress();
         } else {
             // ---- for service provider ----
             localPort = invoker.getUrl().getPort();
-            remoteKey = Constants.CONSUMER;
+            remoteKey = CONSUMER;
             remoteValue = remoteHost;
         }
         String input = "", output = "";
@@ -203,13 +210,13 @@ public class MonitorFilter implements Filter, Filter.Listener {
 
         return new ServiceConfigURL(COUNT_PROTOCOL, NetUtils.getLocalHost(), localPort,
             service + PATH_SEPARATOR + method,
-            Constants.APPLICATION, application,
-            Constants.INTERFACE, service,
-            Constants.METHOD, method,
+            APPLICATION_KEY, application,
+            INTERFACE_KEY, service,
+            METHOD_KEY, method,
             remoteKey, remoteValue,
-            error ? Constants.FAILURE : Constants.SUCCESS, "1",
-            Constants.ELAPSED, String.valueOf(elapsed),
-            Constants.CONCURRENT, String.valueOf(concurrent),
+            error ? FAILURE_KEY : SUCCESS_KEY, "1",
+            ELAPSED_KEY, String.valueOf(elapsed),
+            CONCURRENT_KEY, String.valueOf(concurrent),
             INPUT_KEY, input,
             OUTPUT_KEY, output,
             GROUP_KEY, group,

--- a/dubbo-monitor/dubbo-monitor-api/src/main/java/org/apache/dubbo/monitor/support/MonitorFilter.java
+++ b/dubbo-monitor/dubbo-monitor-api/src/main/java/org/apache/dubbo/monitor/support/MonitorFilter.java
@@ -22,9 +22,9 @@ import org.apache.dubbo.common.logger.Logger;
 import org.apache.dubbo.common.logger.LoggerFactory;
 import org.apache.dubbo.common.url.component.ServiceConfigURL;
 import org.apache.dubbo.common.utils.NetUtils;
+import org.apache.dubbo.monitor.Constants;
 import org.apache.dubbo.monitor.Monitor;
 import org.apache.dubbo.monitor.MonitorFactory;
-import org.apache.dubbo.monitor.MonitorService;
 import org.apache.dubbo.rpc.Filter;
 import org.apache.dubbo.rpc.Invocation;
 import org.apache.dubbo.rpc.Invoker;
@@ -133,10 +133,10 @@ public class MonitorFilter implements Filter, Filter.Listener {
      *
      * @param invoker
      * @param invocation
-     * @param result     the invoke result
+     * @param result     the invocation result
      * @param remoteHost the remote host address
-     * @param start      the timestamp the invoke begin
-     * @param error      if there is an error on the invoke
+     * @param start      the timestamp the invocation begin
+     * @param error      if there is an error on the invocation
      */
     private void collect(Invoker<?> invoker, Invocation invocation, Result result, String remoteHost, long start, boolean error) {
         try {
@@ -185,12 +185,12 @@ public class MonitorFilter implements Filter, Filter.Listener {
         if (CONSUMER_SIDE.equals(invoker.getUrl().getSide())) {
             // ---- for service consumer ----
             localPort = 0;
-            remoteKey = MonitorService.PROVIDER;
+            remoteKey = Constants.PROVIDER;
             remoteValue = invoker.getUrl().getAddress();
         } else {
             // ---- for service provider ----
             localPort = invoker.getUrl().getPort();
-            remoteKey = MonitorService.CONSUMER;
+            remoteKey = Constants.CONSUMER;
             remoteValue = remoteHost;
         }
         String input = "", output = "";
@@ -203,19 +203,17 @@ public class MonitorFilter implements Filter, Filter.Listener {
 
         return new ServiceConfigURL(COUNT_PROTOCOL, NetUtils.getLocalHost(), localPort,
             service + PATH_SEPARATOR + method,
-            MonitorService.APPLICATION,
-            application,
-            MonitorService.INTERFACE,
-            service,
-            MonitorService.METHOD,
-            method, remoteKey,
-            remoteValue,
-            error ? MonitorService.FAILURE : MonitorService.SUCCESS, "1",
-            MonitorService.ELAPSED,
-            String.valueOf(elapsed),
-            MonitorService.CONCURRENT,
-            String.valueOf(concurrent),
-            INPUT_KEY, input, OUTPUT_KEY, output, GROUP_KEY, group, VERSION_KEY, version);
+            Constants.APPLICATION, application,
+            Constants.INTERFACE, service,
+            Constants.METHOD, method,
+            remoteKey, remoteValue,
+            error ? Constants.FAILURE : Constants.SUCCESS, "1",
+            Constants.ELAPSED, String.valueOf(elapsed),
+            Constants.CONCURRENT, String.valueOf(concurrent),
+            INPUT_KEY, input,
+            OUTPUT_KEY, output,
+            GROUP_KEY, group,
+            VERSION_KEY, version);
     }
 
 

--- a/dubbo-monitor/dubbo-monitor-api/src/test/java/org/apache/dubbo/monitor/support/MonitorFilterTest.java
+++ b/dubbo-monitor/dubbo-monitor-api/src/test/java/org/apache/dubbo/monitor/support/MonitorFilterTest.java
@@ -18,6 +18,7 @@ package org.apache.dubbo.monitor.support;
 
 import org.apache.dubbo.common.URL;
 import org.apache.dubbo.common.utils.NetUtils;
+import org.apache.dubbo.monitor.Constants;
 import org.apache.dubbo.monitor.Monitor;
 import org.apache.dubbo.monitor.MonitorFactory;
 import org.apache.dubbo.monitor.MonitorService;
@@ -123,15 +124,15 @@ public class MonitorFilterTest {
         while (lastStatistics == null) {
             Thread.sleep(10);
         }
-        Assertions.assertEquals("abc", lastStatistics.getParameter(MonitorService.APPLICATION));
-        Assertions.assertEquals(MonitorService.class.getName(), lastStatistics.getParameter(MonitorService.INTERFACE));
-        Assertions.assertEquals("aaa", lastStatistics.getParameter(MonitorService.METHOD));
-        Assertions.assertEquals(NetUtils.getLocalHost() + ":20880", lastStatistics.getParameter(MonitorService.PROVIDER));
+        Assertions.assertEquals("abc", lastStatistics.getParameter(Constants.APPLICATION));
+        Assertions.assertEquals(MonitorService.class.getName(), lastStatistics.getParameter(Constants.INTERFACE));
+        Assertions.assertEquals("aaa", lastStatistics.getParameter(Constants.METHOD));
+        Assertions.assertEquals(NetUtils.getLocalHost() + ":20880", lastStatistics.getParameter(Constants.PROVIDER));
         Assertions.assertEquals(NetUtils.getLocalHost(), lastStatistics.getAddress());
-        Assertions.assertNull(lastStatistics.getParameter(MonitorService.CONSUMER));
-        Assertions.assertEquals(1, lastStatistics.getParameter(MonitorService.SUCCESS, 0));
-        Assertions.assertEquals(0, lastStatistics.getParameter(MonitorService.FAILURE, 0));
-        Assertions.assertEquals(1, lastStatistics.getParameter(MonitorService.CONCURRENT, 0));
+        Assertions.assertNull(lastStatistics.getParameter(Constants.CONSUMER));
+        Assertions.assertEquals(1, lastStatistics.getParameter(Constants.SUCCESS, 0));
+        Assertions.assertEquals(0, lastStatistics.getParameter(Constants.FAILURE, 0));
+        Assertions.assertEquals(1, lastStatistics.getParameter(Constants.CONCURRENT, 0));
         Assertions.assertEquals(invocation, lastInvocation);
     }
 
@@ -166,15 +167,15 @@ public class MonitorFilterTest {
         while (lastStatistics == null) {
             Thread.sleep(10);
         }
-        Assertions.assertEquals("abc", lastStatistics.getParameter(MonitorService.APPLICATION));
-        Assertions.assertEquals(MonitorService.class.getName(), lastStatistics.getParameter(MonitorService.INTERFACE));
-        Assertions.assertEquals("xxx", lastStatistics.getParameter(MonitorService.METHOD));
-        Assertions.assertEquals(NetUtils.getLocalHost() + ":20880", lastStatistics.getParameter(MonitorService.PROVIDER));
+        Assertions.assertEquals("abc", lastStatistics.getParameter(Constants.APPLICATION));
+        Assertions.assertEquals(MonitorService.class.getName(), lastStatistics.getParameter(Constants.INTERFACE));
+        Assertions.assertEquals("xxx", lastStatistics.getParameter(Constants.METHOD));
+        Assertions.assertEquals(NetUtils.getLocalHost() + ":20880", lastStatistics.getParameter(Constants.PROVIDER));
         Assertions.assertEquals(NetUtils.getLocalHost(), lastStatistics.getAddress());
-        Assertions.assertNull(lastStatistics.getParameter(MonitorService.CONSUMER));
-        Assertions.assertEquals(1, lastStatistics.getParameter(MonitorService.SUCCESS, 0));
-        Assertions.assertEquals(0, lastStatistics.getParameter(MonitorService.FAILURE, 0));
-        Assertions.assertEquals(1, lastStatistics.getParameter(MonitorService.CONCURRENT, 0));
+        Assertions.assertNull(lastStatistics.getParameter(Constants.CONSUMER));
+        Assertions.assertEquals(1, lastStatistics.getParameter(Constants.SUCCESS, 0));
+        Assertions.assertEquals(0, lastStatistics.getParameter(Constants.FAILURE, 0));
+        Assertions.assertEquals(1, lastStatistics.getParameter(Constants.CONCURRENT, 0));
         Assertions.assertEquals(invocation, lastInvocation);
     }
 

--- a/dubbo-monitor/dubbo-monitor-api/src/test/java/org/apache/dubbo/monitor/support/MonitorFilterTest.java
+++ b/dubbo-monitor/dubbo-monitor-api/src/test/java/org/apache/dubbo/monitor/support/MonitorFilterTest.java
@@ -18,7 +18,6 @@ package org.apache.dubbo.monitor.support;
 
 import org.apache.dubbo.common.URL;
 import org.apache.dubbo.common.utils.NetUtils;
-import org.apache.dubbo.monitor.Constants;
 import org.apache.dubbo.monitor.Monitor;
 import org.apache.dubbo.monitor.MonitorFactory;
 import org.apache.dubbo.monitor.MonitorService;
@@ -38,9 +37,16 @@ import java.util.Arrays;
 import java.util.List;
 
 import static org.apache.dubbo.common.constants.CommonConstants.APPLICATION_KEY;
+import static org.apache.dubbo.common.constants.CommonConstants.CONSUMER;
 import static org.apache.dubbo.common.constants.CommonConstants.CONSUMER_SIDE;
+import static org.apache.dubbo.common.constants.CommonConstants.INTERFACE_KEY;
+import static org.apache.dubbo.common.constants.CommonConstants.METHOD_KEY;
 import static org.apache.dubbo.common.constants.CommonConstants.MONITOR_KEY;
+import static org.apache.dubbo.common.constants.CommonConstants.PROVIDER;
 import static org.apache.dubbo.common.constants.CommonConstants.SIDE_KEY;
+import static org.apache.dubbo.monitor.Constants.CONCURRENT_KEY;
+import static org.apache.dubbo.monitor.Constants.FAILURE_KEY;
+import static org.apache.dubbo.monitor.Constants.SUCCESS_KEY;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
@@ -124,15 +130,15 @@ public class MonitorFilterTest {
         while (lastStatistics == null) {
             Thread.sleep(10);
         }
-        Assertions.assertEquals("abc", lastStatistics.getParameter(Constants.APPLICATION));
-        Assertions.assertEquals(MonitorService.class.getName(), lastStatistics.getParameter(Constants.INTERFACE));
-        Assertions.assertEquals("aaa", lastStatistics.getParameter(Constants.METHOD));
-        Assertions.assertEquals(NetUtils.getLocalHost() + ":20880", lastStatistics.getParameter(Constants.PROVIDER));
+        Assertions.assertEquals("abc", lastStatistics.getParameter(APPLICATION_KEY));
+        Assertions.assertEquals(MonitorService.class.getName(), lastStatistics.getParameter(INTERFACE_KEY));
+        Assertions.assertEquals("aaa", lastStatistics.getParameter(METHOD_KEY));
+        Assertions.assertEquals(NetUtils.getLocalHost() + ":20880", lastStatistics.getParameter(PROVIDER));
         Assertions.assertEquals(NetUtils.getLocalHost(), lastStatistics.getAddress());
-        Assertions.assertNull(lastStatistics.getParameter(Constants.CONSUMER));
-        Assertions.assertEquals(1, lastStatistics.getParameter(Constants.SUCCESS, 0));
-        Assertions.assertEquals(0, lastStatistics.getParameter(Constants.FAILURE, 0));
-        Assertions.assertEquals(1, lastStatistics.getParameter(Constants.CONCURRENT, 0));
+        Assertions.assertNull(lastStatistics.getParameter(CONSUMER));
+        Assertions.assertEquals(1, lastStatistics.getParameter(SUCCESS_KEY, 0));
+        Assertions.assertEquals(0, lastStatistics.getParameter(FAILURE_KEY, 0));
+        Assertions.assertEquals(1, lastStatistics.getParameter(CONCURRENT_KEY, 0));
         Assertions.assertEquals(invocation, lastInvocation);
     }
 
@@ -167,15 +173,15 @@ public class MonitorFilterTest {
         while (lastStatistics == null) {
             Thread.sleep(10);
         }
-        Assertions.assertEquals("abc", lastStatistics.getParameter(Constants.APPLICATION));
-        Assertions.assertEquals(MonitorService.class.getName(), lastStatistics.getParameter(Constants.INTERFACE));
-        Assertions.assertEquals("xxx", lastStatistics.getParameter(Constants.METHOD));
-        Assertions.assertEquals(NetUtils.getLocalHost() + ":20880", lastStatistics.getParameter(Constants.PROVIDER));
+        Assertions.assertEquals("abc", lastStatistics.getParameter(APPLICATION_KEY));
+        Assertions.assertEquals(MonitorService.class.getName(), lastStatistics.getParameter(INTERFACE_KEY));
+        Assertions.assertEquals("xxx", lastStatistics.getParameter(METHOD_KEY));
+        Assertions.assertEquals(NetUtils.getLocalHost() + ":20880", lastStatistics.getParameter(PROVIDER));
         Assertions.assertEquals(NetUtils.getLocalHost(), lastStatistics.getAddress());
-        Assertions.assertNull(lastStatistics.getParameter(Constants.CONSUMER));
-        Assertions.assertEquals(1, lastStatistics.getParameter(Constants.SUCCESS, 0));
-        Assertions.assertEquals(0, lastStatistics.getParameter(Constants.FAILURE, 0));
-        Assertions.assertEquals(1, lastStatistics.getParameter(Constants.CONCURRENT, 0));
+        Assertions.assertNull(lastStatistics.getParameter(CONSUMER));
+        Assertions.assertEquals(1, lastStatistics.getParameter(SUCCESS_KEY, 0));
+        Assertions.assertEquals(0, lastStatistics.getParameter(FAILURE_KEY, 0));
+        Assertions.assertEquals(1, lastStatistics.getParameter(CONCURRENT_KEY, 0));
         Assertions.assertEquals(invocation, lastInvocation);
     }
 

--- a/dubbo-monitor/dubbo-monitor-default/src/main/java/org/apache/dubbo/monitor/dubbo/DubboMonitor.java
+++ b/dubbo-monitor/dubbo-monitor-default/src/main/java/org/apache/dubbo/monitor/dubbo/DubboMonitor.java
@@ -20,6 +20,7 @@ import org.apache.dubbo.common.URL;
 import org.apache.dubbo.common.logger.Logger;
 import org.apache.dubbo.common.logger.LoggerFactory;
 import org.apache.dubbo.common.utils.ExecutorUtil;
+import org.apache.dubbo.monitor.Constants;
 import org.apache.dubbo.monitor.Monitor;
 import org.apache.dubbo.monitor.MonitorService;
 import org.apache.dubbo.rpc.Invoker;
@@ -61,14 +62,14 @@ public class DubboMonitor implements Monitor {
 
     private final MonitorService monitorService;
 
-    private final ConcurrentMap<Statistics, AtomicReference<long[]>> statisticsMap = new ConcurrentHashMap<Statistics, AtomicReference<long[]>>();
+    private final ConcurrentMap<Statistics, AtomicReference<StatisticsItem>> statisticsMap = new ConcurrentHashMap<>();
 
     public DubboMonitor(Invoker<MonitorService> monitorInvoker, MonitorService monitorService) {
         this.monitorInvoker = monitorInvoker;
         this.monitorService = monitorService;
         scheduledExecutorService = monitorInvoker.getUrl().getOrDefaultApplicationModel().getApplicationExecutorRepository().getSharedScheduledExecutor();
         // The time interval for timer <b>scheduledExecutorService</b> to send data
-        final long monitorInterval = monitorInvoker.getUrl().getPositiveParameter("interval", 60000);
+        final long monitorInterval = monitorInvoker.getUrl().getPositiveParameter(Constants.MONITOR_SEND_DATA_INTERVAL_KEY, Constants.DEFAULT_MONITOR_SEND_DATA_INTERVAL);
         // collect timer for collecting statistics data
         sendFuture = scheduledExecutorService.scheduleWithFixedDelay(() -> {
             try {
@@ -86,59 +87,45 @@ public class DubboMonitor implements Monitor {
         }
 
         String timestamp = String.valueOf(System.currentTimeMillis());
-        for (Map.Entry<Statistics, AtomicReference<long[]>> entry : statisticsMap.entrySet()) {
+        for (Map.Entry<Statistics, AtomicReference<StatisticsItem>> entry : statisticsMap.entrySet()) {
             // get statistics data
             Statistics statistics = entry.getKey();
-            AtomicReference<long[]> reference = entry.getValue();
-            long[] numbers = reference.get();
-            long success = numbers[0];
-            long failure = numbers[1];
-            long input = numbers[2];
-            long output = numbers[3];
-            long elapsed = numbers[4];
-            long concurrent = numbers[5];
-            long maxInput = numbers[6];
-            long maxOutput = numbers[7];
-            long maxElapsed = numbers[8];
-            long maxConcurrent = numbers[9];
-            String protocol = getUrl().getParameter(DEFAULT_PROTOCOL);
+            AtomicReference<StatisticsItem> reference = entry.getValue();
+            StatisticsItem statisticsItem = reference.get();
 
             // send statistics data
             URL url = statistics.getUrl()
-                    .addParameters(MonitorService.TIMESTAMP, timestamp,
-                            MonitorService.SUCCESS, String.valueOf(success),
-                            MonitorService.FAILURE, String.valueOf(failure),
-                            MonitorService.INPUT, String.valueOf(input),
-                            MonitorService.OUTPUT, String.valueOf(output),
-                            MonitorService.ELAPSED, String.valueOf(elapsed),
-                            MonitorService.CONCURRENT, String.valueOf(concurrent),
-                            MonitorService.MAX_INPUT, String.valueOf(maxInput),
-                            MonitorService.MAX_OUTPUT, String.valueOf(maxOutput),
-                            MonitorService.MAX_ELAPSED, String.valueOf(maxElapsed),
-                            MonitorService.MAX_CONCURRENT, String.valueOf(maxConcurrent),
-                            DEFAULT_PROTOCOL, protocol
-                    );
+                .addParameters(Constants.TIMESTAMP, timestamp,
+                    Constants.SUCCESS, String.valueOf(statisticsItem.getSuccess()),
+                    Constants.FAILURE, String.valueOf(statisticsItem.getFailure()),
+                    Constants.INPUT, String.valueOf(statisticsItem.getInput()),
+                    Constants.OUTPUT, String.valueOf(statisticsItem.getOutput()),
+                    Constants.ELAPSED, String.valueOf(statisticsItem.getElapsed()),
+                    Constants.CONCURRENT, String.valueOf(statisticsItem.getConcurrent()),
+                    Constants.MAX_INPUT, String.valueOf(statisticsItem.getMaxInput()),
+                    Constants.MAX_OUTPUT, String.valueOf(statisticsItem.getMaxOutput()),
+                    Constants.MAX_ELAPSED, String.valueOf(statisticsItem.getMaxElapsed()),
+                    Constants.MAX_CONCURRENT, String.valueOf(statisticsItem.getMaxConcurrent()),
+                    DEFAULT_PROTOCOL, getUrl().getParameter(DEFAULT_PROTOCOL)
+                );
             monitorService.collect(url.toSerializableURL());
 
             // reset
-            long[] current;
-            long[] update = new long[LENGTH];
+            StatisticsItem current;
+            StatisticsItem update = new StatisticsItem();
             do {
                 current = reference.get();
                 if (current == null) {
-                    update[0] = 0;
-                    update[1] = 0;
-                    update[2] = 0;
-                    update[3] = 0;
-                    update[4] = 0;
-                    update[5] = 0;
+                    update.setItems(0, 0, 0, 0, 0, 0);
                 } else {
-                    update[0] = current[0] - success;
-                    update[1] = current[1] - failure;
-                    update[2] = current[2] - input;
-                    update[3] = current[3] - output;
-                    update[4] = current[4] - elapsed;
-                    update[5] = current[5] - concurrent;
+                    update.setItems(
+                        current.getSuccess() - statisticsItem.getSuccess(),
+                        current.getFailure() - statisticsItem.getFailure(),
+                        current.getInput() - statisticsItem.getInput(),
+                        current.getOutput() - statisticsItem.getOutput(),
+                        current.getElapsed() - statisticsItem.getElapsed(),
+                        current.getConcurrent() - statisticsItem.getConcurrent()
+                    );
                 }
             } while (!reference.compareAndSet(current, update));
         }
@@ -147,42 +134,35 @@ public class DubboMonitor implements Monitor {
     @Override
     public void collect(URL url) {
         // data to collect from url
-        int success = url.getParameter(MonitorService.SUCCESS, 0);
-        int failure = url.getParameter(MonitorService.FAILURE, 0);
-        int input = url.getParameter(MonitorService.INPUT, 0);
-        int output = url.getParameter(MonitorService.OUTPUT, 0);
-        int elapsed = url.getParameter(MonitorService.ELAPSED, 0);
-        int concurrent = url.getParameter(MonitorService.CONCURRENT, 0);
+        int success = url.getParameter(Constants.SUCCESS, 0);
+        int failure = url.getParameter(Constants.FAILURE, 0);
+        int input = url.getParameter(Constants.INPUT, 0);
+        int output = url.getParameter(Constants.OUTPUT, 0);
+        int elapsed = url.getParameter(Constants.ELAPSED, 0);
+        int concurrent = url.getParameter(Constants.CONCURRENT, 0);
         // init atomic reference
         Statistics statistics = new Statistics(url);
-        AtomicReference<long[]> reference = statisticsMap.computeIfAbsent(statistics, k -> new AtomicReference<>());
+        AtomicReference<StatisticsItem> reference = statisticsMap.computeIfAbsent(statistics, k -> new AtomicReference<>());
         // use CompareAndSet to sum
-        long[] current;
-        long[] update = new long[LENGTH];
+        StatisticsItem current;
+        StatisticsItem update = new StatisticsItem();
         do {
             current = reference.get();
             if (current == null) {
-                update[0] = success;
-                update[1] = failure;
-                update[2] = input;
-                update[3] = output;
-                update[4] = elapsed;
-                update[5] = concurrent;
-                update[6] = input;
-                update[7] = output;
-                update[8] = elapsed;
-                update[9] = concurrent;
+                update.setItems(success, failure, input, output, elapsed, concurrent, input, output, elapsed, concurrent);
             } else {
-                update[0] = current[0] + success;
-                update[1] = current[1] + failure;
-                update[2] = current[2] + input;
-                update[3] = current[3] + output;
-                update[4] = current[4] + elapsed;
-                update[5] = (current[5] + concurrent) / 2;
-                update[6] = current[6] > input ? current[6] : input;
-                update[7] = current[7] > output ? current[7] : output;
-                update[8] = current[8] > elapsed ? current[8] : elapsed;
-                update[9] = current[9] > concurrent ? current[9] : concurrent;
+                update.setItems(
+                    current.getSuccess() + success,
+                    current.getFailure() + failure,
+                    current.getInput() + input,
+                    current.getOutput() + output,
+                    current.getElapsed() + elapsed,
+                    (current.getConcurrent() + concurrent) / 2,
+                    current.getMaxInput() > input ? current.getMaxInput() : input,
+                    current.getMaxOutput() > output ? current.getMaxOutput() : output,
+                    current.getMaxElapsed() > elapsed ? current.getMaxElapsed() : elapsed,
+                    current.getMaxConcurrent() > concurrent ? current.getMaxConcurrent() : concurrent
+                );
             }
         } while (!reference.compareAndSet(current, update));
     }

--- a/dubbo-monitor/dubbo-monitor-default/src/main/java/org/apache/dubbo/monitor/dubbo/DubboMonitor.java
+++ b/dubbo-monitor/dubbo-monitor-default/src/main/java/org/apache/dubbo/monitor/dubbo/DubboMonitor.java
@@ -20,7 +20,6 @@ import org.apache.dubbo.common.URL;
 import org.apache.dubbo.common.logger.Logger;
 import org.apache.dubbo.common.logger.LoggerFactory;
 import org.apache.dubbo.common.utils.ExecutorUtil;
-import org.apache.dubbo.monitor.Constants;
 import org.apache.dubbo.monitor.Monitor;
 import org.apache.dubbo.monitor.MonitorService;
 import org.apache.dubbo.rpc.Invoker;
@@ -35,6 +34,19 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.apache.dubbo.common.constants.CommonConstants.DEFAULT_PROTOCOL;
+import static org.apache.dubbo.common.constants.CommonConstants.TIMESTAMP_KEY;
+import static org.apache.dubbo.monitor.Constants.CONCURRENT_KEY;
+import static org.apache.dubbo.monitor.Constants.DEFAULT_MONITOR_SEND_DATA_INTERVAL;
+import static org.apache.dubbo.monitor.Constants.ELAPSED_KEY;
+import static org.apache.dubbo.monitor.Constants.FAILURE_KEY;
+import static org.apache.dubbo.monitor.Constants.INPUT_KEY;
+import static org.apache.dubbo.monitor.Constants.MAX_CONCURRENT_KEY;
+import static org.apache.dubbo.monitor.Constants.MAX_ELAPSED_KEY;
+import static org.apache.dubbo.monitor.Constants.MAX_INPUT_KEY;
+import static org.apache.dubbo.monitor.Constants.MAX_OUTPUT_KEY;
+import static org.apache.dubbo.monitor.Constants.MONITOR_SEND_DATA_INTERVAL_KEY;
+import static org.apache.dubbo.monitor.Constants.OUTPUT_KEY;
+import static org.apache.dubbo.monitor.Constants.SUCCESS_KEY;
 
 /**
  * DubboMonitor
@@ -42,11 +54,6 @@ import static org.apache.dubbo.common.constants.CommonConstants.DEFAULT_PROTOCOL
 public class DubboMonitor implements Monitor {
 
     private static final Logger logger = LoggerFactory.getLogger(DubboMonitor.class);
-
-    /**
-     * The length of the array which is a container of the statistics
-     */
-    private static final int LENGTH = 10;
 
     /**
      * The timer for sending statistics
@@ -69,7 +76,7 @@ public class DubboMonitor implements Monitor {
         this.monitorService = monitorService;
         scheduledExecutorService = monitorInvoker.getUrl().getOrDefaultApplicationModel().getApplicationExecutorRepository().getSharedScheduledExecutor();
         // The time interval for timer <b>scheduledExecutorService</b> to send data
-        final long monitorInterval = monitorInvoker.getUrl().getPositiveParameter(Constants.MONITOR_SEND_DATA_INTERVAL_KEY, Constants.DEFAULT_MONITOR_SEND_DATA_INTERVAL);
+        final long monitorInterval = monitorInvoker.getUrl().getPositiveParameter(MONITOR_SEND_DATA_INTERVAL_KEY, DEFAULT_MONITOR_SEND_DATA_INTERVAL);
         // collect timer for collecting statistics data
         sendFuture = scheduledExecutorService.scheduleWithFixedDelay(() -> {
             try {
@@ -95,17 +102,17 @@ public class DubboMonitor implements Monitor {
 
             // send statistics data
             URL url = statistics.getUrl()
-                .addParameters(Constants.TIMESTAMP, timestamp,
-                    Constants.SUCCESS, String.valueOf(statisticsItem.getSuccess()),
-                    Constants.FAILURE, String.valueOf(statisticsItem.getFailure()),
-                    Constants.INPUT, String.valueOf(statisticsItem.getInput()),
-                    Constants.OUTPUT, String.valueOf(statisticsItem.getOutput()),
-                    Constants.ELAPSED, String.valueOf(statisticsItem.getElapsed()),
-                    Constants.CONCURRENT, String.valueOf(statisticsItem.getConcurrent()),
-                    Constants.MAX_INPUT, String.valueOf(statisticsItem.getMaxInput()),
-                    Constants.MAX_OUTPUT, String.valueOf(statisticsItem.getMaxOutput()),
-                    Constants.MAX_ELAPSED, String.valueOf(statisticsItem.getMaxElapsed()),
-                    Constants.MAX_CONCURRENT, String.valueOf(statisticsItem.getMaxConcurrent()),
+                .addParameters(TIMESTAMP_KEY, timestamp,
+                    SUCCESS_KEY, String.valueOf(statisticsItem.getSuccess()),
+                    FAILURE_KEY, String.valueOf(statisticsItem.getFailure()),
+                    INPUT_KEY, String.valueOf(statisticsItem.getInput()),
+                    OUTPUT_KEY, String.valueOf(statisticsItem.getOutput()),
+                    ELAPSED_KEY, String.valueOf(statisticsItem.getElapsed()),
+                    CONCURRENT_KEY, String.valueOf(statisticsItem.getConcurrent()),
+                    MAX_INPUT_KEY, String.valueOf(statisticsItem.getMaxInput()),
+                    MAX_OUTPUT_KEY, String.valueOf(statisticsItem.getMaxOutput()),
+                    MAX_ELAPSED_KEY, String.valueOf(statisticsItem.getMaxElapsed()),
+                    MAX_CONCURRENT_KEY, String.valueOf(statisticsItem.getMaxConcurrent()),
                     DEFAULT_PROTOCOL, getUrl().getParameter(DEFAULT_PROTOCOL)
                 );
             monitorService.collect(url.toSerializableURL());
@@ -134,12 +141,12 @@ public class DubboMonitor implements Monitor {
     @Override
     public void collect(URL url) {
         // data to collect from url
-        int success = url.getParameter(Constants.SUCCESS, 0);
-        int failure = url.getParameter(Constants.FAILURE, 0);
-        int input = url.getParameter(Constants.INPUT, 0);
-        int output = url.getParameter(Constants.OUTPUT, 0);
-        int elapsed = url.getParameter(Constants.ELAPSED, 0);
-        int concurrent = url.getParameter(Constants.CONCURRENT, 0);
+        int success = url.getParameter(SUCCESS_KEY, 0);
+        int failure = url.getParameter(FAILURE_KEY, 0);
+        int input = url.getParameter(INPUT_KEY, 0);
+        int output = url.getParameter(OUTPUT_KEY, 0);
+        int elapsed = url.getParameter(ELAPSED_KEY, 0);
+        int concurrent = url.getParameter(CONCURRENT_KEY, 0);
         // init atomic reference
         Statistics statistics = new Statistics(url);
         AtomicReference<StatisticsItem> reference = statisticsMap.computeIfAbsent(statistics, k -> new AtomicReference<>());

--- a/dubbo-monitor/dubbo-monitor-default/src/main/java/org/apache/dubbo/monitor/dubbo/MetricsFilter.java
+++ b/dubbo-monitor/dubbo-monitor-default/src/main/java/org/apache/dubbo/monitor/dubbo/MetricsFilter.java
@@ -59,13 +59,13 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.apache.dubbo.common.constants.CommonConstants.DEFAULT_PROTOCOL;
 import static org.apache.dubbo.common.constants.CommonConstants.EXECUTOR_SERVICE_COMPONENT_KEY;
+import static org.apache.dubbo.common.constants.CommonConstants.METHOD_KEY;
 import static org.apache.dubbo.common.constants.CommonConstants.PROVIDER;
 import static org.apache.dubbo.monitor.Constants.DUBBO_CONSUMER;
 import static org.apache.dubbo.monitor.Constants.DUBBO_CONSUMER_METHOD;
 import static org.apache.dubbo.monitor.Constants.DUBBO_GROUP;
 import static org.apache.dubbo.monitor.Constants.DUBBO_PROVIDER;
 import static org.apache.dubbo.monitor.Constants.DUBBO_PROVIDER_METHOD;
-import static org.apache.dubbo.monitor.Constants.METHOD;
 import static org.apache.dubbo.monitor.Constants.SERVICE;
 
 /**
@@ -169,7 +169,7 @@ public class MetricsFilter implements Filter, ExtensionAccessorAware, ScopeModel
             method = new MetricName(DUBBO_PROVIDER_METHOD, new HashMap<String, String>(4) {
                 {
                     put(SERVICE, serviceName);
-                    put(METHOD, methodName);
+                    put(METHOD_KEY, methodName);
                 }
             }, MetricLevel.NORMAL);
         } else {
@@ -177,7 +177,7 @@ public class MetricsFilter implements Filter, ExtensionAccessorAware, ScopeModel
             method = new MetricName(DUBBO_CONSUMER_METHOD, new HashMap<String, String>(4) {
                 {
                     put(SERVICE, serviceName);
-                    put(METHOD, methodName);
+                    put(METHOD_KEY, methodName);
                 }
             }, MetricLevel.NORMAL);
         }

--- a/dubbo-monitor/dubbo-monitor-default/src/main/java/org/apache/dubbo/monitor/dubbo/Statistics.java
+++ b/dubbo-monitor/dubbo-monitor-default/src/main/java/org/apache/dubbo/monitor/dubbo/Statistics.java
@@ -17,7 +17,7 @@
 package org.apache.dubbo.monitor.dubbo;
 
 import org.apache.dubbo.common.URL;
-import org.apache.dubbo.monitor.MonitorService;
+import org.apache.dubbo.monitor.Constants;
 
 import java.io.Serializable;
 
@@ -46,13 +46,13 @@ public class Statistics implements Serializable {
 
     public Statistics(URL url) {
         this.url = url;
-        this.application = url.getParameter(MonitorService.APPLICATION);
-        this.service = url.getParameter(MonitorService.INTERFACE);
-        this.method = url.getParameter(MonitorService.METHOD);
-        this.group = url.getParameter(MonitorService.GROUP);
-        this.version = url.getParameter(MonitorService.VERSION);
-        this.client = url.getParameter(MonitorService.CONSUMER, url.getAddress());
-        this.server = url.getParameter(MonitorService.PROVIDER, url.getAddress());
+        this.application = url.getParameter(Constants.APPLICATION);
+        this.service = url.getParameter(Constants.INTERFACE);
+        this.method = url.getParameter(Constants.METHOD);
+        this.group = url.getParameter(Constants.GROUP);
+        this.version = url.getParameter(Constants.VERSION);
+        this.client = url.getParameter(Constants.CONSUMER, url.getAddress());
+        this.server = url.getParameter(Constants.PROVIDER, url.getAddress());
     }
 
     public URL getUrl() {

--- a/dubbo-monitor/dubbo-monitor-default/src/main/java/org/apache/dubbo/monitor/dubbo/Statistics.java
+++ b/dubbo-monitor/dubbo-monitor-default/src/main/java/org/apache/dubbo/monitor/dubbo/Statistics.java
@@ -17,9 +17,16 @@
 package org.apache.dubbo.monitor.dubbo;
 
 import org.apache.dubbo.common.URL;
-import org.apache.dubbo.monitor.Constants;
 
 import java.io.Serializable;
+
+import static org.apache.dubbo.common.constants.CommonConstants.APPLICATION_KEY;
+import static org.apache.dubbo.common.constants.CommonConstants.CONSUMER;
+import static org.apache.dubbo.common.constants.CommonConstants.GROUP_KEY;
+import static org.apache.dubbo.common.constants.CommonConstants.INTERFACE_KEY;
+import static org.apache.dubbo.common.constants.CommonConstants.METHOD_KEY;
+import static org.apache.dubbo.common.constants.CommonConstants.PROVIDER;
+import static org.apache.dubbo.common.constants.CommonConstants.VERSION_KEY;
 
 /**
  * Statistics. (SPI, Prototype, ThreadSafe)
@@ -46,13 +53,13 @@ public class Statistics implements Serializable {
 
     public Statistics(URL url) {
         this.url = url;
-        this.application = url.getParameter(Constants.APPLICATION);
-        this.service = url.getParameter(Constants.INTERFACE);
-        this.method = url.getParameter(Constants.METHOD);
-        this.group = url.getParameter(Constants.GROUP);
-        this.version = url.getParameter(Constants.VERSION);
-        this.client = url.getParameter(Constants.CONSUMER, url.getAddress());
-        this.server = url.getParameter(Constants.PROVIDER, url.getAddress());
+        this.application = url.getParameter(APPLICATION_KEY);
+        this.service = url.getParameter(INTERFACE_KEY);
+        this.method = url.getParameter(METHOD_KEY);
+        this.group = url.getParameter(GROUP_KEY);
+        this.version = url.getParameter(VERSION_KEY);
+        this.client = url.getParameter(CONSUMER, url.getAddress());
+        this.server = url.getParameter(PROVIDER, url.getAddress());
     }
 
     public URL getUrl() {

--- a/dubbo-monitor/dubbo-monitor-default/src/main/java/org/apache/dubbo/monitor/dubbo/StatisticsItem.java
+++ b/dubbo-monitor/dubbo-monitor-default/src/main/java/org/apache/dubbo/monitor/dubbo/StatisticsItem.java
@@ -1,0 +1,132 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.monitor.dubbo;
+
+public class StatisticsItem {
+
+    private long success;
+    private long failure;
+    private long input;
+    private long output;
+    private long elapsed;
+    private long concurrent;
+    private long maxInput;
+    private long maxOutput;
+    private long maxElapsed;
+    private long maxConcurrent;
+
+    public StatisticsItem() {
+    }
+
+    public void setItems(long success, long failure, long input, long output, long elapsed, long concurrent) {
+        this.setItems(success, failure, input, output, elapsed, concurrent, 0, 0, 0, 0);
+    }
+
+    public void setItems(long success, long failure, long input, long output, long elapsed, long concurrent,
+                         long maxInput, long maxOutput, long maxElapsed, long maxConcurrent) {
+        this.success = success;
+        this.failure = failure;
+        this.input = input;
+        this.output = output;
+        this.elapsed = elapsed;
+        this.concurrent = concurrent;
+        this.maxInput = maxInput;
+        this.maxOutput = maxOutput;
+        this.maxElapsed = maxElapsed;
+        this.maxConcurrent = maxConcurrent;
+    }
+
+    public long getSuccess() {
+        return success;
+    }
+
+    public void setSuccess(long success) {
+        this.success = success;
+    }
+
+    public long getFailure() {
+        return failure;
+    }
+
+    public void setFailure(long failure) {
+        this.failure = failure;
+    }
+
+    public long getInput() {
+        return input;
+    }
+
+    public void setInput(long input) {
+        this.input = input;
+    }
+
+    public long getOutput() {
+        return output;
+    }
+
+    public void setOutput(long output) {
+        this.output = output;
+    }
+
+    public long getElapsed() {
+        return elapsed;
+    }
+
+    public void setElapsed(long elapsed) {
+        this.elapsed = elapsed;
+    }
+
+    public long getConcurrent() {
+        return concurrent;
+    }
+
+    public void setConcurrent(long concurrent) {
+        this.concurrent = concurrent;
+    }
+
+    public long getMaxInput() {
+        return maxInput;
+    }
+
+    public void setMaxInput(long maxInput) {
+        this.maxInput = maxInput;
+    }
+
+    public long getMaxOutput() {
+        return maxOutput;
+    }
+
+    public void setMaxOutput(long maxOutput) {
+        this.maxOutput = maxOutput;
+    }
+
+    public long getMaxElapsed() {
+        return maxElapsed;
+    }
+
+    public void setMaxElapsed(long maxElapsed) {
+        this.maxElapsed = maxElapsed;
+    }
+
+    public long getMaxConcurrent() {
+        return maxConcurrent;
+    }
+
+    public void setMaxConcurrent(long maxConcurrent) {
+        this.maxConcurrent = maxConcurrent;
+    }
+}

--- a/dubbo-monitor/dubbo-monitor-default/src/test/java/org/apache/dubbo/monitor/dubbo/DubboMonitorTest.java
+++ b/dubbo-monitor/dubbo-monitor-default/src/test/java/org/apache/dubbo/monitor/dubbo/DubboMonitorTest.java
@@ -19,6 +19,7 @@ package org.apache.dubbo.monitor.dubbo;
 import org.apache.dubbo.common.URL;
 import org.apache.dubbo.common.URLBuilder;
 import org.apache.dubbo.common.extension.ExtensionLoader;
+import org.apache.dubbo.monitor.Constants;
 import org.apache.dubbo.monitor.Monitor;
 import org.apache.dubbo.monitor.MonitorFactory;
 import org.apache.dubbo.monitor.MonitorService;
@@ -96,35 +97,35 @@ public class DubboMonitorTest {
     public void testCount() throws Exception {
         DubboMonitor monitor = new DubboMonitor(monitorInvoker, monitorService);
         URL statistics = new URLBuilder(DUBBO_PROTOCOL, "10.20.153.10", 0)
-                .addParameter(MonitorService.APPLICATION, "morgan")
-                .addParameter(MonitorService.INTERFACE, "MemberService")
-                .addParameter(MonitorService.METHOD, "findPerson")
-                .addParameter(MonitorService.CONSUMER, "10.20.153.11")
-                .addParameter(MonitorService.SUCCESS, 1)
-                .addParameter(MonitorService.FAILURE, 0)
-                .addParameter(MonitorService.ELAPSED, 3)
-                .addParameter(MonitorService.MAX_ELAPSED, 3)
-                .addParameter(MonitorService.CONCURRENT, 1)
-                .addParameter(MonitorService.MAX_CONCURRENT, 1)
+                .addParameter(Constants.APPLICATION, "morgan")
+                .addParameter(Constants.INTERFACE, "MemberService")
+                .addParameter(Constants.METHOD, "findPerson")
+                .addParameter(Constants.CONSUMER, "10.20.153.11")
+                .addParameter(Constants.SUCCESS, 1)
+                .addParameter(Constants.FAILURE, 0)
+                .addParameter(Constants.ELAPSED, 3)
+                .addParameter(Constants.MAX_ELAPSED, 3)
+                .addParameter(Constants.CONCURRENT, 1)
+                .addParameter(Constants.MAX_CONCURRENT, 1)
                 .build();
         monitor.collect(statistics.toSerializableURL());
         monitor.send();
         while (lastStatistics == null) {
             Thread.sleep(10);
         }
-        Assertions.assertEquals("morgan", lastStatistics.getParameter(MonitorService.APPLICATION));
+        Assertions.assertEquals("morgan", lastStatistics.getParameter(Constants.APPLICATION));
         Assertions.assertEquals("dubbo", lastStatistics.getProtocol());
         Assertions.assertEquals("10.20.153.10", lastStatistics.getHost());
-        Assertions.assertEquals("morgan", lastStatistics.getParameter(MonitorService.APPLICATION));
-        Assertions.assertEquals("MemberService", lastStatistics.getParameter(MonitorService.INTERFACE));
-        Assertions.assertEquals("findPerson", lastStatistics.getParameter(MonitorService.METHOD));
-        Assertions.assertEquals("10.20.153.11", lastStatistics.getParameter(MonitorService.CONSUMER));
-        Assertions.assertEquals("1", lastStatistics.getParameter(MonitorService.SUCCESS));
-        Assertions.assertEquals("0", lastStatistics.getParameter(MonitorService.FAILURE));
-        Assertions.assertEquals("3", lastStatistics.getParameter(MonitorService.ELAPSED));
-        Assertions.assertEquals("3", lastStatistics.getParameter(MonitorService.MAX_ELAPSED));
-        Assertions.assertEquals("1", lastStatistics.getParameter(MonitorService.CONCURRENT));
-        Assertions.assertEquals("1", lastStatistics.getParameter(MonitorService.MAX_CONCURRENT));
+        Assertions.assertEquals("morgan", lastStatistics.getParameter(Constants.APPLICATION));
+        Assertions.assertEquals("MemberService", lastStatistics.getParameter(Constants.INTERFACE));
+        Assertions.assertEquals("findPerson", lastStatistics.getParameter(Constants.METHOD));
+        Assertions.assertEquals("10.20.153.11", lastStatistics.getParameter(Constants.CONSUMER));
+        Assertions.assertEquals("1", lastStatistics.getParameter(Constants.SUCCESS));
+        Assertions.assertEquals("0", lastStatistics.getParameter(Constants.FAILURE));
+        Assertions.assertEquals("3", lastStatistics.getParameter(Constants.ELAPSED));
+        Assertions.assertEquals("3", lastStatistics.getParameter(Constants.MAX_ELAPSED));
+        Assertions.assertEquals("1", lastStatistics.getParameter(Constants.CONCURRENT));
+        Assertions.assertEquals("1", lastStatistics.getParameter(Constants.MAX_CONCURRENT));
         monitor.destroy();
     }
 
@@ -132,16 +133,16 @@ public class DubboMonitorTest {
     public void testMonitorFactory() throws Exception {
         MockMonitorService monitorService = new MockMonitorService();
         URL statistics = new URLBuilder(DUBBO_PROTOCOL, "10.20.153.10", 0)
-                .addParameter(MonitorService.APPLICATION, "morgan")
-                .addParameter(MonitorService.INTERFACE, "MemberService")
-                .addParameter(MonitorService.METHOD, "findPerson")
-                .addParameter(MonitorService.CONSUMER, "10.20.153.11")
-                .addParameter(MonitorService.SUCCESS, 1)
-                .addParameter(MonitorService.FAILURE, 0)
-                .addParameter(MonitorService.ELAPSED, 3)
-                .addParameter(MonitorService.MAX_ELAPSED, 3)
-                .addParameter(MonitorService.CONCURRENT, 1)
-                .addParameter(MonitorService.MAX_CONCURRENT, 1)
+                .addParameter(Constants.APPLICATION, "morgan")
+                .addParameter(Constants.INTERFACE, "MemberService")
+                .addParameter(Constants.METHOD, "findPerson")
+                .addParameter(Constants.CONSUMER, "10.20.153.11")
+                .addParameter(Constants.SUCCESS, 1)
+                .addParameter(Constants.FAILURE, 0)
+                .addParameter(Constants.ELAPSED, 3)
+                .addParameter(Constants.MAX_ELAPSED, 3)
+                .addParameter(Constants.CONCURRENT, 1)
+                .addParameter(Constants.MAX_CONCURRENT, 1)
                 .build();
 
         Protocol protocol = ExtensionLoader.getExtensionLoader(Protocol.class).getAdaptiveExtension();
@@ -165,8 +166,8 @@ public class DubboMonitorTest {
                         Thread.sleep(10);
                     }
                     URL result = monitorService.getStatistics();
-                    Assertions.assertEquals(1, result.getParameter(MonitorService.SUCCESS, 0));
-                    Assertions.assertEquals(3, result.getParameter(MonitorService.ELAPSED, 0));
+                    Assertions.assertEquals(1, result.getParameter(Constants.SUCCESS, 0));
+                    Assertions.assertEquals(3, result.getParameter(Constants.ELAPSED, 0));
                 } finally {
                     monitor.destroy();
                 }
@@ -194,16 +195,16 @@ public class DubboMonitorTest {
     @Test
     public void testSum() {
         URL statistics = new URLBuilder(DUBBO_PROTOCOL, "10.20.153.11", 0)
-                .addParameter(MonitorService.APPLICATION, "morgan")
-                .addParameter(MonitorService.INTERFACE, "MemberService")
-                .addParameter(MonitorService.METHOD, "findPerson")
-                .addParameter(MonitorService.CONSUMER, "10.20.153.11")
-                .addParameter(MonitorService.SUCCESS, 1)
-                .addParameter(MonitorService.FAILURE, 0)
-                .addParameter(MonitorService.ELAPSED, 3)
-                .addParameter(MonitorService.MAX_ELAPSED, 3)
-                .addParameter(MonitorService.CONCURRENT, 1)
-                .addParameter(MonitorService.MAX_CONCURRENT, 1)
+                .addParameter(Constants.APPLICATION, "morgan")
+                .addParameter(Constants.INTERFACE, "MemberService")
+                .addParameter(Constants.METHOD, "findPerson")
+                .addParameter(Constants.CONSUMER, "10.20.153.11")
+                .addParameter(Constants.SUCCESS, 1)
+                .addParameter(Constants.FAILURE, 0)
+                .addParameter(Constants.ELAPSED, 3)
+                .addParameter(Constants.MAX_ELAPSED, 3)
+                .addParameter(Constants.CONCURRENT, 1)
+                .addParameter(Constants.MAX_CONCURRENT, 1)
                 .build();
         Invoker invoker = mock(Invoker.class);
         MonitorService monitorService = mock(MonitorService.class);
@@ -212,9 +213,9 @@ public class DubboMonitorTest {
         DubboMonitor dubboMonitor = new DubboMonitor(invoker, monitorService);
 
         dubboMonitor.collect(statistics.toSerializableURL());
-        dubboMonitor.collect(statistics.addParameter(MonitorService.SUCCESS, 3).addParameter(MonitorService.CONCURRENT, 2)
-                .addParameter(MonitorService.INPUT, 1).addParameter(MonitorService.OUTPUT, 2).toSerializableURL());
-        dubboMonitor.collect(statistics.addParameter(MonitorService.SUCCESS, 6).addParameter(MonitorService.ELAPSED, 2).toSerializableURL());
+        dubboMonitor.collect(statistics.addParameter(Constants.SUCCESS, 3).addParameter(Constants.CONCURRENT, 2)
+                .addParameter(Constants.INPUT, 1).addParameter(Constants.OUTPUT, 2).toSerializableURL());
+        dubboMonitor.collect(statistics.addParameter(Constants.SUCCESS, 6).addParameter(Constants.ELAPSED, 2).toSerializableURL());
 
         dubboMonitor.send();
 
@@ -228,7 +229,7 @@ public class DubboMonitorTest {
             @Override
             public boolean matches(Object item) {
                 URL url = (URL) item;
-                return Integer.valueOf(url.getParameter(MonitorService.SUCCESS)) > 1;
+                return Integer.valueOf(url.getParameter(Constants.SUCCESS)) > 1;
             }
         }));
     }

--- a/dubbo-monitor/dubbo-monitor-default/src/test/java/org/apache/dubbo/monitor/dubbo/DubboMonitorTest.java
+++ b/dubbo-monitor/dubbo-monitor-default/src/test/java/org/apache/dubbo/monitor/dubbo/DubboMonitorTest.java
@@ -19,7 +19,6 @@ package org.apache.dubbo.monitor.dubbo;
 import org.apache.dubbo.common.URL;
 import org.apache.dubbo.common.URLBuilder;
 import org.apache.dubbo.common.extension.ExtensionLoader;
-import org.apache.dubbo.monitor.Constants;
 import org.apache.dubbo.monitor.Monitor;
 import org.apache.dubbo.monitor.MonitorFactory;
 import org.apache.dubbo.monitor.MonitorService;
@@ -39,7 +38,19 @@ import org.mockito.ArgumentCaptor;
 import java.util.Arrays;
 import java.util.List;
 
+import static org.apache.dubbo.common.constants.CommonConstants.APPLICATION_KEY;
+import static org.apache.dubbo.common.constants.CommonConstants.CONSUMER;
 import static org.apache.dubbo.common.constants.CommonConstants.DUBBO_PROTOCOL;
+import static org.apache.dubbo.common.constants.CommonConstants.INTERFACE_KEY;
+import static org.apache.dubbo.common.constants.CommonConstants.METHOD_KEY;
+import static org.apache.dubbo.monitor.Constants.CONCURRENT_KEY;
+import static org.apache.dubbo.monitor.Constants.ELAPSED_KEY;
+import static org.apache.dubbo.monitor.Constants.FAILURE_KEY;
+import static org.apache.dubbo.monitor.Constants.INPUT_KEY;
+import static org.apache.dubbo.monitor.Constants.MAX_CONCURRENT_KEY;
+import static org.apache.dubbo.monitor.Constants.MAX_ELAPSED_KEY;
+import static org.apache.dubbo.monitor.Constants.OUTPUT_KEY;
+import static org.apache.dubbo.monitor.Constants.SUCCESS_KEY;
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
@@ -97,35 +108,35 @@ public class DubboMonitorTest {
     public void testCount() throws Exception {
         DubboMonitor monitor = new DubboMonitor(monitorInvoker, monitorService);
         URL statistics = new URLBuilder(DUBBO_PROTOCOL, "10.20.153.10", 0)
-                .addParameter(Constants.APPLICATION, "morgan")
-                .addParameter(Constants.INTERFACE, "MemberService")
-                .addParameter(Constants.METHOD, "findPerson")
-                .addParameter(Constants.CONSUMER, "10.20.153.11")
-                .addParameter(Constants.SUCCESS, 1)
-                .addParameter(Constants.FAILURE, 0)
-                .addParameter(Constants.ELAPSED, 3)
-                .addParameter(Constants.MAX_ELAPSED, 3)
-                .addParameter(Constants.CONCURRENT, 1)
-                .addParameter(Constants.MAX_CONCURRENT, 1)
+                .addParameter(APPLICATION_KEY, "morgan")
+                .addParameter(INTERFACE_KEY, "MemberService")
+                .addParameter(METHOD_KEY, "findPerson")
+                .addParameter(CONSUMER, "10.20.153.11")
+                .addParameter(SUCCESS_KEY, 1)
+                .addParameter(FAILURE_KEY, 0)
+                .addParameter(ELAPSED_KEY, 3)
+                .addParameter(MAX_ELAPSED_KEY, 3)
+                .addParameter(CONCURRENT_KEY, 1)
+                .addParameter(MAX_CONCURRENT_KEY, 1)
                 .build();
         monitor.collect(statistics.toSerializableURL());
         monitor.send();
         while (lastStatistics == null) {
             Thread.sleep(10);
         }
-        Assertions.assertEquals("morgan", lastStatistics.getParameter(Constants.APPLICATION));
+        Assertions.assertEquals("morgan", lastStatistics.getParameter(APPLICATION_KEY));
         Assertions.assertEquals("dubbo", lastStatistics.getProtocol());
         Assertions.assertEquals("10.20.153.10", lastStatistics.getHost());
-        Assertions.assertEquals("morgan", lastStatistics.getParameter(Constants.APPLICATION));
-        Assertions.assertEquals("MemberService", lastStatistics.getParameter(Constants.INTERFACE));
-        Assertions.assertEquals("findPerson", lastStatistics.getParameter(Constants.METHOD));
-        Assertions.assertEquals("10.20.153.11", lastStatistics.getParameter(Constants.CONSUMER));
-        Assertions.assertEquals("1", lastStatistics.getParameter(Constants.SUCCESS));
-        Assertions.assertEquals("0", lastStatistics.getParameter(Constants.FAILURE));
-        Assertions.assertEquals("3", lastStatistics.getParameter(Constants.ELAPSED));
-        Assertions.assertEquals("3", lastStatistics.getParameter(Constants.MAX_ELAPSED));
-        Assertions.assertEquals("1", lastStatistics.getParameter(Constants.CONCURRENT));
-        Assertions.assertEquals("1", lastStatistics.getParameter(Constants.MAX_CONCURRENT));
+        Assertions.assertEquals("morgan", lastStatistics.getParameter(APPLICATION_KEY));
+        Assertions.assertEquals("MemberService", lastStatistics.getParameter(INTERFACE_KEY));
+        Assertions.assertEquals("findPerson", lastStatistics.getParameter(METHOD_KEY));
+        Assertions.assertEquals("10.20.153.11", lastStatistics.getParameter(CONSUMER));
+        Assertions.assertEquals("1", lastStatistics.getParameter(SUCCESS_KEY));
+        Assertions.assertEquals("0", lastStatistics.getParameter(FAILURE_KEY));
+        Assertions.assertEquals("3", lastStatistics.getParameter(ELAPSED_KEY));
+        Assertions.assertEquals("3", lastStatistics.getParameter(MAX_ELAPSED_KEY));
+        Assertions.assertEquals("1", lastStatistics.getParameter(CONCURRENT_KEY));
+        Assertions.assertEquals("1", lastStatistics.getParameter(MAX_CONCURRENT_KEY));
         monitor.destroy();
     }
 
@@ -133,16 +144,16 @@ public class DubboMonitorTest {
     public void testMonitorFactory() throws Exception {
         MockMonitorService monitorService = new MockMonitorService();
         URL statistics = new URLBuilder(DUBBO_PROTOCOL, "10.20.153.10", 0)
-                .addParameter(Constants.APPLICATION, "morgan")
-                .addParameter(Constants.INTERFACE, "MemberService")
-                .addParameter(Constants.METHOD, "findPerson")
-                .addParameter(Constants.CONSUMER, "10.20.153.11")
-                .addParameter(Constants.SUCCESS, 1)
-                .addParameter(Constants.FAILURE, 0)
-                .addParameter(Constants.ELAPSED, 3)
-                .addParameter(Constants.MAX_ELAPSED, 3)
-                .addParameter(Constants.CONCURRENT, 1)
-                .addParameter(Constants.MAX_CONCURRENT, 1)
+                .addParameter(APPLICATION_KEY, "morgan")
+                .addParameter(INTERFACE_KEY, "MemberService")
+                .addParameter(METHOD_KEY, "findPerson")
+                .addParameter(CONSUMER, "10.20.153.11")
+                .addParameter(SUCCESS_KEY, 1)
+                .addParameter(FAILURE_KEY, 0)
+                .addParameter(ELAPSED_KEY, 3)
+                .addParameter(MAX_ELAPSED_KEY, 3)
+                .addParameter(CONCURRENT_KEY, 1)
+                .addParameter(MAX_CONCURRENT_KEY, 1)
                 .build();
 
         Protocol protocol = ExtensionLoader.getExtensionLoader(Protocol.class).getAdaptiveExtension();
@@ -166,8 +177,8 @@ public class DubboMonitorTest {
                         Thread.sleep(10);
                     }
                     URL result = monitorService.getStatistics();
-                    Assertions.assertEquals(1, result.getParameter(Constants.SUCCESS, 0));
-                    Assertions.assertEquals(3, result.getParameter(Constants.ELAPSED, 0));
+                    Assertions.assertEquals(1, result.getParameter(SUCCESS_KEY, 0));
+                    Assertions.assertEquals(3, result.getParameter(ELAPSED_KEY, 0));
                 } finally {
                     monitor.destroy();
                 }
@@ -195,16 +206,16 @@ public class DubboMonitorTest {
     @Test
     public void testSum() {
         URL statistics = new URLBuilder(DUBBO_PROTOCOL, "10.20.153.11", 0)
-                .addParameter(Constants.APPLICATION, "morgan")
-                .addParameter(Constants.INTERFACE, "MemberService")
-                .addParameter(Constants.METHOD, "findPerson")
-                .addParameter(Constants.CONSUMER, "10.20.153.11")
-                .addParameter(Constants.SUCCESS, 1)
-                .addParameter(Constants.FAILURE, 0)
-                .addParameter(Constants.ELAPSED, 3)
-                .addParameter(Constants.MAX_ELAPSED, 3)
-                .addParameter(Constants.CONCURRENT, 1)
-                .addParameter(Constants.MAX_CONCURRENT, 1)
+                .addParameter(APPLICATION_KEY, "morgan")
+                .addParameter(INTERFACE_KEY, "MemberService")
+                .addParameter(METHOD_KEY, "findPerson")
+                .addParameter(CONSUMER, "10.20.153.11")
+                .addParameter(SUCCESS_KEY, 1)
+                .addParameter(FAILURE_KEY, 0)
+                .addParameter(ELAPSED_KEY, 3)
+                .addParameter(MAX_ELAPSED_KEY, 3)
+                .addParameter(CONCURRENT_KEY, 1)
+                .addParameter(MAX_CONCURRENT_KEY, 1)
                 .build();
         Invoker invoker = mock(Invoker.class);
         MonitorService monitorService = mock(MonitorService.class);
@@ -213,9 +224,9 @@ public class DubboMonitorTest {
         DubboMonitor dubboMonitor = new DubboMonitor(invoker, monitorService);
 
         dubboMonitor.collect(statistics.toSerializableURL());
-        dubboMonitor.collect(statistics.addParameter(Constants.SUCCESS, 3).addParameter(Constants.CONCURRENT, 2)
-                .addParameter(Constants.INPUT, 1).addParameter(Constants.OUTPUT, 2).toSerializableURL());
-        dubboMonitor.collect(statistics.addParameter(Constants.SUCCESS, 6).addParameter(Constants.ELAPSED, 2).toSerializableURL());
+        dubboMonitor.collect(statistics.addParameter(SUCCESS_KEY, 3).addParameter(CONCURRENT_KEY, 2)
+                .addParameter(INPUT_KEY, 1).addParameter(OUTPUT_KEY, 2).toSerializableURL());
+        dubboMonitor.collect(statistics.addParameter(SUCCESS_KEY, 6).addParameter(ELAPSED_KEY, 2).toSerializableURL());
 
         dubboMonitor.send();
 
@@ -229,7 +240,7 @@ public class DubboMonitorTest {
             @Override
             public boolean matches(Object item) {
                 URL url = (URL) item;
-                return Integer.valueOf(url.getParameter(Constants.SUCCESS)) > 1;
+                return Integer.valueOf(url.getParameter(SUCCESS_KEY)) > 1;
             }
         }));
     }

--- a/dubbo-monitor/dubbo-monitor-default/src/test/java/org/apache/dubbo/monitor/dubbo/MetricsFilterTest.java
+++ b/dubbo-monitor/dubbo-monitor-default/src/test/java/org/apache/dubbo/monitor/dubbo/MetricsFilterTest.java
@@ -51,6 +51,7 @@ import java.util.concurrent.Callable;
 import java.util.function.Function;
 
 import static org.apache.dubbo.common.constants.CommonConstants.CONSUMER_SIDE;
+import static org.apache.dubbo.common.constants.CommonConstants.METHOD_KEY;
 import static org.apache.dubbo.common.constants.CommonConstants.PROVIDER;
 import static org.apache.dubbo.common.constants.CommonConstants.SIDE_KEY;
 import static org.apache.dubbo.common.constants.CommonConstants.TIMEOUT_KEY;
@@ -59,7 +60,6 @@ import static org.apache.dubbo.monitor.Constants.DUBBO_CONSUMER_METHOD;
 import static org.apache.dubbo.monitor.Constants.DUBBO_GROUP;
 import static org.apache.dubbo.monitor.Constants.DUBBO_PROVIDER;
 import static org.apache.dubbo.monitor.Constants.DUBBO_PROVIDER_METHOD;
-import static org.apache.dubbo.monitor.Constants.METHOD;
 import static org.apache.dubbo.monitor.Constants.SERVICE;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doNothing;
@@ -154,7 +154,7 @@ public class MetricsFilterTest {
         FastCompass dubboMethod = metricManager.getFastCompass(DUBBO_GROUP, new MetricName(DUBBO_CONSUMER_METHOD, new HashMap<String, String>(4) {
             {
                 put(SERVICE, "org.apache.dubbo.monitor.dubbo.service.DemoService");
-                put(METHOD, "void sayName(Integer)");
+                put(METHOD_KEY, "void sayName(Integer)");
             }
         }, MetricLevel.NORMAL));
         long timestamp = System.currentTimeMillis() / 5000 * 5000;
@@ -186,7 +186,7 @@ public class MetricsFilterTest {
         FastCompass dubboMethod = metricManager.getFastCompass(DUBBO_GROUP, new MetricName(DUBBO_CONSUMER_METHOD, new HashMap<String, String>(4) {
             {
                 put(SERVICE, "org.apache.dubbo.monitor.dubbo.service.DemoService");
-                put(METHOD, "void timeoutException()");
+                put(METHOD_KEY, "void timeoutException()");
             }
         }, MetricLevel.NORMAL));
         long timestamp = System.currentTimeMillis() / 5000 * 5000;
@@ -216,7 +216,7 @@ public class MetricsFilterTest {
         FastCompass dubboMethod = metricManager.getFastCompass(DUBBO_GROUP, new MetricName(DUBBO_PROVIDER_METHOD, new HashMap<String, String>(4) {
             {
                 put(SERVICE, "org.apache.dubbo.monitor.dubbo.service.DemoService");
-                put(METHOD, "void sayName()");
+                put(METHOD_KEY, "void sayName()");
             }
         }, MetricLevel.NORMAL));
         long timestamp = System.currentTimeMillis() / 5000 * 5000;

--- a/dubbo-monitor/dubbo-monitor-default/src/test/java/org/apache/dubbo/monitor/dubbo/StatisticsTest.java
+++ b/dubbo-monitor/dubbo-monitor-default/src/test/java/org/apache/dubbo/monitor/dubbo/StatisticsTest.java
@@ -19,7 +19,7 @@ package org.apache.dubbo.monitor.dubbo;
 import org.apache.dubbo.common.URL;
 import org.apache.dubbo.common.URLBuilder;
 import org.apache.dubbo.common.url.component.ServiceConfigURL;
-import org.apache.dubbo.monitor.MonitorService;
+import org.apache.dubbo.monitor.Constants;
 
 import org.hamcrest.MatcherAssert;
 import org.junit.jupiter.api.Test;
@@ -34,16 +34,16 @@ public class StatisticsTest {
     @Test
     public void testEquals() {
         URL statistics = new URLBuilder(DUBBO_PROTOCOL, "10.20.153.10", 0)
-                .addParameter(MonitorService.APPLICATION, "morgan")
-                .addParameter(MonitorService.INTERFACE, "MemberService")
-                .addParameter(MonitorService.METHOD, "findPerson")
-                .addParameter(MonitorService.CONSUMER, "10.20.153.11")
-                .addParameter(MonitorService.SUCCESS, 1)
-                .addParameter(MonitorService.FAILURE, 0)
-                .addParameter(MonitorService.ELAPSED, 3)
-                .addParameter(MonitorService.MAX_ELAPSED, 3)
-                .addParameter(MonitorService.CONCURRENT, 1)
-                .addParameter(MonitorService.MAX_CONCURRENT, 1)
+                .addParameter(Constants.APPLICATION, "morgan")
+                .addParameter(Constants.INTERFACE, "MemberService")
+                .addParameter(Constants.METHOD, "findPerson")
+                .addParameter(Constants.CONSUMER, "10.20.153.11")
+                .addParameter(Constants.SUCCESS, 1)
+                .addParameter(Constants.FAILURE, 0)
+                .addParameter(Constants.ELAPSED, 3)
+                .addParameter(Constants.MAX_ELAPSED, 3)
+                .addParameter(Constants.CONCURRENT, 1)
+                .addParameter(Constants.MAX_CONCURRENT, 1)
                 .build();
 
         Statistics statistics1 = new Statistics(statistics);
@@ -76,17 +76,17 @@ public class StatisticsTest {
         assertThat(statistics.toString(), is("dubbo://10.20.153.10"));
 
         Statistics statisticsWithDetailInfo = new Statistics(new URLBuilder(DUBBO_PROTOCOL, "10.20.153.10", 0)
-                .addParameter(MonitorService.APPLICATION, "morgan")
-                .addParameter(MonitorService.INTERFACE, "MemberService")
-                .addParameter(MonitorService.METHOD, "findPerson")
-                .addParameter(MonitorService.CONSUMER, "10.20.153.11")
-                .addParameter(MonitorService.GROUP, "unit-test")
-                .addParameter(MonitorService.SUCCESS, 1)
-                .addParameter(MonitorService.FAILURE, 0)
-                .addParameter(MonitorService.ELAPSED, 3)
-                .addParameter(MonitorService.MAX_ELAPSED, 3)
-                .addParameter(MonitorService.CONCURRENT, 1)
-                .addParameter(MonitorService.MAX_CONCURRENT, 1)
+                .addParameter(Constants.APPLICATION, "morgan")
+                .addParameter(Constants.INTERFACE, "MemberService")
+                .addParameter(Constants.METHOD, "findPerson")
+                .addParameter(Constants.CONSUMER, "10.20.153.11")
+                .addParameter(Constants.GROUP, "unit-test")
+                .addParameter(Constants.SUCCESS, 1)
+                .addParameter(Constants.FAILURE, 0)
+                .addParameter(Constants.ELAPSED, 3)
+                .addParameter(Constants.MAX_ELAPSED, 3)
+                .addParameter(Constants.CONCURRENT, 1)
+                .addParameter(Constants.MAX_CONCURRENT, 1)
                 .build());
 
         MatcherAssert.assertThat(statisticsWithDetailInfo.getServer(), equalTo(statistics.getServer()));

--- a/dubbo-monitor/dubbo-monitor-default/src/test/java/org/apache/dubbo/monitor/dubbo/StatisticsTest.java
+++ b/dubbo-monitor/dubbo-monitor-default/src/test/java/org/apache/dubbo/monitor/dubbo/StatisticsTest.java
@@ -19,12 +19,22 @@ package org.apache.dubbo.monitor.dubbo;
 import org.apache.dubbo.common.URL;
 import org.apache.dubbo.common.URLBuilder;
 import org.apache.dubbo.common.url.component.ServiceConfigURL;
-import org.apache.dubbo.monitor.Constants;
 
 import org.hamcrest.MatcherAssert;
 import org.junit.jupiter.api.Test;
 
+import static org.apache.dubbo.common.constants.CommonConstants.APPLICATION_KEY;
+import static org.apache.dubbo.common.constants.CommonConstants.CONSUMER;
 import static org.apache.dubbo.common.constants.CommonConstants.DUBBO_PROTOCOL;
+import static org.apache.dubbo.common.constants.CommonConstants.GROUP_KEY;
+import static org.apache.dubbo.common.constants.CommonConstants.INTERFACE_KEY;
+import static org.apache.dubbo.common.constants.CommonConstants.METHOD_KEY;
+import static org.apache.dubbo.monitor.Constants.CONCURRENT_KEY;
+import static org.apache.dubbo.monitor.Constants.ELAPSED_KEY;
+import static org.apache.dubbo.monitor.Constants.FAILURE_KEY;
+import static org.apache.dubbo.monitor.Constants.MAX_CONCURRENT_KEY;
+import static org.apache.dubbo.monitor.Constants.MAX_ELAPSED_KEY;
+import static org.apache.dubbo.monitor.Constants.SUCCESS_KEY;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
@@ -34,16 +44,16 @@ public class StatisticsTest {
     @Test
     public void testEquals() {
         URL statistics = new URLBuilder(DUBBO_PROTOCOL, "10.20.153.10", 0)
-                .addParameter(Constants.APPLICATION, "morgan")
-                .addParameter(Constants.INTERFACE, "MemberService")
-                .addParameter(Constants.METHOD, "findPerson")
-                .addParameter(Constants.CONSUMER, "10.20.153.11")
-                .addParameter(Constants.SUCCESS, 1)
-                .addParameter(Constants.FAILURE, 0)
-                .addParameter(Constants.ELAPSED, 3)
-                .addParameter(Constants.MAX_ELAPSED, 3)
-                .addParameter(Constants.CONCURRENT, 1)
-                .addParameter(Constants.MAX_CONCURRENT, 1)
+                .addParameter(APPLICATION_KEY, "morgan")
+                .addParameter(INTERFACE_KEY, "MemberService")
+                .addParameter(METHOD_KEY, "findPerson")
+                .addParameter(CONSUMER, "10.20.153.11")
+                .addParameter(SUCCESS_KEY, 1)
+                .addParameter(FAILURE_KEY, 0)
+                .addParameter(ELAPSED_KEY, 3)
+                .addParameter(MAX_ELAPSED_KEY, 3)
+                .addParameter(CONCURRENT_KEY, 1)
+                .addParameter(MAX_CONCURRENT_KEY, 1)
                 .build();
 
         Statistics statistics1 = new Statistics(statistics);
@@ -76,17 +86,17 @@ public class StatisticsTest {
         assertThat(statistics.toString(), is("dubbo://10.20.153.10"));
 
         Statistics statisticsWithDetailInfo = new Statistics(new URLBuilder(DUBBO_PROTOCOL, "10.20.153.10", 0)
-                .addParameter(Constants.APPLICATION, "morgan")
-                .addParameter(Constants.INTERFACE, "MemberService")
-                .addParameter(Constants.METHOD, "findPerson")
-                .addParameter(Constants.CONSUMER, "10.20.153.11")
-                .addParameter(Constants.GROUP, "unit-test")
-                .addParameter(Constants.SUCCESS, 1)
-                .addParameter(Constants.FAILURE, 0)
-                .addParameter(Constants.ELAPSED, 3)
-                .addParameter(Constants.MAX_ELAPSED, 3)
-                .addParameter(Constants.CONCURRENT, 1)
-                .addParameter(Constants.MAX_CONCURRENT, 1)
+                .addParameter(APPLICATION_KEY, "morgan")
+                .addParameter(INTERFACE_KEY, "MemberService")
+                .addParameter(METHOD_KEY, "findPerson")
+                .addParameter(CONSUMER, "10.20.153.11")
+                .addParameter(GROUP_KEY, "unit-test")
+                .addParameter(SUCCESS_KEY, 1)
+                .addParameter(FAILURE_KEY, 0)
+                .addParameter(ELAPSED_KEY, 3)
+                .addParameter(MAX_ELAPSED_KEY, 3)
+                .addParameter(CONCURRENT_KEY, 1)
+                .addParameter(MAX_CONCURRENT_KEY, 1)
                 .build());
 
         MatcherAssert.assertThat(statisticsWithDetailInfo.getServer(), equalTo(statistics.getServer()));


### PR DESCRIPTION
## What is the purpose of the change
For **dubbo-monitor** module

- Unify the constants into `Constants`(Move the constants of the original `MonitorService` to `Constants`) class
- Abstract the statistical array into StatisticsItem(Originally used `AtomicReference<long[]>`, now adjusted to `AtomicReference<StatisticsItem>`)
