### PR TITLE
[3.0 ]metadata-report support a separate configuration username …

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/constants/CommonConstants.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/constants/CommonConstants.java
@@ -533,4 +533,6 @@ public interface CommonConstants {
     String CLEAR_FUTURE_AFTER_GET = "future.clear.once";
 
     String NATIVE_STUB = "nativestub";
+
+    String METADATA = "metadata";
 }

--- a/dubbo-common/src/main/java/org/apache/dubbo/config/MetadataReportConfig.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/config/MetadataReportConfig.java
@@ -27,6 +27,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.apache.dubbo.common.constants.CommonConstants.CYCLE_REPORT_KEY;
+import static org.apache.dubbo.common.constants.CommonConstants.METADATA;
 import static org.apache.dubbo.common.constants.CommonConstants.PROTOCOL_KEY;
 import static org.apache.dubbo.common.constants.CommonConstants.REPORT_DEFINITION_KEY;
 import static org.apache.dubbo.common.constants.CommonConstants.REPORT_METADATA_KEY;
@@ -143,7 +144,7 @@ public class MetadataReportConfig extends AbstractConfig {
         if (isEmpty(address)) {
             throw new IllegalArgumentException("The address of metadata report is invalid.");
         }
-        Map<String, String> map = new HashMap<String, String>();
+        Map<String, String> map = new HashMap<>();
         URL url = URL.valueOf(address, getScopeModel());
         // Issue : https://github.com/apache/dubbo/issues/6491
         // Append the parameters from address
@@ -153,10 +154,10 @@ public class MetadataReportConfig extends AbstractConfig {
         // Normalize the parameters
         map.putAll(convert(map, null));
         // put the protocol of URL as the "metadata"
-        map.put("metadata", isEmpty(url.getProtocol()) ? map.get(PROTOCOL_KEY) : url.getProtocol());
-        return new ServiceConfigURL("metadata", url.getUsername(), url.getPassword(), url.getHost(),
-                url.getPort(), url.getPath(), map).setScopeModel(getScopeModel());
-
+        map.put(METADATA, isEmpty(url.getProtocol()) ? map.get(PROTOCOL_KEY) : url.getProtocol());
+        return new ServiceConfigURL(METADATA, StringUtils.isBlank(url.getUsername()) ? this.getUsername() : url.getUsername(),
+            StringUtils.isBlank(url.getPassword()) ? this.getPassword() : url.getPassword(), url.getHost(),
+            url.getPort(), url.getPath(), map).setScopeModel(getScopeModel());
     }
 
     public String getProtocol() {
@@ -191,7 +192,8 @@ public class MetadataReportConfig extends AbstractConfig {
                 updateParameters(params);
             } catch (Exception ignored) {
             }
-        }    }
+        }
+    }
 
     public Integer getPort() {
         return port;

--- a/dubbo-metadata/dubbo-metadata-api/src/test/java/org/apache/dubbo/metadata/report/MetadataReportInstanceTest.java
+++ b/dubbo-metadata/dubbo-metadata-api/src/test/java/org/apache/dubbo/metadata/report/MetadataReportInstanceTest.java
@@ -41,7 +41,7 @@ class MetadataReportInstanceTest {
     private MetadataReportConfig metadataReportConfig;
     private ConfigManager configManager;
 
-    private String registryId = "9103";
+    private final String registryId = "9103";
 
     @BeforeEach
     public void setUp() {
@@ -52,6 +52,9 @@ class MetadataReportInstanceTest {
 
         URL url = URL.valueOf("metadata://127.0.0.1:20880/TestService?version=1.0.0&metadata=JTest");
         metadataReportConfig = mock(MetadataReportConfig.class);
+        when(metadataReportConfig.getUsername()).thenReturn("username");
+        when(metadataReportConfig.getPassword()).thenReturn("password");
+
         when(metadataReportConfig.getApplicationModel()).thenReturn(applicationModel);
         when(metadataReportConfig.toUrl()).thenReturn(url);
         when(metadataReportConfig.getScopeModel()).thenReturn(applicationModel);
@@ -65,8 +68,7 @@ class MetadataReportInstanceTest {
 
     @Test
     public void test() {
-        Assertions.assertNull(metadataReportInstance.getMetadataReport(registryId),
-            "the metadata report was not initialized.");
+        Assertions.assertNull(metadataReportInstance.getMetadataReport(registryId), "the metadata report was not initialized.");
         assertThat(metadataReportInstance.getMetadataReports(true), Matchers.anEmptyMap());
 
         metadataReportInstance.init(Arrays.asList(metadataReportConfig));
@@ -79,6 +81,9 @@ class MetadataReportInstanceTest {
         Map<String, MetadataReport> metadataReports = metadataReportInstance.getMetadataReports(true);
         Assertions.assertEquals(metadataReports.size(), 1);
         Assertions.assertEquals(metadataReports.get(registryId), metadataReport);
+
+        Assertions.assertEquals(metadataReportConfig.getUsername(), "username");
+        Assertions.assertEquals(metadataReportConfig.getPassword(), "password");
     }
 
 }


### PR DESCRIPTION
fix #9910, metadata-report support a separate configuration username and password