### PR TITLE
fix BigDecimal is converted to scientific notation when using Generic

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/utils/CompatibleTypeUtils.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/utils/CompatibleTypeUtils.java
@@ -131,7 +131,8 @@ public class CompatibleTypeUtils {
             } else if (type == BigInteger.class) {
                 return BigInteger.valueOf(number.longValue());
             } else if (type == BigDecimal.class) {
-                return BigDecimal.valueOf(number.doubleValue());
+//                return BigDecimal.valueOf(number.doubleValue());
+                return new BigDecimal(number.doubleValue());
             } else if (type == Date.class) {
                 return new Date(number.longValue());
             }


### PR DESCRIPTION

## What is the purpose of the change
fix BigDecimal is converted to scientific notation when using Generic


## Brief changelog


## Verifying this change
see #9562

<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [ ] GitHub Actions works fine on your own branch.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
