### PR TITLE
fix async call issues, rpc context and response future callback race conditions

### DIFF
--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/filter/DefaultFilterChainBuilder.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/filter/DefaultFilterChainBuilder.java
@@ -71,7 +71,7 @@ public class DefaultFilterChainBuilder implements FilterChainBuilder {
             }
         }
 
-        return last;
+        return new CallbackRegistrationInvoker<>(last, filters);
     }
 
     /**
@@ -107,7 +107,7 @@ public class DefaultFilterChainBuilder implements FilterChainBuilder {
             }
         }
 
-        return last;
+        return new ClusterCallbackRegistrationInvoker<>(originalInvoker, last, filters);
     }
 
     private <T> List<T> sortingAndDeduplication(List<T> filters, List<ExtensionDirector> directors) {

--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/filter/DefaultFilterChainBuilder.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/filter/DefaultFilterChainBuilder.java
@@ -69,9 +69,10 @@ public class DefaultFilterChainBuilder implements FilterChainBuilder {
                 final Invoker<T> next = last;
                 last = new FilterChainNode<>(originalInvoker, next, filter);
             }
+            return new CallbackRegistrationInvoker<>(last, filters);
         }
 
-        return new CallbackRegistrationInvoker<>(last, filters);
+        return last;
     }
 
     /**
@@ -105,9 +106,10 @@ public class DefaultFilterChainBuilder implements FilterChainBuilder {
                 final Invoker<T> next = last;
                 last = new ClusterFilterChainNode<>(originalInvoker, next, filter);
             }
+            return new ClusterCallbackRegistrationInvoker<>(originalInvoker, last, filters);
         }
 
-        return new ClusterCallbackRegistrationInvoker<>(originalInvoker, last, filters);
+        return last;
     }
 
     private <T> List<T> sortingAndDeduplication(List<T> filters, List<ExtensionDirector> directors) {

--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/filter/DefaultFilterChainBuilder.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/filter/DefaultFilterChainBuilder.java
@@ -67,7 +67,7 @@ public class DefaultFilterChainBuilder implements FilterChainBuilder {
             for (int i = filters.size() - 1; i >= 0; i--) {
                 final Filter filter = filters.get(i);
                 final Invoker<T> next = last;
-                last = new FilterChainNode<>(originalInvoker, next, filter);
+                last = new CopyOfFilterChainNode<>(originalInvoker, next, filter);
             }
             return new CallbackRegistrationInvoker<>(last, filters);
         }
@@ -104,7 +104,7 @@ public class DefaultFilterChainBuilder implements FilterChainBuilder {
             for (int i = filters.size() - 1; i >= 0; i--) {
                 final ClusterFilter filter = filters.get(i);
                 final Invoker<T> next = last;
-                last = new ClusterFilterChainNode<>(originalInvoker, next, filter);
+                last = new CopyOfClusterFilterChainNode<>(originalInvoker, next, filter);
             }
             return new ClusterCallbackRegistrationInvoker<>(originalInvoker, last, filters);
         }

--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/filter/FilterChainBuilder.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/filter/FilterChainBuilder.java
@@ -150,8 +150,8 @@ public interface FilterChainBuilder {
 
     class CallbackRegistrationInvoker<T, FILTER extends BaseFilter> implements Invoker<T> {
         static final Logger LOGGER = LoggerFactory.getLogger(CallbackRegistrationInvoker.class);
-        private final Invoker<T> filterInvoker;
-        private final List<FILTER> filters;
+        final Invoker<T> filterInvoker;
+        final List<FILTER> filters;
 
         public CallbackRegistrationInvoker(Invoker<T> filterInvoker, List<FILTER> filters) {
             this.filterInvoker = filterInvoker;

--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/filter/FilterChainBuilder.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/filter/FilterChainBuilder.java
@@ -30,8 +30,8 @@ import org.apache.dubbo.rpc.RpcException;
 import org.apache.dubbo.rpc.cluster.ClusterInvoker;
 import org.apache.dubbo.rpc.cluster.Directory;
 
-import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static org.apache.dubbo.common.extension.ExtensionScope.APPLICATION;
 
@@ -188,11 +188,9 @@ public interface FilterChainBuilder {
                             }
                         }
                     } catch (Throwable filterThrowable) {
-                        List<String> filterNames = new ArrayList<>(filters.size());
-                        filters.forEach(tmpFilter -> filterNames.add(tmpFilter.getClass().getSimpleName()));
                         LOGGER.error(String.format("Exception occurred while executing the %s filter named %s.", i, filter.getClass().getSimpleName()));
                         if (LOGGER.isDebugEnabled()) {
-                            LOGGER.debug(String.format("Whole filter list is: %s", filterNames));
+                            LOGGER.debug(String.format("Whole filter list is: %s", filters.stream().map(tmpFilter -> tmpFilter.getClass().getSimpleName()).collect(Collectors.toList())));
                         }
                         throw filterThrowable;
                     }

--- a/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/filter/DefaultFilterChainBuilderTest.java
+++ b/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/filter/DefaultFilterChainBuilderTest.java
@@ -19,16 +19,17 @@ package org.apache.dubbo.rpc.cluster.filter;
 
 import org.apache.dubbo.common.URL;
 import org.apache.dubbo.rpc.Invocation;
-import org.apache.dubbo.rpc.Result;
 import org.apache.dubbo.rpc.Invoker;
+import org.apache.dubbo.rpc.Result;
 import org.apache.dubbo.rpc.model.ApplicationModel;
 import org.apache.dubbo.rpc.protocol.AbstractInvoker;
+
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import static org.apache.dubbo.common.constants.CommonConstants.CONSUMER;
 import static org.apache.dubbo.common.constants.CommonConstants.INTERFACE_KEY;
 import static org.apache.dubbo.common.constants.CommonConstants.REFERENCE_FILTER_KEY;
-import static org.apache.dubbo.common.constants.CommonConstants.CONSUMER;
 
 public class DefaultFilterChainBuilderTest {
 
@@ -62,8 +63,8 @@ public class DefaultFilterChainBuilderTest {
             }
         };
         invokerAfterBuild = defaultFilterChainBuilder.buildInvokerChain(invokerWithFilter, REFERENCE_FILTER_KEY, CONSUMER);
-        Assertions.assertTrue(invokerAfterBuild instanceof FilterChainBuilder.FilterChainNode);
-        Assertions.assertTrue(((FilterChainBuilder.FilterChainNode<?, ?, ?>) invokerAfterBuild).filter instanceof LogFilter);
+        Assertions.assertTrue(invokerAfterBuild instanceof FilterChainBuilder.CallbackRegistrationInvoker);
+        Assertions.assertEquals(1, ((FilterChainBuilder.CallbackRegistrationInvoker<?, ?>) invokerAfterBuild).filters.size());
 
     }
 
@@ -97,8 +98,7 @@ public class DefaultFilterChainBuilderTest {
             }
         };
         invokerAfterBuild = defaultFilterChainBuilder.buildInvokerChain(invokerWithFilter, REFERENCE_FILTER_KEY, CONSUMER);
-        Assertions.assertTrue(invokerAfterBuild instanceof FilterChainBuilder.FilterChainNode);
-        Assertions.assertTrue(((FilterChainBuilder.FilterChainNode<?, ?, ?>) invokerAfterBuild).filter instanceof LogFilter);
+        Assertions.assertTrue(invokerAfterBuild instanceof FilterChainBuilder.CallbackRegistrationInvoker);
 
     }
 }

--- a/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/support/FailoverClusterInvokerTest.java
+++ b/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/support/FailoverClusterInvokerTest.java
@@ -295,7 +295,7 @@ public class FailoverClusterInvokerTest {
             }
             invokers.clear();
             MockInvoker<Demo> invoker3 = new MockInvoker<>(Demo.class, url);
-            invoker3.setResult(AsyncRpcResult.newDefaultAsyncResult(null));
+            invoker3.setResult(AsyncRpcResult.newDefaultAsyncResult(mock(RpcInvocation.class)));
             invokers.add(invoker3);
             dic.notify(invokers);
             return null;

--- a/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/support/MergeableClusterInvokerTest.java
+++ b/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/support/MergeableClusterInvokerTest.java
@@ -23,6 +23,7 @@ import org.apache.dubbo.rpc.Invocation;
 import org.apache.dubbo.rpc.Invoker;
 import org.apache.dubbo.rpc.Result;
 import org.apache.dubbo.rpc.RpcException;
+import org.apache.dubbo.rpc.RpcInvocation;
 import org.apache.dubbo.rpc.cluster.Directory;
 import org.apache.dubbo.rpc.model.ApplicationModel;
 import org.apache.dubbo.rpc.model.ModuleModel;
@@ -41,8 +42,6 @@ import java.util.Map;
 
 import static org.apache.dubbo.common.constants.CommonConstants.GROUP_KEY;
 import static org.apache.dubbo.rpc.Constants.MERGER_KEY;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -55,7 +54,7 @@ public class MergeableClusterInvokerTest {
     private Directory directory = mock(Directory.class);
     private Invoker firstInvoker = mock(Invoker.class);
     private Invoker secondInvoker = mock(Invoker.class);
-    private Invocation invocation = mock(Invocation.class);
+    private Invocation invocation = mock(RpcInvocation.class);
     private ModuleModel moduleModel = mock(ModuleModel.class);
 
     private MergeableClusterInvoker<MenuService> mergeableClusterInvoker;
@@ -98,7 +97,7 @@ public class MergeableClusterInvokerTest {
         directory = mock(Directory.class);
         firstInvoker = mock(Invoker.class);
         secondInvoker = mock(Invoker.class);
-        invocation = mock(Invocation.class);
+        invocation = mock(RpcInvocation.class);
 
     }
 

--- a/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/support/wrapper/AbstractClusterTest.java
+++ b/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/support/wrapper/AbstractClusterTest.java
@@ -28,8 +28,8 @@ import org.apache.dubbo.rpc.cluster.LoadBalance;
 import org.apache.dubbo.rpc.cluster.filter.DemoService;
 import org.apache.dubbo.rpc.cluster.filter.FilterChainBuilder;
 import org.apache.dubbo.rpc.cluster.support.AbstractClusterInvoker;
-
 import org.apache.dubbo.rpc.model.ApplicationModel;
+
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -69,7 +69,7 @@ public class AbstractClusterTest {
         Invoker<?> invoker = demoCluster.join(directory, true);
         Assertions.assertTrue(invoker instanceof AbstractCluster.ClusterFilterInvoker);
         Assertions.assertTrue(((AbstractCluster.ClusterFilterInvoker<?>) invoker).getFilterInvoker()
-            instanceof FilterChainBuilder.ClusterFilterChainNode);
+            instanceof FilterChainBuilder.ClusterCallbackRegistrationInvoker);
 
 
     }

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/Experimental.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/Experimental.java
@@ -22,7 +22,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Indicating unstable API, may get removed or changed in the next release.
+ * Indicating unstable API, may get removed or changed in future releases.
  */
 @Retention(RetentionPolicy.CLASS)
 @Target({

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/constants/CommonConstants.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/constants/CommonConstants.java
@@ -503,4 +503,9 @@ public interface CommonConstants {
     String ENABLE_CONNECTIVITY_VALIDATION = "dubbo.connectivity.validation";
 
     String DUBBO_INTERNAL_APPLICATION = "DUBBO_INTERNAL_APPLICATION";
+
+    String WORKING_CLASSLOADER_KEY = "WORKING_CLASSLOADER";
+
+    String STAGED_CLASSLOADER_KEY = "STAGED_CLASSLOADER";
+
 }

--- a/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/integration/AbstractRegistryCenterExporterListener.java
+++ b/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/integration/AbstractRegistryCenterExporterListener.java
@@ -26,9 +26,9 @@ import org.apache.dubbo.rpc.listener.ListenerExporterWrapper;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.HashSet;
 
 /**
  * The abstraction of {@link ExporterListener} is to record exported exporters, which should be extended by different sub-classes.
@@ -56,12 +56,13 @@ public abstract class AbstractRegistryCenterExporterListener implements Exporter
     @Override
     public void exported(Exporter<?> exporter) throws RpcException {
         ListenerExporterWrapper listenerExporterWrapper = (ListenerExporterWrapper) exporter;
-        FilterChainBuilder.FilterChainNode filterChainNode = (FilterChainBuilder.FilterChainNode) listenerExporterWrapper.getInvoker();
-        if (filterChainNode == null ||
-            filterChainNode.getInterface() != getInterface()) {
+        FilterChainBuilder.CallbackRegistrationInvoker callbackRegistrationInvoker = (FilterChainBuilder.CallbackRegistrationInvoker) listenerExporterWrapper.getInvoker();
+        if (callbackRegistrationInvoker == null ||
+            callbackRegistrationInvoker.getInterface() != getInterface()) {
             return;
         }
         exportedExporters.add(exporter);
+        FilterChainBuilder.CopyOfFilterChainNode filterChainNode = getFilterChainNode(callbackRegistrationInvoker);
         do {
             Filter filter = this.getFilter(filterChainNode);
             if (filter != null) {
@@ -96,7 +97,24 @@ public abstract class AbstractRegistryCenterExporterListener implements Exporter
     /**
      * Use reflection to obtain {@link Filter}
      */
-    private Filter getFilter(FilterChainBuilder.FilterChainNode filterChainNode) {
+    private FilterChainBuilder.CopyOfFilterChainNode getFilterChainNode(FilterChainBuilder.CallbackRegistrationInvoker callbackRegistrationInvoker) {
+        if (callbackRegistrationInvoker != null) {
+            Field field = null;
+            try {
+                field = callbackRegistrationInvoker.getClass().getDeclaredField("filterInvoker");
+                field.setAccessible(true);
+                return (FilterChainBuilder.CopyOfFilterChainNode) field.get(callbackRegistrationInvoker);
+            } catch (NoSuchFieldException | IllegalAccessException e) {
+                // ignore
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Use reflection to obtain {@link Filter}
+     */
+    private Filter getFilter(FilterChainBuilder.CopyOfFilterChainNode filterChainNode) {
         if (filterChainNode != null) {
             Field field = null;
             try {
@@ -111,17 +129,17 @@ public abstract class AbstractRegistryCenterExporterListener implements Exporter
     }
 
     /**
-     * Use reflection to obtain {@link FilterChainBuilder.FilterChainNode}
+     * Use reflection to obtain {@link FilterChainBuilder.CopyOfFilterChainNode}
      */
-    private FilterChainBuilder.FilterChainNode getNextNode(FilterChainBuilder.FilterChainNode filterChainNode) {
+    private FilterChainBuilder.CopyOfFilterChainNode getNextNode(FilterChainBuilder.CopyOfFilterChainNode filterChainNode) {
         if (filterChainNode != null) {
             Field field = null;
             try {
                 field = filterChainNode.getClass().getDeclaredField("nextNode");
                 field.setAccessible(true);
                 Object object = field.get(filterChainNode);
-                if (object instanceof FilterChainBuilder.FilterChainNode) {
-                    return (FilterChainBuilder.FilterChainNode) object;
+                if (object instanceof FilterChainBuilder.CopyOfFilterChainNode) {
+                    return (FilterChainBuilder.CopyOfFilterChainNode) object;
                 }
             } catch (NoSuchFieldException | IllegalAccessException e) {
                 // ignore

--- a/dubbo-plugin/dubbo-auth/src/test/java/org/apache/dubbo/auth/filter/ProviderAuthFilterTest.java
+++ b/dubbo-plugin/dubbo-auth/src/test/java/org/apache/dubbo/auth/filter/ProviderAuthFilterTest.java
@@ -24,7 +24,9 @@ import org.apache.dubbo.common.constants.CommonConstants;
 import org.apache.dubbo.rpc.Invocation;
 import org.apache.dubbo.rpc.Invoker;
 import org.apache.dubbo.rpc.Result;
+import org.apache.dubbo.rpc.RpcInvocation;
 import org.apache.dubbo.rpc.model.ApplicationModel;
+
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -43,7 +45,7 @@ class ProviderAuthFilterTest {
     void testAuthDisabled() {
         URL url = mock(URL.class);
         Invoker invoker = mock(Invoker.class);
-        Invocation invocation = mock(Invocation.class);
+        Invocation invocation = mock(RpcInvocation.class);
         when(invoker.getUrl()).thenReturn(url);
         ProviderAuthFilter providerAuthFilter = new ProviderAuthFilter(ApplicationModel.defaultModel());
         providerAuthFilter.invoke(invoker, invocation);
@@ -58,7 +60,7 @@ class ProviderAuthFilterTest {
                 .addParameter(CommonConstants.APPLICATION_KEY, "test")
                 .addParameter(Constants.SERVICE_AUTH, true);
         Invoker invoker = mock(Invoker.class);
-        Invocation invocation = mock(Invocation.class);
+        Invocation invocation = mock(RpcInvocation.class);
         when(invoker.getUrl()).thenReturn(url);
         ProviderAuthFilter providerAuthFilter = new ProviderAuthFilter(ApplicationModel.defaultModel());
         providerAuthFilter.invoke(invoker, invocation);
@@ -74,7 +76,7 @@ class ProviderAuthFilterTest {
                 .addParameter(CommonConstants.APPLICATION_KEY, "test")
                 .addParameter(Constants.SERVICE_AUTH, true);
         Invoker invoker = mock(Invoker.class);
-        Invocation invocation = mock(Invocation.class);
+        Invocation invocation = mock(RpcInvocation.class);
         when(invocation.getAttachment(Constants.REQUEST_SIGNATURE_KEY)).thenReturn(null);
         when(invoker.getUrl()).thenReturn(url);
 
@@ -92,7 +94,7 @@ class ProviderAuthFilterTest {
                 .addParameter(CommonConstants.APPLICATION_KEY, "test")
                 .addParameter(Constants.SERVICE_AUTH, true);
         Invoker invoker = mock(Invoker.class);
-        Invocation invocation = mock(Invocation.class);
+        Invocation invocation = mock(RpcInvocation.class);
         when(invocation.getAttachment(Constants.REQUEST_SIGNATURE_KEY)).thenReturn(null);
         when(invoker.getUrl()).thenReturn(url);
 
@@ -107,7 +109,7 @@ class ProviderAuthFilterTest {
                 .addParameter(CommonConstants.APPLICATION_KEY, "test-provider")
                 .addParameter(Constants.SERVICE_AUTH, true);
         Invoker invoker = mock(Invoker.class);
-        Invocation invocation = mock(Invocation.class);
+        Invocation invocation = mock(RpcInvocation.class);
         when(invocation.getObjectAttachment(Constants.REQUEST_SIGNATURE_KEY)).thenReturn("dubbo");
         when(invocation.getObjectAttachment(Constants.AK_KEY)).thenReturn("ak");
         when(invocation.getObjectAttachment(CommonConstants.CONSUMER)).thenReturn("test-consumer");
@@ -135,7 +137,7 @@ class ProviderAuthFilterTest {
                 .addParameter(Constants.SERVICE_AUTH, true);
 
         Invoker invoker = mock(Invoker.class);
-        Invocation invocation = mock(Invocation.class);
+        Invocation invocation = mock(RpcInvocation.class);
         when(invocation.getObjectAttachment(Constants.AK_KEY)).thenReturn("ak");
         when(invocation.getObjectAttachment(CommonConstants.CONSUMER)).thenReturn("test-consumer");
         when(invocation.getObjectAttachment(Constants.REQUEST_TIMESTAMP_KEY)).thenReturn(currentTimeMillis);
@@ -168,7 +170,7 @@ class ProviderAuthFilterTest {
                 .addParameter(CommonConstants.APPLICATION_KEY, "test-provider")
                 .addParameter(Constants.SERVICE_AUTH, true);
         Invoker invoker = mock(Invoker.class);
-        Invocation invocation = mock(Invocation.class);
+        Invocation invocation = mock(RpcInvocation.class);
         when(invocation.getAttachment(Constants.AK_KEY)).thenReturn("ak");
         when(invocation.getAttachment(CommonConstants.CONSUMER)).thenReturn("test-consumer");
         when(invocation.getAttachment(Constants.REQUEST_TIMESTAMP_KEY)).thenReturn(String.valueOf(currentTimeMillis));

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/AsyncContext.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/AsyncContext.java
@@ -74,4 +74,50 @@ public interface AsyncContext {
      * </code>
      */
     void signalContextSwitch();
+
+    /**
+     * Reset Context is not necessary. Only reset context after result was write back if it is necessary.
+     *
+     * <code>
+     * public class AsyncServiceImpl implements AsyncService {
+     * public String sayHello(String name) {
+     * final AsyncContext asyncContext = RpcContext.startAsync();
+     * new Thread(() -> {
+     * <p>
+     * // the right place to use this method
+     * asyncContext.signalContextSwitch();
+     * <p>
+     * try {
+     * Thread.sleep(500);
+     * } catch (InterruptedException e) {
+     * e.printStackTrace();
+     * }
+     * asyncContext.write("Hello " + name + ", response from provider.");
+     * // only reset after asyncContext.write()
+     * asyncContext.resetContext();
+     * }).start();
+     * return null;
+     * }
+     * }
+     * </code>
+     *
+     * <code>
+     * public class AsyncServiceImpl implements AsyncService {
+     * public CompletableFuture sayHello(String name) {
+     * CompletableFuture future = new CompletableFuture();
+     * final AsyncContext asyncContext = RpcContext.startAsync();
+     * new Thread(() -> {
+     * // the right place to use this method
+     * asyncContext.signalContextSwitch();
+     * // some operations...
+     * future.complete();
+     * // only reset after future.complete()
+     * asyncContext.resetContext();
+     * }).start();
+     * return future;
+     * }
+     * }
+     * </code>
+     */
+    void resetContext();
 }

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/AsyncContextImpl.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/AsyncContextImpl.java
@@ -31,7 +31,7 @@ public class AsyncContextImpl implements AsyncContext {
     private ClassLoader stagedClassLoader;
 
     public AsyncContextImpl() {
-        restoreContext = RpcContext.storeContext();
+        restoreContext = RpcContext.storeContext(true);
         restoreClassLoader = Thread.currentThread().getContextClassLoader();
     }
 

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/AsyncContextImpl.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/AsyncContextImpl.java
@@ -26,12 +26,10 @@ public class AsyncContextImpl implements AsyncContext {
 
     private CompletableFuture<Object> future;
 
-    private RpcContextAttachment storedContext;
-    private RpcContextAttachment storedServerContext;
+    private final RpcContext.RestoreContext restoreContext;
 
     public AsyncContextImpl() {
-        this.storedContext = RpcContext.getClientAttachment();
-        this.storedServerContext = RpcContext.getServerContext();
+        restoreContext = RpcContext.storeContext();
     }
 
     @Override
@@ -67,9 +65,7 @@ public class AsyncContextImpl implements AsyncContext {
 
     @Override
     public void signalContextSwitch() {
-        RpcContext.restoreContext(storedContext);
-        RpcContext.restoreServerContext(storedServerContext);
-        // Restore any other contexts in here if necessary.
+        RpcContext.restoreContext(restoreContext);
     }
 
     public CompletableFuture<Object> getInternalFuture() {

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/AsyncContextImpl.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/AsyncContextImpl.java
@@ -31,7 +31,7 @@ public class AsyncContextImpl implements AsyncContext {
     private ClassLoader stagedClassLoader;
 
     public AsyncContextImpl() {
-        restoreContext = RpcContext.storeContext(true);
+        restoreContext = RpcContext.storeContext(false);
         restoreClassLoader = Thread.currentThread().getContextClassLoader();
     }
 

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/AsyncRpcResult.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/AsyncRpcResult.java
@@ -20,6 +20,7 @@ import org.apache.dubbo.common.logger.Logger;
 import org.apache.dubbo.common.logger.LoggerFactory;
 import org.apache.dubbo.common.threadpool.ThreadlessExecutor;
 import org.apache.dubbo.rpc.model.ConsumerMethodModel;
+import org.apache.dubbo.rpc.protocol.dubbo.FutureAdapter;
 
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -51,11 +52,12 @@ public class AsyncRpcResult implements Result {
 
     /**
      * RpcContext may already have been changed when callback happens, it happens when the same thread is used to execute another RPC call.
-     * So we should keep the reference of current RpcContext instance and restore it before callback being executed.
+     * So we should keep the copy of current RpcContext instance and restore it before callback being executed.
      */
-    private RpcContextAttachment storedContext;
-    private RpcContextAttachment storedServerContext;
+    private RpcContext.RestoreContext storedContext;
+
     private Executor executor;
+    private boolean async;
 
     private Invocation invocation;
 
@@ -64,8 +66,11 @@ public class AsyncRpcResult implements Result {
     public AsyncRpcResult(CompletableFuture<AppResponse> future, Invocation invocation) {
         this.responseFuture = future;
         this.invocation = invocation;
-        this.storedContext = RpcContext.getClientAttachment();
-        this.storedServerContext = RpcContext.getServerContext();
+        RpcInvocation rpcInvocation = (RpcInvocation) invocation;
+        if (InvokeMode.SYNC != rpcInvocation.getInvokeMode() && !future.isDone()) {
+            async = true;
+            this.storedContext = RpcContext.storeContext();
+        }
     }
 
     /**
@@ -193,10 +198,20 @@ public class AsyncRpcResult implements Result {
 
     public Result whenCompleteWithContext(BiConsumer<Result, Throwable> fn) {
         this.responseFuture = this.responseFuture.whenComplete((v, t) -> {
-            beforeContext.accept(v, t);
+            RpcContext.RestoreContext tmpContext = null;
+            if (async) {
+                tmpContext = RpcContext.storeContext();
+                RpcContext.restoreContext(storedContext);
+            }
             fn.accept(v, t);
-            afterContext.accept(v, t);
+            if (async) {
+                RpcContext.restoreContext(tmpContext);
+            }
         });
+
+        // Necessary! update future in context, see https://github.com/apache/dubbo/issues/9461
+        RpcContext.getServiceContext().setFuture(new FutureAdapter<>(this.responseFuture));
+
         return this;
     }
 
@@ -279,24 +294,6 @@ public class AsyncRpcResult implements Result {
     public void setExecutor(Executor executor) {
         this.executor = executor;
     }
-
-    /**
-     * tmp context to use when the thread switch to Dubbo thread.
-     */
-    private RpcContextAttachment tmpContext;
-
-    private RpcContextAttachment tmpServerContext;
-    private BiConsumer<Result, Throwable> beforeContext = (appResponse, t) -> {
-        tmpContext = RpcContext.getClientAttachment();
-        tmpServerContext = RpcContext.getServerContext();
-        RpcContext.restoreContext(storedContext);
-        RpcContext.restoreServerContext(storedServerContext);
-    };
-
-    private BiConsumer<Result, Throwable> afterContext = (appResponse, t) -> {
-        RpcContext.restoreContext(tmpContext);
-        RpcContext.restoreServerContext(tmpServerContext);
-    };
 
     /**
      * Some utility methods used to quickly generate default AsyncRpcResult instance.

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/BaseFilter.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/BaseFilter.java
@@ -22,10 +22,33 @@ public interface BaseFilter {
      */
     Result invoke(Invoker<?> invoker, Invocation invocation) throws RpcException;
 
+    /**
+     * This callback listener applies to both synchronous and asynchronous calls, please put logics that need to be executed
+     * on return of rpc result in onResponse or onError respectively based on it is normal return or exception return.
+     * <p>
+     * There's something that needs to pay attention on legacy synchronous style filer refactor, the thing is, try to move logics
+     * previously defined in the 'finally block' to both onResponse and onError.
+     */
     interface Listener {
 
+        /**
+         * This method will only be called on successful remote rpc execution, that means, the service in on remote received
+         * the request and the result (normal or exceptional) returned successfully.
+         *
+         * @param appResponse, the rpc call result, it can represent both normal result and exceptional result
+         * @param invoker,     context
+         * @param invocation,  context
+         */
         void onResponse(Result appResponse, Invoker<?> invoker, Invocation invocation);
 
+        /**
+         * This method will be called on detection of framework exceptions, for example, TimeoutException, NetworkException
+         * Exception raised in Filters, etc.
+         *
+         * @param t,          framework exception
+         * @param invoker,    context
+         * @param invocation, context
+         */
         void onError(Throwable t, Invoker<?> invoker, Invocation invocation);
     }
 }

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/ListenableFilter.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/ListenableFilter.java
@@ -23,9 +23,10 @@ import java.util.concurrent.ConcurrentMap;
  * It's recommended to implement Filter.Listener directly for callback registration, check the default implementation,
  * see {@link org.apache.dubbo.rpc.filter.ExceptionFilter}, for example.
  * <p>
- * If you do not want to share Listener instance between RPC calls. You can use ListenableFilter
+ * If you do not want to share Listener instance between RPC calls. ListenableFilter can be used
  * to keep a 'one Listener each RPC call' model.
  */
+@Deprecated
 public abstract class ListenableFilter implements Filter {
 
     protected Listener listener = null;

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/RpcContext.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/RpcContext.java
@@ -803,8 +803,8 @@ public class RpcContext {
         RpcServiceContext.setRpcContext(url);
     }
 
-    protected static RestoreContext storeContext() {
-        return new RestoreContext();
+    protected static RestoreContext storeContext(boolean needCopy) {
+        return new RestoreContext(needCopy);
     }
 
     protected static void restoreContext(RestoreContext restoreContext) {
@@ -838,11 +838,11 @@ public class RpcContext {
         private final RpcContextAttachment serverAttachment;
         private final RpcContextAttachment serverLocal;
 
-        public RestoreContext() {
-            serviceContext = getServiceContext().copyOf();
-            clientAttachment = getClientAttachment().copyOf();
-            serverAttachment = getServerAttachment().copyOf();
-            serverLocal = getServerContext().copyOf();
+        public RestoreContext(boolean needCopy) {
+            serviceContext = getServiceContext().copyOf(needCopy);
+            clientAttachment = getClientAttachment().copyOf(needCopy);
+            serverAttachment = getServerAttachment().copyOf(needCopy);
+            serverLocal = getServerContext().copyOf(needCopy);
         }
 
         public void restore() {

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/RpcContext.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/RpcContext.java
@@ -803,12 +803,14 @@ public class RpcContext {
         RpcServiceContext.setRpcContext(url);
     }
 
-    public static RestoreContext storeContext() {
+    protected static RestoreContext storeContext() {
         return new RestoreContext();
     }
 
-    public static void restoreContext(RestoreContext restoreContext) {
-        restoreContext.restore();
+    protected static void restoreContext(RestoreContext restoreContext) {
+        if (restoreContext != null) {
+            restoreContext.restore();
+        }
     }
 
     protected static void restoreClientAttachment(RpcContextAttachment oldContext) {
@@ -831,21 +833,21 @@ public class RpcContext {
      * Used to temporarily store and restore all kinds of contexts of current thread.
      */
     public static class RestoreContext {
-        private final RpcServiceContext clientServiceContext;
+        private final RpcServiceContext serviceContext;
         private final RpcContextAttachment clientAttachment;
         private final RpcContextAttachment serverAttachment;
         private final RpcContextAttachment serverLocal;
 
         public RestoreContext() {
-            clientServiceContext = getServiceContext().copyOf();
+            serviceContext = getServiceContext().copyOf();
             clientAttachment = getClientAttachment().copyOf();
             serverAttachment = getServerAttachment().copyOf();
             serverLocal = getServerContext().copyOf();
         }
 
         public void restore() {
-            if (clientServiceContext != null) {
-                restoreServiceContext(clientServiceContext);
+            if (serviceContext != null) {
+                restoreServiceContext(serviceContext);
             }
             if (clientAttachment != null) {
                 restoreClientAttachment(clientAttachment);

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/RpcContext.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/RpcContext.java
@@ -122,10 +122,6 @@ public class RpcContext {
         return SERVER_LOCAL.get();
     }
 
-    public static void restoreServerContext(RpcContextAttachment oldServerContext) {
-        SERVER_LOCAL.set(oldServerContext);
-    }
-
     /**
      * remove server side context.
      *
@@ -196,10 +192,6 @@ public class RpcContext {
 
     public void clearAfterEachInvoke(boolean remove) {
         this.remove = remove;
-    }
-
-    public static void restoreContext(RpcContextAttachment oldContext) {
-        CLIENT_ATTACHMENT.set(oldContext);
     }
 
     /**
@@ -809,5 +801,61 @@ public class RpcContext {
 
     public static void setRpcContext(URL url) {
         RpcServiceContext.setRpcContext(url);
+    }
+
+    public static RestoreContext storeContext() {
+        return new RestoreContext();
+    }
+
+    public static void restoreContext(RestoreContext restoreContext) {
+        restoreContext.restore();
+    }
+
+    protected static void restoreClientAttachment(RpcContextAttachment oldContext) {
+        CLIENT_ATTACHMENT.set(oldContext);
+    }
+
+    protected static void restoreServerContext(RpcContextAttachment oldServerContext) {
+        SERVER_LOCAL.set(oldServerContext);
+    }
+
+    protected static void restoreServerAttachment(RpcContextAttachment oldServerContext) {
+        SERVER_ATTACHMENT.set(oldServerContext);
+    }
+
+    protected static void restoreServiceContext(RpcServiceContext oldServiceContext) {
+        SERVICE_CONTEXT.set(oldServiceContext);
+    }
+
+    /**
+     * Used to temporarily store and restore all kinds of contexts of current thread.
+     */
+    public static class RestoreContext {
+        private final RpcServiceContext clientServiceContext;
+        private final RpcContextAttachment clientAttachment;
+        private final RpcContextAttachment serverAttachment;
+        private final RpcContextAttachment serverLocal;
+
+        public RestoreContext() {
+            clientServiceContext = getServiceContext().copyOf();
+            clientAttachment = getClientAttachment().copyOf();
+            serverAttachment = getServerAttachment().copyOf();
+            serverLocal = getServerContext().copyOf();
+        }
+
+        public void restore() {
+            if (clientServiceContext != null) {
+                restoreServiceContext(clientServiceContext);
+            }
+            if (clientAttachment != null) {
+                restoreClientAttachment(clientAttachment);
+            }
+            if (serverAttachment != null) {
+                restoreServerAttachment(serverAttachment);
+            }
+            if (serverLocal != null) {
+                restoreServerContext(serverLocal);
+            }
+        }
     }
 }

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/RpcContext.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/RpcContext.java
@@ -848,15 +848,23 @@ public class RpcContext {
         public void restore() {
             if (serviceContext != null) {
                 restoreServiceContext(serviceContext);
+            } else {
+                removeServiceContext();
             }
             if (clientAttachment != null) {
                 restoreClientAttachment(clientAttachment);
+            } else {
+                removeClientAttachment();
             }
             if (serverAttachment != null) {
                 restoreServerAttachment(serverAttachment);
+            } else {
+                removeServerAttachment();
             }
             if (serverLocal != null) {
                 restoreServerContext(serverLocal);
+            } else {
+                removeServerContext();
             }
         }
     }

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/RpcContextAttachment.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/RpcContextAttachment.java
@@ -202,20 +202,24 @@ public class RpcContextAttachment extends RpcContext{
     }
 
     /**
-     * Also see {@link RpcServiceContext#copyOf()}
+     * Also see {@link RpcServiceContext#copyOf(boolean)}
      *
      * @return a copy of RpcContextAttachment with deep copied attachments
      */
-    public RpcContextAttachment copyOf() {
+    public RpcContextAttachment copyOf(boolean needCopy) {
         if (!isValid()) {
             return null;
         }
 
-        RpcContextAttachment copy = new RpcContextAttachment();
-        if (CollectionUtils.isNotEmptyMap(attachments)) {
-            copy.attachments.putAll(this.attachments);
+        if (needCopy) {
+            RpcContextAttachment copy = new RpcContextAttachment();
+            if (CollectionUtils.isNotEmptyMap(attachments)) {
+                copy.attachments.putAll(this.attachments);
+            }
+            return copy;
+        } else {
+            return this;
         }
-        return copy;
     }
 
     private boolean isValid() {

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/RpcContextAttachment.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/RpcContextAttachment.java
@@ -201,4 +201,24 @@ public class RpcContextAttachment extends RpcContext{
         return getAttachment(key);
     }
 
+    /**
+     * Also see {@link RpcServiceContext#copyOf()}
+     *
+     * @return a copy of RpcContextAttachment with deep copied attachments
+     */
+    public RpcContextAttachment copyOf() {
+        if (!isValid()) {
+            return null;
+        }
+
+        RpcContextAttachment copy = new RpcContextAttachment();
+        if (CollectionUtils.isNotEmptyMap(attachments)) {
+            copy.attachments.putAll(this.attachments);
+        }
+        return copy;
+    }
+
+    private boolean isValid() {
+        return CollectionUtils.isNotEmptyMap(attachments);
+    }
 }

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/RpcServiceContext.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/RpcServiceContext.java
@@ -41,6 +41,9 @@ public class RpcServiceContext extends RpcContext {
     protected RpcServiceContext() {
     }
 
+    // RPC service context updated before each service call.
+    private URL consumerUrl;
+
     private List<URL> urls;
 
     private URL url;
@@ -584,9 +587,6 @@ public class RpcServiceContext extends RpcContext {
         return asyncContext;
     }
 
-    // RPC service context updated before each service call.
-    private URL consumerUrl;
-
     @Override
     public String getGroup() {
         if (consumerUrl == null) {
@@ -649,4 +649,34 @@ public class RpcServiceContext extends RpcContext {
         RpcServiceContext rpcContext = RpcContext.getServiceContext();
         rpcContext.setConsumerUrl(url);
     }
+
+    /**
+     * Only part of the properties are copied, the others are either not used currently or can be got from invocation.
+     * Also see {@link RpcContextAttachment#copyOf()}
+     *
+     * @return a shallow copy of RpcServiceContext
+     */
+    public RpcServiceContext copyOf() {
+        if (!isValid()) {
+            return this;
+        }
+
+        RpcServiceContext copy = new RpcServiceContext();
+        copy.consumerUrl = this.consumerUrl;
+        copy.localAddress = this.localAddress;
+        copy.remoteAddress = this.remoteAddress;
+        copy.invocation = this.invocation;
+        copy.asyncContext = this.asyncContext;
+        return copy;
+    }
+
+
+    private boolean isValid() {
+        return this.consumerUrl != null
+            || this.localAddress != null
+            || this.remoteAddress != null
+            || this.invocation != null
+            || this.asyncContext != null;
+    }
+
 }

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/RpcServiceContext.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/RpcServiceContext.java
@@ -652,22 +652,27 @@ public class RpcServiceContext extends RpcContext {
 
     /**
      * Only part of the properties are copied, the others are either not used currently or can be got from invocation.
-     * Also see {@link RpcContextAttachment#copyOf()}
+     * Also see {@link RpcContextAttachment#copyOf(boolean)}
      *
+     * @param needCopy
      * @return a shallow copy of RpcServiceContext
      */
-    public RpcServiceContext copyOf() {
+    public RpcServiceContext copyOf(boolean needCopy) {
         if (!isValid()) {
             return this;
         }
 
-        RpcServiceContext copy = new RpcServiceContext();
-        copy.consumerUrl = this.consumerUrl;
-        copy.localAddress = this.localAddress;
-        copy.remoteAddress = this.remoteAddress;
-        copy.invocation = this.invocation;
-        copy.asyncContext = this.asyncContext;
-        return copy;
+        if (needCopy) {
+            RpcServiceContext copy = new RpcServiceContext();
+            copy.consumerUrl = this.consumerUrl;
+            copy.localAddress = this.localAddress;
+            copy.remoteAddress = this.remoteAddress;
+            copy.invocation = this.invocation;
+            copy.asyncContext = this.asyncContext;
+            return copy;
+        } else {
+            return this;
+        }
     }
 
 

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/filter/ClassLoaderCallbackFilter.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/filter/ClassLoaderCallbackFilter.java
@@ -25,44 +25,33 @@ import org.apache.dubbo.rpc.Invoker;
 import org.apache.dubbo.rpc.Result;
 import org.apache.dubbo.rpc.RpcException;
 
-import static org.apache.dubbo.common.constants.CommonConstants.STAGED_CLASSLOADER_KEY;
 import static org.apache.dubbo.common.constants.CommonConstants.WORKING_CLASSLOADER_KEY;
 
 /**
- * Set the current execution thread class loader to service interface's class loader.
+ * Switch thread context class loader on filter callback.
  */
-@Activate(group = CommonConstants.PROVIDER, order = -30000)
-public class ClassLoaderFilter implements Filter, BaseFilter.Listener {
+@Activate(group = CommonConstants.PROVIDER, order = Integer.MAX_VALUE)
+public class ClassLoaderCallbackFilter implements Filter, BaseFilter.Listener {
 
     @Override
     public Result invoke(Invoker<?> invoker, Invocation invocation) throws RpcException {
-        ClassLoader stagedClassLoader = Thread.currentThread().getContextClassLoader();
-        ClassLoader effectiveClassLoader = invoker.getInterface().getClassLoader();
-        invocation.put(STAGED_CLASSLOADER_KEY, stagedClassLoader);
-        invocation.put(WORKING_CLASSLOADER_KEY, effectiveClassLoader);
-
-        Thread.currentThread().setContextClassLoader(effectiveClassLoader);
-        try {
-            return invoker.invoke(invocation);
-        } finally {
-            Thread.currentThread().setContextClassLoader(stagedClassLoader);
-        }
+        return invoker.invoke(invocation);
     }
 
     @Override
     public void onResponse(Result appResponse, Invoker<?> invoker, Invocation invocation) {
-        resetClassLoader(invoker, invocation);
+        setClassLoader(invoker, invocation);
     }
 
     @Override
     public void onError(Throwable t, Invoker<?> invoker, Invocation invocation) {
-        resetClassLoader(invoker, invocation);
+        setClassLoader(invoker, invocation);
     }
 
-    private void resetClassLoader(Invoker<?> invoker, Invocation invocation) {
-        ClassLoader stagedClassLoader = (ClassLoader) invocation.get(STAGED_CLASSLOADER_KEY);
-        if (stagedClassLoader != null) {
-            Thread.currentThread().setContextClassLoader(stagedClassLoader);
+    private void setClassLoader(Invoker<?> invoker, Invocation invocation) {
+        ClassLoader workingClassLoader = (ClassLoader) invocation.get(WORKING_CLASSLOADER_KEY);
+        if (workingClassLoader != null) {
+            Thread.currentThread().setContextClassLoader(workingClassLoader);
         }
     }
 }

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/filter/ContextFilter.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/filter/ContextFilter.java
@@ -133,7 +133,7 @@ public class ContextFilter implements Filter, Filter.Listener {
             context.clearAfterEachInvoke(true);
             RpcContext.removeServerAttachment();
             RpcContext.removeServiceContext();
-            // IMPORTANT! For async scenario, we must remove context from current thread, so we always create a new RpcContext for the next invoke for the same thread.
+            // IMPORTANT! For async scenario, context must be removed from current thread, so a new RpcContext is always created for the next invoke for the same thread.
             RpcContext.getClientAttachment().removeAttachment(TIME_COUNTDOWN_KEY);
             RpcContext.removeServerContext();
         }

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/proxy/AbstractProxyInvoker.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/proxy/AbstractProxyInvoker.java
@@ -108,10 +108,10 @@ public abstract class AbstractProxyInvoker<T> implements Invoker<T> {
     }
 
     private CompletableFuture<Object> wrapWithFuture(Object value) {
-        if (RpcContext.getServiceContext().isAsyncStarted()) {
-            return ((AsyncContextImpl)(RpcContext.getServiceContext().getAsyncContext())).getInternalFuture();
-        } else if (value instanceof CompletableFuture) {
+        if (value instanceof CompletableFuture) {
             return (CompletableFuture<Object>) value;
+        } else if (RpcContext.getServiceContext().isAsyncStarted()) {
+            return ((AsyncContextImpl) (RpcContext.getServiceContext().getAsyncContext())).getInternalFuture();
         }
         return CompletableFuture.completedFuture(value);
     }

--- a/dubbo-rpc/dubbo-rpc-api/src/main/resources/META-INF/dubbo/internal/org.apache.dubbo.rpc.Filter
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/resources/META-INF/dubbo/internal/org.apache.dubbo.rpc.Filter
@@ -4,6 +4,7 @@ genericimpl=org.apache.dubbo.rpc.filter.GenericImplFilter
 token=org.apache.dubbo.rpc.filter.TokenFilter
 accesslog=org.apache.dubbo.rpc.filter.AccessLogFilter
 classloader=org.apache.dubbo.rpc.filter.ClassLoaderFilter
+classloader-callback=org.apache.dubbo.rpc.filter.ClassLoaderCallbackFilter
 context=org.apache.dubbo.rpc.filter.ContextFilter
 exception=org.apache.dubbo.rpc.filter.ExceptionFilter
 executelimit=org.apache.dubbo.rpc.filter.ExecuteLimitFilter

--- a/dubbo-rpc/dubbo-rpc-api/src/test/java/org/apache/dubbo/rpc/RpcContextTest.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/test/java/org/apache/dubbo/rpc/RpcContextTest.java
@@ -202,4 +202,9 @@ public class RpcContextTest {
         rpcContext.setObjectAttachments(map);
         Assertions.assertEquals(map, rpcContext.getObjectAttachments());
     }
+
+    @Test
+    public void testRestore() {
+
+    }
 }

--- a/dubbo-rpc/dubbo-rpc-api/src/test/java/org/apache/dubbo/rpc/filter/CompatibleFilterFilterTest.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/test/java/org/apache/dubbo/rpc/filter/CompatibleFilterFilterTest.java
@@ -22,6 +22,7 @@ import org.apache.dubbo.rpc.AsyncRpcResult;
 import org.apache.dubbo.rpc.Invocation;
 import org.apache.dubbo.rpc.Invoker;
 import org.apache.dubbo.rpc.Result;
+import org.apache.dubbo.rpc.RpcInvocation;
 import org.apache.dubbo.rpc.support.DemoService;
 import org.apache.dubbo.rpc.support.Type;
 
@@ -49,7 +50,7 @@ public class CompatibleFilterFilterTest {
 
     @Test
     public void testInvokerGeneric() {
-        invocation = mock(Invocation.class);
+        invocation = mock(RpcInvocation.class);
         given(invocation.getMethodName()).willReturn("$enumlength");
         given(invocation.getParameterTypes()).willReturn(new Class<?>[]{Enum.class});
         given(invocation.getArguments()).willReturn(new Object[]{"hello"});
@@ -69,7 +70,7 @@ public class CompatibleFilterFilterTest {
 
     @Test
     public void testResultHasException() {
-        invocation = mock(Invocation.class);
+        invocation = mock(RpcInvocation.class);
         given(invocation.getMethodName()).willReturn("enumlength");
         given(invocation.getParameterTypes()).willReturn(new Class<?>[]{Enum.class});
         given(invocation.getArguments()).willReturn(new Object[]{"hello"});
@@ -90,7 +91,7 @@ public class CompatibleFilterFilterTest {
 
     @Test
     public void testInvokerJsonPojoSerialization() throws Exception {
-        invocation = mock(Invocation.class);
+        invocation = mock(RpcInvocation.class);
         given(invocation.getMethodName()).willReturn("enumlength");
         given(invocation.getParameterTypes()).willReturn(new Class<?>[]{Type[].class});
         given(invocation.getArguments()).willReturn(new Object[]{"hello"});
@@ -100,7 +101,8 @@ public class CompatibleFilterFilterTest {
         given(invoker.getInterface()).willReturn(DemoService.class);
         AppResponse result = new AppResponse();
         result.setValue("High");
-        given(invoker.invoke(invocation)).willReturn(AsyncRpcResult.newDefaultAsyncResult(result, invocation));
+        AsyncRpcResult defaultAsyncResult = AsyncRpcResult.newDefaultAsyncResult(result, invocation);
+        given(invoker.invoke(invocation)).willReturn(defaultAsyncResult);
         URL url = URL.valueOf("test://test:11/test?group=dubbo&version=1.1&serialization=json");
         given(invoker.getUrl()).willReturn(url);
 
@@ -112,7 +114,7 @@ public class CompatibleFilterFilterTest {
 
     @Test
     public void testInvokerNonJsonEnumSerialization() throws Exception {
-        invocation = mock(Invocation.class);
+        invocation = mock(RpcInvocation.class);
         given(invocation.getMethodName()).willReturn("enumlength");
         given(invocation.getParameterTypes()).willReturn(new Class<?>[]{Type[].class});
         given(invocation.getArguments()).willReturn(new Object[]{"hello"});
@@ -122,7 +124,8 @@ public class CompatibleFilterFilterTest {
         given(invoker.getInterface()).willReturn(DemoService.class);
         AppResponse result = new AppResponse();
         result.setValue("High");
-        given(invoker.invoke(invocation)).willReturn(AsyncRpcResult.newDefaultAsyncResult(result, invocation));
+        AsyncRpcResult defaultAsyncResult = AsyncRpcResult.newDefaultAsyncResult(result, invocation);
+        given(invoker.invoke(invocation)).willReturn(defaultAsyncResult);
         URL url = URL.valueOf("test://test:11/test?group=dubbo&version=1.1");
         given(invoker.getUrl()).willReturn(url);
 
@@ -134,7 +137,7 @@ public class CompatibleFilterFilterTest {
 
     @Test
     public void testInvokerNonJsonNonPojoSerialization() {
-        invocation = mock(Invocation.class);
+        invocation = mock(RpcInvocation.class);
         given(invocation.getMethodName()).willReturn("echo");
         given(invocation.getParameterTypes()).willReturn(new Class<?>[]{String.class});
         given(invocation.getArguments()).willReturn(new Object[]{"hello"});
@@ -154,7 +157,7 @@ public class CompatibleFilterFilterTest {
 
     @Test
     public void testInvokerNonJsonPojoSerialization() {
-        invocation = mock(Invocation.class);
+        invocation = mock(RpcInvocation.class);
         given(invocation.getMethodName()).willReturn("echo");
         given(invocation.getParameterTypes()).willReturn(new Class<?>[]{String.class});
         given(invocation.getArguments()).willReturn(new Object[]{"hello"});

--- a/dubbo-rpc/dubbo-rpc-api/src/test/java/org/apache/dubbo/rpc/filter/EchoFilterTest.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/test/java/org/apache/dubbo/rpc/filter/EchoFilterTest.java
@@ -22,6 +22,7 @@ import org.apache.dubbo.rpc.Filter;
 import org.apache.dubbo.rpc.Invocation;
 import org.apache.dubbo.rpc.Invoker;
 import org.apache.dubbo.rpc.Result;
+import org.apache.dubbo.rpc.RpcInvocation;
 import org.apache.dubbo.rpc.support.DemoService;
 
 import org.junit.jupiter.api.Test;
@@ -37,7 +38,7 @@ public class EchoFilterTest {
     @SuppressWarnings("unchecked")
     @Test
     public void testEcho() {
-        Invocation invocation = mock(Invocation.class);
+        Invocation invocation = mock(RpcInvocation.class);
         given(invocation.getMethodName()).willReturn("$echo");
         given(invocation.getParameterTypes()).willReturn(new Class<?>[]{Enum.class});
         given(invocation.getArguments()).willReturn(new Object[]{"hello"});

--- a/dubbo-rpc/dubbo-rpc-api/src/test/java/org/apache/dubbo/rpc/filter/TimeoutFilterTest.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/test/java/org/apache/dubbo/rpc/filter/TimeoutFilterTest.java
@@ -21,6 +21,7 @@ import org.apache.dubbo.rpc.AppResponse;
 import org.apache.dubbo.rpc.Invocation;
 import org.apache.dubbo.rpc.Invoker;
 import org.apache.dubbo.rpc.Result;
+import org.apache.dubbo.rpc.RpcInvocation;
 import org.apache.dubbo.rpc.support.BlockMyInvoker;
 
 import org.junit.jupiter.api.Assertions;
@@ -56,7 +57,7 @@ public class TimeoutFilterTest {
         URL url = URL.valueOf("test://test:11/test?accesslog=true&group=dubbo&version=1.1&timeout=" + timeout);
         Invoker invoker = new BlockMyInvoker(url, (timeout + 100));
 
-        Invocation invocation = Mockito.mock(Invocation.class);
+        Invocation invocation = Mockito.mock(RpcInvocation.class);
         when(invocation.getMethodName()).thenReturn("testInvokeWithTimeout");
 
         Result result = timeoutFilter.invoke(invoker, invocation);

--- a/dubbo-rpc/dubbo-rpc-api/src/test/java/org/apache/dubbo/rpc/support/MockInvocation.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/test/java/org/apache/dubbo/rpc/support/MockInvocation.java
@@ -17,8 +17,8 @@
 package org.apache.dubbo.rpc.support;
 
 import org.apache.dubbo.rpc.AttachmentsAdapter;
-import org.apache.dubbo.rpc.Invocation;
 import org.apache.dubbo.rpc.Invoker;
+import org.apache.dubbo.rpc.RpcInvocation;
 import org.apache.dubbo.rpc.model.ServiceModel;
 
 import java.util.HashMap;
@@ -34,7 +34,7 @@ import static org.apache.dubbo.rpc.Constants.TOKEN_KEY;
 /**
  * MockInvocation.java
  */
-public class MockInvocation implements Invocation {
+public class MockInvocation extends RpcInvocation {
 
     private Map<String, Object> attachments;
 


### PR DESCRIPTION
related issues https://github.com/apache/dubbo/issues/9461 https://github.com/apache/dubbo/issues/8602

* RpcContext deep/shallow copy before async context switch, see AsyncRpcResult constructor.
* Update Future instance in RpcContext to guarantee user registered callbacks will be triggered after framework filter callbacks. See AyncRpcResult.whenCompleteWithContext()
* Refactor recursive filter callback stack to flat iteration to reduce context switch, see FilterChainBuilder.java