### PR TITLE
fix bug lazy client share_executor is null

### DIFF
--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/protocol/AbstractInvoker.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/protocol/AbstractInvoker.java
@@ -197,6 +197,9 @@ public abstract class AbstractInvoker<T> implements Invoker<T> {
     protected ExecutorService getCallbackExecutor(URL url, Invocation inv) {
         ExecutorService sharedExecutor = ExtensionLoader.getExtensionLoader(ExecutorRepository.class).getDefaultExtension().getExecutor(url);
         if (InvokeMode.SYNC == RpcUtils.getInvokeMode(getUrl(), inv)) {
+            if(sharedExecutor == null) {
+                sharedExecutor = ExtensionLoader.getExtensionLoader(ExecutorRepository.class).getDefaultExtension().getSharedExecutor();
+            }
             return new ThreadlessExecutor(sharedExecutor);
         } else {
             return sharedExecutor;


### PR DESCRIPTION
## What is the purpose of the change
fix bug lazy client ThreadlessExecutor.sharedExecutor is null error

发现的现象：
lazy模式的dubboreference第一次调用不会返回直到超时（实际数据已经很快返回收到）

问题点：
ThreadlessExecutor.execute函数，waiting = false，所以sharedExecutor is null 报空指针

原因分析：
lazy模式ThreadlessExecutor先创建，后Exchangers.connect导致（因为线程创建在AbstractClient的构造函数initExecutor）

