### PR TITLE
fix: Download zookeeper archive binary in github workflow

### DIFF
--- a/.github/workflows/build-and-test-3.yml
+++ b/.github/workflows/build-and-test-3.yml
@@ -65,8 +65,57 @@ jobs:
           echo "::set-output name=version::$REVISION"
           echo "dubbo version: $REVISION"
 
+  unit-test-prepare:
+    name: " Preparation for Unit Test On ${{ matrix.os }} (JDK: ${{ matrix.jdk }})"
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ ubuntu-18.04, windows-2019 ]
+        jdk: [ 8, 11 ]
+    env:
+      DISABLE_FILE_SYSTEM_TEST: true
+    steps:
+      - name: "Set up msys2 if necessary"
+        if: ${{ startsWith( matrix.os, 'windows') }}
+        uses: msys2/setup-msys2@v2
+        with:
+          release: false  # support cache, see https://github.com/msys2/setup-msys2#context
+      - name: "Download zookeeper binary archive in Linux OS"
+        if: ${{ startsWith( matrix.os, 'ubuntu') }}
+        run: |
+          mkdir -p ${{ github.workspace }}/.tmp/zookeeper/
+          wget -c https://archive.apache.org/dist/zookeeper/zookeeper-3.6.3/apache-zookeeper-3.6.3-bin.tar.gz -O ${{ github.workspace }}/.tmp/zookeeper/apache-zookeeper-bin.tar.gz ||
+          wget -c https://apache.website-solution.net/zookeeper/zookeeper-3.6.3/apache-zookeeper-3.6.3-bin.tar.gz -O ${{ github.workspace }}/.tmp/zookeeper/apache-zookeeper-bin.tar.gz ||
+          wget -c http://apache.stu.edu.tw/zookeeper/zookeeper-3.6.3/apache-zookeeper-3.6.3-bin.tar.gz -O ${{ github.workspace }}/.tmp/zookeeper/apache-zookeeper-bin.tar.gz ||
+          wget -c http://ftp.jaist.ac.jp/pub/apache/zookeeper/zookeeper-3.6.3/apache-zookeeper-3.6.3-bin.tar.gz -O ${{ github.workspace }}/.tmp/zookeeper/apache-zookeeper-bin.tar.gz ||
+          wget -c http://apache.mirror.cdnetworks.com/zookeeper/zookeeper-3.6.3/apache-zookeeper-3.6.3-bin.tar.gz -O ${{ github.workspace }}/.tmp/zookeeper/apache-zookeeper-bin.tar.gz ||
+          wget -c http://mirror.apache-kr.org/apache/zookeeper/zookeeper-3.6.3/apache-zookeeper-3.6.3-bin.tar.gz -O ${{ github.workspace }}/.tmp/zookeeper/apache-zookeeper-bin.tar.gz
+          echo "list the downloaded zookeeper binary archive"
+          ls -al ${{ github.workspace }}/.tmp/zookeeper/apache-zookeeper-bin.tar.gz
+      - name: "Download zookeeper binary archive in Windows OS"
+        if: ${{ startsWith( matrix.os, 'windows') }}
+        shell: msys2 {0}
+        run: |
+          mkdir -p ${{ github.workspace }}/.tmp/zookeeper/
+          wget -c https://archive.apache.org/dist/zookeeper/zookeeper-3.6.3/apache-zookeeper-3.6.3-bin.tar.gz -O ${{ github.workspace }}/.tmp/zookeeper/apache-zookeeper-bin.tar.gz ||
+          wget -c https://apache.website-solution.net/zookeeper/zookeeper-3.6.3/apache-zookeeper-3.6.3-bin.tar.gz -O ${{ github.workspace }}/.tmp/zookeeper/apache-zookeeper-bin.tar.gz ||
+          wget -c http://apache.stu.edu.tw/zookeeper/zookeeper-3.6.3/apache-zookeeper-3.6.3-bin.tar.gz -O ${{ github.workspace }}/.tmp/zookeeper/apache-zookeeper-bin.tar.gz ||
+          wget -c http://ftp.jaist.ac.jp/pub/apache/zookeeper/zookeeper-3.6.3/apache-zookeeper-3.6.3-bin.tar.gz -O ${{ github.workspace }}/.tmp/zookeeper/apache-zookeeper-bin.tar.gz ||
+          wget -c http://apache.mirror.cdnetworks.com/zookeeper/zookeeper-3.6.3/apache-zookeeper-3.6.3-bin.tar.gz -O ${{ github.workspace }}/.tmp/zookeeper/apache-zookeeper-bin.tar.gz ||
+          wget -c http://mirror.apache-kr.org/apache/zookeeper/zookeeper-3.6.3/apache-zookeeper-3.6.3-bin.tar.gz -O ${{ github.workspace }}/.tmp/zookeeper/apache-zookeeper-bin.tar.gz
+          echo "list the downloaded zookeeper binary archive"
+          ls -al ${{ github.workspace }}/.tmp/zookeeper/apache-zookeeper-bin.tar.gz
+      - uses: actions/cache@v2
+        name: "Cache zookeeper binary archive"
+        with:
+          path: ${{ github.workspace }}/.tmp/zookeeper
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+
   unit-test:
-    needs: [build-source]
+    needs: [build-source, unit-test-prepare]
     name: "Unit Test On ${{ matrix.os }} (JDK: ${{ matrix.jdk }})"
     runs-on: ${{ matrix.os }}
     strategy:


### PR DESCRIPTION
## What is the purpose of the change

see: #9430

## Brief changelog

Try to download zookeeper archive binary from different repositories

## Verifying this change


<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [x] Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [x] GitHub Actions works fine on your own branch.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
