### PR TITLE
Bump spring to 5.2.20 to mitigate CVE-2022-22965

### DIFF
--- a/dubbo-dependencies-bom/pom.xml
+++ b/dubbo-dependencies-bom/pom.xml
@@ -90,7 +90,7 @@
     <properties>
         <!-- Common libs -->
         <!-- <spring_version>4.3.30.RELEASE</spring_version> -->
-        <spring_version>5.2.9.RELEASE</spring_version>
+        <spring_version>5.2.20.RELEASE</spring_version>
         <javassist_version>3.28.0-GA</javassist_version>
         <netty_version>3.2.5.Final</netty_version>
         <netty4_version>4.1.56.Final</netty4_version>


### PR DESCRIPTION
See details: https://tanzu.vmware.com/security/cve-2022-22965