### PR TITLE
SimpleReferenceCache bug to cause genericInvoke high lantency(fix:  #9829)

### DIFF
--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/utils/SimpleReferenceCache.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/utils/SimpleReferenceCache.java
@@ -67,7 +67,7 @@ public class SimpleReferenceCache implements ReferenceCache {
 
     private final Map<String, List<ReferenceConfigBase<?>>> referenceKeyMap = new ConcurrentHashMap<>();
     private final Map<Class<?>, List<ReferenceConfigBase<?>>> referenceTypeMap = new ConcurrentHashMap<>();
-    private final Map<ReferenceConfigBase<?>, Object> references = new ConcurrentHashMap<>();
+    private final Map<String, Object> references = new ConcurrentHashMap<>();
 
     protected SimpleReferenceCache(String name, KeyGenerator generator) {
         this.name = name;
@@ -107,9 +107,9 @@ public class SimpleReferenceCache implements ReferenceCache {
     public <T> T get(ReferenceConfigBase<T> rc) {
         String key = generator.generateKey(rc);
         Class<?> type = rc.getInterfaceClass();
-        Object proxy = rc.get();
 
-        references.computeIfAbsent(rc, _rc -> {
+        return (T) references.computeIfAbsent(key, _rc -> {
+            Object proxy = rc.get();
             List<ReferenceConfigBase<?>> referencesOfType = referenceTypeMap.computeIfAbsent(type, _t -> Collections.synchronizedList(new ArrayList<>()));
             referencesOfType.add(rc);
             List<ReferenceConfigBase<?>> referenceConfigList = referenceKeyMap.computeIfAbsent(key, _k -> Collections.synchronizedList(new ArrayList<>()));
@@ -117,7 +117,6 @@ public class SimpleReferenceCache implements ReferenceCache {
             return proxy;
         });
 
-        return (T) proxy;
     }
 
     /**

--- a/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/utils/ReferenceCacheTest.java
+++ b/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/utils/ReferenceCacheTest.java
@@ -25,8 +25,7 @@ import org.apache.dubbo.config.utils.service.FooService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class ReferenceCacheTest {
 
@@ -48,10 +47,10 @@ public class ReferenceCacheTest {
         MockReferenceConfig configCopy = buildMockReferenceConfig("org.apache.dubbo.config.utils.service.FooService", "group1", "1.0.0");
         assertEquals(1L, configCopy.getCounter());
         cache.get(configCopy);
-        assertTrue(configCopy.isGetMethodRun());
+        assertFalse(configCopy.isGetMethodRun());
 
-        assertEquals(2L, config.getCounter());
-        assertEquals(2L, configCopy.getCounter());
+        assertEquals(1L, config.getCounter());
+        assertEquals(1L, configCopy.getCounter());
     }
 
     @Test

--- a/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/utils/ReferenceCacheTest.java
+++ b/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/utils/ReferenceCacheTest.java
@@ -25,7 +25,9 @@ import org.apache.dubbo.config.utils.service.FooService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 public class ReferenceCacheTest {
 


### PR DESCRIPTION
## What is the purpose of the change
fix: https://github.com/apache/dubbo/issues/9829


## Brief changelog
#### org.apache.dubbo.config.utils.SimpleReferenceCache
method `public <T> T get(ReferenceConfigBase<T> rc)` always cost much time, because `Object proxy = rc.get();` always been called outside and `init` is heavy.

org.apache.dubbo.config.utils.ReferenceCacheTest
fix some test. revert them to older version.

## Verifying this change
org.apache.dubbo.config.utils.ReferenceCacheTest all passed

<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [ ] GitHub Actions works fine on your own branch.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).