### PR TITLE
Adjust the logic of initializing serviceDefinition attribute in ServiceDescriptor

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/rpc/model/ServiceDescriptor.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/rpc/model/ServiceDescriptor.java
@@ -30,8 +30,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import java.util.concurrent.ConcurrentNavigableMap;
-import java.util.concurrent.ConcurrentSkipListMap;
 
 /**
  * ServiceModel and ServiceMetadata are to some extend duplicated with each other. We should merge them in the future.
@@ -42,18 +40,13 @@ public class ServiceDescriptor {
     // to accelerate search
     private final Map<String, List<MethodDescriptor>> methods = new HashMap<>();
     private final Map<String, Map<String, MethodDescriptor>> descToMethods = new HashMap<>();
-    private ConcurrentNavigableMap<String, FullServiceDefinition> serviceDefinitions = new ConcurrentSkipListMap<>();
+    private final FullServiceDefinition serviceDefinition;
 
     public ServiceDescriptor(Class<?> interfaceClass) {
         this.serviceInterfaceClass = interfaceClass;
         this.serviceName = interfaceClass.getName();
+        this.serviceDefinition = ServiceDefinitionBuilder.buildFullDefinition(interfaceClass, Collections.emptyMap());
         initMethods();
-        initServiceDefinition(interfaceClass);
-    }
-
-    private void initServiceDefinition(Class<?> interfaceClass) {
-        FullServiceDefinition fullServiceDefinition = ServiceDefinitionBuilder.buildFullDefinition(interfaceClass, Collections.emptyMap());
-        serviceDefinitions.put(serviceName, fullServiceDefinition);
     }
 
     private void initMethods() {
@@ -70,9 +63,6 @@ public class ServiceDescriptor {
         methods.forEach((methodName, methodList) -> {
             Map<String, MethodDescriptor> descMap = descToMethods.computeIfAbsent(methodName, k -> new HashMap<>());
             methodList.forEach(methodModel -> descMap.put(methodModel.getParamDesc(), methodModel));
-
-//            Map<Class<?>[], MethodModel> typesMap = typeToMethods.computeIfAbsent(methodName, k -> new HashMap<>());
-//            methodList.forEach(methodModel -> typesMap.put(methodModel.getParameterClasses(), methodModel));
         });
     }
 
@@ -128,12 +118,8 @@ public class ServiceDescriptor {
         return methods.get(methodName);
     }
 
-    public ConcurrentNavigableMap<String, FullServiceDefinition> getServiceDefinitions() {
-        return serviceDefinitions;
-    }
-
-    public FullServiceDefinition getServiceDefinition(String serviceName) {
-        return serviceDefinitions.get(serviceName);
+    public FullServiceDefinition getServiceDefinition() {
+        return serviceDefinition;
     }
 
     @Override

--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/metadata/MetadataUtils.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/metadata/MetadataUtils.java
@@ -78,7 +78,7 @@ public class MetadataUtils {
                 if (serviceDescriptor == null) {
                     return;
                 }
-                FullServiceDefinition serviceDefinition = serviceDescriptor.getServiceDefinition(serviceName);
+                FullServiceDefinition serviceDefinition = serviceDescriptor.getServiceDefinition();
 
                 if (StringUtils.isNotEmpty(serviceName) && serviceDefinition != null) {
                     serviceDefinition.setParameters(url.getParameters());


### PR DESCRIPTION

## What is the purpose of the change
There is no need to use map type container for `serviceDefinition` attribute  of `ServiceDescriptor`