### PR TITLE
Fix the problem that NPE may appear in ReferenceBeanSupport#convertToString method

### DIFF
--- a/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/util/DubboAnnotationUtils.java
+++ b/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/util/DubboAnnotationUtils.java
@@ -27,6 +27,7 @@ import org.springframework.util.Assert;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -154,7 +155,7 @@ public class DubboAnnotationUtils {
      */
     public static Map<String, String> convertParameters(String[] parameters) {
         if (ArrayUtils.isEmpty(parameters)) {
-            return null;
+            return Collections.emptyMap();
         }
 
         List<String> compatibleParameterArray = Arrays.stream(parameters)


### PR DESCRIPTION
## What is the purpose of the change

issue #9647

When processing all properties of `@Method`, the `parameters` property is an empty array, resulting in null return at `obj = DubboAnnotationUtils.convertParameters((String[]) obj);`, the following `else if (obj.getClass().isArray ())` NPE appears