### PR TITLE
[3.0] Support Optional Clear Future

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/constants/CommonConstants.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/constants/CommonConstants.java
@@ -524,4 +524,7 @@ public interface CommonConstants {
 
     String INJVM_IGNORE_SAME_MODULE_KEY = "injvm.ignore.same-module";
 
+    String SET_FUTURE_IN_SYNC_MODE = "future.sync.set";
+
+    String CLEAR_FUTURE_AFTER_GET = "future.clear.once";
 }

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/AsyncRpcResult.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/AsyncRpcResult.java
@@ -16,6 +16,7 @@
  */
 package org.apache.dubbo.rpc;
 
+import org.apache.dubbo.common.constants.CommonConstants;
 import org.apache.dubbo.common.logger.Logger;
 import org.apache.dubbo.common.logger.LoggerFactory;
 import org.apache.dubbo.common.threadpool.ThreadlessExecutor;
@@ -63,6 +64,11 @@ public class AsyncRpcResult implements Result {
     private final boolean async;
 
     private CompletableFuture<AppResponse> responseFuture;
+
+    /**
+     * Whether set future to Thread Local when invocation mode is sync
+     */
+    private static final boolean setFutureWhenSync = Boolean.parseBoolean(System.getProperty(CommonConstants.SET_FUTURE_IN_SYNC_MODE, "true"));
 
     public AsyncRpcResult(CompletableFuture<AppResponse> future, Invocation invocation) {
         this.responseFuture = future;
@@ -207,8 +213,10 @@ public class AsyncRpcResult implements Result {
             fn.accept(v, t);
         });
 
-        // Necessary! update future in context, see https://github.com/apache/dubbo/issues/9461
-        RpcContext.getServiceContext().setFuture(new FutureAdapter<>(this.responseFuture));
+        if (setFutureWhenSync || ((RpcInvocation) invocation).getInvokeMode() != InvokeMode.SYNC) {
+            // Necessary! update future in context, see https://github.com/apache/dubbo/issues/9461
+            RpcContext.getServiceContext().setFuture(new FutureAdapter<>(this.responseFuture));
+        }
 
         return this;
     }

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/FutureContext.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/FutureContext.java
@@ -16,6 +16,7 @@
  */
 package org.apache.dubbo.rpc;
 
+import org.apache.dubbo.common.constants.CommonConstants;
 import org.apache.dubbo.common.threadlocal.InternalThreadLocal;
 import org.apache.dubbo.rpc.protocol.dubbo.FutureAdapter;
 
@@ -45,6 +46,11 @@ public class FutureContext {
     private CompletableFuture<?> compatibleFuture;
 
     /**
+     * Whether clear future once get
+     */
+    private final static boolean clearFutureAfterGet = Boolean.parseBoolean(System.getProperty(CommonConstants.CLEAR_FUTURE_AFTER_GET, "false"));
+
+    /**
      * get future.
      *
      * @param <T>
@@ -52,7 +58,13 @@ public class FutureContext {
      */
     @SuppressWarnings("unchecked")
     public <T> CompletableFuture<T> getCompletableFuture() {
-        return (CompletableFuture<T>) future;
+        try {
+            return (CompletableFuture<T>) future;
+        } finally {
+            if (clearFutureAfterGet) {
+                this.future = null;
+            }
+        }
     }
 
     /**
@@ -67,7 +79,13 @@ public class FutureContext {
     @Deprecated
     @SuppressWarnings("unchecked")
     public <T> CompletableFuture<T> getCompatibleCompletableFuture() {
-        return (CompletableFuture<T>) compatibleFuture;
+        try {
+            return (CompletableFuture<T>) compatibleFuture;
+        } finally {
+            if (clearFutureAfterGet) {
+                this.compatibleFuture = null;
+            }
+        }
     }
 
     /**

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/protocol/AbstractInvoker.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/protocol/AbstractInvoker.java
@@ -19,6 +19,7 @@ package org.apache.dubbo.rpc.protocol;
 import org.apache.dubbo.common.Node;
 import org.apache.dubbo.common.URL;
 import org.apache.dubbo.common.Version;
+import org.apache.dubbo.common.constants.CommonConstants;
 import org.apache.dubbo.common.logger.Logger;
 import org.apache.dubbo.common.logger.LoggerFactory;
 import org.apache.dubbo.common.threadpool.ThreadlessExecutor;
@@ -84,6 +85,11 @@ public abstract class AbstractInvoker<T> implements Invoker<T> {
      * {@link Node} destroy
      */
     private boolean destroyed = false;
+
+    /**
+     * Whether set future to Thread Local when invocation mode is sync
+     */
+    private static final boolean setFutureWhenSync = Boolean.parseBoolean(System.getProperty(CommonConstants.SET_FUTURE_IN_SYNC_MODE, "true"));
 
     // -- Constructor
 
@@ -235,8 +241,10 @@ public abstract class AbstractInvoker<T> implements Invoker<T> {
             asyncResult = AsyncRpcResult.newDefaultAsyncResult(null, e, invocation);
         }
 
-        // set server context
-        RpcContext.getServiceContext().setFuture(new FutureAdapter<>(asyncResult.getResponseFuture()));
+        if (setFutureWhenSync || invocation.getInvokeMode() != InvokeMode.SYNC) {
+            // set server context
+            RpcContext.getServiceContext().setFuture(new FutureAdapter<>(asyncResult.getResponseFuture()));
+        }
 
         return asyncResult;
     }


### PR DESCRIPTION
## What is the purpose of the change

- Add `future.sync.set` property to indicate whether set future when sync invoke
- Add `future.clear.once` property to indicate whether clear future once get


## Brief changelog


## Verifying this change


<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [ ] GitHub Actions works fine on your own branch.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
