### PR TITLE
Fix config-center includeSpringEnv #9207

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/config/context/AbstractConfigManager.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/config/context/AbstractConfigManager.java
@@ -43,6 +43,7 @@ import org.apache.dubbo.rpc.model.ApplicationModel;
 import org.apache.dubbo.rpc.model.ScopeModel;
 import org.apache.dubbo.rpc.model.ScopeModelUtil;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.LinkedHashMap;
@@ -454,7 +455,8 @@ public abstract class AbstractConfigManager extends LifecycleAdapter {
 
     public abstract void loadConfigs();
 
-    public <T extends AbstractConfig> void loadConfigsOfTypeFromProps(Class<T> cls) {
+    public <T extends AbstractConfig> List<T> loadConfigsOfTypeFromProps(Class<T> cls) {
+        List<T> tmpConfigs = new ArrayList<>();
         PropertiesConfiguration properties = environment.getPropertiesConfiguration();
 
         // load multiple configs with id
@@ -481,6 +483,7 @@ public abstract class AbstractConfigManager extends LifecycleAdapter {
 
                     config.refresh();
                     this.addConfig(config);
+                    tmpConfigs.add(config);
                 } catch (Exception e) {
                     logger.error("load config failed, id: " + id + ", type:" + cls.getSimpleName(), e);
                     throw new IllegalStateException("load config failed, id: " + id + ", type:" + cls.getSimpleName());
@@ -506,9 +509,11 @@ public abstract class AbstractConfigManager extends LifecycleAdapter {
                 }
 
                 this.addConfig(config);
+                tmpConfigs.add(config);
             }
         }
 
+        return tmpConfigs;
     }
 
     private <T extends AbstractConfig> T createConfig(Class<T> cls, ScopeModel scopeModel) throws ReflectiveOperationException {

--- a/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/context/DubboConfigBeanInitializer.java
+++ b/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/context/DubboConfigBeanInitializer.java
@@ -43,6 +43,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 
+import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 
@@ -99,7 +100,7 @@ public class DubboConfigBeanInitializer implements BeanFactoryAware, Initializin
         logger.info("loading dubbo config beans ...");
 
         //Make sure all these config beans are inited and registered to ConfigManager
-        // load application configs
+        // load application config beans
         loadConfigBeansOfType(ApplicationConfig.class, configManager);
         loadConfigBeansOfType(RegistryConfig.class, configManager);
         loadConfigBeansOfType(ProtocolConfig.class, configManager);
@@ -109,10 +110,17 @@ public class DubboConfigBeanInitializer implements BeanFactoryAware, Initializin
         loadConfigBeansOfType(MetricsConfig.class, configManager);
         loadConfigBeansOfType(SslConfig.class, configManager);
 
-        // load module configs
+        // load module config beans
         loadConfigBeansOfType(ModuleConfig.class, moduleModel.getConfigManager());
         loadConfigBeansOfType(ProviderConfig.class, moduleModel.getConfigManager());
         loadConfigBeansOfType(ConsumerConfig.class, moduleModel.getConfigManager());
+
+        // load ConfigCenterBean from properties, fix https://github.com/apache/dubbo/issues/9207
+        List<ConfigCenterBean> configCenterBeans = configManager.loadConfigsOfTypeFromProps(ConfigCenterBean.class);
+        for (ConfigCenterBean configCenterBean : configCenterBeans) {
+            String beanName = configCenterBean.getId() != null ? configCenterBean.getId() : "configCenterBean";
+            beanFactory.initializeBean(configCenterBean, beanName);
+        }
 
         logger.info("dubbo config beans are loaded.");
     }

--- a/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/issues/issue9207/ConfigCenterBeanTest.java
+++ b/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/issues/issue9207/ConfigCenterBeanTest.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.dubbo.config.spring.issues.issue9207;
 
 import org.apache.dubbo.config.ConfigCenterConfig;

--- a/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/issues/issue9207/ConfigCenterBeanTest.java
+++ b/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/issues/issue9207/ConfigCenterBeanTest.java
@@ -1,0 +1,92 @@
+package org.apache.dubbo.config.spring.issues.issue9207;
+
+import org.apache.dubbo.config.ConfigCenterConfig;
+import org.apache.dubbo.config.context.ConfigManager;
+import org.apache.dubbo.config.spring.ConfigCenterBean;
+import org.apache.dubbo.config.spring.SysProps;
+import org.apache.dubbo.config.spring.context.annotation.EnableDubbo;
+import org.apache.dubbo.config.spring.util.DubboBeanUtils;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.config.BeanFactoryPostProcessor;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.MapPropertySource;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.StringReader;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+import java.util.stream.Collectors;
+
+public class ConfigCenterBeanTest {
+
+    private static final String DUBBO_PROPERTIES_FILE = "/META-INF/issues/issue9207/dubbo-properties-in-configcenter.properties";
+    private static final String DUBBO_EXTERNAL_CONFIG_KEY = "my-dubbo.properties";
+
+    @Test
+    public void testConfigCenterBeanFromProps() throws IOException {
+        SysProps.setProperty("dubbo.config-center.include-spring-env", "true");
+        SysProps.setProperty("dubbo.config-center.config-file", DUBBO_EXTERNAL_CONFIG_KEY);
+
+        AnnotationConfigApplicationContext applicationContext = new AnnotationConfigApplicationContext(ProviderConfiguration.class);
+        try {
+            ConfigManager configManager = DubboBeanUtils.getApplicationModel(applicationContext).getApplicationConfigManager();
+            Collection<ConfigCenterConfig> configCenters = configManager.getConfigCenters();
+            Assertions.assertEquals(1, configCenters.size());
+
+            ConfigCenterConfig cc = configCenters.stream().findFirst().get();
+            Assertions.assertFalse(cc.getExternalConfiguration().isEmpty());
+            Assertions.assertTrue( cc instanceof ConfigCenterBean);
+
+            // check loaded external config
+            String content = readContent(DUBBO_PROPERTIES_FILE);
+            content = applicationContext.getEnvironment().resolvePlaceholders(content);
+            Properties properties = new Properties();
+            properties.load(new StringReader(content));
+            Assertions.assertEquals(properties, cc.getExternalConfiguration());
+        } finally {
+            SysProps.clear();
+            if (applicationContext != null) {
+                applicationContext.close();
+            }
+        }
+
+    }
+
+    @EnableDubbo(scanBasePackages = "")
+    @Configuration
+    static class ProviderConfiguration {
+
+        @Bean
+        public BeanFactoryPostProcessor envPostProcessor(ConfigurableEnvironment environment) {
+            return new BeanFactoryPostProcessor() {
+                @Override
+                public void postProcessBeanFactory(ConfigurableListableBeanFactory beanFactory) throws BeansException {
+                    // add custom external configs to spring environment early before processing normal bean.
+                    // e.g. we can do it in BeanFactoryPostProcessor or EnvironmentPostProcessor
+                    Map<String, Object> dubboProperties = new HashMap<>();
+                    String content = readContent(DUBBO_PROPERTIES_FILE);
+                    dubboProperties.put(DUBBO_EXTERNAL_CONFIG_KEY, content);
+                    MapPropertySource dubboPropertySource = new MapPropertySource("dubbo external config", dubboProperties);
+                    environment.getPropertySources().addLast(dubboPropertySource);
+                }
+            };
+        }
+
+    }
+
+    private static String readContent(String file) {
+        BufferedReader reader = new BufferedReader(new InputStreamReader(ConfigCenterBeanTest.class.getResourceAsStream(file)));
+        String content = reader.lines().collect(Collectors.joining("\n"));
+        return content;
+    }
+}

--- a/dubbo-config/dubbo-config-spring/src/test/resources/META-INF/issues/issue9207/dubbo-properties-in-configcenter.properties
+++ b/dubbo-config/dubbo-config-spring/src/test/resources/META-INF/issues/issue9207/dubbo-properties-in-configcenter.properties
@@ -1,0 +1,24 @@
+#
+#
+#   Licensed to the Apache Software Foundation (ASF) under one or more
+#   contributor license agreements.  See the NOTICE file distributed with
+#   this work for additional information regarding copyright ownership.
+#   The ASF licenses this file to You under the Apache License, Version 2.0
+#   (the "License"); you may not use this file except in compliance with
+#   the License.  You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+#
+dubbo.application.name=provider-app
+dubbo.config-center.address=zookeeper://${zookeeper.address:127.0.0.1}:2181
+dubbo.registry.address=zookeeper://${zookeeper.address:127.0.0.1}:2181
+dubbo.protocol.name=dubbo
+dubbo.protocol.port=20880
+dubbo.consumer.timeout=3000


### PR DESCRIPTION
## What is the purpose of the change

Fix `dubbo.config-center.include-spring-env` handling, fix #9207

## Brief changelog

1. Load `ConfigCenterBean` from props in ` DubboConfigBeanInitializer`
2. Inject spring context by beanFactory.initializeBean(configCenterBean,..)