### PR TITLE
[3.0] ServiceDefinition usage refactor & distinguish serviceName and interfaceName

### DIFF
--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/filter/support/ConsumerContextFilter.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/filter/support/ConsumerContextFilter.java
@@ -99,7 +99,7 @@ public class ConsumerContextFilter implements ClusterFilter, ClusterFilter.Liste
             TimeoutCountDown timeoutCountDown = (TimeoutCountDown) countDown;
             if (timeoutCountDown.isExpired()) {
                 return AsyncRpcResult.newDefaultAsyncResult(new RpcException(RpcException.TIMEOUT_TERMINATE,
-                    "No time left for making the following call: " + invocation.getServiceName() + "."
+                    "No time left for making the following call: " + invocation.getInterfaceName() + "."
                         + invocation.getMethodName() + ", terminate directly."), invocation);
             }
         }

--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/router/mesh/route/MeshRuleRouter.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/router/mesh/route/MeshRuleRouter.java
@@ -148,7 +148,7 @@ public abstract class MeshRuleRouter<T> extends AbstractStateRouter<T> implement
      * Match virtual service (by serviceName)
      */
     protected DubboRoute getDubboRoute(VirtualServiceRule virtualServiceRule, Invocation invocation) {
-        String serviceName = invocation.getServiceName();
+        String serviceName = invocation.getInterfaceName();
 
         VirtualServiceSpec spec = virtualServiceRule.getSpec();
         List<DubboRoute> dubboRouteList = spec.getDubbo();

--- a/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/directory/MockDirInvocation.java
+++ b/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/directory/MockDirInvocation.java
@@ -63,7 +63,7 @@ public class MockDirInvocation implements Invocation {
     }
 
     @Override
-    public String getServiceName() {
+    public String getInterfaceName() {
         return "DemoService";
     }
 

--- a/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/router/mesh/route/MeshRuleRouterTest.java
+++ b/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/router/mesh/route/MeshRuleRouterTest.java
@@ -293,7 +293,7 @@ public class MeshRuleRouterTest {
 
         RpcInvocation rpcInvocation = new RpcInvocation();
 
-        rpcInvocation.setServiceName("ccc");
+        rpcInvocation.setInterfaceName("ccc");
         rpcInvocation.setAttachment("trafficLabel", "xxx");
         assertEquals(1, meshRuleRouter.route(invokers.clone(), null, rpcInvocation, false, null).size());
         assertEquals(isolation, meshRuleRouter.route(invokers.clone(), null, rpcInvocation, false, null).get(0));
@@ -309,7 +309,7 @@ public class MeshRuleRouterTest {
         assertEquals(1, meshRuleRouter.route(invokers.clone(), null, rpcInvocation, false, null).size());
         assertEquals(testing, meshRuleRouter.route(invokers.clone(), null, rpcInvocation, false, null).get(0));
 
-        rpcInvocation.setServiceName("aaa");
+        rpcInvocation.setInterfaceName("aaa");
         assertEquals(invokers, meshRuleRouter.route(invokers.clone(), null, rpcInvocation, false, null));
         message = new Holder<>();
         meshRuleRouter.doRoute(invokers.clone(), null, rpcInvocation, true, null, message);
@@ -320,7 +320,7 @@ public class MeshRuleRouterTest {
         rules.add(yaml.load(rule3));
         meshRuleRouter.onRuleChange("app1", rules);
 
-        rpcInvocation.setServiceName("ccc");
+        rpcInvocation.setInterfaceName("ccc");
         rpcInvocation.setAttachment("trafficLabel", "xxx");
         assertEquals(1, meshRuleRouter.route(invokers.clone(), null, rpcInvocation, false, null).size());
         assertEquals(isolation, meshRuleRouter.route(invokers.clone(), null, rpcInvocation, false, null).get(0));
@@ -333,7 +333,7 @@ public class MeshRuleRouterTest {
         assertEquals(1, meshRuleRouter.route(invokers.clone(), null, rpcInvocation, false, null).size());
         assertEquals(testing, meshRuleRouter.route(invokers.clone(), null, rpcInvocation, false, null).get(0));
 
-        rpcInvocation.setServiceName("aaa");
+        rpcInvocation.setInterfaceName("aaa");
         assertEquals(1, meshRuleRouter.route(invokers.clone(), null, rpcInvocation, false, null).size());
         assertEquals(testing, meshRuleRouter.route(invokers.clone(), null, rpcInvocation, false, null).get(0));
 

--- a/dubbo-common/src/main/java/org/apache/dubbo/rpc/model/ApplicationModel.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/rpc/model/ApplicationModel.java
@@ -71,8 +71,6 @@ public class ApplicationModel extends ScopeModel {
     private AtomicInteger moduleIndex = new AtomicInteger(0);
     private Object moduleLock = new Object();
 
-    private final boolean isInternal;
-
     // --------- static methods ----------//
 
     public static ApplicationModel ofNullable(ApplicationModel applicationModel) {
@@ -197,9 +195,8 @@ public class ApplicationModel extends ScopeModel {
     }
 
     public ApplicationModel(FrameworkModel frameworkModel, boolean isInternal) {
-        super(frameworkModel, ExtensionScope.APPLICATION);
+        super(frameworkModel, ExtensionScope.APPLICATION, isInternal);
         Assert.notNull(frameworkModel, "FrameworkModel can not be null");
-        this.isInternal = isInternal;
         this.frameworkModel = frameworkModel;
         frameworkModel.addApplication(this);
         if (LOGGER.isInfoEnabled()) {
@@ -451,9 +448,5 @@ public class ApplicationModel extends ScopeModel {
 
     public void setDeployer(ApplicationDeployer deployer) {
         this.deployer = deployer;
-    }
-
-    public boolean isInternal() {
-        return isInternal;
     }
 }

--- a/dubbo-common/src/main/java/org/apache/dubbo/rpc/model/FrameworkModel.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/rpc/model/FrameworkModel.java
@@ -66,7 +66,7 @@ public class FrameworkModel extends ScopeModel {
     private Object instLock = new Object();
 
     public FrameworkModel() {
-        super(null, ExtensionScope.FRAMEWORK);
+        super(null, ExtensionScope.FRAMEWORK, false);
         this.setInternalId(String.valueOf(index.getAndIncrement()));
         // register FrameworkModel instance early
         synchronized (globalLock) {

--- a/dubbo-common/src/main/java/org/apache/dubbo/rpc/model/ModuleModel.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/rpc/model/ModuleModel.java
@@ -49,7 +49,7 @@ public class ModuleModel extends ScopeModel {
     }
 
     public ModuleModel(ApplicationModel applicationModel, boolean isInternal) {
-        super(applicationModel, ExtensionScope.MODULE);
+        super(applicationModel, ExtensionScope.MODULE, isInternal);
         Assert.notNull(applicationModel, "ApplicationModel can not be null");
         this.applicationModel = applicationModel;
         applicationModel.addModule(this, isInternal);
@@ -67,7 +67,6 @@ public class ModuleModel extends ScopeModel {
         if (applicationDeployer != null) {
             applicationDeployer.notifyModuleChanged(this, DeployState.PENDING);
         }
-        this.internalModule = isInternal;
     }
 
     @Override

--- a/dubbo-common/src/main/java/org/apache/dubbo/rpc/model/ScopeModel.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/rpc/model/ScopeModel.java
@@ -72,11 +72,12 @@ public abstract class ScopeModel implements ExtensionAccessor {
 
     private Map<String, Object> attributes;
     private final AtomicBoolean destroyed = new AtomicBoolean(false);
-    protected boolean internalModule;
+    private final boolean internalScope;
 
-    public ScopeModel(ScopeModel parent, ExtensionScope scope) {
+    public ScopeModel(ScopeModel parent, ExtensionScope scope, boolean isInternal) {
         this.parent = parent;
         this.scope = scope;
+        this.internalScope = isInternal;
     }
 
     /**
@@ -229,7 +230,7 @@ public abstract class ScopeModel implements ExtensionAccessor {
     }
 
     public boolean isInternal() {
-        return internalModule;
+        return internalScope;
     }
 
     /**

--- a/dubbo-common/src/test/java/org/apache/dubbo/rpc/model/ScopeModelUtilTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/rpc/model/ScopeModelUtilTest.java
@@ -97,7 +97,7 @@ public class ScopeModelUtilTest {
 
     class MockScopeModel extends ScopeModel {
         public MockScopeModel(ScopeModel parent, ExtensionScope scope) {
-            super(parent, scope);
+            super(parent, scope, false);
         }
 
         @Override

--- a/dubbo-compatible/src/main/java/com/alibaba/dubbo/rpc/Invocation.java
+++ b/dubbo-compatible/src/main/java/com/alibaba/dubbo/rpc/Invocation.java
@@ -61,7 +61,6 @@ public interface Invocation extends org.apache.dubbo.rpc.Invocation {
         setObjectAttachmentIfAbsent(key, value);
     }
 
-    @Override
     default String getServiceName() {
         return null;
     }
@@ -137,6 +136,11 @@ public interface Invocation extends org.apache.dubbo.rpc.Invocation {
         @Override
         public String getMethodName() {
             return delegate.getMethodName();
+        }
+
+        @Override
+        public String getInterfaceName() {
+            return null;
         }
 
         @Override

--- a/dubbo-compatible/src/main/java/com/alibaba/dubbo/rpc/Invocation.java
+++ b/dubbo-compatible/src/main/java/com/alibaba/dubbo/rpc/Invocation.java
@@ -61,7 +61,9 @@ public interface Invocation extends org.apache.dubbo.rpc.Invocation {
         setObjectAttachmentIfAbsent(key, value);
     }
 
-    default String getServiceName() {
+
+    @Override
+    default String getInterfaceName() {
         return null;
     }
 

--- a/dubbo-compatible/src/test/java/org/apache/dubbo/service/MockInvocation.java
+++ b/dubbo-compatible/src/test/java/org/apache/dubbo/service/MockInvocation.java
@@ -67,7 +67,7 @@ public class MockInvocation implements Invocation {
     }
 
     @Override
-    public String getServiceName() {
+    public String getInterfaceName() {
         return "DemoService";
     }
 

--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/ReferenceConfig.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/ReferenceConfig.java
@@ -403,7 +403,7 @@ public class ReferenceConfig<T> extends ReferenceConfigBase<T> {
             referenceParameters.get(INTERFACE_KEY), referenceParameters);
         consumerUrl = consumerUrl.setScopeModel(getScopeModel());
         consumerUrl = consumerUrl.setServiceModel(consumerModel);
-        MetadataUtils.publishServiceDefinition(interfaceName, consumerUrl, getScopeModel(), getApplicationModel());
+        MetadataUtils.publishServiceDefinition(consumerUrl, consumerModel.getServiceModel(), getApplicationModel());
 
         // create service proxy
         return (T) proxyFactory.getProxy(invoker, ProtocolUtils.isGeneric(generic));

--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/ServiceConfig.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/ServiceConfig.java
@@ -81,7 +81,6 @@ import static org.apache.dubbo.config.Constants.DUBBO_IP_TO_REGISTRY;
 import static org.apache.dubbo.config.Constants.DUBBO_PORT_TO_BIND;
 import static org.apache.dubbo.config.Constants.DUBBO_PORT_TO_REGISTRY;
 import static org.apache.dubbo.config.Constants.SCOPE_NONE;
-import static org.apache.dubbo.metadata.MetadataService.isMetadataService;
 import static org.apache.dubbo.remoting.Constants.BIND_IP_KEY;
 import static org.apache.dubbo.remoting.Constants.BIND_PORT_KEY;
 import static org.apache.dubbo.rpc.Constants.GENERIC_KEY;
@@ -568,11 +567,8 @@ public class ServiceConfig<T> extends ServiceConfigBase<T> {
             // export to remote if the config is not local (export to local only when config is local)
             if (!SCOPE_LOCAL.equalsIgnoreCase(scope)) {
                 url = exportRemote(url, registryURLs);
-                if (!isGeneric(generic) && !isMetadataService(interfaceName)) {
-                    ServiceDescriptor descriptor = getScopeModel().getServiceRepository().getService(interfaceName);
-                    if (descriptor != null) {
-                        MetadataUtils.publishServiceDefinition(interfaceName, url, getScopeModel(), getApplicationModel());
-                    }
+                if (!isGeneric(generic) && !getScopeModel().isInternal()) {
+                    MetadataUtils.publishServiceDefinition(url, providerModel.getServiceModel(), getApplicationModel());
                 }
             }
         }

--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/migration/ServiceDiscoveryMigrationInvoker.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/migration/ServiceDiscoveryMigrationInvoker.java
@@ -63,7 +63,7 @@ public class ServiceDiscoveryMigrationInvoker<T> extends MigrationInvoker<T> {
     public Result invoke(Invocation invocation) throws RpcException {
         ClusterInvoker<T> invoker = getServiceDiscoveryInvoker();
         if (invoker == null) {
-            throw new IllegalStateException("There's no service discovery invoker available for service " + invocation.getServiceName());
+            throw new IllegalStateException("There's no service discovery invoker available for service " + invocation.getInterfaceName());
         }
         return invoker.invoke(invocation);
     }

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/Invocation.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/Invocation.java
@@ -51,7 +51,7 @@ public interface Invocation {
      *
      * @return
      */
-    String getServiceName();
+    String getInterfaceName();
 
     /**
      * get parameter types.

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/RpcInvocation.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/RpcInvocation.java
@@ -60,7 +60,7 @@ public class RpcInvocation implements Invocation, Serializable {
 
     private String methodName;
 
-    private String serviceName;
+    private String interfaceName;
 
     private transient Class<?>[] parameterTypes;
     private String parameterTypesDesc;
@@ -90,7 +90,7 @@ public class RpcInvocation implements Invocation, Serializable {
     }
 
     public RpcInvocation(Invocation invocation, Invoker<?> invoker) {
-        this(invocation.getServiceModel(), invocation.getMethodName(), invocation.getServiceName(), invocation.getProtocolServiceKey(),
+        this(invocation.getServiceModel(), invocation.getMethodName(), invocation.getInterfaceName(), invocation.getProtocolServiceKey(),
                 invocation.getParameterTypes(), invocation.getArguments(), new HashMap<>(invocation.getObjectAttachments()),
                 invocation.getInvoker(), invocation.getAttributes());
         if (invoker != null) {
@@ -120,64 +120,64 @@ public class RpcInvocation implements Invocation, Serializable {
     }
 
     public RpcInvocation(Invocation invocation) {
-        this(invocation.getServiceModel(), invocation.getMethodName(), invocation.getServiceName(), invocation.getProtocolServiceKey(), invocation.getParameterTypes(),
+        this(invocation.getServiceModel(), invocation.getMethodName(), invocation.getInterfaceName(), invocation.getProtocolServiceKey(), invocation.getParameterTypes(),
                 invocation.getArguments(), invocation.getObjectAttachments(), invocation.getInvoker(), invocation.getAttributes());
         this.targetServiceUniqueName = invocation.getTargetServiceUniqueName();
     }
 
-    public RpcInvocation(ServiceModel serviceModel, Method method, String serviceName, String protocolServiceKey, Object[] arguments) {
-        this(serviceModel, method, serviceName, protocolServiceKey, arguments, null, null);
+    public RpcInvocation(ServiceModel serviceModel, Method method, String interfaceName, String protocolServiceKey, Object[] arguments) {
+        this(serviceModel, method, interfaceName, protocolServiceKey, arguments, null, null);
     }
 
     @Deprecated
-    public RpcInvocation(Method method, String serviceName, String protocolServiceKey, Object[] arguments) {
-        this(null, method, serviceName, protocolServiceKey, arguments, null, null);
+    public RpcInvocation(Method method, String interfaceName, String protocolServiceKey, Object[] arguments) {
+        this(null, method, interfaceName, protocolServiceKey, arguments, null, null);
     }
 
-    public RpcInvocation(ServiceModel serviceModel, Method method, String serviceName, String protocolServiceKey, Object[] arguments, Map<String, Object> attachment, Map<Object, Object> attributes) {
-        this(null, serviceModel, method.getName(), serviceName, protocolServiceKey, method.getParameterTypes(), arguments, attachment, null, attributes);
-    }
-
-    @Deprecated
-    public RpcInvocation(Method method, String serviceName, String protocolServiceKey, Object[] arguments, Map<String, Object> attachment, Map<Object, Object> attributes) {
-        this(null, null, method.getName(), serviceName, protocolServiceKey, method.getParameterTypes(), arguments, attachment, null, attributes);
-    }
-
-    public RpcInvocation(ServiceModel serviceModel, String methodName, String serviceName, String protocolServiceKey, Class<?>[] parameterTypes, Object[] arguments) {
-        this(null, serviceModel, methodName, serviceName, protocolServiceKey, parameterTypes, arguments, null, null, null);
+    public RpcInvocation(ServiceModel serviceModel, Method method, String interfaceName, String protocolServiceKey, Object[] arguments, Map<String, Object> attachment, Map<Object, Object> attributes) {
+        this(null, serviceModel, method.getName(), interfaceName, protocolServiceKey, method.getParameterTypes(), arguments, attachment, null, attributes);
     }
 
     @Deprecated
-    public RpcInvocation(String methodName, String serviceName, String protocolServiceKey, Class<?>[] parameterTypes, Object[] arguments) {
-        this(null, null, methodName, serviceName, protocolServiceKey, parameterTypes, arguments, null, null, null);
+    public RpcInvocation(Method method, String interfaceName, String protocolServiceKey, Object[] arguments, Map<String, Object> attachment, Map<Object, Object> attributes) {
+        this(null, null, method.getName(), interfaceName, protocolServiceKey, method.getParameterTypes(), arguments, attachment, null, attributes);
     }
 
-    public RpcInvocation(ServiceModel serviceModel, String methodName, String serviceName, String protocolServiceKey, Class<?>[] parameterTypes, Object[] arguments, Map<String, Object> attachments) {
-        this(null, serviceModel, methodName, serviceName, protocolServiceKey, parameterTypes, arguments, attachments, null, null);
-    }
-
-    @Deprecated
-    public RpcInvocation(String methodName, String serviceName, String protocolServiceKey, Class<?>[] parameterTypes, Object[] arguments, Map<String, Object> attachments) {
-        this(null, null, methodName, serviceName, protocolServiceKey, parameterTypes, arguments, attachments, null, null);
+    public RpcInvocation(ServiceModel serviceModel, String methodName, String interfaceName, String protocolServiceKey, Class<?>[] parameterTypes, Object[] arguments) {
+        this(null, serviceModel, methodName, interfaceName, protocolServiceKey, parameterTypes, arguments, null, null, null);
     }
 
     @Deprecated
-    public RpcInvocation(String methodName, String serviceName, String protocolServiceKey, Class<?>[] parameterTypes, Object[] arguments,
+    public RpcInvocation(String methodName, String interfaceName, String protocolServiceKey, Class<?>[] parameterTypes, Object[] arguments) {
+        this(null, null, methodName, interfaceName, protocolServiceKey, parameterTypes, arguments, null, null, null);
+    }
+
+    public RpcInvocation(ServiceModel serviceModel, String methodName, String interfaceName, String protocolServiceKey, Class<?>[] parameterTypes, Object[] arguments, Map<String, Object> attachments) {
+        this(null, serviceModel, methodName, interfaceName, protocolServiceKey, parameterTypes, arguments, attachments, null, null);
+    }
+
+    @Deprecated
+    public RpcInvocation(String methodName, String interfaceName, String protocolServiceKey, Class<?>[] parameterTypes, Object[] arguments, Map<String, Object> attachments) {
+        this(null, null, methodName, interfaceName, protocolServiceKey, parameterTypes, arguments, attachments, null, null);
+    }
+
+    @Deprecated
+    public RpcInvocation(String methodName, String interfaceName, String protocolServiceKey, Class<?>[] parameterTypes, Object[] arguments,
                          Map<String, Object> attachments, Invoker<?> invoker, Map<Object, Object> attributes) {
-        this(null, null, methodName, serviceName, protocolServiceKey, parameterTypes, arguments, attachments, invoker, attributes);
+        this(null, null, methodName, interfaceName, protocolServiceKey, parameterTypes, arguments, attachments, invoker, attributes);
     }
 
-    public RpcInvocation(ServiceModel serviceModel, String methodName, String serviceName, String protocolServiceKey, Class<?>[] parameterTypes, Object[] arguments,
+    public RpcInvocation(ServiceModel serviceModel, String methodName, String interfaceName, String protocolServiceKey, Class<?>[] parameterTypes, Object[] arguments,
                          Map<String, Object> attachments, Invoker<?> invoker, Map<Object, Object> attributes) {
-        this(null, serviceModel, methodName, serviceName, protocolServiceKey, parameterTypes, arguments, attachments, invoker, attributes);
+        this(null, serviceModel, methodName, interfaceName, protocolServiceKey, parameterTypes, arguments, attachments, invoker, attributes);
     }
 
-    public RpcInvocation(String targetServiceUniqueName, ServiceModel serviceModel, String methodName, String serviceName, String protocolServiceKey, Class<?>[] parameterTypes, Object[] arguments,
+    public RpcInvocation(String targetServiceUniqueName, ServiceModel serviceModel, String methodName, String interfaceName, String protocolServiceKey, Class<?>[] parameterTypes, Object[] arguments,
                          Map<String, Object> attachments, Invoker<?> invoker, Map<Object, Object> attributes) {
         this.targetServiceUniqueName = targetServiceUniqueName;
         this.serviceModel = serviceModel;
         this.methodName = methodName;
-        this.serviceName = serviceName;
+        this.interfaceName = interfaceName;
         this.protocolServiceKey = protocolServiceKey;
         this.parameterTypes = parameterTypes == null ? new Class<?>[0] : parameterTypes;
         this.arguments = arguments == null ? new Object[0] : arguments;
@@ -191,14 +191,14 @@ public class RpcInvocation implements Invocation, Serializable {
         AtomicReference<ServiceDescriptor> serviceDescriptor = new AtomicReference<>();
         if (serviceModel != null) {
             serviceDescriptor.set(serviceModel.getServiceModel());
-        } else if (StringUtils.isNotEmpty(serviceName)){
+        } else if (StringUtils.isNotEmpty(interfaceName)){
             // TODO: Multi Instance compatible mode
             FrameworkModel.defaultModel()
                 .getServiceRepository()
                 .allProviderModels()
                 .stream()
                 .map(ProviderModel::getServiceModel)
-                .filter(s->serviceName.equals(s.getServiceName()))
+                .filter(s-> interfaceName.equals(s.getInterfaceName()))
                 .findFirst()
                 .ifPresent(serviceDescriptor::set);
         }
@@ -270,12 +270,12 @@ public class RpcInvocation implements Invocation, Serializable {
     }
 
     @Override
-    public String getServiceName() {
-        return serviceName;
+    public String getInterfaceName() {
+        return interfaceName;
     }
 
-    public void setServiceName(String serviceName) {
-        this.serviceName = serviceName;
+    public void setInterfaceName(String interfaceName) {
+        this.interfaceName = interfaceName;
     }
 
     @Override

--- a/dubbo-rpc/dubbo-rpc-api/src/test/java/org/apache/dubbo/rpc/support/MockInvocation.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/test/java/org/apache/dubbo/rpc/support/MockInvocation.java
@@ -63,7 +63,7 @@ public class MockInvocation extends RpcInvocation {
     }
 
     @Override
-    public String getServiceName() {
+    public String getInterfaceName() {
         return "DemoService";
     }
 

--- a/dubbo-rpc/dubbo-rpc-injvm/src/main/java/org/apache/dubbo/rpc/protocol/injvm/InjvmInvoker.java
+++ b/dubbo-rpc/dubbo-rpc-injvm/src/main/java/org/apache/dubbo/rpc/protocol/injvm/InjvmInvoker.java
@@ -162,7 +162,7 @@ public class InjvmInvoker<T> extends AbstractInvoker<T> {
         if(CommonConstants.$INVOKE.equals(methodName) || shouldSkip) {
             // generic invoke, skip copy arguments
             RpcInvocation copiedInvocation = new RpcInvocation(invocation.getTargetServiceUniqueName(),
-                providerServiceModel, methodName, invocation.getServiceName(), invocation.getProtocolServiceKey(),
+                providerServiceModel, methodName, invocation.getInterfaceName(), invocation.getProtocolServiceKey(),
                 invocation.getParameterTypes(), invocation.getArguments(), new HashMap<>(invocation.getObjectAttachments()),
                 invocation.getInvoker(), invocation.getAttributes());
             copiedInvocation.setInvoker(invoker);
@@ -191,7 +191,7 @@ public class InjvmInvoker<T> extends AbstractInvoker<T> {
                 }
 
                 RpcInvocation copiedInvocation = new RpcInvocation(invocation.getTargetServiceUniqueName(),
-                    providerServiceModel, methodName, invocation.getServiceName(), invocation.getProtocolServiceKey(),
+                    providerServiceModel, methodName, invocation.getInterfaceName(), invocation.getProtocolServiceKey(),
                     pts, realArgument, new HashMap<>(invocation.getObjectAttachments()),
                     invocation.getInvoker(), invocation.getAttributes());
                 copiedInvocation.setInvoker(invoker);

--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/AbstractServerStream.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/AbstractServerStream.java
@@ -140,7 +140,7 @@ public abstract class AbstractServerStream extends AbstractStream implements Str
      */
     protected RpcInvocation buildInvocation(Metadata metadata) {
         RpcInvocation inv = new RpcInvocation(getUrl().getServiceModel(),
-            getMethodName(), getServiceDescriptor().getServiceName(),
+            getMethodName(), getServiceDescriptor().getInterfaceName(),
             getUrl().getProtocolServiceKey(), getMethodDescriptor().getRealParameterClasses(), new Object[0]);
         inv.setTargetServiceUniqueName(getUrl().getServiceKey());
         inv.setReturnTypes(getMethodDescriptor().getReturnTypes());
@@ -157,7 +157,7 @@ public abstract class AbstractServerStream extends AbstractStream implements Str
                 }
             }
         } catch (Throwable t) {
-            LOGGER.warn(String.format("Failed to parse request timeout set from:%s, service=%s method=%s", timeout, getServiceDescriptor().getServiceName(),
+            LOGGER.warn(String.format("Failed to parse request timeout set from:%s, service=%s method=%s", timeout, getServiceDescriptor().getInterfaceName(),
                 getMethodName()));
         }
         invokeHeaderFilter(inv);
@@ -285,7 +285,7 @@ public abstract class AbstractServerStream extends AbstractStream implements Str
             if (getMethodDescriptor() == null) {
                 transportError(GrpcStatus.fromCode(GrpcStatus.Code.UNIMPLEMENTED)
                     .withDescription("Method :" + getMethodName() + "[" + Arrays.toString(paramTypes) + "] " +
-                        "not found of service:" + getServiceDescriptor().getServiceName()));
+                        "not found of service:" + getServiceDescriptor().getInterfaceName()));
                 return null;
             }
         }


### PR DESCRIPTION
## What is the purpose of the change

- Prevent `ServiceConfig#exportUrl` fetch service definition from global data.
- Make `serviceDefinitions` map work
- `ServiceDescriptor#serviceName`: distinguish serviceName and interfaceName
- Refactor `isInternal` property in scope model

## Brief changelog


## Verifying this change


<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [ ] GitHub Actions works fine on your own branch.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
