### PR TITLE
fix: Obtain the downloaded zookeeper path when run unit test

### DIFF
--- a/.github/workflows/build-and-test-3.yml
+++ b/.github/workflows/build-and-test-3.yml
@@ -39,7 +39,7 @@ jobs:
       - name: "Build Dubbo with Maven"
         run: |
           cd ./dubbo
-          ./mvnw --batch-mode --no-snapshot-updates -e --no-transfer-progress --fail-fast clean source:jar install -Pjacoco,rat,checkstyle -Dmaven.wagon.httpconnectionManager.ttlSeconds=120 -Dmaven.wagon.http.retryHandler.count=5 -Dmaven.test.skip=true -Dmaven.test.skip.exec=true
+          ./mvnw --batch-mode --no-snapshot-updates -e --no-transfer-progress --fail-fast clean source:jar install -Pjacoco,rat,checkstyle -Dmaven.wagon.httpconnectionManager.ttlSeconds=120 -Dmaven.wagon.http.retryHandler.count=5 -Dmaven.test.skip=true -Dmaven.test.skip.exec=true -DembeddedZookeeperPath=${{ github.workspace }}/.tmp/zookeeper
       - name: "Pack rat file if failure"
         if: failure()
         run: 7z a ${{ github.workspace }}/rat.zip *rat.txt -r
@@ -143,11 +143,11 @@ jobs:
       - name: "Test with Maven with Integration Tests"
         timeout-minutes: 70
         if: ${{ startsWith( matrix.os, 'ubuntu') }}
-        run: ./mvnw --batch-mode --no-snapshot-updates -e --no-transfer-progress --fail-fast clean test verify -Pjacoco -Dmaven.wagon.httpconnectionManager.ttlSeconds=120 -Dmaven.wagon.http.retryHandler.count=5 -DskipTests=false -DskipIntegrationTests=false -Dcheckstyle.skip=false -Dcheckstyle_unix.skip=false -Drat.skip=false -Dmaven.javadoc.skip=true
+        run: ./mvnw --batch-mode --no-snapshot-updates -e --no-transfer-progress --fail-fast clean test verify -Pjacoco -Dmaven.wagon.httpconnectionManager.ttlSeconds=120 -Dmaven.wagon.http.retryHandler.count=5 -DskipTests=false -DskipIntegrationTests=false -Dcheckstyle.skip=false -Dcheckstyle_unix.skip=false -Drat.skip=false -Dmaven.javadoc.skip=true -DembeddedZookeeperPath=${{ github.workspace }}/.tmp/zookeeper
       - name: "Test with Maven without Integration Tests"
         timeout-minutes: 90
         if: ${{ startsWith( matrix.os, 'windows') }}
-        run: ./mvnw --batch-mode --no-snapshot-updates -e --no-transfer-progress --fail-fast clean test verify -Pjacoco -D"http.keepAlive=false" -D"maven.wagon.http.pool=false" -D"maven.wagon.httpconnectionManager.ttlSeconds=120" -D"maven.wagon.http.retryHandler.count=5" -DskipTests=false -DskipIntegrationTests=true -D"checkstyle.skip=false" -D"checkstyle_unix.skip=true" -D"rat.skip=false" -D"maven.javadoc.skip=true"
+        run: ./mvnw --batch-mode --no-snapshot-updates -e --no-transfer-progress --fail-fast clean test verify -Pjacoco -D"http.keepAlive=false" -D"maven.wagon.http.pool=false" -D"maven.wagon.httpconnectionManager.ttlSeconds=120" -D"maven.wagon.http.retryHandler.count=5" -DskipTests=false -DskipIntegrationTests=true -D"checkstyle.skip=false" -D"checkstyle_unix.skip=true" -D"rat.skip=false" -D"maven.javadoc.skip=true" -D"embeddedZookeeperPath=${{ github.workspace }}/.tmp/zookeeper"
       - name: "Upload coverage to Codecov"
         uses: codecov/codecov-action@v1
 

