### PR TITLE
Use existing methods to generate serviceKey for SimpleReferenceCache

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/BaseServiceMetadata.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/BaseServiceMetadata.java
@@ -39,11 +39,11 @@ public class BaseServiceMetadata {
         length += version == null ? 0 : version.length();
         length += 3;
         StringBuilder buf = new StringBuilder(length);
-        if (group != null && group.length() > 0) {
+        if (StringUtils.isNotEmpty(group)) {
             buf.append(group).append('/');
         }
         buf.append(path);
-        if (version != null && version.length() > 0) {
+        if (StringUtils.isNotEmpty(version)) {
             buf.append(':').append(version);
         }
         return buf.toString().intern();

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/extension/ExtensionLoader.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/extension/ExtensionLoader.java
@@ -444,7 +444,7 @@ public class ExtensionLoader<T> {
         }
         for (String[] keyPair : keyPairs) {
             // @Active(value="key1:value1, key2:value2")
-            String key = null;
+            String key;
             String keyValue = null;
             if (keyPair.length > 1) {
                 key = keyPair[0];

--- a/dubbo-common/src/main/java/org/apache/dubbo/config/ProtocolConfig.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/config/ProtocolConfig.java
@@ -566,45 +566,4 @@ public class ProtocolConfig extends AbstractConfig {
         return StringUtils.isNotEmpty(name);
     }
 
-    @Override
-    public String toString() {
-        final StringBuilder sb = new StringBuilder("ProtocolConfig{");
-        sb.append("name='").append(name).append('\'');
-        sb.append(", host='").append(host).append('\'');
-        sb.append(", port=").append(port);
-        sb.append(", contextpath='").append(contextpath).append('\'');
-        sb.append(", threadpool='").append(threadpool).append('\'');
-        sb.append(", threadname='").append(threadname).append('\'');
-        sb.append(", corethreads=").append(corethreads);
-        sb.append(", threads=").append(threads);
-        sb.append(", iothreads=").append(iothreads);
-        sb.append(", alive=").append(alive);
-        sb.append(", queues=").append(queues);
-        sb.append(", accepts=").append(accepts);
-        sb.append(", codec='").append(codec).append('\'');
-        sb.append(", serialization='").append(serialization).append('\'');
-        sb.append(", charset='").append(charset).append('\'');
-        sb.append(", payload=").append(payload);
-        sb.append(", buffer=").append(buffer);
-        sb.append(", heartbeat=").append(heartbeat);
-        sb.append(", accesslog='").append(accesslog).append('\'');
-        sb.append(", transporter='").append(transporter).append('\'');
-        sb.append(", exchanger='").append(exchanger).append('\'');
-        sb.append(", dispatcher='").append(dispatcher).append('\'');
-        sb.append(", networker='").append(networker).append('\'');
-        sb.append(", server='").append(server).append('\'');
-        sb.append(", client='").append(client).append('\'');
-        sb.append(", telnet='").append(telnet).append('\'');
-        sb.append(", prompt='").append(prompt).append('\'');
-        sb.append(", status='").append(status).append('\'');
-        sb.append(", register=").append(register);
-        sb.append(", keepAlive=").append(keepAlive);
-        sb.append(", optimizer='").append(optimizer).append('\'');
-        sb.append(", extension='").append(extension).append('\'');
-        sb.append(", parameters=").append(parameters);
-        sb.append(", isDefault=").append(isDefault);
-        sb.append(", sslEnabled=").append(sslEnabled);
-        sb.append('}');
-        return sb.toString();
-    }
 }

--- a/dubbo-common/src/main/java/org/apache/dubbo/config/ProviderConfig.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/config/ProviderConfig.java
@@ -444,35 +444,4 @@ public class ProviderConfig extends AbstractServiceConfig {
         this.exportBackground = exportBackground;
     }
 
-    @Override
-    public String toString() {
-        final StringBuilder sb = new StringBuilder("ProviderConfig{");
-        sb.append("host='").append(host).append('\'');
-        sb.append(", port=").append(port);
-        sb.append(", contextpath='").append(contextpath).append('\'');
-        sb.append(", threadpool='").append(threadpool).append('\'');
-        sb.append(", threadname='").append(threadname).append('\'');
-        sb.append(", threads=").append(threads);
-        sb.append(", iothreads=").append(iothreads);
-        sb.append(", alive=").append(alive);
-        sb.append(", queues=").append(queues);
-        sb.append(", accepts=").append(accepts);
-        sb.append(", codec='").append(codec).append('\'');
-        sb.append(", charset='").append(charset).append('\'');
-        sb.append(", payload=").append(payload);
-        sb.append(", buffer=").append(buffer);
-        sb.append(", transporter='").append(transporter).append('\'');
-        sb.append(", exchanger='").append(exchanger).append('\'');
-        sb.append(", dispatcher='").append(dispatcher).append('\'');
-        sb.append(", networker='").append(networker).append('\'');
-        sb.append(", server='").append(server).append('\'');
-        sb.append(", client='").append(client).append('\'');
-        sb.append(", telnet='").append(telnet).append('\'');
-        sb.append(", prompt='").append(prompt).append('\'');
-        sb.append(", status='").append(status).append('\'');
-        sb.append(", wait=").append(wait);
-        sb.append(", isDefault=").append(isDefault);
-        sb.append('}');
-        return sb.toString();
-    }
 }

--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/invoker/DelegateProviderMetaDataInvoker.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/invoker/DelegateProviderMetaDataInvoker.java
@@ -24,8 +24,7 @@ import org.apache.dubbo.rpc.Result;
 import org.apache.dubbo.rpc.RpcException;
 
 /**
- *
- * A Invoker wrapper that wrap the invoker and all the metadata (ServiceConfig)
+ * An invoker wrapper that wrap the invoker and all the metadata (ServiceConfig)
  */
 public class DelegateProviderMetaDataInvoker<T> implements Invoker {
     protected final Invoker<T> invoker;

--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/utils/SimpleReferenceCache.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/utils/SimpleReferenceCache.java
@@ -16,6 +16,7 @@
  */
 package org.apache.dubbo.config.utils;
 
+import org.apache.dubbo.common.BaseServiceMetadata;
 import org.apache.dubbo.common.config.ReferenceCache;
 import org.apache.dubbo.common.utils.CollectionUtils;
 import org.apache.dubbo.common.utils.StringUtils;
@@ -55,15 +56,7 @@ public class SimpleReferenceCache implements ReferenceCache {
             throw new IllegalArgumentException("No interface info in ReferenceConfig" + referenceConfig);
         }
 
-        StringBuilder ret = new StringBuilder();
-        if (!StringUtils.isBlank(referenceConfig.getGroup())) {
-            ret.append(referenceConfig.getGroup()).append('/');
-        }
-        ret.append(iName);
-        if (!StringUtils.isBlank(referenceConfig.getVersion())) {
-            ret.append(':').append(referenceConfig.getVersion());
-        }
-        return ret.toString();
+        return BaseServiceMetadata.buildServiceKey(iName, referenceConfig.getGroup(), referenceConfig.getVersion());
     };
 
     private static final AtomicInteger nameIndex = new AtomicInteger();
@@ -141,7 +134,7 @@ public class SimpleReferenceCache implements ReferenceCache {
     @SuppressWarnings("unchecked")
     public <T> T get(String key, Class<T> type) {
         List<ReferenceConfigBase<?>> referenceConfigs = referenceKeyMap.get(key);
-        if (referenceConfigs != null && referenceConfigs.size() > 0) {
+        if (CollectionUtils.isNotEmpty(referenceConfigs)) {
             return (T) referenceConfigs.get(0).get();
         }
         return null;

--- a/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/ConfigScopeModelInitializerTest.java
+++ b/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/ConfigScopeModelInitializerTest.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.config;
+
+import org.apache.dubbo.rpc.model.ApplicationModel;
+import org.apache.dubbo.rpc.model.FrameworkModel;
+import org.apache.dubbo.rpc.model.ModuleModel;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class ConfigScopeModelInitializerTest {
+    private FrameworkModel frameworkModel;
+    private ApplicationModel applicationModel;
+    private ModuleModel moduleModel;
+
+    @BeforeEach
+    public void setUp() {
+        frameworkModel = new FrameworkModel();
+        applicationModel = new ApplicationModel(frameworkModel);
+        moduleModel = new ModuleModel(applicationModel);
+    }
+
+    @AfterEach
+    public void reset() {
+        frameworkModel.destroy();
+    }
+
+    @Test
+    public void test(){
+        Assertions.assertNotNull(applicationModel.getDeployer());
+        Assertions.assertNotNull(moduleModel.getDeployer());
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

Use existing methods to generate serviceKey for SimpleReferenceCache 

1.Use existing methods to generate serviceKey for SimpleReferenceCache
2.add test case for ServiceInstanceHostPortCustomizer
3.Remove the toString method of AbstractConfig subclass
4.Add unit test for ConfigScopeModelInitializer