### PR TITLE
fix: Fix the bug of downloading zk binary file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,4 +47,4 @@ dubbo-serialization/dubbo-serialization-protobuf/build/*
 dubbo-demo/dubbo-demo-triple/build/*
 
 # global registry center
-.tmp/zookeeper/
+.tmp

--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ compiler/.gradle/*
 # protobuf
 dubbo-serialization/dubbo-serialization-protobuf/build/*
 dubbo-demo/dubbo-demo-triple/build/*
+
+# global registry center
+test/zookeeper/

--- a/.gitignore
+++ b/.gitignore
@@ -47,4 +47,4 @@ dubbo-serialization/dubbo-serialization-protobuf/build/*
 dubbo-demo/dubbo-demo-triple/build/*
 
 # global registry center
-test/zookeeper/
+.tmp/zookeeper/

--- a/dubbo-test/dubbo-test-check/pom.xml
+++ b/dubbo-test/dubbo-test-check/pom.xml
@@ -38,6 +38,7 @@
         <commons.compress.version>1.20</commons.compress.version>
         <junit.platform.launcher.version>1.6.2</junit.platform.launcher.version>
         <commons.exec.version>1.3</commons.exec.version>
+        <async.http.client.version>2.12.1</async.http.client.version>
     </properties>
 
     <dependencies>
@@ -91,6 +92,12 @@
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-exec</artifactId>
             <version>${commons.exec.version}</version>
+        </dependency>
+        <!-- async-http-client -->
+        <dependency>
+            <groupId>org.asynchttpclient</groupId>
+            <artifactId>async-http-client</artifactId>
+            <version>${async.http.client.version}</version>
         </dependency>
     </dependencies>
 </project>

--- a/dubbo-test/dubbo-test-check/src/main/java/org/apache/dubbo/test/check/registrycenter/ZookeeperRegistryCenter.java
+++ b/dubbo-test/dubbo-test-check/src/main/java/org/apache/dubbo/test/check/registrycenter/ZookeeperRegistryCenter.java
@@ -189,6 +189,8 @@ class ZookeeperRegistryCenter implements RegistryCenter {
                     for (Initializer initializer : this.initializers) {
                         initializer.initialize(this.context);
                     }
+                    // add shutdown hook
+                    Runtime.getRuntime().addShutdownHook(new Thread(() -> shutdown()));
                     INITIALIZED.set(true);
                 }
             }

--- a/dubbo-test/dubbo-test-check/src/main/java/org/apache/dubbo/test/check/registrycenter/ZookeeperRegistryCenter.java
+++ b/dubbo-test/dubbo-test-check/src/main/java/org/apache/dubbo/test/check/registrycenter/ZookeeperRegistryCenter.java
@@ -113,7 +113,7 @@ class ZookeeperRegistryCenter implements RegistryCenter {
      * The zookeeper binary file named {@link #TARGET_ZOOKEEPER_FILE_NAME} will be saved in
      * {@link #TARGET_DIRECTORY} if it downloaded successfully.
      */
-    private static final String TARGET_DIRECTORY = "test" + File.separator + "zookeeper";
+    private static final String TARGET_DIRECTORY = ".tmp" + File.separator + "zookeeper";
 
     /**
      * The path of target zookeeper binary file.

--- a/dubbo-test/dubbo-test-check/src/main/java/org/apache/dubbo/test/check/registrycenter/ZookeeperRegistryCenter.java
+++ b/dubbo-test/dubbo-test-check/src/main/java/org/apache/dubbo/test/check/registrycenter/ZookeeperRegistryCenter.java
@@ -71,7 +71,8 @@ class ZookeeperRegistryCenter implements RegistryCenter {
             this.context = new ZookeeperWindowsContext();
         }
 
-        // set target file path
+        // initialize the context
+        this.context.setUnpackedDirectory(UNPACKED_DIRECTORY);
         this.context.setSourceFile(TARGET_FILE_PATH);
     }
 
@@ -98,9 +99,14 @@ class ZookeeperRegistryCenter implements RegistryCenter {
     private Map<OS, Map<Command, Processor>> processors = new HashMap<>();
 
     /**
+     * The default unpacked directory.
+     */
+    private static final String UNPACKED_DIRECTORY = "apache-zookeeper-bin";
+
+    /**
      * The target name of zookeeper binary file.
      */