--- a/dubbo-test/dubbo-test-check/src/main/java/org/apache/dubbo/test/check/registrycenter/ZookeeperRegistryCenter.java
+++ b/dubbo-test/dubbo-test-check/src/main/java/org/apache/dubbo/test/check/registrycenter/ZookeeperRegistryCenter.java
@@ -116,13 +116,6 @@ class ZookeeperRegistryCenter implements RegistryCenter {
     private static final String TARGET_ZOOKEEPER_FILE_NAME = UNPACKED_DIRECTORY + ".tar.gz";
 
     /**
-     * The target directory.
-     * The zookeeper binary file named {@link #TARGET_ZOOKEEPER_FILE_NAME} will be saved in
-     * {@link #TARGET_DIRECTORY} if it downloaded successfully.
-     */
-    private static final String TARGET_DIRECTORY = ".tmp" + File.separator + "zookeeper";
-
-    /**
      * The path of target zookeeper binary file.
      */
     private static final Path TARGET_FILE_PATH = getTargetFilePath();

--- a/dubbo-test/dubbo-test-check/src/main/java/org/apache/dubbo/test/check/registrycenter/ZookeeperRegistryCenter.java
+++ b/dubbo-test/dubbo-test-check/src/main/java/org/apache/dubbo/test/check/registrycenter/ZookeeperRegistryCenter.java
@@ -136,17 +136,21 @@ class ZookeeperRegistryCenter implements RegistryCenter {
         String directory;
         // Use System.getProperty({@link #CONFIG_EMBEDDED_ZOOKEEPER_DIRECTORY})
         directory = System.getProperty(CONFIG_EMBEDDED_ZOOKEEPER_DIRECTORY);
+        logger.info(String.format("The customized directory is %s to store zookeeper binary archive.",directory));
         if (StringUtils.isNotEmpty(directory)) {
             return directory;
         }
         // Use System.getProperty(user.home)
+        logger.info(String.format("The user home is %s to store zookeeper binary archive.",directory));
         directory = System.getProperty("user.home");
+        logger.info(String.format("user.home is %s",directory));
         if (StringUtils.isEmpty(directory)) {
             // Use default temporary directory
             directory = System.getProperty("java.io.tmpdir");
+            logger.info(String.format("The temporary directory is %s to store zookeeper binary archive.",directory));
         }
         Assert.notEmptyString(directory, "The directory to store zookeeper binary archive cannot be null or empty.");
-        return directory + File.separator + ".tmp";
+        return directory + File.separator + ".tmp" + File.separator + "zookeeper";
 
     }
 
@@ -155,7 +159,7 @@ class ZookeeperRegistryCenter implements RegistryCenter {
      */
     private static Path getTargetFilePath() {
         String zookeeperDirectory = getEmbeddedZookeeperDirectory();
-        Path targetFilePath = Paths.get(zookeeperDirectory, "zookeeper", TARGET_ZOOKEEPER_FILE_NAME);
+        Path targetFilePath = Paths.get(zookeeperDirectory, TARGET_ZOOKEEPER_FILE_NAME);
         logger.info("Target file's absolute directory: " + targetFilePath);
         return targetFilePath;
     }

--- a/dubbo-test/dubbo-test-check/src/main/java/org/apache/dubbo/test/check/registrycenter/ZookeeperRegistryCenter.java
+++ b/dubbo-test/dubbo-test-check/src/main/java/org/apache/dubbo/test/check/registrycenter/ZookeeperRegistryCenter.java
@@ -18,6 +18,8 @@ package org.apache.dubbo.test.check.registrycenter;
 
 import org.apache.dubbo.common.logger.Logger;
 import org.apache.dubbo.common.logger.LoggerFactory;
+import org.apache.dubbo.common.utils.Assert;
+import org.apache.dubbo.common.utils.StringUtils;
 import org.apache.dubbo.test.check.exception.DubboTestException;
 import org.apache.dubbo.test.check.registrycenter.context.ZookeeperContext;
 import org.apache.dubbo.test.check.registrycenter.context.ZookeeperWindowsContext;
@@ -34,11 +36,11 @@ import org.apache.dubbo.test.check.registrycenter.processor.StopZookeeperWindows
 import java.io.File;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.List;
 import java.util.ArrayList;
-import java.util.Objects;
+import java.util.List;
 import java.util.Map;
 import java.util.HashMap;
+import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
@@ -77,6 +79,11 @@ class ZookeeperRegistryCenter implements RegistryCenter {
     }
 
     private static final Logger logger = LoggerFactory.getLogger(ZookeeperRegistryCenter.class);
+
+    /**
+     * The JVM arguments to set the embedded zookeeper directory.
+     */
+    private static final String CONFIG_EMBEDDED_ZOOKEEPER_DIRECTORY = "embeddedZookeeperPath";
 
     /**
      * The OS type.
@@ -126,17 +133,37 @@ class ZookeeperRegistryCenter implements RegistryCenter {
     private static final AtomicBoolean INITIALIZED = new AtomicBoolean(false);
 
     /**
+     * Returns the directory to store zookeeper binary archive.
+     * <p>The priorities to obtain the directory are as follows:</p>
+     * <p>1. Use System.getProperty({@link #CONFIG_EMBEDDED_ZOOKEEPER_DIRECTORY}) if not null or empty</p>
+     * <p>2. Use System.getProperty(user.home) if not null or empty</p>
+     * <p>3. Use System.getProperty(java.io.tmpdir)</p>
+     */
+    private static String getEmbeddedZookeeperDirectory() {
+        String directory;
+        // Use System.getProperty({@link #CONFIG_EMBEDDED_ZOOKEEPER_DIRECTORY})
+        directory = System.getProperty(CONFIG_EMBEDDED_ZOOKEEPER_DIRECTORY);
+        if (StringUtils.isNotEmpty(directory)) {
+            return directory;
+        }
+        // Use System.getProperty(user.home)
+        directory = System.getProperty("user.home");
+        if (StringUtils.isEmpty(directory)) {
+            // Use default temporary directory
+            directory = System.getProperty("java.io.tmpdir");
+        }
+        Assert.notEmptyString(directory, "The directory to store zookeeper binary archive cannot be null or empty.");
+        return directory + File.separator + ".tmp";
+
+    }
+
+    /**
      * Returns the target file path.
      */
     private static Path getTargetFilePath() {
-        String currentWorkDirectory = System.getProperty("user.dir");
-        logger.info("Current work directory: " + currentWorkDirectory);
-        int index = currentWorkDirectory.lastIndexOf(File.separator + "dubbo" + File.separator);
-        Path targetFilePath = Paths.get(currentWorkDirectory.substring(0, index),
-            "dubbo",
-            TARGET_DIRECTORY,
-            TARGET_ZOOKEEPER_FILE_NAME);
-        logger.info("Target file's absolute directory: " + targetFilePath.toString());
+        String zookeeperDirectory = getEmbeddedZookeeperDirectory();
+        Path targetFilePath = Paths.get(zookeeperDirectory, "zookeeper", TARGET_ZOOKEEPER_FILE_NAME);
+        logger.info("Target file's absolute directory: " + targetFilePath);
         return targetFilePath;
     }
 


### PR DESCRIPTION
## What is the purpose of the change

see #9478 

## Brief changelog

1. Set priorities for the downloaed zookeeper path
2. Support environment variables

## Verifying this change


<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [x] Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [x] GitHub Actions works fine on your own branch.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
