### PR TITLE
[3.0 Triple] Support Connection IDLE

### DIFF
--- a/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/api/Connection.java
+++ b/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/api/Connection.java
@@ -117,8 +117,8 @@ public class Connection extends AbstractReferenceCounted {
                 //.addLast("logging",new LoggingHandler(LogLevel.INFO))//for debug
 
                 int heartbeatInterval = UrlUtils.getHeartbeat(getUrl());
-                pipeline.addLast("idleStateHandler", new IdleStateHandler(heartbeatInterval,
-                    0, 0, TimeUnit.SECONDS));
+                pipeline.addLast("idleStateHandler", new IdleStateHandler(0,
+                    heartbeatInterval, 0, TimeUnit.SECONDS));
                 pipeline.addLast(new HeartbeatServerHandler());
 
                 pipeline.addLast(connectionHandler);

--- a/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/api/HeartbeatServerHandler.java
+++ b/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/api/HeartbeatServerHandler.java
@@ -31,7 +31,7 @@ import io.netty.handler.timeout.IdleStateEvent;
  */
 public class HeartbeatServerHandler extends ChannelDuplexHandler {
 
-    private static final Logger log = LoggerFactory.getLogger(ConnectionHandler.class);
+    private static final Logger log = LoggerFactory.getLogger(HeartbeatServerHandler.class);
 
     private int lossConnectCount = 0;
 

--- a/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/api/HeartbeatServerHandler.java
+++ b/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/api/HeartbeatServerHandler.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.dubbo.remoting.api;
+
+import org.apache.dubbo.common.logger.Logger;
+import org.apache.dubbo.common.logger.LoggerFactory;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.handler.timeout.IdleState;
+import io.netty.handler.timeout.IdleStateEvent;
+
+/**
+ * handle the IdleStateEvent triggered by IdleStateHandler
+ */
+public class HeartbeatServerHandler extends ChannelInboundHandlerAdapter {
+
+    private static final Logger log = LoggerFactory.getLogger(ConnectionHandler.class);
+
+    private int lossConnectCount = 0;
+
+    @Override
+    public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
+        if (evt instanceof IdleStateEvent) {
+            IdleStateEvent e = (IdleStateEvent) evt;
+            if (e.state() == IdleState.READER_IDLE) {
+                lossConnectCount++;
+                if (lossConnectCount > 2) {
+                    log.warn(String.format("Server read idle, close:%s", ctx.channel()));
+                    ctx.close();
+                }
+            } else if (e.state() == IdleState.WRITER_IDLE) {
+                log.warn(String.format("Server write idle, channel:%s", ctx.channel()));
+            } else if (e.state() == IdleState.ALL_IDLE) {
+                log.warn("Server All idle");
+            }
+        } else {
+            super.userEventTriggered(ctx, evt);
+        }
+    }
+
+    public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+        lossConnectCount = 0;
+    }
+
+    @Override
+    public void channelReadComplete(ChannelHandlerContext ctx) {
+        ctx.flush();
+    }
+
+    @Override
+    public void channelActive(ChannelHandlerContext ctx) {
+        log.info(String.format("Channel:%s ", ctx.channel() + "is active"));
+    }
+
+    @Override
+    public void channelInactive(ChannelHandlerContext ctx) {
+        log.info(String.format("Channel:%s ", ctx.channel() + "is inactive"));
+    }
+
+    @Override
+    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+        log.error(String.format("Channel error:%s ", ctx.channel()), cause);
+        ctx.close();
+    }
+
+}

--- a/dubbo-remoting/dubbo-remoting-api/src/test/java/org/apache/dubbo/remoting/handler/HeartbeatServerHandlerTest.java
+++ b/dubbo-remoting/dubbo-remoting-api/src/test/java/org/apache/dubbo/remoting/handler/HeartbeatServerHandlerTest.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.dubbo.remoting.handler;
+
+import org.apache.dubbo.common.URL;
+import org.apache.dubbo.common.utils.NetUtils;
+import org.apache.dubbo.remoting.Constants;
+import org.apache.dubbo.remoting.api.Connection;
+import org.apache.dubbo.remoting.api.PortUnificationServer;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test for HeartbeatServerHandler
+ */
+public class HeartbeatServerHandlerTest {
+
+    /**
+     * Set the heartbeat time to 10s. Triggered HeartbeatServerHandler to reconnect when connection timeout,
+     * and verify that connection still active.
+     */
+    @Test
+    public void connectSyncTest() {
+        int port = NetUtils.getAvailablePort();
+        URL url = URL.valueOf("empty://127.0.0.1:" + port + "?foo=bar&" + Constants.HEARTBEAT_KEY + "=" + 10);
+        PortUnificationServer server = null;
+        try {
+            server = new PortUnificationServer(url);
+            server.bind();
+
+            Connection connection = new Connection(url);
+            Assertions.assertTrue(connection.isAvailable());
+
+//            connection.getChannel().closeFuture().sync();
+            connection.getChannel().close();
+            Assertions.assertTrue(connection.isAvailable());
+
+        } finally {
+            try {
+                server.close();
+            } catch (Throwable e) {
+                // ignored
+            }
+        }
+    }
+}


### PR DESCRIPTION
Use netty IdleStateEvent to compensate idle. When the idle time is greater than three heartbeat intervals and the channel is inactive, the server adopts the reconnection strategy.