### PR TITLE
[3.0 Triple] Support HTTP2 connection Keepalive

### DIFF
--- a/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/api/Connection.java
+++ b/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/api/Connection.java
@@ -114,7 +114,6 @@ public class Connection extends AbstractReferenceCounted {
                 }
 
                 //.addLast("logging",new LoggingHandler(LogLevel.INFO))//for debug
-                // TODO support IDLE
                 int heartbeatInterval = UrlUtils.getHeartbeat(getUrl());
                 pipeline.addLast(connectionHandler);
                 protocol.configClientPipeline(url, pipeline, sslContext, heartbeatInterval);

--- a/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/api/Connection.java
+++ b/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/api/Connection.java
@@ -24,6 +24,7 @@ import org.apache.dubbo.common.utils.ExecutorUtil;
 import org.apache.dubbo.common.utils.NetUtils;
 import org.apache.dubbo.remoting.Constants;
 import org.apache.dubbo.remoting.RemotingException;
+import org.apache.dubbo.remoting.utils.UrlUtils;
 
 import io.netty.bootstrap.Bootstrap;
 import io.netty.buffer.PooledByteBufAllocator;
@@ -114,9 +115,9 @@ public class Connection extends AbstractReferenceCounted {
 
                 //.addLast("logging",new LoggingHandler(LogLevel.INFO))//for debug
                 // TODO support IDLE
-//                int heartbeatInterval = UrlUtils.getHeartbeat(getUrl());
+                int heartbeatInterval = UrlUtils.getHeartbeat(getUrl());
                 pipeline.addLast(connectionHandler);
-                protocol.configClientPipeline(url, pipeline, sslContext);
+                protocol.configClientPipeline(url, pipeline, sslContext, heartbeatInterval);
                 // TODO support Socks5
             }
         });

--- a/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/api/WireProtocol.java
+++ b/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/api/WireProtocol.java
@@ -30,7 +30,7 @@ public interface WireProtocol {
 
     void configServerPipeline(URL url, ChannelPipeline pipeline, SslContext sslContext);
 
-    void configClientPipeline(URL url, ChannelPipeline pipeline, SslContext sslContext);
+    void configClientPipeline(URL url, ChannelPipeline pipeline, SslContext sslContext, int heartbeatInterval);
 
     void close();
 }

--- a/dubbo-remoting/dubbo-remoting-api/src/test/java/org/apache/dubbo/remoting/api/EmptyProtocol.java
+++ b/dubbo-remoting/dubbo-remoting-api/src/test/java/org/apache/dubbo/remoting/api/EmptyProtocol.java
@@ -33,7 +33,7 @@ public class EmptyProtocol implements WireProtocol {
     }
 
     @Override
-    public void configClientPipeline(URL url, ChannelPipeline pipeline, SslContext sslContext) {
+    public void configClientPipeline(URL url, ChannelPipeline pipeline, SslContext sslContext, int heartbeatInterval) {
 
     }
 

--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/TripleHttp2Protocol.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/TripleHttp2Protocol.java
@@ -137,7 +137,7 @@ public class TripleHttp2Protocol extends Http2WireProtocol implements ScopeModel
     }
 
     @Override
-    public void configClientPipeline(URL url, ChannelPipeline pipeline, SslContext sslContext) {
+    public void configClientPipeline(URL url, ChannelPipeline pipeline, SslContext sslContext, int heartbeatInterval) {
         final Http2FrameCodec codec = Http2FrameCodecBuilder.forClient()
             .gracefulShutdownTimeoutMillis(10000)
             .initialSettings(new Http2Settings().headerTableSize(
@@ -153,7 +153,7 @@ public class TripleHttp2Protocol extends Http2WireProtocol implements ScopeModel
             .frameLogger(CLIENT_LOGGER)
             .build();
         final Http2MultiplexHandler handler = new Http2MultiplexHandler(
-            new TripleClientHandler(frameworkModel));
+            new TripleClientHandler(frameworkModel, codec, heartbeatInterval));
         pipeline.addLast(codec, handler, new TripleTailHandler());
     }
 }

--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/transport/TripleServerConnectionHandler.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/transport/TripleServerConnectionHandler.java
@@ -33,6 +33,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 import static org.apache.dubbo.rpc.protocol.tri.transport.GracefulShutdown.GRACEFUL_SHUTDOWN_PING;
+import static org.apache.dubbo.rpc.protocol.tri.transport.TripleClientHandler.CLIENT_SCHEDULE_PING;
 
 public class TripleServerConnectionHandler extends Http2ChannelDuplexHandler {
     private static final Logger logger = LoggerFactory.getLogger(TripleServerConnectionHandler.class);
@@ -58,6 +59,9 @@ public class TripleServerConnectionHandler extends Http2ChannelDuplexHandler {
                 } else {
                     gracefulShutdown.secondGoAwayAndClose(ctx);
                 }
+            } else if (((Http2PingFrame) msg).content() == CLIENT_SCHEDULE_PING
+                && ((Http2PingFrame) msg).ack()) {
+                ctx.writeAndFlush(msg);
             }
         } else if (msg instanceof Http2GoAwayFrame) {
             ReferenceCountUtil.release(msg);


### PR DESCRIPTION
## What is the purpose of the change
Support HTTP2 connection Keepalive. 
- When connection have not any active stream will schedule to send ping frame to keep connection alive. 
- It would close the connection when it have not received ping ack timeout.
- The value of the scheduled task use `UrlUtils.getHeartbeat(getUrl())`


## Brief changelog


## Verifying this change


<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [ ] GitHub Actions works fine on your own branch.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
