### PR TITLE
fix can't expose custom metadata

### DIFF
--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/ReferenceConfig.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/ReferenceConfig.java
@@ -308,6 +308,7 @@ public class ReferenceConfig<T> extends ReferenceConfigBase<T> {
         }
         map.put(REGISTER_IP_KEY, hostToRegistry);
 
+        serviceMetadata.getAttachments().forEach((k, v) -> map.put(k, String.valueOf(v)));
         serviceMetadata.getAttachments().putAll(map);
 
         ref = createProxy(map);

--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/ServiceConfig.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/ServiceConfig.java
@@ -457,6 +457,7 @@ public class ServiceConfig<T> extends ServiceConfigBase<T> {
             }
         }
         //init serviceMetadata attachments
+        serviceMetadata.getAttachments().forEach((k, v) -> map.put(k, String.valueOf(v)));
         serviceMetadata.getAttachments().putAll(map);
 
         // export service


### PR DESCRIPTION
## What is the purpose of the change
fix #9690 
修复接口级自定义元数据没有被暴露的问题

## Brief changelog
修改了两处.
1. ServiceConfig
2. ReferenceConfig
两者的改动一致，均是在构造服务URL对象之前，将需要暴露的元数据填充

## Verifying this change
ServiceConfig<DemoServiceImpl> service = new ServiceConfig<>();
service.getServiceMetadata().addAttachment("my-metadata", "99999");
使用service.getServiceMetadata().addAttachment后可以将一些用户自定义的元数据字段正常暴露
<img width="846" alt="image" src="https://user-images.githubusercontent.com/42876375/154313746-76187502-33da-4b13-bfb8-1da25cad17c8.png">

