### PR TITLE
keep both old and new keys

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/config/ConfigurationUtils.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/config/ConfigurationUtils.java
@@ -35,6 +35,7 @@ import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Properties;
 import java.util.Set;
 
@@ -238,8 +239,11 @@ public class ConfigurationUtils {
 
                     String k = key.substring(prefix.length());
                     // convert camelCase/snake_case to kebab-case
-                    k = StringUtils.convertToSplitName(k, "-");
-                    resultMap.putIfAbsent(k, val);
+                    String newK = StringUtils.convertToSplitName(k, "-");
+                    resultMap.putIfAbsent(newK, val);
+                    if (!Objects.equals(k, newK)) {
+                        resultMap.putIfAbsent(k, val);
+                    }
                 }
             }
         }


### PR DESCRIPTION
When using extended parameters, Dubbo will keep the original keys if they are of snake/camel case format while at the same time creating new duplicate keys - dash-separated/kebab-case keys for compatibility purpose. For example, `testKey=value` will finally have a duplication of `test-key=value` in URL.

The following different ways of configurations are supported to add extra parameters:

1. spring boot `application.properties`
```yaml
dubbo:
  application:
    name: dubbo-springboot-demo-provider
    parameters:
      testKey: value
```

2. API/XML/Annotation/Spring-boot `dubbo.properties`
```properties
dubbo.registry.parameters=[{testKey:value},{testKey2:value2}]
# or
# dubbo.registry.address=zookeeper://127.0.0.1:2181?testKey=value
```

3. XML
```xml
<dubbo:application name="demo-provider">
    <dubbo:parameter key="testKey" value="value"/>
</dubbo:application>
```
