### PR TITLE
Fixes #9913, rmi protocol supoort group and version

### DIFF
--- a/dubbo-rpc/dubbo-rpc-rmi/src/main/java/org/apache/dubbo/rpc/protocol/rmi/RmiProtocol.java
+++ b/dubbo-rpc/dubbo-rpc-rmi/src/main/java/org/apache/dubbo/rpc/protocol/rmi/RmiProtocol.java
@@ -35,6 +35,8 @@ import static org.apache.dubbo.common.Version.isRelease263OrHigher;
 import static org.apache.dubbo.common.Version.isRelease270OrHigher;
 import static org.apache.dubbo.common.constants.CommonConstants.DUBBO_VERSION_KEY;
 import static org.apache.dubbo.common.constants.CommonConstants.RELEASE_KEY;
+import static org.apache.dubbo.common.constants.CommonConstants.GROUP_KEY;
+import static org.apache.dubbo.common.constants.CommonConstants.VERSION_KEY;
 import static org.apache.dubbo.rpc.Constants.GENERIC_KEY;
 
 /**
@@ -102,7 +104,14 @@ public class RmiProtocol extends AbstractProxyProtocol{
                 return invocation;
             });
         }
-        String serviceUrl = url.toIdentityString();
+
+        String pathKey = URL.buildKey(url.getPath(), url.getParameter(GROUP_KEY), url.getParameter(VERSION_KEY));
+        //The format is 'rmi://{host}:{ip}/{group}/{interfaceName}:{version}'
+        StringBuilder buf = new StringBuilder();
+        buf.append(url.getProtocol()).append("://")
+                .append(url.getHost()).append(":").append(url.getPort())
+                .append("/").append(pathKey);
+        String serviceUrl = buf.toString();
         if (isGeneric) {
             serviceUrl = serviceUrl + "/" + GENERIC_KEY;
         }
@@ -137,9 +146,9 @@ public class RmiProtocol extends AbstractProxyProtocol{
         final RmiServiceExporter rmiServiceExporter = new RmiServiceExporter();
         rmiServiceExporter.setRegistryPort(url.getPort());
         if (isGeneric) {
-            rmiServiceExporter.setServiceName(url.getPath() + "/" + GENERIC_KEY);
+            rmiServiceExporter.setServiceName(url.getServiceKey() + "/" + GENERIC_KEY);
         } else {
-            rmiServiceExporter.setServiceName(url.getPath());
+            rmiServiceExporter.setServiceName(url.getServiceKey());
         }
         rmiServiceExporter.setServiceInterface(type);
         rmiServiceExporter.setService(impl);

--- a/dubbo-rpc/dubbo-rpc-rmi/src/test/java/org/apache/dubbo/rpc/protocol/rmi/RemoteService2Impl.java
+++ b/dubbo-rpc/dubbo-rpc-rmi/src/test/java/org/apache/dubbo/rpc/protocol/rmi/RemoteService2Impl.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.rpc.protocol.rmi;
+
+import org.apache.dubbo.rpc.RpcContext;
+
+import java.rmi.RemoteException;
+
+/**
+ * analog multi-implementation
+ */
+public class RemoteService2Impl implements RemoteService {
+
+    public String getThreadName() throws RemoteException {
+        System.out.println("RpcContext.getContext().getRemoteHost()=" + RpcContext.getContext().getRemoteHost());
+        return Thread.currentThread().getName();
+    }
+
+    public String sayHello(String name) throws RemoteException {
+        return "hello " + name + "@" + RemoteService2Impl.class.getName();
+    }
+}

--- a/dubbo-rpc/dubbo-rpc-rmi/src/test/java/org/apache/dubbo/rpc/protocol/rmi/RmiProtocolTest.java
+++ b/dubbo-rpc/dubbo-rpc-rmi/src/test/java/org/apache/dubbo/rpc/protocol/rmi/RmiProtocolTest.java
@@ -155,6 +155,30 @@ public class RmiProtocolTest {
 
     }
 
+    @Test
+    public void testRmiProtocalGroupAndVersion() throws Exception {
+        int port = NetUtils.getAvailablePort();
+        RemoteService remoteService = new RemoteServiceImpl();
+        RemoteService remoteService2 = new RemoteService2Impl();
+
+        URL url = URL.valueOf("rmi://127.0.0.1:" + port + "/" + DemoService.class.getName() + "?version=v1&group=g1");
+        URL url2 = URL.valueOf("rmi://127.0.0.1:" + port + "/" + DemoService.class.getName() + "?version=v2&group=g2");
+        Exporter<?> rpcExporter = protocol.export(proxy.getInvoker(remoteService, RemoteService.class, url));
+        Exporter<?> rpcExporter2 = protocol.export(proxy.getInvoker(remoteService2, RemoteService.class, url2));
+
+        remoteService = proxy.getProxy(protocol.refer(RemoteService.class, url));
+        remoteService2 = proxy.getProxy(protocol.refer(RemoteService.class, url2));
+        for (int i = 0; i < 1; i++) {
+            String say = remoteService.sayHello("abcd");
+            assertEquals("hello abcd@" + RemoteServiceImpl.class.getName(), say);
+            String say2 = remoteService2.sayHello("group");
+            assertEquals("hello group@" + RemoteService2Impl.class.getName(), say2);
+        }
+        rpcExporter.unexport();
+        rpcExporter2.unexport();
+
+    }
+
     public interface NonStdRmiInterface {
         void bark();
     }


### PR DESCRIPTION
see 9913 bug.
I added support for grouping and versioning in the RmiProtocol doRefer(), createExporter() method. A test method is written in RmiProtocolTest to verify its correctness.