### PR TITLE
upgrade log4j2 to 2.16.0

### DIFF
--- a/compiler/pom.xml
+++ b/compiler/pom.xml
@@ -103,7 +103,7 @@
         <profile>
             <id>release</id>
             <properties>
-                <log4j2_version>2.11.1</log4j2_version>
+                <log4j2_version>2.16.0</log4j2_version>
             </properties>
             <build>
                 <plugins>

--- a/dubbo-dependencies-bom/pom.xml
+++ b/dubbo-dependencies-bom/pom.xml
@@ -139,7 +139,7 @@
         <log4j_version>1.2.16</log4j_version>
         <logback_version>1.2.2</logback_version>
         <!-- Fix the bug of log4j refer:https://github.com/apache/logging-log4j2/pull/608 -->
-        <log4j2_version>2.15.0</log4j2_version>
+        <log4j2_version>2.16.0</log4j2_version>
         <commons_io_version>2.7</commons_io_version>
 
         <embedded_redis_version>0.10.0</embedded_redis_version>

--- a/dubbo-spring-boot/pom.xml
+++ b/dubbo-spring-boot/pom.xml
@@ -42,7 +42,7 @@
         <spring-boot.version>2.3.1.RELEASE</spring-boot.version>
         <dubbo.version>${revision}</dubbo.version>
         <!-- Fix the bug of log4j refer:https://github.com/apache/logging-log4j2/pull/608 -->
-        <log4j2_version>2.15.0</log4j2_version>
+        <log4j2_version>2.16.0</log4j2_version>
     </properties>
 
     <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -323,7 +323,7 @@
         <profile>
             <id>release</id>
             <properties>
-                <log4j2_version>2.11.1</log4j2_version>
+                <log4j2_version>2.16.0</log4j2_version>
             </properties>
             <build>
                 <plugins>


### PR DESCRIPTION
## What is the purpose of the change
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-45046

> It was found that the fix to address CVE-2021-44228 in Apache Log4j 2.15.0 was incomplete in certain non-default configurations. This could allows attackers with control over Thread Context Map (MDC) input data when the logging configuration uses a non-default Pattern Layout with either a Context Lookup (for example, $${ctx:loginId}) or a Thread Context Map pattern (%X, %mdc, or %MDC) to craft malicious input data using a JNDI Lookup pattern resulting in a denial of service (DOS) attack. Log4j 2.15.0 makes a best-effort attempt to restrict JNDI LDAP lookups to localhost by default. Log4j 2.16.0 fixes this issue by removing support for message lookup patterns and disabling JNDI functionality by default.