### PR TITLE
remove redundant volatile on initialized

### DIFF
--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/ReferenceConfig.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/ReferenceConfig.java
@@ -134,7 +134,7 @@ public class ReferenceConfig<T> extends ReferenceConfigBase<T> {
     /**
      * The flag whether the ReferenceConfig has been initialized
      */
-    private transient volatile boolean initialized;
+    private transient boolean initialized;
 
     /**
      * whether this ReferenceConfig has been destroyed


### PR DESCRIPTION

## What is the purpose of the change

init(org.apache.dubbo.config.ReferenceConfig#init) is a synchronized method, and field initialized only access in init, so volatile on initialized is redundant.

## Brief changelog
remove redundant volatile flag on initialized


## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [ ] GitHub Actions works fine on your own branch.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
