### PR TITLE
[3.0] tri support Bzip2

### DIFF
--- a/dubbo-dependencies-bom/pom.xml
+++ b/dubbo-dependencies-bom/pom.xml
@@ -170,7 +170,7 @@
         <mortbay_jetty_version>6.1.26</mortbay_jetty_version>
         <portlet_version>2.0</portlet_version>
         <maven_flatten_version>1.1.0</maven_flatten_version>
-        <commons.compress.version>1.2.1</commons.compress.version>
+        <commons.compress.version>1.21</commons.compress.version>
         <revision>3.0.8-SNAPSHOT</revision>
     </properties>
 

--- a/dubbo-dependencies-bom/pom.xml
+++ b/dubbo-dependencies-bom/pom.xml
@@ -171,7 +171,7 @@
         <mortbay_jetty_version>6.1.26</mortbay_jetty_version>
         <portlet_version>2.0</portlet_version>
         <maven_flatten_version>1.1.0</maven_flatten_version>
-        <commons.compress.version>1.21</commons.compress.version>
+        <commons_compress_version>1.21</commons_compress_version>
         <revision>3.0.8-SNAPSHOT</revision>
     </properties>
 
@@ -741,7 +741,7 @@
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-compress</artifactId>
-                <version>${commons.compress.version}</version>
+                <version>${commons_compress_version}</version>
             </dependency>
             <dependency>
                 <groupId>org.xerial.snappy</groupId>

--- a/dubbo-dependencies-bom/pom.xml
+++ b/dubbo-dependencies-bom/pom.xml
@@ -170,6 +170,7 @@
         <mortbay_jetty_version>6.1.26</mortbay_jetty_version>
         <portlet_version>2.0</portlet_version>
         <maven_flatten_version>1.1.0</maven_flatten_version>
+        <commons.compress.version>1.2.1</commons.compress.version>
         <revision>3.0.8-SNAPSHOT</revision>
     </properties>
 
@@ -734,6 +735,13 @@
                 <artifactId>kubernetes-server-mock</artifactId>
                 <scope>test</scope>
                 <version>${fabric8_kubernetes_version}</version>
+            </dependency>
+            <!-- tri compress support-->
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-compress</artifactId>
+                <version>${commons.compress.version}</version>
+                <optional>true</optional>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/dubbo-rpc/dubbo-rpc-triple/pom.xml
+++ b/dubbo-rpc/dubbo-rpc-triple/pom.xml
@@ -62,7 +62,6 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-compress</artifactId>
-            <version>1.21</version>
         </dependency>
         <dependency>
             <groupId>io.reactivex.rxjava2</groupId>

--- a/dubbo-rpc/dubbo-rpc-triple/pom.xml
+++ b/dubbo-rpc/dubbo-rpc-triple/pom.xml
@@ -60,6 +60,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-compress</artifactId>
+            <version>1.21</version>
+        </dependency>
+        <dependency>
             <groupId>io.reactivex.rxjava2</groupId>
             <artifactId>rxjava</artifactId>
             <version>2.2.21</version>

