### PR TITLE
fix: Fix the problem of wrong number of retries in failback mode

### DIFF
--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/support/FailbackClusterInvoker.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/support/FailbackClusterInvoker.java
@@ -52,6 +52,9 @@ public class FailbackClusterInvoker<T> extends AbstractClusterInvoker<T> {
 
     private static final long RETRY_FAILED_PERIOD = 5;
 
+    /**
+     * Number of retries obtained from the configuration, don't contain the first invoke.
+     */
     private final int retries;
 
     private final int failbackTasks;
@@ -62,7 +65,7 @@ public class FailbackClusterInvoker<T> extends AbstractClusterInvoker<T> {
         super(directory);
 
         int retriesConfig = getUrl().getParameter(RETRIES_KEY, DEFAULT_FAILBACK_TIMES);
-        if (retriesConfig <= 0) {
+        if (retriesConfig < 0) {
             retriesConfig = DEFAULT_FAILBACK_TIMES;
         }
         int failbackTasksConfig = getUrl().getParameter(FAIL_BACK_TASKS_KEY, DEFAULT_FAILBACK_TASKS);
@@ -124,10 +127,18 @@ public class FailbackClusterInvoker<T> extends AbstractClusterInvoker<T> {
         private final Invocation invocation;
         private final LoadBalance loadbalance;
         private final List<Invoker<T>> invokers;
-        private final int retries;
         private final long tick;
         private Invoker<T> lastInvoker;
-        private int retryTimes = 0;
+
+        /**
+         * Number of retries obtained from the configuration, don't contain the first invoke.
+         */
+        private final int retries;
+
+        /**
+         * Number of retried.
+         */
+        private int retriedTimes = 0;
 
         RetryTimerTask(LoadBalance loadbalance, Invocation invocation, List<Invoker<T>> invokers, Invoker<T> lastInvoker, int retries, long tick) {
             this.loadbalance = loadbalance;
@@ -141,12 +152,14 @@ public class FailbackClusterInvoker<T> extends AbstractClusterInvoker<T> {
         @Override
         public void run(Timeout timeout) {
             try {
+                logger.info("Attempt to retry to invoke method " + invocation.getMethodName() +
+                        ". The total will retry " + retries + " times, the current is the " + retriedTimes + " retry");
                 Invoker<T> retryInvoker = select(loadbalance, invocation, invokers, Collections.singletonList(lastInvoker));
                 lastInvoker = retryInvoker;
                 retryInvoker.invoke(invocation);
             } catch (Throwable e) {
                 logger.error("Failed retry to invoke method " + invocation.getMethodName() + ", waiting again.", e);
-                if ((++retryTimes) >= retries) {
+                if ((++retriedTimes) >= retries) {
                     logger.error("Failed retry times exceed threshold (" + retries + "), We have to abandon, invocation->" + invocation);
                 } else {
                     rePut(timeout);

--- a/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/support/FailbackClusterInvokerTest.java
+++ b/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/support/FailbackClusterInvokerTest.java
@@ -18,6 +18,7 @@
 package org.apache.dubbo.rpc.cluster.support;
 
 import org.apache.dubbo.common.URL;
+import org.apache.dubbo.common.constants.CommonConstants;
 import org.apache.dubbo.common.utils.DubboAppender;
 import org.apache.dubbo.common.utils.LogUtil;
 import org.apache.dubbo.rpc.AppResponse;
@@ -37,11 +38,13 @@ import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 
+import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
+import static org.apache.dubbo.common.constants.CommonConstants.RETRIES_KEY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
@@ -173,5 +176,98 @@ public class FailbackClusterInvokerTest {
         Assertions.assertEquals(2, LogUtil.findMessage(Level.ERROR, "Failed retry times exceed threshold"), "must have two error message ");
         Assertions.assertEquals(1, LogUtil.findMessage(Level.ERROR, "Failback background works error"), "must have one error message ");
         // it can be invoke successfully
+    }
+
+
+    private long getRetryFailedPeriod() throws NoSuchFieldException, IllegalAccessException {
+        Field retryFailedPeriod = FailbackClusterInvoker.class.getDeclaredField("RETRY_FAILED_PERIOD");
+        retryFailedPeriod.setAccessible(true);
+        return retryFailedPeriod.getLong(FailbackClusterInvoker.class);
+    }
+
+    @Test
+    @Order(5)
+    public void testInvokeRetryTimesWithZeroValue() throws InterruptedException, NoSuchFieldException,
+            IllegalAccessException {
+        int retries = 0;
+        resetInvokerToException();
+        given(dic.getConsumerUrl()).willReturn(url.addParameter(RETRIES_KEY, retries));
+
+        FailbackClusterInvoker<FailbackClusterInvokerTest> invoker = new FailbackClusterInvoker<>(dic);
+        LogUtil.start();
+        DubboAppender.clear();
+
+        invocation.setMethodName("testInvokeRetryTimesWithZeroValue");
+        invoker.invoke(invocation);
+
+        CountDownLatch countDown = new CountDownLatch(1);
+        countDown.await(getRetryFailedPeriod() * (retries + 1), TimeUnit.SECONDS);
+        LogUtil.stop();
+        Assertions.assertEquals(0, LogUtil.findMessage(Level.INFO, "Attempt to retry to invoke method " +
+                "testInvokeRetryTimesWithZeroValue"), "No retry messages allowed");
+    }
+
+    @Test
+    @Order(6)
+    public void testInvokeRetryTimesWithTwoValue() throws InterruptedException, NoSuchFieldException,
+            IllegalAccessException {
+        int retries = 2;
+        resetInvokerToException();
+        given(dic.getConsumerUrl()).willReturn(url.addParameter(RETRIES_KEY, retries));
+
+        FailbackClusterInvoker<FailbackClusterInvokerTest> invoker = new FailbackClusterInvoker<>(dic);
+        LogUtil.start();
+        DubboAppender.clear();
+
+        invocation.setMethodName("testInvokeRetryTimesWithTwoValue");
+        invoker.invoke(invocation);
+
+        CountDownLatch countDown = new CountDownLatch(1);
+        countDown.await(getRetryFailedPeriod() * (retries + 1), TimeUnit.SECONDS);
+        LogUtil.stop();
+        Assertions.assertEquals(2, LogUtil.findMessage(Level.INFO, "Attempt to retry to invoke method " +
+                "testInvokeRetryTimesWithTwoValue"), "Must have two error message ");
+    }
+
+    @Test
+    @Order(7)
+    public void testInvokeRetryTimesWithDefaultValue() throws InterruptedException, NoSuchFieldException,
+            IllegalAccessException {
+        resetInvokerToException();
+        given(dic.getConsumerUrl()).willReturn(URL.valueOf("test://test:11/test"));
+
+        FailbackClusterInvoker<FailbackClusterInvokerTest> invoker = new FailbackClusterInvoker<>(dic);
+        LogUtil.start();
+        DubboAppender.clear();
+
+        invocation.setMethodName("testInvokeRetryTimesWithDefaultValue");
+        invoker.invoke(invocation);
+
+        CountDownLatch countDown = new CountDownLatch(1);
+        countDown.await(getRetryFailedPeriod() * (CommonConstants.DEFAULT_FAILBACK_TIMES + 1), TimeUnit.SECONDS);
+        LogUtil.stop();
+        Assertions.assertEquals(3, LogUtil.findMessage(Level.INFO, "Attempt to retry to invoke method " +
+                "testInvokeRetryTimesWithDefaultValue"), "Must have three error message ");
+    }
+
+    @Test
+    @Order(8)
+    public void testInvokeRetryTimesWithIllegalValue() throws InterruptedException, NoSuchFieldException,
+            IllegalAccessException {
+        resetInvokerToException();
+        given(dic.getConsumerUrl()).willReturn(url.addParameter(RETRIES_KEY, -100));
+
+        FailbackClusterInvoker<FailbackClusterInvokerTest> invoker = new FailbackClusterInvoker<>(dic);
+        LogUtil.start();
+        DubboAppender.clear();
+
+        invocation.setMethodName("testInvokeRetryTimesWithIllegalValue");
+        invoker.invoke(invocation);
+
+        CountDownLatch countDown = new CountDownLatch(1);
+        countDown.await(getRetryFailedPeriod() * (CommonConstants.DEFAULT_FAILBACK_TIMES + 1), TimeUnit.SECONDS);
+        LogUtil.stop();
+        Assertions.assertEquals(3, LogUtil.findMessage(Level.INFO, "Attempt to retry to invoke method " +
+                "testInvokeRetryTimesWithIllegalValue"), "Must have three error message ");
     }
 }


### PR DESCRIPTION
## What is the purpose of the change
Fix the problem of wrong number of retries in failback mode. When the retries value is zero, the logic in failback mode resets it to the default value of 3, making it impossible to turn off the retry mechanism.

## Brief changelog
**before**
```java
if (retriesConfig <= 0) {
    retriesConfig = DEFAULT_FAILBACK_TIMES;
}
```
**after**
```java
if (retriesConfig < 0) {
    retriesConfig = DEFAULT_FAILBACK_TIMES;
}
```

**1. Reset retriesConfig to its default value only when it is zero.**
**2. Add some retry logs.**


## Verifying this change
Some test units.


<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [x] Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [x] GitHub Actions works fine on your own branch.
- [x] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
