### PR TITLE
fix: "qos-enable" and "qosEnable" is not equal in application.property

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/utils/StringUtils.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/utils/StringUtils.java
@@ -23,7 +23,17 @@ import org.apache.dubbo.common.logger.LoggerFactory;
 import com.alibaba.fastjson.JSON;
 
 import java.io.PrintWriter;
-import java.util.*;
+import java.util.Map;
+import java.util.HashMap;
+import java.util.List;
+import java.util.ArrayList;
+import java.util.TreeMap;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Collection;
+
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/utils/StringUtils.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/utils/StringUtils.java
@@ -23,16 +23,7 @@ import org.apache.dubbo.common.logger.LoggerFactory;
 import com.alibaba.fastjson.JSON;
 
 import java.io.PrintWriter;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.TreeMap;
+import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -970,6 +961,48 @@ public final class StringUtils {
             return replace(lowerCase, "_", split);
         }
         return snakeName;
+    }
+
+    /**
+     * kebab-case 2 camelCase
+     *
+     * "key-a","keyA"
+     * "key-a-b","keyAB"
+     * "-a","A"
+     * "--a","A"
+     * "a-","a-"
+     * "a--","a-"
+     * "a--a","aA"
+     *
+     * @param kebabName
+     * @return
+     */
+    public static String kebabToCamelName(String kebabName) {
+
+        StringBuilder buf = new StringBuilder();
+        for (int i = 0; i < kebabName.length(); i++) {
+            char ch = kebabName.charAt(i);
+            if (ch == '-') {
+                i++;
+                if (i == kebabName.length()){
+                    buf.append(ch);
+                    break;
+                }
+                if (kebabName.charAt(i) == '-'){
+                    i--;
+                    continue;
+                }
+                char nextCh = kebabName.charAt(i);
+                buf.append(Character.toUpperCase(nextCh));
+            } else{
+                buf.append(ch);
+            }
+        }
+        return buf.toString();
+    }
+
+    public static boolean isKebabCase(String str) {
+        return str.contains("-");
     }
 
     protected static boolean isSnakeCase(String str) {

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/utils/StringUtilsTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/utils/StringUtilsTest.java
@@ -32,10 +32,7 @@ import static org.apache.dubbo.common.constants.CommonConstants.GROUP_KEY;
 import static org.apache.dubbo.common.constants.CommonConstants.INTERFACE_KEY;
 import static org.apache.dubbo.common.constants.CommonConstants.VERSION_KEY;
 import static org.apache.dubbo.common.utils.CollectionUtils.ofSet;
-import static org.apache.dubbo.common.utils.StringUtils.splitToList;
-import static org.apache.dubbo.common.utils.StringUtils.splitToSet;
-import static org.apache.dubbo.common.utils.StringUtils.startsWithIgnoreCase;
-import static org.apache.dubbo.common.utils.StringUtils.toCommaDelimitedString;
+import static org.apache.dubbo.common.utils.StringUtils.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
@@ -501,5 +498,16 @@ public class StringUtilsTest {
         assertTrue(startsWithIgnoreCase("dubbo.Application.name", "dubbo.application."));
         assertTrue(startsWithIgnoreCase("Dubbo.application.name", "dubbo.application."));
 
+    }
+
+    @Test
+    public void testKebabToCamelName() {
+        assertEquals(kebabToCamelName("key-a"),"keyA");
+        assertEquals(kebabToCamelName("key-a-b"),"keyAB");
+        assertEquals(kebabToCamelName("-a"),"A");
+        assertEquals(kebabToCamelName("--a"),"A");
+        assertEquals(kebabToCamelName("a-"),"a-");
+        assertEquals(kebabToCamelName("a--"),"a-");
+        assertEquals(kebabToCamelName("a--a"),"aA");
     }
 }

--- a/dubbo-spring-boot/dubbo-spring-boot-compatible/autoconfigure/src/main/java/org/apache/dubbo/spring/boot/env/DubboDefaultPropertiesEnvironmentPostProcessor.java
+++ b/dubbo-spring-boot/dubbo-spring-boot-compatible/autoconfigure/src/main/java/org/apache/dubbo/spring/boot/env/DubboDefaultPropertiesEnvironmentPostProcessor.java
@@ -28,7 +28,10 @@ import org.springframework.core.env.PropertySource;
 import org.springframework.util.CollectionUtils;
 import org.springframework.util.StringUtils;
 
