### PR TITLE
[master] set parameter weight if needed, keep RegistryConfig same with 3.0

### DIFF
--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/loadbalance/AbstractLoadBalance.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/loadbalance/AbstractLoadBalance.java
@@ -25,8 +25,6 @@ import org.apache.dubbo.rpc.cluster.LoadBalance;
 import java.util.List;
 
 import static org.apache.dubbo.common.constants.CommonConstants.TIMESTAMP_KEY;
-import static org.apache.dubbo.common.constants.RegistryConstants.REGISTRY_KEY;
-import static org.apache.dubbo.common.constants.RegistryConstants.REGISTRY_SERVICE_REFERENCE_PATH;
 import static org.apache.dubbo.rpc.cluster.Constants.DEFAULT_WARMUP;
 import static org.apache.dubbo.rpc.cluster.Constants.DEFAULT_WEIGHT;
 import static org.apache.dubbo.rpc.cluster.Constants.WARMUP_KEY;
@@ -75,22 +73,17 @@ public abstract class AbstractLoadBalance implements LoadBalance {
     int getWeight(Invoker<?> invoker, Invocation invocation) {
         int weight;
         URL url = invoker.getUrl();
-        // Multiple registry scenario, load balance among multiple registries.
-        if (REGISTRY_SERVICE_REFERENCE_PATH.equals(url.getServiceInterface())) {
-            weight = url.getParameter(REGISTRY_KEY + "." + WEIGHT_KEY, DEFAULT_WEIGHT);
-        } else {
-            weight = url.getMethodParameter(invocation.getMethodName(), WEIGHT_KEY, DEFAULT_WEIGHT);
-            if (weight > 0) {
-                long timestamp = invoker.getUrl().getParameter(TIMESTAMP_KEY, 0L);
-                if (timestamp > 0L) {
-                    long uptime = System.currentTimeMillis() - timestamp;
-                    if (uptime < 0) {
-                        return 1;
-                    }
-                    int warmup = invoker.getUrl().getParameter(WARMUP_KEY, DEFAULT_WARMUP);
-                    if (uptime > 0 && uptime < warmup) {
-                        weight = calculateWarmupWeight((int)uptime, warmup, weight);
-                    }
+        weight = url.getMethodParameter(invocation.getMethodName(), WEIGHT_KEY, DEFAULT_WEIGHT);
+        if (weight > 0) {
+            long timestamp = invoker.getUrl().getParameter(TIMESTAMP_KEY, 0L);
+            if (timestamp > 0L) {
+                long uptime = System.currentTimeMillis() - timestamp;
+                if (uptime < 0) {
+                    return 1;
+                }
+                int warmup = invoker.getUrl().getParameter(WARMUP_KEY, DEFAULT_WARMUP);
+                if (uptime > 0 && uptime < warmup) {
+                    weight = calculateWarmupWeight((int) uptime, warmup, weight);
                 }
             }
         }

--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/support/registry/ZoneAwareClusterInvoker.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/support/registry/ZoneAwareClusterInvoker.java
@@ -39,11 +39,11 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static org.apache.dubbo.common.constants.CommonConstants.PREFERRED_KEY;
 import static org.apache.dubbo.common.constants.RegistryConstants.LOADBALANCE_AMONG_REGISTRIES;
 import static org.apache.dubbo.common.constants.RegistryConstants.REGISTRY_ZONE;
 import static org.apache.dubbo.common.constants.RegistryConstants.REGISTRY_ZONE_FORCE;
 import static org.apache.dubbo.common.constants.RegistryConstants.ZONE_KEY;
-import static org.apache.dubbo.config.RegistryConfig.PREFER_REGISTRY_KEY;
 
 /**
  * When there're more than one registry for subscription.
@@ -71,7 +71,7 @@ public class ZoneAwareClusterInvoker<T> extends AbstractClusterInvoker<T> {
         for (Invoker<T> invoker : invokers) {
             ClusterInvoker<T> clusterInvoker = (ClusterInvoker<T>) invoker;
             if (clusterInvoker.isAvailable() && clusterInvoker.getRegistryUrl()
-                    .getParameter(PREFER_REGISTRY_KEY, false)) {
+                    .getParameter(PREFERRED_KEY, false)) {
                 return clusterInvoker.invoke(invocation);
             }
         }

--- a/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/loadbalance/AbstractLoadBalanceTest.java
+++ b/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/loadbalance/AbstractLoadBalanceTest.java
@@ -68,15 +68,15 @@ public class AbstractLoadBalanceTest {
 
         Invoker invoker1 = mock(Invoker.class, Mockito.withSettings().stubOnly());
         URL url1 = new URL("", "", 0, "DemoService", new HashMap<>());
-        url1 = url1.addParameter(REGISTRY_KEY + "." + WEIGHT_KEY, 10);
+        url1 = url1.addParameter(WEIGHT_KEY, 10);
         given(invoker1.getUrl()).willReturn(url1);
 
         Invoker invoker2 = mock(Invoker.class, Mockito.withSettings().stubOnly());
         URL url2 = new URL("", "", 0, "org.apache.dubbo.registry.RegistryService", new HashMap<>());
-        url2 = url2.addParameter(REGISTRY_KEY + "." + WEIGHT_KEY, 20);
+        url2 = url2.addParameter(WEIGHT_KEY, 20);
         given(invoker2.getUrl()).willReturn(url2);
 
-        Assertions.assertEquals(100, balance.getWeight(invoker1, invocation));
+        Assertions.assertEquals(10, balance.getWeight(invoker1, invocation));
         Assertions.assertEquals(20, balance.getWeight(invoker2, invocation));
     }
 }

--- a/dubbo-common/src/main/java/org/apache/dubbo/config/RegistryConfig.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/config/RegistryConfig.java
@@ -25,8 +25,6 @@ import java.util.Map;
 
 import static org.apache.dubbo.common.constants.CommonConstants.EXTRA_KEYS_KEY;
 import static org.apache.dubbo.common.constants.CommonConstants.SHUTDOWN_WAIT_KEY;
-import static org.apache.dubbo.common.constants.CommonConstants.PREFERRED_KEY;
-import static org.apache.dubbo.common.constants.RegistryConstants.REGISTRY_KEY;
 import static org.apache.dubbo.common.constants.RemotingConstants.BACKUP_KEY;
 import static org.apache.dubbo.common.utils.PojoUtils.updatePropertyIfAbsent;
 import static org.apache.dubbo.config.Constants.REGISTRIES_PREFIX;

--- a/dubbo-common/src/main/java/org/apache/dubbo/config/RegistryConfig.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/config/RegistryConfig.java
@@ -39,7 +39,6 @@ import static org.apache.dubbo.config.Constants.REGISTRIES_PREFIX;
 public class RegistryConfig extends AbstractConfig {
 
     public static final String NO_AVAILABLE = "N/A";
-    public static final String PREFER_REGISTRY_KEY = REGISTRY_KEY + "." + PREFERRED_KEY;
     private static final long serialVersionUID = 5508512956753757169L;
 
     /**
@@ -484,7 +483,6 @@ public class RegistryConfig extends AbstractConfig {
         this.accepts = accepts;
     }
 
-    @Parameter(key = PREFER_REGISTRY_KEY)
     public Boolean getPreferred() {
         return preferred;
     }

--- a/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/RegistryConfigTest.java
+++ b/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/RegistryConfigTest.java
@@ -27,9 +27,9 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.apache.dubbo.common.constants.CommonConstants.PREFERRED_KEY;
 import static org.apache.dubbo.common.constants.CommonConstants.SHUTDOWN_WAIT_KEY;
 import static org.apache.dubbo.config.Constants.SHUTDOWN_TIMEOUT_KEY;
-import static org.apache.dubbo.config.RegistryConfig.PREFER_REGISTRY_KEY;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
@@ -200,7 +200,7 @@ public class RegistryConfigTest {
         AbstractConfig.appendParameters(map, registry);
         // Simulate the check that ZoneAwareClusterInvoker#doInvoke do
         URL url = UrlUtils.parseURL("zookeeper://127.0.0.1:2181", map);
-        Assertions.assertTrue(url.getParameter(PREFER_REGISTRY_KEY, false));
+        Assertions.assertTrue(url.getParameter(PREFERRED_KEY, false));
     }
 
     @Test
@@ -212,6 +212,6 @@ public class RegistryConfigTest {
         AbstractConfig.appendParameters(map, registry);
         // Simulate the check that ZoneAwareClusterInvoker#doInvoke do
         URL url = UrlUtils.parseURL("zookeeper://127.0.0.1:2181", map);
-        Assertions.assertFalse(url.getParameter(PREFER_REGISTRY_KEY, false));
+        Assertions.assertFalse(url.getParameter(PREFERRED_KEY, false));
     }
 }

--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/integration/RegistryProtocol.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/integration/RegistryProtocol.java
@@ -467,6 +467,15 @@ public class RegistryProtocol implements Protocol {
 
         // group="a,b" or group="*"
         Map<String, String> qs = StringUtils.parseQueryString(url.getParameterAndDecoded(REFER_KEY));
+
+        // set parameter weight for consumerUrl if needed.
+        if (!qs.containsKey(WEIGHT_KEY)) {
+            String weight = url.getParameter(WEIGHT_KEY);
+            if (!StringUtils.isEmpty(weight)) {
+                qs.put(WEIGHT_KEY, weight);
+            }
+        }
+
         String group = qs.get(GROUP_KEY);
         if (group != null && group.length() > 0) {
             if ((COMMA_SPLIT_PATTERN.split(group)).length > 1 || "*".equals(group)) {

--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/integration/RegistryProtocol.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/integration/RegistryProtocol.java
@@ -467,15 +467,6 @@ public class RegistryProtocol implements Protocol {
 
         // group="a,b" or group="*"
         Map<String, String> qs = StringUtils.parseQueryString(url.getParameterAndDecoded(REFER_KEY));
-
-        // set parameter weight for consumerUrl if needed.
-        if (!qs.containsKey(WEIGHT_KEY)) {
-            String weight = url.getParameter(WEIGHT_KEY);
-            if (!StringUtils.isEmpty(weight)) {
-                qs.put(WEIGHT_KEY, weight);
-            }
-        }
-
         String group = qs.get(GROUP_KEY);
         if (group != null && group.length() > 0) {
             if ((COMMA_SPLIT_PATTERN.split(group)).length > 1 || "*".equals(group)) {


### PR DESCRIPTION
## What is the purpose of the change
1. Fixes #9546 by setting consumer URL weight if needed
2. keep RegistryConfig.getPreferred() and ZoneAwareClusterInvoker.doInvoke() same with branch 3.0 
