### PR TITLE
[3.0] change zk server admin port to 1808x

### DIFF
--- a/dubbo-test/dubbo-test-check/src/main/java/org/apache/dubbo/test/check/registrycenter/config/ZookeeperConfig.java
+++ b/dubbo-test/dubbo-test-check/src/main/java/org/apache/dubbo/test/check/registrycenter/config/ZookeeperConfig.java
@@ -71,7 +71,7 @@ public class ZookeeperConfig implements Config {
     /**
      * The default admin server ports of zookeeper.
      */
-    private static final int[] DEFAULT_ADMIN_SERVER_PORTS = new int[]{8081, 8082};
+    private static final int[] DEFAULT_ADMIN_SERVER_PORTS = new int[]{18081, 18082};
 
     /**
      * The default version of zookeeper.


### PR DESCRIPTION
## What is the purpose of the change

Change zk server admin port to 18081/18082,  to avoid port confilcts.
Fix https://github.com/apache/dubbo/issues/9268 