-    private static final String TARGET_ZOOKEEPER_FILE_NAME = "apache-zookeeper-bin.tar.gz";
+    private static final String TARGET_ZOOKEEPER_FILE_NAME = UNPACKED_DIRECTORY + ".tar.gz";
 
     /**
      * The target directory.

--- a/dubbo-test/dubbo-test-check/src/main/java/org/apache/dubbo/test/check/registrycenter/ZookeeperRegistryCenter.java
+++ b/dubbo-test/dubbo-test-check/src/main/java/org/apache/dubbo/test/check/registrycenter/ZookeeperRegistryCenter.java
@@ -16,6 +16,8 @@
  */
 package org.apache.dubbo.test.check.registrycenter;
 
+import org.apache.dubbo.common.logger.Logger;
+import org.apache.dubbo.common.logger.LoggerFactory;
 import org.apache.dubbo.test.check.exception.DubboTestException;
 import org.apache.dubbo.test.check.registrycenter.context.ZookeeperContext;
 import org.apache.dubbo.test.check.registrycenter.context.ZookeeperWindowsContext;
@@ -29,6 +31,9 @@ import org.apache.dubbo.test.check.registrycenter.processor.ResetZookeeperProces
 import org.apache.dubbo.test.check.registrycenter.processor.StopZookeeperUnixProcessor;
 import org.apache.dubbo.test.check.registrycenter.processor.StopZookeeperWindowsProcessor;
 
+import java.io.File;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.List;
 import java.util.ArrayList;
 import java.util.Objects;
@@ -65,7 +70,12 @@ class ZookeeperRegistryCenter implements RegistryCenter {
         } else {
             this.context = new ZookeeperWindowsContext();
         }
+
+        // set target file path
+        this.context.setSourceFile(TARGET_FILE_PATH);
     }
+
+    private static final Logger logger = LoggerFactory.getLogger(ZookeeperRegistryCenter.class);
 
     /**
      * The OS type.
@@ -88,9 +98,41 @@ class ZookeeperRegistryCenter implements RegistryCenter {
     private Map<OS, Map<Command, Processor>> processors = new HashMap<>();
 
     /**
+     * The target name of zookeeper binary file.
+     */
+    private static final String TARGET_ZOOKEEPER_FILE_NAME = "apache-zookeeper-bin.tar.gz";
+
+    /**
+     * The target directory.
+     * The zookeeper binary file named {@link #TARGET_ZOOKEEPER_FILE_NAME} will be saved in
+     * {@link #TARGET_DIRECTORY} if it downloaded successfully.
+     */
+    private static final String TARGET_DIRECTORY = "test" + File.separator + "zookeeper";
+
+    /**
+     * The path of target zookeeper binary file.
+     */
+    private static final Path TARGET_FILE_PATH = getTargetFilePath();
+
+    /**
      * The {@link #INITIALIZED} for flagging the {@link #startup()} method is called or not.
      */
     private static final AtomicBoolean INITIALIZED = new AtomicBoolean(false);
+
+    /**
+     * Returns the target file path.
+     */
+    private static Path getTargetFilePath() {
+        String currentWorkDirectory = System.getProperty("user.dir");
+        logger.info("Current work directory: " + currentWorkDirectory);
+        int index = currentWorkDirectory.lastIndexOf(File.separator + "dubbo" + File.separator);
+        Path targetFilePath = Paths.get(currentWorkDirectory.substring(0, index),
+            "dubbo",
+            TARGET_DIRECTORY,
+            TARGET_ZOOKEEPER_FILE_NAME);
+        logger.info("Target file's absolute directory: " + targetFilePath.toString());
+        return targetFilePath;
+    }
 
     /**
      * Returns the Operating System.

--- a/dubbo-test/dubbo-test-check/src/main/java/org/apache/dubbo/test/check/registrycenter/ZookeeperRegistryCenter.java
+++ b/dubbo-test/dubbo-test-check/src/main/java/org/apache/dubbo/test/check/registrycenter/ZookeeperRegistryCenter.java
@@ -93,11 +93,6 @@ class ZookeeperRegistryCenter implements RegistryCenter {
     private static final AtomicBoolean INITIALIZED = new AtomicBoolean(false);
 
     /**
-     * The {@link #STOPPED} for flagging the {@link #shutdown()} method is called or not.
-     */
-    private static final AtomicBoolean STOPPED = new AtomicBoolean(false);
-
-    /**
      * Returns the Operating System.
      */
     private static OS getOS() {
@@ -152,11 +147,11 @@ class ZookeeperRegistryCenter implements RegistryCenter {
                     for (Initializer initializer : this.initializers) {
                         initializer.initialize(this.context);
                     }
-                    this.get(os, Command.Start).process(this.context);
                     INITIALIZED.set(true);
                 }
             }
         }
