### PR TITLE
Remove duplicate function

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/rpc/model/ModuleServiceRepository.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/rpc/model/ModuleServiceRepository.java
@@ -188,22 +188,13 @@ public class ModuleServiceRepository {
         return Collections.unmodifiableList(serviceDescriptors);
     }
 
-    public ServiceDescriptor getService(String serviceName) {
+    public ServiceDescriptor lookupService(String serviceName) {
         // TODO, may need to distinguish service by class loader.
         List<ServiceDescriptor> serviceDescriptors = services.get(serviceName);
         if (CollectionUtils.isEmpty(serviceDescriptors)) {
             return null;
         }
         return serviceDescriptors.get(0);
-    }
-
-    public ServiceDescriptor lookupService(String interfaceName) {
-        if (services.containsKey(interfaceName)) {
-            List<ServiceDescriptor> serviceDescriptors = services.get(interfaceName);
-            return serviceDescriptors.size() > 0 ? serviceDescriptors.get(0) : null;
-        } else {
-            return null;
-        }
     }
 
     public MethodDescriptor lookupMethod(String interfaceName, String methodName) {

--- a/dubbo-rpc/dubbo-rpc-triple/src/test/java/org/apache/dubbo/rpc/protocol/tri/stream/ClientStreamTest.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/test/java/org/apache/dubbo/rpc/protocol/tri/stream/ClientStreamTest.java
@@ -64,7 +64,7 @@ class ClientStreamTest {
 
         final ModuleServiceRepository repo = ApplicationModel.defaultModel().getDefaultModule().getServiceRepository();
         repo.registerService(IGreeter.class);
-        final ServiceDescriptor serviceDescriptor = repo.getService(IGreeter.class.getName());
+        final ServiceDescriptor serviceDescriptor = repo.lookupService(IGreeter.class.getName());
         final MethodDescriptor methodDescriptor = serviceDescriptor.getMethod("echo", new Class<?>[]{String.class});
 
         final RpcInvocation invocation = mock(RpcInvocation.class);


### PR DESCRIPTION
## What is the purpose of the change

The functions of `getService` and `lookupService` are the same, keep the lookupService method

## Brief changelog


## Verifying this change


<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [ ] GitHub Actions works fine on your own branch.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
