### PR TITLE
Fixed test order dependencies in class `PojoUtilsTest`

### DIFF
--- a/dubbo-common/src/test/java/org/apache/dubbo/common/utils/SerializeClassCheckerTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/utils/SerializeClassCheckerTest.java
@@ -37,7 +37,7 @@ public class SerializeClassCheckerTest {
     }
 
     @AfterAll
-    public void tearDown() {
+    public static void tearDown() {
         SerializeClassChecker.clearInstance();
     }
 

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/utils/SerializeClassCheckerTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/utils/SerializeClassCheckerTest.java
@@ -21,6 +21,7 @@ import org.apache.dubbo.common.constants.CommonConstants;
 import javassist.compiler.Javac;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 
 import java.net.Socket;
@@ -32,6 +33,11 @@ public class SerializeClassCheckerTest {
 
     @BeforeEach
     public void setUp() {
+        SerializeClassChecker.clearInstance();
+    }
+
+    @AfterAll
+    public void tearDown() {
         SerializeClassChecker.clearInstance();
     }
 


### PR DESCRIPTION
## What is the purpose of the change
In `dubbo-common`, several test cases in `PojoUtilsTest.java` can trigger `java.lang.IllegalArgumentException`  when being run after running tests in `SerializeClassCheckerTest.java`. 
For example, if we run the following command:
```
o=reversealphabetical; mvn test -Dsurefire.runOrder=$o -Dtest=org.apache.dubbo.common.utils.PojoUtilsTest#testArrayToCollection,SerializeClassCheckerTest#testBlockAll
```
We get the following error:
```
[ERROR] org.apache.dubbo.common.utils.PojoUtilsTest.testArrayToCollection  Time elapsed: 0.61 s  <<< ERROR!
java.lang.IllegalArgumentException: Trigger the safety barrier! Catch not allowed serialize class. Class name: org.apache.dubbo.common.model.person . This means currently maybe being attacking by others.If you are sure this is a mistake, please add this class name to `dubbo.security.serialize.allowedClassList` as a system environment property.
        at org.apache.dubbo.common.utils.PojoUtilsTest.testArrayToCollection(PojoUtilsTest.java:230)
```
The reason for such dependency is that tests in `SerializeClassCheckerTest.java`, specifically `testBlockAll()`, disables deserialization of all classes except for `LinkedList`. Therefore, in the example above, `realize()` will trigger the exception as deserialization of the class `Person` has been blocked if we run `SerializeClassCheckerTest.testBlockAll()` before it.
The test dependency shall be fixed as unit tests shall run successfully in any order.


## Brief changelog
Add an `@AfterAll` routine in `SerializeClassCheckerTest.java` to properly clean up the changes in the test class. 

## Verifying this change
All tests still pass in the default order. Also, the order dependency has been removed. This can be verified by running 
```
o=reversealphabetical; mvn test -Dsurefire.runOrder=$o -Dtest=org.apache.dubbo.common.utils.PojoUtilsTest#TEST1,SerializeClassCheckerTest#TEST2
```
where TEST1 and TEST2 are arbitray tests in the corresponding test cases.