### PR TITLE
[3.0] tri support Snappy

### DIFF
--- a/dubbo-dependencies-bom/pom.xml
+++ b/dubbo-dependencies-bom/pom.xml
@@ -162,6 +162,7 @@
         <hessian_lite_version>3.2.12</hessian_lite_version>
         <swagger_version>1.5.24</swagger_version>
 
+        <snappy_java_version>1.1.8.4</snappy_java_version>
         <bouncycastle-bcprov_version>1.68</bouncycastle-bcprov_version>
         <metrics_version>2.0.1</metrics_version>
         <sofa_registry_version>5.2.0</sofa_registry_version>
@@ -734,6 +735,13 @@
                 <artifactId>kubernetes-server-mock</artifactId>
                 <scope>test</scope>
                 <version>${fabric8_kubernetes_version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.xerial.snappy</groupId>
+                <artifactId>snappy-java</artifactId>
+                <version>${snappy_java_version}</version>
+                <optional>true</optional>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/dubbo-rpc/dubbo-rpc-triple/pom.xml
+++ b/dubbo-rpc/dubbo-rpc-triple/pom.xml
@@ -65,6 +65,11 @@
             <version>2.2.21</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.xerial.snappy</groupId>
+            <artifactId>snappy-java</artifactId>
+            <version>1.1.8.4</version>
+        </dependency>
     </dependencies>
     <build>
         <extensions>

--- a/dubbo-rpc/dubbo-rpc-triple/pom.xml
+++ b/dubbo-rpc/dubbo-rpc-triple/pom.xml
@@ -68,7 +68,6 @@
         <dependency>
             <groupId>org.xerial.snappy</groupId>
             <artifactId>snappy-java</artifactId>
-            <version>1.1.8.4</version>
         </dependency>
     </dependencies>
     <build>

--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/compressor/Snappy.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/compressor/Snappy.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.rpc.protocol.tri.compressor;
+
+import org.apache.dubbo.rpc.RpcException;
+
+import java.io.IOException;
+
+/**
+ * snappy compressor
+ *
+ * @link https://github.com/google/snappy
+ */
+public class Snappy implements Compressor, DeCompressor {
+
+    public static final String SNAPPY = "snappy";
+
+    @Override
+    public String getMessageEncoding() {
+        return SNAPPY;
+    }
+
+    @Override
+    public byte[] compress(byte[] payloadByteArr) throws RpcException {
+        if (null == payloadByteArr || 0 == payloadByteArr.length) {
+            return new byte[0];
+        }
+
+        try {
+            return org.xerial.snappy.Snappy.compress(payloadByteArr);
+        } catch (IOException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    @Override
+    public byte[] decompress(byte[] payloadByteArr) {
+        if (null == payloadByteArr || 0 == payloadByteArr.length) {
+            return new byte[0];
+        }
+
+        try {
+            return org.xerial.snappy.Snappy.uncompress(payloadByteArr);
+        } catch (IOException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+}

--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/compressor/Snappy.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/compressor/Snappy.java
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.dubbo.rpc.protocol.tri.compressor;
 
 import org.apache.dubbo.rpc.RpcException;
@@ -21,7 +22,7 @@ import org.apache.dubbo.rpc.RpcException;
 import java.io.IOException;
 
 /**
- * snappy compressor
+ * snappy compressor, Provide high-speed compression speed and reasonable compression ratio
  *
  * @link https://github.com/google/snappy
  */

--- a/dubbo-rpc/dubbo-rpc-triple/src/main/resources/META-INF/dubbo/internal/org.apache.dubbo.rpc.protocol.tri.compressor.Compressor
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/resources/META-INF/dubbo/internal/org.apache.dubbo.rpc.protocol.tri.compressor.Compressor
@@ -1,1 +1,2 @@
 gzip=org.apache.dubbo.rpc.protocol.tri.compressor.Gzip
+snappy=org.apache.dubbo.rpc.protocol.tri.compressor.Snappy

--- a/dubbo-rpc/dubbo-rpc-triple/src/main/resources/META-INF/dubbo/internal/org.apache.dubbo.rpc.protocol.tri.compressor.DeCompressor
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/resources/META-INF/dubbo/internal/org.apache.dubbo.rpc.protocol.tri.compressor.DeCompressor
@@ -1,1 +1,2 @@
 gzip=org.apache.dubbo.rpc.protocol.tri.compressor.Gzip
+snappy=org.apache.dubbo.rpc.protocol.tri.compressor.Snappy

--- a/dubbo-rpc/dubbo-rpc-triple/src/test/java/org/apache/dubbo/rpc/protocol/tri/compressor/SnappyTest.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/test/java/org/apache/dubbo/rpc/protocol/tri/compressor/SnappyTest.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.rpc.protocol.tri.compressor;
+
+import org.apache.dubbo.rpc.model.ApplicationModel;
+import org.apache.dubbo.rpc.model.FrameworkModel;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * test for snappy
+ */
+public class SnappyTest {
+
+    private static final String TEST_STR;
+
+    static {
+        StringBuilder builder = new StringBuilder();
+        int charNum = 1000000;
+        for (int i = 0; i < charNum; i++) {
+            builder.append("a");
+        }
+
+        TEST_STR = builder.toString();
+    }
+
+    @ValueSource(strings = {"snappy"})
+    @ParameterizedTest
+    void compression(String compressorName) {
+        Compressor compressor = ApplicationModel.defaultModel().getDefaultModule()
+            .getExtensionLoader(Compressor.class)
+            .getExtension(compressorName);
+        String loadByStatic = Compressor.getCompressor(new FrameworkModel(), compressorName)
+            .getMessageEncoding();
+        Assertions.assertEquals(loadByStatic, compressor.getMessageEncoding());
+
+        byte[] compressedByteArr = compressor.compress(TEST_STR.getBytes());
+
+        DeCompressor deCompressor = ApplicationModel.defaultModel().getDefaultModule()
+            .getExtensionLoader(DeCompressor.class)
+            .getExtension(compressorName);
+
+        byte[] decompressedByteArr = deCompressor.decompress(compressedByteArr);
+        Assertions.assertEquals(new String(decompressedByteArr), TEST_STR);
+    }
+}


### PR DESCRIPTION
tri 压缩算法支持snappy，它的目标并非最大压缩率或与其他压缩程序库的兼容性，而是非常高的速度和合理的压缩率。