### PR TITLE
Fix issue#9953

### DIFF
--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/filter/AccessLogFilter.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/filter/AccessLogFilter.java
@@ -141,7 +141,6 @@ public class AccessLogFilter implements Filter {
                 processWithAccessKeyLogger(logQueue, file);
             }
         } catch (Exception e) {
-            logQueue.poll();
             logger.error(e.getMessage(), e);
         }
     }
@@ -157,22 +156,21 @@ public class AccessLogFilter implements Filter {
     }
 
     private void processWithAccessKeyLogger(Queue<AccessLogData> logQueue, File file) throws IOException {
-        try (FileWriter writer = new FileWriter(file, true)) {
-            for (Iterator<AccessLogData> iterator = logQueue.iterator();
-                 iterator.hasNext();
-                 iterator.remove()) {
-                writer.write(iterator.next().getLogMessage());
+        FileWriter writer = new FileWriter(file, true);
+        try  {
+            while (!logQueue.isEmpty()) {
+                writer.write(logQueue.poll().getLogMessage());
                 writer.write(System.getProperty(LINE_SEPARATOR));
             }
+        }finally {
             writer.flush();
+            writer.close();
         }
     }
 
     private void processWithServiceLogger(Queue<AccessLogData> logQueue) {
-        for (Iterator<AccessLogData> iterator = logQueue.iterator();
-             iterator.hasNext();
-             iterator.remove()) {
-            AccessLogData logData = iterator.next();
+        while (!logQueue.isEmpty()) {
+            AccessLogData logData = logQueue.poll();
             LoggerFactory.getLogger(LOG_KEY + "." + logData.getServiceName()).info(logData.getLogMessage());
         }
     }

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/filter/AccessLogFilter.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/filter/AccessLogFilter.java
@@ -34,7 +34,6 @@ import java.io.IOException;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Date;
-import java.util.Iterator;
 import java.util.Map;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentHashMap;

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/filter/AccessLogFilter.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/filter/AccessLogFilter.java
@@ -141,6 +141,7 @@ public class AccessLogFilter implements Filter {
                 processWithAccessKeyLogger(logQueue, file);
             }
         } catch (Exception e) {
+            logQueue.poll();
             logger.error(e.getMessage(), e);
         }
     }


### PR DESCRIPTION
## What is the purpose of the change

fix the issue #9953 

## Brief changelog

Modified the way the logQueue is traversed to ensure that items are removed from the queue before throwing an exception.
修改了logQueue的遍历方式，确保在抛出异常前将item从队列中移除。

## Verifying this change


<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [x] Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [ ] GitHub Actions works fine on your own branch.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
