### PR TITLE
[3.x] add detail log for generic and interface type conflicts

### DIFF
--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/ReferenceConfig.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/ReferenceConfig.java
@@ -567,7 +567,13 @@ public class ReferenceConfig<T> extends ReferenceConfigBase<T> {
             setGeneric(getConsumer().getGeneric());
         }
         if (ProtocolUtils.isGeneric(generic)) {
-            interfaceClass = GenericService.class;
+            if (interfaceClass != null && !interfaceClass.equals(GenericService.class)) {
+                logger.warn(String.format("Found conflicting attributes for interface type: [interfaceClass=%s] and [generic=%s], " +
+                        "because the 'generic' attribute has higher priority than 'interfaceClass', so change 'interfaceClass' to '%s'. " +
+                        "Note: it will make this reference bean as a candidate bean of type '%s' instead of '%s' when resolving dependency in Spring.",
+                    interfaceClass.getName(), generic, GenericService.class.getName(), GenericService.class.getName(), interfaceClass.getName()));
+                interfaceClass = GenericService.class;
+            }
         } else {
             try {
                 if (getInterfaceClassLoader() != null && (interfaceClass == null || interfaceClass.getClassLoader() != getInterfaceClassLoader())) {

--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/ReferenceConfig.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/ReferenceConfig.java
@@ -572,8 +572,8 @@ public class ReferenceConfig<T> extends ReferenceConfigBase<T> {
                         "because the 'generic' attribute has higher priority than 'interfaceClass', so change 'interfaceClass' to '%s'. " +
                         "Note: it will make this reference bean as a candidate bean of type '%s' instead of '%s' when resolving dependency in Spring.",
                     interfaceClass.getName(), generic, GenericService.class.getName(), GenericService.class.getName(), interfaceClass.getName()));
-                interfaceClass = GenericService.class;
             }
+            interfaceClass = GenericService.class;
         } else {
             try {
                 if (getInterfaceClassLoader() != null && (interfaceClass == null || interfaceClass.getClassLoader() != getInterfaceClassLoader())) {

--- a/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/ReferenceConfigTest.java
+++ b/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/ReferenceConfigTest.java
@@ -16,6 +16,13 @@
  */
 package org.apache.dubbo.config;
 
+import demo.MultiClassLoaderService;
+import demo.MultiClassLoaderServiceImpl;
+import demo.MultiClassLoaderServiceRequest;
+import demo.MultiClassLoaderServiceResult;
+import javassist.CannotCompileException;
+import javassist.CtClass;
+import javassist.NotFoundException;
 import org.apache.dubbo.common.URL;
 import org.apache.dubbo.common.Version;
 import org.apache.dubbo.common.compiler.support.CtClassBuilder;
@@ -44,14 +51,7 @@ import org.apache.dubbo.rpc.model.ModuleModel;
 import org.apache.dubbo.rpc.model.ServiceMetadata;
 import org.apache.dubbo.rpc.protocol.injvm.InjvmInvoker;
 import org.apache.dubbo.rpc.protocol.injvm.InjvmProtocol;
-
-import demo.MultiClassLoaderService;
-import demo.MultiClassLoaderServiceImpl;
-import demo.MultiClassLoaderServiceRequest;
-import demo.MultiClassLoaderServiceResult;
-import javassist.CannotCompileException;
-import javassist.CtClass;
-import javassist.NotFoundException;
+import org.apache.dubbo.rpc.service.GenericService;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
@@ -847,6 +847,22 @@ public class ReferenceConfigTest {
         System.out.println("ReferenceConfig get prefixes cost: " + (end - start));
 
     }
+
+    @Test
+    public void testGenericAndInterfaceConflicts() {
+
+        ReferenceConfig referenceConfig = new ReferenceConfig();
+        referenceConfig.setInterface(DemoService.class);
+        referenceConfig.setGeneric("true");
+
+        DubboBootstrap.getInstance()
+            .application("demo app")
+            .reference(referenceConfig)
+            .initialize();
+
+        Assertions.assertEquals(GenericService.class, referenceConfig.getInterfaceClass());
+    }
+
 
     @Test
     public void testLargeReferences() throws InterruptedException {


### PR DESCRIPTION
## What is the purpose of the change

Add detail log for `generic` and `interface` type conflicts. 

```
Found conflicting attributes for interface type: [interfaceClass=org.apache.dubbo.config.api.DemoService] and [generic=true], because the 'generic' attribute has higher priority than 'interfaceClass', so change 'interfaceClass' to 'org.apache.dubbo.rpc.service.GenericService'. Note: it will make this reference bean as a candidate bean of type 'org.apache.dubbo.rpc.service.GenericService' instead of 'org.apache.dubbo.config.api.DemoService' when resolving dependency in Spring., dubbo version: , current host: 30.250.193.243

```