### PR TITLE
[dubbo-8601] Support Dynamic Token And add BroadCastTest

### DIFF
--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/support/BroadcastCluster.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/support/BroadcastCluster.java
@@ -26,6 +26,8 @@ import org.apache.dubbo.rpc.cluster.support.wrapper.AbstractCluster;
  */
 public class BroadcastCluster extends AbstractCluster {
 
+
+
     @Override
     public <T> AbstractClusterInvoker<T> doJoin(Directory<T> directory) throws RpcException {
         return new BroadcastClusterInvoker<>(directory);

--- a/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/support/BroadCastClusterInvokerTest.java
+++ b/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/support/BroadCastClusterInvokerTest.java
@@ -144,7 +144,7 @@ public class BroadCastClusterInvokerTest {
     @Test
     public void testFailoverInvokerSelect(){
         given(dic.list(invocation)).willReturn(Arrays.asList(invoker1, invoker2, invoker3, invoker4));
-        //取得当前调用链的所有invoker，逐个判断调用是否成功
+        //Get all invokers of the current call chain, and judge whether the call is successful one by one
 
         invokers =  dicIncludeInvokers.getAllInvokers();
 
@@ -176,7 +176,7 @@ class MockLoadBalance implements LoadBalance {
 }
 
 
-//设置一个注册中心地址，便于consumer本地进行远程调用测试
+//Set a registry address to facilitate the consumer to perform remote call testing locally
 class MockRegistryInvoker implements Invoker<DemoService> {
     private static int count = 0;
     private URL url = URL.valueOf("registry://localhost:9090/org.apache.dubbo.rpc.cluster.filter.DemoService?refer=" + URL.encode("application=BroadcastClusterInvokerTest"));

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/filter/TokenFilter.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/filter/TokenFilter.java
@@ -47,10 +47,14 @@ public class TokenFilter implements Filter {
             Class<?> serviceType = invoker.getInterface();
             Map<String, Object> attachments = inv.getObjectAttachments();
             String remoteToken = (attachments == null ? null : (String) attachments.get(TOKEN_KEY));
-            if (!token.equals(remoteToken)) {
-                throw new RpcException("Invalid token! Forbid invoke remote service " + serviceType + " method " + inv.getMethodName() +
-                        "() from consumer " + RpcContext.getServiceContext().getRemoteHost() + " to provider " +
-                        RpcContext.getServiceContext().getLocalHost()+ ", consumer incorrect token is " + remoteToken);
+            if (ConfigUtils.isDefault(token)){
+                inv.setAttachment(TOKEN_KEY,token);
+            }
+            if (!token.equals(remoteToken) && !ConfigUtils.isDefault(token)) {
+
+                throw new RpcException("Invalid token! Forbid invoke remote service " + serviceType + " method " + inv.getMethodName()
+                    + "() from consumer " + RpcContext.getContext().getRemoteHost() + " to provider " + RpcContext.getContext().getLocalHost()
+                    + ", consumer incorrect token is " + remoteToken);
             }
         }
         return invoker.invoke(inv);

--- a/dubbo-rpc/dubbo-rpc-api/src/test/java/org/apache/dubbo/rpc/filter/TokenFilterTest.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/test/java/org/apache/dubbo/rpc/filter/TokenFilterTest.java
@@ -90,5 +90,21 @@ public class TokenFilterTest {
             tokenFilter.invoke(invoker, invocation);
         });
     }
+
+    @Test
+    public void testInvokeWithoutDynamicToken() throws Exception {
+        Assertions.assertDoesNotThrow( () -> {
+            String token = "default";
+
+            Invoker invoker = Mockito.mock(Invoker.class);
+            URL url = URL.valueOf("test://test:11/test?accesslog=true&group=dubbo&version=1.1&token=" + token);
+            when(invoker.getUrl()).thenReturn(url);
+            when(invoker.invoke(any(Invocation.class))).thenReturn(new AppResponse("result"));
+
+            Invocation invocation = Mockito.mock(Invocation.class);
+
+            tokenFilter.invoke(invoker, invocation);
+        });
+    }
 }
 


### PR DESCRIPTION
## What is the purpose of the change

When the user uses the broadcast address, an exception is thrown after the dynamic token is updated. And add related unit tests

Related to [dubbo-8601](https://github.com/apache/dubbo/issues/8601)


## Brief changelog


## Verifying this change

BroacastCluster2Test
TokenFilterTest#testInvokeWithoutDynamicToken

<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [ ] GitHub Actions works fine on your own branch.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