--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/compressor/Bzip2.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/compressor/Bzip2.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.dubbo.rpc.protocol.tri.compressor;
+
+import org.apache.dubbo.rpc.RpcException;
+
+import org.apache.commons.compress.compressors.bzip2.BZip2CompressorInputStream;
+import org.apache.commons.compress.compressors.bzip2.BZip2CompressorOutputStream;
+import org.apache.commons.io.output.ByteArrayOutputStream;
+
+import java.io.ByteArrayInputStream;
+
+
+/**
+ * bzip2 compressor, faster compression efficiency
+ *
+ * @link https://commons.apache.org/proper/commons-compress/
+ */
+public class Bzip2 implements Compressor, DeCompressor {
+
+    public static final String BZIP2 = "bzip2";
+
+    @Override
+    public String getMessageEncoding() {
+        return BZIP2;
+    }
+
+    @Override
+    public byte[] compress(byte[] payloadByteArr) throws RpcException {
+        if (null == payloadByteArr || 0 == payloadByteArr.length) {
+            return new byte[0];
+        }
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        BZip2CompressorOutputStream cos;
+        try {
+            cos = new BZip2CompressorOutputStream(out);
+            cos.write(payloadByteArr);
+            cos.close();
+        } catch (Exception e) {
+            throw new IllegalStateException(e);
+        }
+
+        return out.toByteArray();
+    }
+
+    @Override
+    public byte[] decompress(byte[] payloadByteArr) {
+        if (null == payloadByteArr || 0 == payloadByteArr.length) {
+            return new byte[0];
+        }
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        ByteArrayInputStream in = new ByteArrayInputStream(payloadByteArr);
+        try {
+            BZip2CompressorInputStream unZip = new BZip2CompressorInputStream(in);
+            byte[] buffer = new byte[2048];
+            int n;
+            while ((n = unZip.read(buffer)) >= 0) {
+                out.write(buffer, 0, n);
+            }
+        } catch (Exception e) {
+            throw new IllegalStateException(e);
+        }
+        return out.toByteArray();
+    }
+}

--- a/dubbo-rpc/dubbo-rpc-triple/src/main/resources/META-INF/dubbo/internal/org.apache.dubbo.rpc.protocol.tri.compressor.Compressor
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/resources/META-INF/dubbo/internal/org.apache.dubbo.rpc.protocol.tri.compressor.Compressor
@@ -1,1 +1,3 @@
 gzip=org.apache.dubbo.rpc.protocol.tri.compressor.Gzip
+bzip2=org.apache.dubbo.rpc.protocol.tri.compressor.Bzip2
+

--- a/dubbo-rpc/dubbo-rpc-triple/src/main/resources/META-INF/dubbo/internal/org.apache.dubbo.rpc.protocol.tri.compressor.DeCompressor
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/resources/META-INF/dubbo/internal/org.apache.dubbo.rpc.protocol.tri.compressor.DeCompressor
@@ -1,1 +1,2 @@
 gzip=org.apache.dubbo.rpc.protocol.tri.compressor.Gzip
+bzip2=org.apache.dubbo.rpc.protocol.tri.compressor.Bzip2

--- a/dubbo-rpc/dubbo-rpc-triple/src/test/java/org/apache/dubbo/rpc/protocol/tri/compressor/Bzip2Test.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/test/java/org/apache/dubbo/rpc/protocol/tri/compressor/Bzip2Test.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.dubbo.rpc.protocol.tri.compressor;
+
+import org.apache.dubbo.rpc.model.ApplicationModel;
+import org.apache.dubbo.rpc.model.FrameworkModel;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * test for Bzip2
+ */
+public class Bzip2Test {
+
+    private static final String TEST_STR;
+
+    static {
+        StringBuilder builder = new StringBuilder();
+        int charNum = 1000000;
+        for (int i = 0; i < charNum; i++) {
+            builder.append("a");
+        }
+
+        TEST_STR = builder.toString();
+    }
+
+    @ValueSource(strings = {"bzip2"})
+    @ParameterizedTest
+    void compression(String compressorName) {
+        Compressor compressor = ApplicationModel.defaultModel().getDefaultModule()
+            .getExtensionLoader(Compressor.class)
+            .getExtension(compressorName);
+        String loadByStatic = Compressor.getCompressor(new FrameworkModel(), compressorName)
+            .getMessageEncoding();
+        Assertions.assertEquals(loadByStatic, compressor.getMessageEncoding());
+
+        byte[] compressedByteArr = compressor.compress(TEST_STR.getBytes());
+
+        DeCompressor deCompressor = ApplicationModel.defaultModel().getDefaultModule()
+            .getExtensionLoader(DeCompressor.class)
+            .getExtension(compressorName);
+
+        byte[] decompressedByteArr = deCompressor.decompress(compressedByteArr);
+        Assertions.assertEquals(new String(decompressedByteArr), TEST_STR);
+    }
+}


### PR DESCRIPTION
tri 压缩算法支持bzip2，bzip2比传统的gzip的压缩效率更高，但是它的压缩速度较慢