### PR TITLE
fix dubbo.metadata-report.protocol cannot be applied

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/constants/CommonConstants.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/constants/CommonConstants.java
@@ -94,10 +94,6 @@ public interface CommonConstants {
 
     Pattern EQUAL_SPLIT_PATTERN = Pattern.compile("\\s*[=]+\\s*");
 
-    String DEFAULT_PROXY = "javassist";
-
-    String DEFAULT_DIRECTORY = "dubbo";
-
     String PROTOCOL_KEY = "protocol";
 
     String DEFAULT_PROTOCOL = "dubbo";

--- a/dubbo-common/src/main/java/org/apache/dubbo/config/MetadataReportConfig.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/config/MetadataReportConfig.java
@@ -45,6 +45,9 @@ public class MetadataReportConfig extends AbstractConfig {
 
     private static final long serialVersionUID = 55233L;
 
+    /**
+     * metadata center protocol
+     */
     private String protocol;
 
     /**

--- a/dubbo-metadata/dubbo-metadata-api/src/main/java/org/apache/dubbo/metadata/report/MetadataReportInstance.java
+++ b/dubbo-metadata/dubbo-metadata-api/src/main/java/org/apache/dubbo/metadata/report/MetadataReportInstance.java
@@ -18,6 +18,8 @@ package org.apache.dubbo.metadata.report;
 
 import org.apache.dubbo.common.URL;
 import org.apache.dubbo.common.URLBuilder;
+import org.apache.dubbo.common.logger.Logger;
+import org.apache.dubbo.common.logger.LoggerFactory;
 import org.apache.dubbo.common.resource.Disposable;
 import org.apache.dubbo.config.MetadataReportConfig;
 import org.apache.dubbo.metadata.report.support.NopMetadataReport;
@@ -48,6 +50,8 @@ import static org.apache.dubbo.metadata.report.support.Constants.METADATA_REPORT
  * <dubbo:metadata id=demo2 address="metadata://"/>
  */
 public class MetadataReportInstance implements Disposable {
+
+    private static final Logger log = LoggerFactory.getLogger(MetadataReportInstance.class);
 
     private AtomicBoolean init = new AtomicBoolean(false);
     private String metadataType;
@@ -82,6 +86,9 @@ public class MetadataReportInstance implements Disposable {
         URL url = config.toUrl();
         if (METADATA_REPORT_KEY.equals(url.getProtocol())) {
             String protocol = url.getParameter(METADATA_REPORT_KEY, config.getProtocol());
+            if(isEmpty(protocol)){
+                log.error("Metadata report instance cannot work with an empty protocol,please check your address or protocol configuration");
+            }
             url = URLBuilder.from(url)
                     .setProtocol(protocol)
                     .setScopeModel(config.getScopeModel())

--- a/dubbo-metadata/dubbo-metadata-api/src/main/java/org/apache/dubbo/metadata/report/MetadataReportInstance.java
+++ b/dubbo-metadata/dubbo-metadata-api/src/main/java/org/apache/dubbo/metadata/report/MetadataReportInstance.java
@@ -29,7 +29,6 @@ import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.apache.dubbo.common.constants.CommonConstants.APPLICATION_KEY;
-import static org.apache.dubbo.common.constants.CommonConstants.DEFAULT_DIRECTORY;
 import static org.apache.dubbo.common.constants.CommonConstants.DEFAULT_KEY;
 import static org.apache.dubbo.common.constants.CommonConstants.DEFAULT_METADATA_STORAGE_TYPE;
 import static org.apache.dubbo.common.utils.StringUtils.isEmpty;
@@ -82,7 +81,7 @@ public class MetadataReportInstance implements Disposable {
     private void init(MetadataReportConfig config, MetadataReportFactory metadataReportFactory) {
         URL url = config.toUrl();
         if (METADATA_REPORT_KEY.equals(url.getProtocol())) {
-            String protocol = url.getParameter(METADATA_REPORT_KEY, DEFAULT_DIRECTORY);
+            String protocol = url.getParameter(METADATA_REPORT_KEY, config.getProtocol());
             url = URLBuilder.from(url)
                     .setProtocol(protocol)
                     .setScopeModel(config.getScopeModel())


### PR DESCRIPTION
## What is the purpose of the change

fix #9806

## Brief changelog

fix a bug: ```dubbo.metadata-report.protocol``` cannot be applied

## Verifying this change


<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [ ] GitHub Actions works fine on your own branch.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
