### PR TITLE
Fix not find server provider startup time

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/URLStrParser.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/URLStrParser.java
@@ -30,7 +30,6 @@ import static org.apache.dubbo.common.utils.Utf8Utils.decodeUtf8;
 
 public final class URLStrParser {
     public static final String ENCODED_QUESTION_MARK = "%3F";
-    public static final String ENCODED_TIMESTAMP_KEY = "timestamp%3D";
     public static final String ENCODED_PID_KEY = "pid%3D";
     public static final String ENCODED_AND_MARK = "%26";
     private static final char SPACE = 0x20;

--- a/dubbo-metadata/dubbo-metadata-api/src/main/java/org/apache/dubbo/metadata/MetadataInfo.java
+++ b/dubbo-metadata/dubbo-metadata-api/src/main/java/org/apache/dubbo/metadata/MetadataInfo.java
@@ -48,7 +48,6 @@ import static org.apache.dubbo.common.constants.CommonConstants.GROUP_CHAR_SEPAR
 import static org.apache.dubbo.common.constants.CommonConstants.METHODS_KEY;
 import static org.apache.dubbo.common.constants.CommonConstants.MONITOR_KEY;
 import static org.apache.dubbo.common.constants.CommonConstants.PID_KEY;
-import static org.apache.dubbo.common.constants.CommonConstants.TIMESTAMP_KEY;
 import static org.apache.dubbo.common.constants.FilterConstants.VALIDATION_KEY;
 import static org.apache.dubbo.common.constants.QosConstants.ACCEPT_FOREIGN_IP;
 import static org.apache.dubbo.common.constants.QosConstants.QOS_ENABLE;
@@ -444,7 +443,7 @@ public class MetadataInfo implements Serializable {
         private transient URL url;
 
         private final static String[] KEYS_TO_REMOVE = {MONITOR_KEY, BIND_IP_KEY, BIND_PORT_KEY, QOS_ENABLE,
-            QOS_HOST, QOS_PORT, ACCEPT_FOREIGN_IP, VALIDATION_KEY, INTERFACES, PID_KEY, TIMESTAMP_KEY};
+            QOS_HOST, QOS_PORT, ACCEPT_FOREIGN_IP, VALIDATION_KEY, INTERFACES, PID_KEY};
 
         public ServiceInfo() {}
 

--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/AbstractServiceDiscovery.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/AbstractServiceDiscovery.java
@@ -33,8 +33,10 @@ import org.apache.dubbo.registry.client.metadata.store.MetaCacheManager;
 import org.apache.dubbo.rpc.model.ApplicationModel;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
+import static org.apache.dubbo.common.constants.CommonConstants.TIMESTAMP_KEY;
 import static org.apache.dubbo.common.constants.RegistryConstants.REGISTRY_CLUSTER_KEY;
 import static org.apache.dubbo.metadata.RevisionResolver.EMPTY_REVISION;
 import static org.apache.dubbo.registry.client.metadata.ServiceInstanceMetadataUtils.EXPORTED_SERVICES_REVISION_PROPERTY_NAME;
@@ -254,7 +256,13 @@ public abstract class AbstractServiceDiscovery implements ServiceDiscovery {
         instance.setServiceMetadata(metadataInfo);
         setMetadataStorageType(instance, metadataType);
         ServiceInstanceMetadataUtils.customizeInstance(instance, applicationModel);
+        appendRuntimeParameters(instance);
         return instance;
+    }
+
+    protected void appendRuntimeParameters(DefaultServiceInstance instance) {
+        Map<String, String> metadata = instance.getMetadata();
+        metadata.put(TIMESTAMP_KEY, String.valueOf(System.currentTimeMillis()));
     }
 
     protected boolean calOrUpdateInstanceRevision(ServiceInstance instance) {

--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/AbstractServiceDiscovery.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/AbstractServiceDiscovery.java
@@ -33,10 +33,8 @@ import org.apache.dubbo.registry.client.metadata.store.MetaCacheManager;
 import org.apache.dubbo.rpc.model.ApplicationModel;
 
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
-import static org.apache.dubbo.common.constants.CommonConstants.TIMESTAMP_KEY;
 import static org.apache.dubbo.common.constants.RegistryConstants.REGISTRY_CLUSTER_KEY;
 import static org.apache.dubbo.metadata.RevisionResolver.EMPTY_REVISION;
 import static org.apache.dubbo.registry.client.metadata.ServiceInstanceMetadataUtils.EXPORTED_SERVICES_REVISION_PROPERTY_NAME;
@@ -256,13 +254,7 @@ public abstract class AbstractServiceDiscovery implements ServiceDiscovery {
         instance.setServiceMetadata(metadataInfo);
         setMetadataStorageType(instance, metadataType);
         ServiceInstanceMetadataUtils.customizeInstance(instance, applicationModel);
-        appendRuntimeParameters(instance);
         return instance;
-    }
-
-    protected void appendRuntimeParameters(DefaultServiceInstance instance) {
-        Map<String, String> metadata = instance.getMetadata();
-        metadata.put(TIMESTAMP_KEY, String.valueOf(System.currentTimeMillis()));
     }
 
     protected boolean calOrUpdateInstanceRevision(ServiceInstance instance) {

--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/support/CacheableFailbackRegistry.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/support/CacheableFailbackRegistry.java
@@ -49,7 +49,6 @@ import java.util.concurrent.TimeUnit;
 import static org.apache.dubbo.common.URLStrParser.ENCODED_AND_MARK;
 import static org.apache.dubbo.common.URLStrParser.ENCODED_PID_KEY;
 import static org.apache.dubbo.common.URLStrParser.ENCODED_QUESTION_MARK;
-import static org.apache.dubbo.common.URLStrParser.ENCODED_TIMESTAMP_KEY;
 import static org.apache.dubbo.common.constants.CommonConstants.CACHE_CLEAR_TASK_INTERVAL;
 import static org.apache.dubbo.common.constants.CommonConstants.CACHE_CLEAR_WAITING_THRESHOLD;
 import static org.apache.dubbo.common.constants.CommonConstants.CHECK_KEY;
@@ -66,7 +65,7 @@ import static org.apache.dubbo.common.constants.RegistryConstants.PROVIDERS_CATE
  */
 public abstract class CacheableFailbackRegistry extends FailbackRegistry {
     private static final Logger logger = LoggerFactory.getLogger(CacheableFailbackRegistry.class);
-    private static String[] VARIABLE_KEYS = new String[]{ENCODED_TIMESTAMP_KEY, ENCODED_PID_KEY};
+    private static String[] VARIABLE_KEYS = new String[]{ENCODED_PID_KEY};
 
     protected Map<String, URLAddress> stringAddress = new ConcurrentHashMap<>();
     protected Map<String, URLParam> stringParam = new ConcurrentHashMap<>();


### PR DESCRIPTION
## What is the purpose of the change

Fix the problem that the server provider startup time cannot be found on the consumer side

close #9675 

## Brief changelog


## Verifying this change


<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [ ] GitHub Actions works fine on your own branch.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
