### PR TITLE
Update log4j to 2.17 to address CVE-2021-45105.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -379,7 +379,7 @@
         <profile>
             <id>release</id>
             <properties>
-                <log4j2_version>2.11.1</log4j2_version>
+                <log4j2_version>2.17.0</log4j2_version>
                 <jacoco.skip>false</jacoco.skip>
             </properties>
             <build>


### PR DESCRIPTION
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-45105