### PR TITLE
Including setup method to clean state between tests

### DIFF
--- a/dubbo-common/src/test/java/org/apache/dubbo/common/threadlocal/InternalThreadLocalTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/threadlocal/InternalThreadLocalTest.java
@@ -18,6 +18,7 @@
 package org.apache.dubbo.common.threadlocal;
 
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.CountDownLatch;
@@ -32,6 +33,11 @@ public class InternalThreadLocalTest {
     private static final int PERFORMANCE_THREAD_COUNT = 1000;
 
     private static final int GET_COUNT = 1000000;
+
+    @BeforeEach
+    public void setup() {
+        InternalThreadLocalMap.remove();
+    }
 
     @Test
     public void testInternalThreadLocal() throws InterruptedException {

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/threadlocal/InternalThreadLocalTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/threadlocal/InternalThreadLocalTest.java
@@ -17,8 +17,8 @@
 
 package org.apache.dubbo.common.threadlocal;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.CountDownLatch;
@@ -34,7 +34,7 @@ public class InternalThreadLocalTest {
 
     private static final int GET_COUNT = 1000000;
 
-    @BeforeEach
+    @AfterEach
     public void setup() {
         InternalThreadLocalMap.remove();
     }


### PR DESCRIPTION
## What is the purpose of the change
In InternalThreadLocalTest, testSize fails when run after testSetAndGet, testRemove, or testRemoveAll in the same test class. I found that running InternalThreadLocalMap.remove() before testSize ensures the starting state is correct such that testSize can pass even when run after those three tests. I introduced the setup method to ensure this resetting logic is run before each test. Please let me know if there is a more preferred way to address this issue.

## Brief changelog
Including a setup method that sets the state through InternalThreadLocalMap.remove().

## Verifying this change


<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [ ] GitHub Actions works fine on your own branch.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
