### PR TITLE
Fix the issue that ApplicationConfig#getmetadataserviceprotocol method maps the wrong key

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/config/ApplicationConfig.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/config/ApplicationConfig.java
@@ -42,6 +42,7 @@ import static org.apache.dubbo.common.constants.CommonConstants.HOST_KEY;
 import static org.apache.dubbo.common.constants.CommonConstants.LIVENESS_PROBE_KEY;
 import static org.apache.dubbo.common.constants.CommonConstants.METADATA_KEY;
 import static org.apache.dubbo.common.constants.CommonConstants.METADATA_SERVICE_PORT_KEY;
+import static org.apache.dubbo.common.constants.CommonConstants.METADATA_SERVICE_PROTOCOL_KEY;
 import static org.apache.dubbo.common.constants.CommonConstants.READINESS_PROBE_KEY;
 import static org.apache.dubbo.common.constants.CommonConstants.REGISTRY_LOCAL_FILE_CACHE_ENABLED;
 import static org.apache.dubbo.common.constants.CommonConstants.SHUTDOWN_WAIT_KEY;
@@ -532,7 +533,7 @@ public class ApplicationConfig extends AbstractConfig {
         this.metadataServicePort = metadataServicePort;
     }
 
-    @Parameter(key = METADATA_SERVICE_PORT_KEY)
+    @Parameter(key = METADATA_SERVICE_PROTOCOL_KEY)
     public String getMetadataServiceProtocol() {
         return metadataServiceProtocol;
     }

--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/metadata/ConfigurableMetadataServiceExporter.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/metadata/ConfigurableMetadataServiceExporter.java
@@ -183,7 +183,6 @@ public class ConfigurableMetadataServiceExporter implements MetadataServiceExpor
                     if (it.hasNext()) {
                         String addr = it.next().getAddress();
                         String rawPort = addr.substring(addr.indexOf(":") + 1);
-                        logger.info("Using " + specifiedProtocol +" protocol to export MetadataService on port " + rawPort);
                         protocolConfig.setPort(Integer.parseInt(rawPort));
                     }
                 }
@@ -198,7 +197,7 @@ public class ConfigurableMetadataServiceExporter implements MetadataServiceExpor
             protocolConfig.setPort(-1);
         }
 
-        logger.info("Using dubbo protocol to export metadata service on port " + protocolConfig.getPort());
+        logger.info("Using " + specifiedProtocol + " protocol to export metadata service on port " + protocolConfig.getPort());
 
         return protocolConfig;
     }

--- a/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/ReferenceConfigTest.java
+++ b/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/ReferenceConfigTest.java
@@ -92,6 +92,7 @@ import static org.apache.dubbo.common.constants.CommonConstants.INTERFACE_KEY;
 import static org.apache.dubbo.common.constants.CommonConstants.LIVENESS_PROBE_KEY;
 import static org.apache.dubbo.common.constants.CommonConstants.METADATA_KEY;
 import static org.apache.dubbo.common.constants.CommonConstants.METADATA_SERVICE_PORT_KEY;
+import static org.apache.dubbo.common.constants.CommonConstants.METADATA_SERVICE_PROTOCOL_KEY;
 import static org.apache.dubbo.common.constants.CommonConstants.METHODS_KEY;
 import static org.apache.dubbo.common.constants.CommonConstants.PID_KEY;
 import static org.apache.dubbo.common.constants.CommonConstants.READINESS_PROBE_KEY;
@@ -180,6 +181,7 @@ public class ReferenceConfigTest {
         applicationConfig.setPublishInterface(false);
         applicationConfig.setProtocol("dubbo");
         applicationConfig.setMetadataServicePort(88888);
+        applicationConfig.setMetadataServiceProtocol("tri");
         applicationConfig.setLivenessProbe("livenessProbe");
         applicationConfig.setReadinessProbe("readinessProb");
         applicationConfig.setStartupProbe("startupProbe");
@@ -320,6 +322,8 @@ public class ReferenceConfigTest {
         Assertions.assertTrue(serviceMetadata.getAttachments().containsKey(REGISTRY_PUBLISH_INTERFACE_KEY));
         Assertions.assertEquals(applicationConfig.getMetadataServicePort().toString(),
             serviceMetadata.getAttachments().get(METADATA_SERVICE_PORT_KEY));
+        Assertions.assertEquals(applicationConfig.getMetadataServiceProtocol().toString(),
+            serviceMetadata.getAttachments().get(METADATA_SERVICE_PROTOCOL_KEY));
         Assertions.assertEquals(applicationConfig.getLivenessProbe(),
             serviceMetadata.getAttachments().get(LIVENESS_PROBE_KEY));
         Assertions.assertEquals(applicationConfig.getReadinessProbe(),

--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/metadata/ServiceInstanceMetadataUtils.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/metadata/ServiceInstanceMetadataUtils.java
@@ -116,10 +116,7 @@ public class ServiceInstanceMetadataUtils {
         if (url == null) {
             return "";
         }
-        url = url.removeParameter(APPLICATION_KEY);
-        url = url.removeParameter(GROUP_KEY);
-        url = url.removeParameter(DEPRECATED_KEY);
-        url = url.removeParameter(TIMESTAMP_KEY);
+        url = url.removeParameters(APPLICATION_KEY, GROUP_KEY, DEPRECATED_KEY, TIMESTAMP_KEY);
         Map<String, String> params = getParams(url);
 
         if (params.isEmpty()) {
@@ -278,7 +275,7 @@ public class ServiceInstanceMetadataUtils {
                 LOGGER.warn("Refreshing of service instance started, but instance hasn't been registered yet.");
                 instance = serviceInstance;
             }
-            // copy instance again, in case the same instance accidently shared among registries
+            // copy instance again, in case the same instance accidentally shared among registries
             instance = new DefaultServiceInstance((DefaultServiceInstance) instance);
             calInstanceRevision(serviceDiscovery, instance);
             customizeInstance(instance);

--- a/dubbo-registry/dubbo-registry-zookeeper/src/main/java/org/apache/dubbo/registry/zookeeper/util/CuratorFrameworkUtils.java
+++ b/dubbo-registry/dubbo-registry-zookeeper/src/main/java/org/apache/dubbo/registry/zookeeper/util/CuratorFrameworkUtils.java
@@ -107,7 +107,7 @@ public abstract class CuratorFrameworkUtils {
         int port = serviceInstance.getPort();
         Map<String, String> metadata = serviceInstance.getSortedMetadata();
         String id = generateId(host, port);
-        ZookeeperInstance zookeeperInstance = new ZookeeperInstance(null, serviceName, metadata);
+        ZookeeperInstance zookeeperInstance = new ZookeeperInstance(id, serviceName, metadata);
         try {
             builder = builder()
                 .id(id)


### PR DESCRIPTION
## What is the purpose of the change



## Brief changelog


## Verifying this change


<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [ ] GitHub Actions works fine on your own branch.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
