### PR TITLE
[master] fix #9847

### DIFF
--- a/dubbo-metadata/dubbo-metadata-api/src/main/java/org/apache/dubbo/metadata/definition/builder/MapTypeBuilder.java
+++ b/dubbo-metadata/dubbo-metadata-api/src/main/java/org/apache/dubbo/metadata/definition/builder/MapTypeBuilder.java
@@ -21,8 +21,6 @@ import org.apache.dubbo.metadata.definition.model.TypeDefinition;
 
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
-import java.text.MessageFormat;
-import java.util.Arrays;
 import java.util.Map;
 
 import static org.apache.dubbo.common.utils.TypeUtils.getRawClass;
@@ -51,12 +49,6 @@ public class MapTypeBuilder implements TypeBuilder {
         ParameterizedType parameterizedType = (ParameterizedType) type;
         Type[] actualTypeArgs = parameterizedType.getActualTypeArguments();
         int actualTypeArgsLength = actualTypeArgs == null ? 0 : actualTypeArgs.length;
-
-        if (actualTypeArgsLength != 2) {
-            throw new IllegalArgumentException(MessageFormat.format(
-                    "[ServiceDefinitionBuilder] Map type [{0}] with unexpected amount of arguments [{1}]."
-                            + Arrays.toString(actualTypeArgs), type, actualTypeArgs));
-        }
 
         String mapType = type.toString();
 


### PR DESCRIPTION
fix #9847

翻了以前的一些issue 比如 https://github.com/apache/dubbo/issues/8212 和 https://github.com/apache/dubbo/issues/5122 都提到过这个问题，我认为这段强校验的代码没必要存在。

        if (actualTypeArgsLength != 2) {
            throw new IllegalArgumentException(MessageFormat.format(
                    "[ServiceDefinitionBuilder] Map type [{0}] with unexpected amount of arguments [{1}]."
                            + Arrays.toString(actualTypeArgs), type, actualTypeArgs));
        }
虽然可以通过SPI来扩展，但是还是给用户带来了一定的困扰。