-import java.util.*;
+import java.util.Properties;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import static org.apache.dubbo.spring.boot.util.DubboUtils.DUBBO_APPLICATION_NAME_PROPERTY;

--- a/dubbo-spring-boot/dubbo-spring-boot-compatible/autoconfigure/src/main/java/org/apache/dubbo/spring/boot/util/DubboUtils.java
+++ b/dubbo-spring-boot/dubbo-spring-boot-compatible/autoconfigure/src/main/java/org/apache/dubbo/spring/boot/util/DubboUtils.java
@@ -171,7 +171,7 @@ public abstract class DubboUtils {
      *
      * @since 2.7.1
      */
-    public static final String DUBBO_APPLICATION_QOS_ENABLE_PROPERTY = "dubbo.application.qos-enable";
+    public static final String DUBBO_APPLICATION_QOS_ENABLE_PROPERTY = "dubbo.application.qosEnable";
 
     /**
      * The property name of {@link EnableDubboConfig#multiple() @EnableDubboConfig.multiple()}


### PR DESCRIPTION
## What is the purpose of the change
the setting in application such as "dubbo.application.qosEnable" is useless, you must set "dubbo.application.qos-enable" to enable QoS, But they are supposed to be be equivalent

## Brief changelog
i may not be able to express the bug and my action ​explictly in English, so i would like to use Chinese then.
现状：
目前只有这一个属性（qosEnable qos-enable）不一致，因为目前只有这个属性是kebab-case的默认property
如果日后新加默认kebab-case的属性，也会导致用户配置失效

本pr：
兼容kebab-case与camelCase配置；
保证用户配置不会被默认配置覆盖；


## Verifying this change

原因：
错误发生流程：
precondition： dubbo通过反射进行环境变量值绑定，而在绑定过程中做匹配的都是kebab-case的值

0. 假设我在property文件中设置了dubbo.application.qosEnable = true（待会我们会看到这个设置如何无效化的）
1. dubbo实现了一个spring的EnvironmentPostProcessor接口，实现类是DubboDefaultPropertiesEnvironmentPostProcessor。这个类会设置一些默认配置，包括dubbo.application.qos-enable=false，这个kebab-case的.qos-enable是罪魁祸首。
2. spring环境初始化过程中，会调很多个不同优先级的EnvironmentPostProcessor，DubboDefaultPropertiesEnvironmentPostProcessor在的执行优先级被设置为最低，于是它会在spring加载完其余所有环境变量后执行（此时，我们的environmentMap中，已经有用户配置<dubbo.application.qosEnable , true>），在设置完默认值后，它会执行addOrReplace方法，这是合理的，只有没有用户配置才应该加默认配置。但是问题来了：”dubbo.application.qosEnable“ != "dubbo.application.qos-enable" 即使我们设置了qosEnable，默认值还是加成功了！
3. 在最后的绑定值前，ConfigurationUtils.getSubProperties会把environmentMap中qosEnable这种小驼峰格式的值（<dubbo.application.qosEnable , true>）转化为kebab-case（<dubbo.application.qos-nable , true>），再插回到environmentMap里。
4. 插入方法是putIfAbsent，但是我们的默认值<dubbo.application.qos-enable, false>已经在map里了！插入失败！我们后面使用的其实是默认值 false

修改方法：
在默认配置添加完后进行额外处理，将所有kebab-case的默认配置转为camelCase，比如qos相关的默认配置将转化为qosEnable 。

正确性：
如果用户采用kebab-case的配置，则默认配置将被静默（就和现在用户配置被静默的原理一样，不过只是默认配置不生效）
如果用户采用camelCase的配置，则DubboDefaultPropertiesEnvironmentPostProcessor时，默认配置不会成功添加，因为已经有用户默认配置

<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [x] Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [x] GitHub Actions works fine on your own branch.
- [x] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).