### PR TITLE
Fix the problem of InvokeTelnet that user use [invoke sayHello(xxx)] without executing the cd command first

### DIFF
--- a/dubbo-plugin/dubbo-qos/src/test/java/org/apache/dubbo/qos/command/impl/InvokeTelnetTest.java
+++ b/dubbo-plugin/dubbo-qos/src/test/java/org/apache/dubbo/qos/command/impl/InvokeTelnetTest.java
@@ -68,6 +68,14 @@ public class InvokeTelnetTest {
     }
 
     @Test
+    public void testInvokeWithoutServicePrefixAndWithoutDefaultService() throws RemotingException {
+        registerProvider(DemoService.class.getName(), new DemoServiceImpl(), DemoService.class);
+        String result = invoke.execute(mockCommandContext, new String[]{"echo(\"ok\")"});
+        assertTrue(result.contains("If you want to invoke like [invoke sayHello(\"xxxx\")], please execute cd command first," +
+            " or you can execute it like [invoke IHelloService.sayHello(\"xxxx\")]"));
+    }
+
+    @Test
     public void testInvokeDefaultService() throws RemotingException {
         defaultAttributeMap.attr(ChangeTelnet.SERVICE_KEY).set(DemoService.class.getName());
         defaultAttributeMap.attr(SelectTelnet.SELECT_KEY).set(null);

--- a/dubbo-plugin/dubbo-qos/src/test/java/org/apache/dubbo/qos/command/impl/InvokeTelnetTest.java
+++ b/dubbo-plugin/dubbo-qos/src/test/java/org/apache/dubbo/qos/command/impl/InvokeTelnetTest.java
@@ -123,7 +123,7 @@ public class InvokeTelnetTest {
 
     @Test
     public void testInvokeByPassingEnumValue() throws RemotingException {
-        defaultAttributeMap.attr(ChangeTelnet.SERVICE_KEY).set(null);
+        defaultAttributeMap.attr(ChangeTelnet.SERVICE_KEY).set(DemoService.class.getName());
         defaultAttributeMap.attr(SelectTelnet.SELECT_KEY).set(null);
 
         given(mockChannel.attr(ChangeTelnet.SERVICE_KEY)).willReturn(defaultAttributeMap.attr(ChangeTelnet.SERVICE_KEY));


### PR DESCRIPTION

## What is the purpose of the change
If the user directly uses the invocation method without the service name prefix, that is, `invoke sayHello (xxxx)`, and has not executed the `cd xxx `command beforehand, the NPE problem will occur
