### PR TITLE
fix #9546 default load policy can not correctly obtain the weights of registries

### DIFF
--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/loadbalance/AbstractLoadBalance.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/loadbalance/AbstractLoadBalance.java
@@ -26,7 +26,6 @@ import org.apache.dubbo.rpc.cluster.support.migration.MigrationClusterInvoker;
 import java.util.List;
 
 import static org.apache.dubbo.common.constants.CommonConstants.TIMESTAMP_KEY;
-import static org.apache.dubbo.common.constants.RegistryConstants.REGISTRY_KEY;
 import static org.apache.dubbo.common.constants.RegistryConstants.REGISTRY_SERVICE_REFERENCE_PATH;
 import static org.apache.dubbo.rpc.cluster.Constants.DEFAULT_WARMUP;
 import static org.apache.dubbo.rpc.cluster.Constants.DEFAULT_WEIGHT;
@@ -77,7 +76,7 @@ public abstract class AbstractLoadBalance implements LoadBalance {
         int weight;
         URL url;
         if (invoker instanceof MigrationClusterInvoker) {
-            url = ((MigrationClusterInvoker)invoker).getRegistryUrl();
+            url = ((MigrationClusterInvoker) invoker).getRegistryUrl();
         } else {
             url = invoker.getUrl();
         }

--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/loadbalance/AbstractLoadBalance.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/loadbalance/AbstractLoadBalance.java
@@ -21,6 +21,7 @@ import org.apache.dubbo.common.utils.CollectionUtils;
 import org.apache.dubbo.rpc.Invocation;
 import org.apache.dubbo.rpc.Invoker;
 import org.apache.dubbo.rpc.cluster.LoadBalance;
+import org.apache.dubbo.rpc.cluster.support.migration.MigrationClusterInvoker;
 
 import java.util.List;
 
@@ -74,10 +75,15 @@ public abstract class AbstractLoadBalance implements LoadBalance {
      */
     int getWeight(Invoker<?> invoker, Invocation invocation) {
         int weight;
-        URL url = invoker.getUrl();
+        URL url;
+        if (invoker instanceof MigrationClusterInvoker) {
+            url = ((MigrationClusterInvoker)invoker).getRegistryUrl();
+        } else {
+            url = invoker.getUrl();
+        }
         // Multiple registry scenario, load balance among multiple registries.
         if (REGISTRY_SERVICE_REFERENCE_PATH.equals(url.getServiceInterface())) {
-            weight = url.getParameter(REGISTRY_KEY + "." + WEIGHT_KEY, DEFAULT_WEIGHT);
+            weight = url.getParameter(WEIGHT_KEY, DEFAULT_WEIGHT);
         } else {
             weight = url.getMethodParameter(invocation.getMethodName(), WEIGHT_KEY, DEFAULT_WEIGHT);
             if (weight > 0) {

--- a/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/loadbalance/AbstractLoadBalanceTest.java
+++ b/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/loadbalance/AbstractLoadBalanceTest.java
@@ -21,6 +21,7 @@ import org.apache.dubbo.rpc.Invocation;
 import org.apache.dubbo.rpc.Invoker;
 import org.apache.dubbo.rpc.RpcInvocation;
 
+import org.apache.dubbo.rpc.cluster.support.migration.MigrationClusterInvoker;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -78,5 +79,18 @@ public class AbstractLoadBalanceTest {
 
         Assertions.assertEquals(100, balance.getWeight(invoker1, invocation));
         Assertions.assertEquals(20, balance.getWeight(invoker2, invocation));
+    }
+
+    @Test
+    public void testGetMultiRegistryWeight() {
+        RpcInvocation invocation = new RpcInvocation();
+        invocation.setMethodName("say");
+
+        MigrationClusterInvoker invoker = mock(MigrationClusterInvoker.class, Mockito.withSettings().stubOnly());
+        URL url = new URL("", "", 0, "org.apache.dubbo.registry.RegistryService", new HashMap<>());
+        url = url.addParameter(WEIGHT_KEY, 20);
+        given(invoker.getRegistryUrl()).willReturn(url);
+
+        Assertions.assertEquals(20, balance.getWeight(invoker, invocation));
     }
 }

--- a/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/loadbalance/AbstractLoadBalanceTest.java
+++ b/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/loadbalance/AbstractLoadBalanceTest.java
@@ -73,7 +73,7 @@ public class AbstractLoadBalanceTest {
 
         Invoker invoker2 = mock(Invoker.class, Mockito.withSettings().stubOnly());
         URL url2 = new URL("", "", 0, "org.apache.dubbo.registry.RegistryService", new HashMap<>());
-        url2 = url2.addParameter(REGISTRY_KEY + "." + WEIGHT_KEY, 20);
+        url2 = url2.addParameter(WEIGHT_KEY, 20);
         given(invoker2.getUrl()).willReturn(url2);
 
         Assertions.assertEquals(100, balance.getWeight(invoker1, invocation));


### PR DESCRIPTION
## What is the purpose of the change

fix #9546  default load policy can not correctly obtain the weights of registries

## Brief changelog
dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/loadbalance/AbstractLoadBalance.java
dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/loadbalance/AbstractLoadBalanceTest.java

## Verifying this change


<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [x ] Each commit in the pull request should have a meaningful subject line and body.
- [x ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x ] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [x ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [ ] GitHub Actions works fine on your own branch.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