+        this.get(os, Command.Start).process(this.context);
     }
 
     /**
@@ -172,15 +167,7 @@ class ZookeeperRegistryCenter implements RegistryCenter {
      */
     @Override
     public void shutdown() throws DubboTestException {
-        if (!STOPPED.get()) {
-            // global look, make sure only one thread can stop the zookeeper instances.
-            synchronized (ZookeeperRegistryCenter.class) {
-                if (!STOPPED.get()) {
-                    this.get(os, Command.Stop).process(this.context);
-                }
-                STOPPED.set(true);
-            }
-        }
+        this.get(os, Command.Stop).process(this.context);
     }
 
     /**

--- a/dubbo-test/dubbo-test-check/src/main/java/org/apache/dubbo/test/check/registrycenter/context/ZookeeperContext.java
+++ b/dubbo-test/dubbo-test-check/src/main/java/org/apache/dubbo/test/check/registrycenter/context/ZookeeperContext.java
@@ -37,6 +37,11 @@ public class ZookeeperContext implements Context {
     private Path sourceFile;
 
     /**
+     * The directory after unpacked zookeeper archive binary file.
+     */
+    private String unpackedDirectory;
+
+    /**
      * Sets the source file path of downloaded zookeeper binary archive.
      */
     public void setSourceFile(Path sourceFile) {
@@ -48,6 +53,20 @@ public class ZookeeperContext implements Context {
      */
     public Path getSourceFile() {
         return this.sourceFile;
+    }
+
+    /**
+     * Returns the directory after unpacked zookeeper archive binary file.
+     */
+    public String getUnpackedDirectory() {
+        return unpackedDirectory;
+    }
+
+    /**
+     * Sets the directory after unpacked zookeeper archive binary file.
+     */
+    public void setUnpackedDirectory(String unpackedDirectory) {
+        this.unpackedDirectory = unpackedDirectory;
     }
 
     /**

--- a/dubbo-test/dubbo-test-check/src/main/java/org/apache/dubbo/test/check/registrycenter/initializer/ConfigZookeeperInitializer.java
+++ b/dubbo-test/dubbo-test-check/src/main/java/org/apache/dubbo/test/check/registrycenter/initializer/ConfigZookeeperInitializer.java
@@ -47,7 +47,7 @@ public class ConfigZookeeperInitializer extends ZookeeperInitializer {
     private void updateConfig(ZookeeperContext context, int clientPort, int adminServerPort) throws DubboTestException {
         Path zookeeperConf = Paths.get(context.getSourceFile().getParent().toString(),
             String.valueOf(clientPort),
-            "apache-zookeeper-bin",
+            context.getUnpackedDirectory(),
             "conf");
         File zooSample = Paths.get(zookeeperConf.toString(), "zoo_sample.cfg").toFile();
 

--- a/dubbo-test/dubbo-test-check/src/main/java/org/apache/dubbo/test/check/registrycenter/initializer/ConfigZookeeperInitializer.java
+++ b/dubbo-test/dubbo-test-check/src/main/java/org/apache/dubbo/test/check/registrycenter/initializer/ConfigZookeeperInitializer.java
@@ -47,7 +47,7 @@ public class ConfigZookeeperInitializer extends ZookeeperInitializer {
     private void updateConfig(ZookeeperContext context, int clientPort, int adminServerPort) throws DubboTestException {
         Path zookeeperConf = Paths.get(context.getSourceFile().getParent().toString(),
             String.valueOf(clientPort),
-            String.format("apache-zookeeper-%s-bin", context.getVersion()),
+            "apache-zookeeper-bin",
             "conf");
         File zooSample = Paths.get(zookeeperConf.toString(), "zoo_sample.cfg").toFile();
 

--- a/dubbo-test/dubbo-test-check/src/main/java/org/apache/dubbo/test/check/registrycenter/initializer/DownloadZookeeperInitializer.java
+++ b/dubbo-test/dubbo-test-check/src/main/java/org/apache/dubbo/test/check/registrycenter/initializer/DownloadZookeeperInitializer.java
@@ -95,11 +95,20 @@ public class DownloadZookeeperInitializer extends ZookeeperInitializer {
             throw new IllegalArgumentException(String.format("There are some unknown problem occurred when downloaded the zookeeper binary archive file, file path:%s", temporaryFilePath));
         }
 
-        // copy the downloaded zookeeper binary file into the target file path
+        // create target file if necessary
+        if(!Files.exists(context.getSourceFile())){
+            try {
+                Files.createFile(context.getSourceFile());
+            } catch (IOException e) {
+                throw new IllegalArgumentException(String.format("Failed to create file, the file path: %s", context.getSourceFile()), e);
+            }
+        }
+
+        // move the downloaded zookeeper binary file into the target file path
         try {
-            Files.copy(temporaryFilePath, context.getSourceFile(), StandardCopyOption.REPLACE_EXISTING);
+            Files.move(temporaryFilePath, context.getSourceFile(), StandardCopyOption.ATOMIC_MOVE);
         } catch (IOException e) {
-            throw new IllegalArgumentException(String.format("Failed to copy file, the source file path: %s, the target file path: %s", temporaryFilePath, context.getSourceFile()), e);
+            throw new IllegalArgumentException(String.format("Failed to move file, the source file path: %s, the target file path: %s", temporaryFilePath, context.getSourceFile()), e);
         }
 
         // checks the zookeeper binary file exists or not again

--- a/dubbo-test/dubbo-test-check/src/main/java/org/apache/dubbo/test/check/registrycenter/initializer/DownloadZookeeperInitializer.java
+++ b/dubbo-test/dubbo-test-check/src/main/java/org/apache/dubbo/test/check/registrycenter/initializer/DownloadZookeeperInitializer.java
@@ -21,7 +21,6 @@ import org.apache.dubbo.common.logger.LoggerFactory;
 import org.apache.dubbo.test.check.exception.DubboTestException;
 import org.apache.dubbo.test.check.registrycenter.context.ZookeeperContext;
 
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
@@ -43,41 +42,9 @@ public class DownloadZookeeperInitializer extends ZookeeperInitializer {
     private static final String ZOOKEEPER_FILE_NAME_FORMAT = "apache-zookeeper-%s-bin.tar.gz";
 
     /**
-     * The target name of zookeeper binary file.
-     */
-    private static final String TARGET_ZOOKEEPER_FILE_NAME = "apache-zookeeper-bin.tar.gz";
-
-    /**
-     * The target directory.
-     * The zookeeper binary file named {@link #TARGET_ZOOKEEPER_FILE_NAME} will be saved in
-     * {@link #TARGET_DIRECTORY} if it downloaded successfully.
-     */
-    private static final String TARGET_DIRECTORY = "test" + File.separator + "zookeeper";
-
-    /**
      * The url format for zookeeper binary file.
      */
     private static final String ZOOKEEPER_BINARY_URL_FORMAT = "https://archive.apache.org/dist/zookeeper/zookeeper-%s/" + ZOOKEEPER_FILE_NAME_FORMAT;
-
-    /**
-     * The path of target zookeeper binary file.
-     */
-    private static final Path TARGET_FILE_PATH = getTargetFilePath();
-
-    /**
-     * Returns the target file path.
-     */
-    private static Path getTargetFilePath() {
-        String currentWorkDirectory = System.getProperty("user.dir");
-        logger.info("Current work directory: " + currentWorkDirectory);
-        int index = currentWorkDirectory.lastIndexOf(File.separator + "dubbo" + File.separator);
-        Path targetFilePath = Paths.get(currentWorkDirectory.substring(0, index),
-            "dubbo",
-            TARGET_DIRECTORY,
-            TARGET_ZOOKEEPER_FILE_NAME);
-        logger.info("Target file's absolute directory: " + targetFilePath.toString());
-        return targetFilePath;
-    }
 
     /**
      * Returns {@code true} if the file exists with the given file path, otherwise {@code false}.
@@ -91,29 +58,17 @@ public class DownloadZookeeperInitializer extends ZookeeperInitializer {
     @Override
     protected void doInitialize(ZookeeperContext context) throws DubboTestException {
         // checks the zookeeper binary file exists or not
-        if (checkFile(TARGET_FILE_PATH)) {
-            context.setSourceFile(TARGET_FILE_PATH);
+        if (checkFile(context.getSourceFile())) {
             return;
         }
         String zookeeperFileName = String.format(ZOOKEEPER_FILE_NAME_FORMAT, context.getVersion());
         Path temporaryFilePath;
         try {
             temporaryFilePath = Paths.get(Files.createTempDirectory("").getParent().toString(),
-                TARGET_DIRECTORY,
                 zookeeperFileName);
         } catch (IOException e) {
-            throw new RuntimeException(String.format("Cannot create the temporary directory, related directory:%s/%s",
-                TARGET_DIRECTORY, zookeeperFileName), e);
-        }
-
-        // delete the downloaded zookeeper binary file in temporary, because it maybe a broken file.
-        if (Files.exists(temporaryFilePath)) {
-            try {
-                Files.deleteIfExists(temporaryFilePath);
-            } catch (IOException e) {
-                //ignored
-                logger.warn("Failed to delete the zookeeper binary file, file path: " + temporaryFilePath.toString(), e);
-            }
+            throw new RuntimeException(String.format("Cannot create the temporary directory, related directory:%s",
+                zookeeperFileName), e);
         }
 
         // create the temporary directory path.
@@ -132,7 +87,7 @@ public class DownloadZookeeperInitializer extends ZookeeperInitializer {
             Files.copy(inputStream, temporaryFilePath, StandardCopyOption.REPLACE_EXISTING);
         } catch (Exception e) {
             throw new RuntimeException(String.format("Download zookeeper binary archive failed, download url:%s, file path:%s",
-                zookeeperBinaryUrl, context.getSourceFile()), e);
+                zookeeperBinaryUrl, temporaryFilePath), e);
         }
 
         // check downloaded zookeeper binary file in temporary directory.
@@ -140,20 +95,16 @@ public class DownloadZookeeperInitializer extends ZookeeperInitializer {
             throw new IllegalArgumentException(String.format("There are some unknown problem occurred when downloaded the zookeeper binary archive file, file path:%s", temporaryFilePath));
         }
 
-        // move the downloaded zookeeper binary file into the target file path
+        // copy the downloaded zookeeper binary file into the target file path
         try {
-            // make sure the action of MOVE is atomic.
-            Files.move(temporaryFilePath, TARGET_FILE_PATH, StandardCopyOption.ATOMIC_MOVE);
+            Files.copy(temporaryFilePath, context.getSourceFile(), StandardCopyOption.REPLACE_EXISTING);
         } catch (IOException e) {
-            throw new IllegalArgumentException(String.format("Failed to move file, the source file path: %s, the target file path: %s", temporaryFilePath, TARGET_FILE_PATH));
+            throw new IllegalArgumentException(String.format("Failed to copy file, the source file path: %s, the target file path: %s", temporaryFilePath, context.getSourceFile()));
         }
 
         // checks the zookeeper binary file exists or not again
-        if (!checkFile(TARGET_FILE_PATH)) {
-            throw new IllegalArgumentException(String.format("The zookeeper binary archive file doesn't exist, file path:%s", TARGET_FILE_PATH));
+        if (!checkFile(context.getSourceFile())) {
+            throw new IllegalArgumentException(String.format("The zookeeper binary archive file doesn't exist, file path:%s", context.getSourceFile()));
         }
-
-        // set the source file's path.
-        context.setSourceFile(TARGET_FILE_PATH);
     }
 }

--- a/dubbo-test/dubbo-test-check/src/main/java/org/apache/dubbo/test/check/registrycenter/initializer/DownloadZookeeperInitializer.java
+++ b/dubbo-test/dubbo-test-check/src/main/java/org/apache/dubbo/test/check/registrycenter/initializer/DownloadZookeeperInitializer.java
@@ -47,6 +47,11 @@ public class DownloadZookeeperInitializer extends ZookeeperInitializer {
     private static final String ZOOKEEPER_BINARY_URL_FORMAT = "https://archive.apache.org/dist/zookeeper/zookeeper-%s/" + ZOOKEEPER_FILE_NAME_FORMAT;
 
     /**
+     * The temporary directory.
+     */
+    private static final String TEMPORARY_DIRECTORY = "zookeeper";
+
+    /**
      * Returns {@code true} if the file exists with the given file path, otherwise {@code false}.
      *
      * @param filePath the file path to check.
@@ -65,10 +70,10 @@ public class DownloadZookeeperInitializer extends ZookeeperInitializer {
         Path temporaryFilePath;
         try {
             temporaryFilePath = Paths.get(Files.createTempDirectory("").getParent().toString(),
-                "zookeeper",
+                TEMPORARY_DIRECTORY,
                 zookeeperFileName);
         } catch (IOException e) {
-            throw new RuntimeException("Cannot create the temporary directory", e);
+            throw new RuntimeException(String.format("Cannot create the temporary directory, file path: %s", TEMPORARY_DIRECTORY), e);
         }
 
         // create the temporary directory path.
@@ -95,12 +100,12 @@ public class DownloadZookeeperInitializer extends ZookeeperInitializer {
             throw new IllegalArgumentException(String.format("There are some unknown problem occurred when downloaded the zookeeper binary archive file, file path:%s", temporaryFilePath));
         }
 
-        // create target file if necessary
-        if(!Files.exists(context.getSourceFile())){
+        // create target directory if necessary
+        if (!Files.exists(context.getSourceFile())) {
             try {
-                Files.createFile(context.getSourceFile());
+                Files.createDirectories(context.getSourceFile().getParent());
             } catch (IOException e) {
-                throw new IllegalArgumentException(String.format("Failed to create file, the file path: %s", context.getSourceFile()), e);
+                throw new IllegalArgumentException(String.format("Failed to create target directory, the directory path: %s", context.getSourceFile().getParent()), e);
             }
         }
 

--- a/dubbo-test/dubbo-test-check/src/main/java/org/apache/dubbo/test/check/registrycenter/initializer/DownloadZookeeperInitializer.java
+++ b/dubbo-test/dubbo-test-check/src/main/java/org/apache/dubbo/test/check/registrycenter/initializer/DownloadZookeeperInitializer.java
@@ -109,11 +109,11 @@ public class DownloadZookeeperInitializer extends ZookeeperInitializer {
             }
         }
 
-        // move the downloaded zookeeper binary file into the target file path
+        // copy the downloaded zookeeper binary file into the target file path
         try {
-            Files.move(temporaryFilePath, context.getSourceFile(), StandardCopyOption.ATOMIC_MOVE);
+            Files.copy(temporaryFilePath, context.getSourceFile(), StandardCopyOption.REPLACE_EXISTING);
         } catch (IOException e) {
-            throw new IllegalArgumentException(String.format("Failed to move file, the source file path: %s, the target file path: %s", temporaryFilePath, context.getSourceFile()), e);
+            throw new IllegalArgumentException(String.format("Failed to copy file, the source file path: %s, the target file path: %s", temporaryFilePath, context.getSourceFile()), e);
         }
 
         // checks the zookeeper binary file exists or not again

--- a/dubbo-test/dubbo-test-check/src/main/java/org/apache/dubbo/test/check/registrycenter/initializer/DownloadZookeeperInitializer.java
+++ b/dubbo-test/dubbo-test-check/src/main/java/org/apache/dubbo/test/check/registrycenter/initializer/DownloadZookeeperInitializer.java
@@ -65,10 +65,10 @@ public class DownloadZookeeperInitializer extends ZookeeperInitializer {
         Path temporaryFilePath;
         try {
             temporaryFilePath = Paths.get(Files.createTempDirectory("").getParent().toString(),
+                "zookeeper",
                 zookeeperFileName);
         } catch (IOException e) {
-            throw new RuntimeException(String.format("Cannot create the temporary directory, related directory:%s",
-                zookeeperFileName), e);
+            throw new RuntimeException("Cannot create the temporary directory", e);
         }
 
         // create the temporary directory path.
@@ -99,7 +99,7 @@ public class DownloadZookeeperInitializer extends ZookeeperInitializer {
         try {
             Files.copy(temporaryFilePath, context.getSourceFile(), StandardCopyOption.REPLACE_EXISTING);
         } catch (IOException e) {
-            throw new IllegalArgumentException(String.format("Failed to copy file, the source file path: %s, the target file path: %s", temporaryFilePath, context.getSourceFile()));
+            throw new IllegalArgumentException(String.format("Failed to copy file, the source file path: %s, the target file path: %s", temporaryFilePath, context.getSourceFile()), e);
         }
 
         // checks the zookeeper binary file exists or not again

--- a/dubbo-test/dubbo-test-check/src/main/java/org/apache/dubbo/test/check/registrycenter/initializer/UnpackZookeeperInitializer.java
+++ b/dubbo-test/dubbo-test-check/src/main/java/org/apache/dubbo/test/check/registrycenter/initializer/UnpackZookeeperInitializer.java
@@ -94,7 +94,7 @@ public class UnpackZookeeperInitializer extends ZookeeperInitializer {
             }
             // rename directory
             File sourceFile = parentPath.toFile().listFiles()[0];
-            File targetFile = Paths.get(parentPath.toString(),"apache-zookeeper-bin").toFile();
+            File targetFile = Paths.get(parentPath.toString(), context.getUnpackedDirectory()).toFile();
             sourceFile.renameTo(targetFile);
             if (!Files.exists(targetFile.toPath()) || !targetFile.isDirectory()) {
                 throw new IllegalStateException(String.format("Failed to rename the directory. source directory: %s, target directory: %s",

--- a/dubbo-test/dubbo-test-check/src/main/java/org/apache/dubbo/test/check/registrycenter/initializer/UnpackZookeeperInitializer.java
+++ b/dubbo-test/dubbo-test-check/src/main/java/org/apache/dubbo/test/check/registrycenter/initializer/UnpackZookeeperInitializer.java
@@ -29,6 +29,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
@@ -82,11 +83,27 @@ public class UnpackZookeeperInitializer extends ZookeeperInitializer {
     protected void doInitialize(ZookeeperContext context) throws DubboTestException {
         for (int clientPort : context.getClientPorts()) {
             this.unpack(context, clientPort);
+            // get the file name, just like apache-zookeeper-{version}-bin
+            // the version we maybe unknown if the zookeeper archive binary file is copied by user self.
+            Path parentPath = Paths.get(context.getSourceFile().getParent().toString(),
+                String.valueOf(clientPort));
+            if (!Files.exists(parentPath) ||
+                !parentPath.toFile().isDirectory() ||
+                parentPath.toFile().listFiles().length != 1) {
+                throw new IllegalStateException("There is something wrong in unpacked file!");
+            }
+            // rename directory
+            File sourceFile = parentPath.toFile().listFiles()[0];
+            File targetFile = Paths.get(parentPath.toString(),"apache-zookeeper-bin").toFile();
+            sourceFile.renameTo(targetFile);
+            if (!Files.exists(targetFile.toPath()) || !targetFile.isDirectory()) {
+                throw new IllegalStateException(String.format("Failed to rename the directory. source directory: %s, target directory: %s",
+                    sourceFile.toPath().toString(),
+                    targetFile.toPath().toString()));
+            }
+            // get the bin path
+            Path zookeeperBin = Paths.get(targetFile.toString(), "bin");
             // update file permission
-            Path zookeeperBin = Paths.get(context.getSourceFile().getParent().toString(),
-                String.valueOf(clientPort),
-                String.format("apache-zookeeper-%s-bin", context.getVersion()),
-                "bin");
             for (File file : zookeeperBin.toFile().listFiles()) {
                 file.setExecutable(true, false);
                 file.setReadable(true, false);

--- a/dubbo-test/dubbo-test-check/src/main/java/org/apache/dubbo/test/check/registrycenter/processor/StartZookeeperUnixProcessor.java
+++ b/dubbo-test/dubbo-test-check/src/main/java/org/apache/dubbo/test/check/registrycenter/processor/StartZookeeperUnixProcessor.java
@@ -41,7 +41,7 @@ public class StartZookeeperUnixProcessor extends ZookeeperUnixProcessor {
         List<String> commands = new ArrayList<>();
         Path zookeeperBin = Paths.get(context.getSourceFile().getParent().toString(),
             String.valueOf(clientPort),
-            String.format("apache-zookeeper-%s-bin", context.getVersion()),
+            String.format("apache-zookeeper-bin", context.getVersion()),
             "bin");
         commands.add(Paths.get(zookeeperBin.toString(), "zkServer.sh")
             .toAbsolutePath().toString());

--- a/dubbo-test/dubbo-test-check/src/main/java/org/apache/dubbo/test/check/registrycenter/processor/StartZookeeperUnixProcessor.java
+++ b/dubbo-test/dubbo-test-check/src/main/java/org/apache/dubbo/test/check/registrycenter/processor/StartZookeeperUnixProcessor.java
@@ -41,7 +41,7 @@ public class StartZookeeperUnixProcessor extends ZookeeperUnixProcessor {
         List<String> commands = new ArrayList<>();
         Path zookeeperBin = Paths.get(context.getSourceFile().getParent().toString(),
             String.valueOf(clientPort),
-            String.format("apache-zookeeper-bin", context.getVersion()),
+            context.getUnpackedDirectory(),
             "bin");
         commands.add(Paths.get(zookeeperBin.toString(), "zkServer.sh")
             .toAbsolutePath().toString());

--- a/dubbo-test/dubbo-test-check/src/main/java/org/apache/dubbo/test/check/registrycenter/processor/StartZookeeperWindowsProcessor.java
+++ b/dubbo-test/dubbo-test-check/src/main/java/org/apache/dubbo/test/check/registrycenter/processor/StartZookeeperWindowsProcessor.java
@@ -56,7 +56,7 @@ public class StartZookeeperWindowsProcessor extends ZookeeperWindowsProcessor {
             logger.info(String.format("The zookeeper-%d is starting...", clientPort));
             Path zookeeperBin = Paths.get(context.getSourceFile().getParent().toString(),
                 String.valueOf(clientPort),
-                String.format("apache-zookeeper-%s-bin", context.getVersion()),
+                context.getUnpackedDirectory(),
                 "bin");
             Executor executor = new DefaultExecutor();
             executor.setExitValues(null);

--- a/dubbo-test/dubbo-test-check/src/main/java/org/apache/dubbo/test/check/registrycenter/processor/StopZookeeperUnixProcessor.java
+++ b/dubbo-test/dubbo-test-check/src/main/java/org/apache/dubbo/test/check/registrycenter/processor/StopZookeeperUnixProcessor.java
@@ -41,7 +41,7 @@ public class StopZookeeperUnixProcessor extends ZookeeperUnixProcessor {
         List<String> commands = new ArrayList<>();
         Path zookeeperBin = Paths.get(context.getSourceFile().getParent().toString(),
             String.valueOf(clientPort),
-            String.format("apache-zookeeper-%s-bin", context.getVersion()),
+            String.format("apache-zookeeper-bin", context.getVersion()),
             "bin");
         commands.add(Paths.get(zookeeperBin.toString(), "zkServer.sh")
             .toAbsolutePath().toString());

--- a/dubbo-test/dubbo-test-check/src/main/java/org/apache/dubbo/test/check/registrycenter/processor/StopZookeeperUnixProcessor.java
+++ b/dubbo-test/dubbo-test-check/src/main/java/org/apache/dubbo/test/check/registrycenter/processor/StopZookeeperUnixProcessor.java
@@ -41,7 +41,7 @@ public class StopZookeeperUnixProcessor extends ZookeeperUnixProcessor {
         List<String> commands = new ArrayList<>();
         Path zookeeperBin = Paths.get(context.getSourceFile().getParent().toString(),
             String.valueOf(clientPort),
-            String.format("apache-zookeeper-bin", context.getVersion()),
+            context.getUnpackedDirectory(),
             "bin");
         commands.add(Paths.get(zookeeperBin.toString(), "zkServer.sh")
             .toAbsolutePath().toString());

--- a/dubbo-test/dubbo-test-check/src/main/java/org/apache/dubbo/test/check/registrycenter/processor/ZookeeperUnixProcessor.java
+++ b/dubbo-test/dubbo-test-check/src/main/java/org/apache/dubbo/test/check/registrycenter/processor/ZookeeperUnixProcessor.java
@@ -43,6 +43,12 @@ public abstract class ZookeeperUnixProcessor implements Processor {
             Process process = this.doProcess(zookeeperContext, clientPort);
             this.logErrorStream(process.getErrorStream());
             this.awaitProcessReady(process.getInputStream());
+            // kill the process
+            try {
+                process.destroy();
+            } catch (Throwable cause) {
+                logger.warn(String.format("Failed to kill the process, with client port %s !", clientPort), cause);
+            }
         }
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -628,6 +628,7 @@
                         <exclude>Jenkinsfile</exclude>
                         <exclude>**/codestyle/*</exclude>
                         <exclude>**/resources/META-INF/**</exclude>
+                        <exclude>**/test/**</exclude>
                         <!-- exclude the netty files -->
                         <exclude>**/org/apache/dubbo/common/threadlocal/InternalThreadLocal.java</exclude>
                         <exclude>**/org/apache/dubbo/common/threadlocal/InternalThreadLocalMap.java</exclude>

--- a/pom.xml
+++ b/pom.xml
@@ -628,7 +628,7 @@
                         <exclude>Jenkinsfile</exclude>
                         <exclude>**/codestyle/*</exclude>
                         <exclude>**/resources/META-INF/**</exclude>
-                        <exclude>**/test/**</exclude>
+                        <exclude>**/.tmp/**</exclude>
                         <!-- exclude the netty files -->
                         <exclude>**/org/apache/dubbo/common/threadlocal/InternalThreadLocal.java</exclude>
                         <exclude>**/org/apache/dubbo/common/threadlocal/InternalThreadLocalMap.java</exclude>

--- a/pom.xml
+++ b/pom.xml
@@ -628,7 +628,6 @@
                         <exclude>Jenkinsfile</exclude>
                         <exclude>**/codestyle/*</exclude>
                         <exclude>**/resources/META-INF/**</exclude>
-                        <exclude>**/.tmp/**</exclude>
                         <!-- exclude the netty files -->
                         <exclude>**/org/apache/dubbo/common/threadlocal/InternalThreadLocal.java</exclude>
                         <exclude>**/org/apache/dubbo/common/threadlocal/InternalThreadLocalMap.java</exclude>


### PR DESCRIPTION
see: https://github.com/apache/dubbo/issues/9227

## Brief changelog

1. Avoid the concurrence when donwloading zookeeper binary file
2. Destroy the process after stopped zookeeper instance in Unix OS
3. Support to provide zookeeper binary file by use self and avoid to download zookeeper binary file

## Verifying this change


<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [x] Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [x] GitHub Actions works fine on your own branch.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
