### PR TITLE
fix: Fix the problem of wrong number of retries in failback mode

### DIFF
--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/support/FailbackClusterInvoker.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/support/FailbackClusterInvoker.java
@@ -134,7 +134,6 @@ public class FailbackClusterInvoker<T> extends AbstractClusterInvoker<T> {
         private final List<Invoker<T>> invokers;
         private final long tick;
         private Invoker<T> lastInvoker;
-        private int retryTimes = 0;
         private URL consumerUrl;
 
         /**

--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/support/FailbackClusterInvoker.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/support/FailbackClusterInvoker.java
@@ -54,6 +54,9 @@ public class FailbackClusterInvoker<T> extends AbstractClusterInvoker<T> {
 
     private static final long RETRY_FAILED_PERIOD = 5;
 
+    /**
+     * Number of retries obtained from the configuration, don't contain the first invoke.
+     */
     private final int retries;
 
     private final int failbackTasks;
@@ -64,7 +67,7 @@ public class FailbackClusterInvoker<T> extends AbstractClusterInvoker<T> {
         super(directory);
 
         int retriesConfig = getUrl().getParameter(RETRIES_KEY, DEFAULT_FAILBACK_TIMES);
-        if (retriesConfig <= 0) {
+        if (retriesConfig < 0) {
             retriesConfig = DEFAULT_FAILBACK_TIMES;
         }
         int failbackTasksConfig = getUrl().getParameter(FAIL_BACK_TASKS_KEY, DEFAULT_FAILBACK_TASKS);
@@ -129,11 +132,20 @@ public class FailbackClusterInvoker<T> extends AbstractClusterInvoker<T> {
         private final Invocation invocation;
         private final LoadBalance loadbalance;
         private final List<Invoker<T>> invokers;
-        private final int retries;
         private final long tick;
         private Invoker<T> lastInvoker;
         private int retryTimes = 0;
         private URL consumerUrl;
+
+        /**
+         * Number of retries obtained from the configuration, don't contain the first invoke.
+         */
+        private final int retries;
+
+        /**
+         * Number of retried.
+         */
+        private int retriedTimes = 0;
 
         RetryTimerTask(LoadBalance loadbalance, Invocation invocation, List<Invoker<T>> invokers, Invoker<T> lastInvoker,
                        int retries, long tick, URL consumerUrl) {
@@ -149,12 +161,14 @@ public class FailbackClusterInvoker<T> extends AbstractClusterInvoker<T> {
         @Override
         public void run(Timeout timeout) {
             try {
+                logger.info("Attempt to retry to invoke method " + invocation.getMethodName() +
+                        ". The total will retry " + retries + " times, the current is the " + retriedTimes + " retry");
                 Invoker<T> retryInvoker = select(loadbalance, invocation, invokers, Collections.singletonList(lastInvoker));
                 lastInvoker = retryInvoker;
                 invokeWithContextAsync(retryInvoker, invocation, consumerUrl);
             } catch (Throwable e) {
                 logger.error("Failed retry to invoke method " + invocation.getMethodName() + ", waiting again.", e);
-                if ((++retryTimes) >= retries) {
+                if ((++retriedTimes) >= retries) {
                     logger.error("Failed retry times exceed threshold (" + retries + "), We have to abandon, invocation->" + invocation);
                 } else {
                     rePut(timeout);


### PR DESCRIPTION
## What is the purpose of the change
Fix the problem of wrong number of retries in failback mode. When the retries value is zero, the logic in failback mode resets it to the default value of 3, making it impossible to turn off the retry mechanism.

## Brief changelog
**before**
```java
if (retriesConfig <= 0) {
    retriesConfig = DEFAULT_FAILBACK_TIMES;
}
```
**after**
```java
if (retriesConfig < 0) {
    retriesConfig = DEFAULT_FAILBACK_TIMES;
}
```

**1. Reset retriesConfig to its default value only when it is zero.**
**2. Add some retry logs.**


## Verifying this change
Some test units.


<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [x] Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [x] GitHub Actions works fine on your own branch.
- [x] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
