### PR TITLE
[3.0] dubbo-spring-boot-actuator compatible with Spring Boot Actuator 2.6.x

### DIFF
--- a/dubbo-spring-boot/dubbo-spring-boot-actuator/README.md
+++ b/dubbo-spring-boot/dubbo-spring-boot-actuator/README.md
@@ -150,7 +150,7 @@ Actuator endpoint `dubbo` supports Actuator Endpoints :
 | ------------------- | ----------- | ----------------------------------- | ------------------ | ------------------ | ------------------ |
 | `dubbo`    | `true`      | `/actuator/dubbo`            | `GET`       | Exposes Dubbo's meta data           | `application/json` |
 | `dubboproperties` | `true` | `/actuator/dubbo/properties` | `GET`       | Exposes all Dubbo's Properties      | `application/json` |
-| `dubboservices` | `false`     | `/dubbo/services`            | `GET`       | Exposes all Dubbo's `ServiceBean`   | `application/json` |
+| `dubboservices` | `false`     | `/actuator/dubbo/services`            | `GET`       | Exposes all Dubbo's `ServiceBean`   | `application/json` |
 | `dubboreferences` | `false` | `/actuator/dubbo/references` | `GET`       | Exposes all Dubbo's `ReferenceBean` | `application/json` |
 | `dubboconfigs` | `true` | `/actuator/dubbo/configs`    | `GET`       | Exposes all Dubbo's `*Config`       | `application/json` |
 | `dubboshutdown` | `false` | `/actuator/dubbo/shutdown`   | `POST`      | Shutdown Dubbo services             | `application/json` |

--- a/dubbo-spring-boot/dubbo-spring-boot-actuator/src/main/java/org/apache/dubbo/spring/boot/actuate/autoconfigure/DubboEndpointAnnotationAutoConfiguration.java
+++ b/dubbo-spring-boot/dubbo-spring-boot-actuator/src/main/java/org/apache/dubbo/spring/boot/actuate/autoconfigure/DubboEndpointAnnotationAutoConfiguration.java
@@ -24,6 +24,7 @@ import org.apache.dubbo.spring.boot.actuate.endpoint.DubboServicesMetadataEndpoi
 import org.apache.dubbo.spring.boot.actuate.endpoint.DubboShutdownEndpoint;
 import org.apache.dubbo.spring.boot.actuate.endpoint.condition.CompatibleConditionalOnEnabledEndpoint;
 
+import org.springframework.boot.actuate.autoconfigure.endpoint.condition.ConditionalOnAvailableEndpoint;
 import org.springframework.boot.actuate.endpoint.annotation.Endpoint;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
@@ -45,6 +46,7 @@ public class DubboEndpointAnnotationAutoConfiguration {
 
     @Bean
     @ConditionalOnMissingBean
+    @ConditionalOnAvailableEndpoint
     @CompatibleConditionalOnEnabledEndpoint
     public DubboMetadataEndpoint dubboEndpoint() {
         return new DubboMetadataEndpoint();
@@ -52,6 +54,7 @@ public class DubboEndpointAnnotationAutoConfiguration {
 
     @Bean
     @ConditionalOnMissingBean
+    @ConditionalOnAvailableEndpoint
     @CompatibleConditionalOnEnabledEndpoint
     public DubboConfigsMetadataEndpoint dubboConfigsMetadataEndpoint() {
         return new DubboConfigsMetadataEndpoint();
@@ -59,6 +62,7 @@ public class DubboEndpointAnnotationAutoConfiguration {
 
     @Bean
     @ConditionalOnMissingBean
+    @ConditionalOnAvailableEndpoint
     @CompatibleConditionalOnEnabledEndpoint
     public DubboPropertiesMetadataEndpoint dubboPropertiesEndpoint() {
         return new DubboPropertiesMetadataEndpoint();
@@ -66,6 +70,7 @@ public class DubboEndpointAnnotationAutoConfiguration {
 
     @Bean
     @ConditionalOnMissingBean
+    @ConditionalOnAvailableEndpoint
     @CompatibleConditionalOnEnabledEndpoint
     public DubboReferencesMetadataEndpoint dubboReferencesMetadataEndpoint() {
         return new DubboReferencesMetadataEndpoint();
@@ -73,6 +78,7 @@ public class DubboEndpointAnnotationAutoConfiguration {
 
     @Bean
     @ConditionalOnMissingBean
+    @ConditionalOnAvailableEndpoint
     @CompatibleConditionalOnEnabledEndpoint
     public DubboServicesMetadataEndpoint dubboServicesMetadataEndpoint() {
         return new DubboServicesMetadataEndpoint();
@@ -80,6 +86,7 @@ public class DubboEndpointAnnotationAutoConfiguration {
 
     @Bean
     @ConditionalOnMissingBean
+    @ConditionalOnAvailableEndpoint
     @CompatibleConditionalOnEnabledEndpoint
     public DubboShutdownEndpoint dubboShutdownEndpoint() {
         return new DubboShutdownEndpoint();


### PR DESCRIPTION
## What is the purpose of the change
fix #9394 


## Brief changelog
CompatibleOnEnabledEndpointCondition only handle `org.springframework.boot.actuate.autoconfigure.endpoint.condition.OnEnabledEndpointCondition` (Spring Boot 2.0.0 ~ 2.2.x)
Endpint beans add @ConditionalOnAvailableEndpoint derectly (Spring Boot 2.2x +)


## Verifying this change
you can verify by this case: https://github.com/gitchenjh/dubbo-test

<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [x] Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [ ] GitHub Actions works fine on your own branch.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
