### PR TITLE
Update TagRouter.java

### DIFF
--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/router/tag/TagRouter.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/router/tag/TagRouter.java
@@ -117,7 +117,7 @@ public class TagRouter extends AbstractRouter implements ConfigurationListener {
             }
             // If there's no tagged providers that can match the current tagged request. force.tag is set by default
             // to false, which means it will invoke any providers without a tag unless it's explicitly disallowed.
-            if (CollectionUtils.isNotEmpty(result) || isForceUseTag(invocation)) {
+            if (CollectionUtils.isNotEmpty(result) || isForceUseTag(invocation,invokers)) {
                 return result;
             }
             // FAILOVER: return all Providers without any tags.
@@ -168,7 +168,7 @@ public class TagRouter extends AbstractRouter implements ConfigurationListener {
         // Tag request
         if (!StringUtils.isEmpty(tag)) {
             result = filterInvoker(invokers, invoker -> tag.equals(invoker.getUrl().getParameter(TAG_KEY)));
-            if (CollectionUtils.isEmpty(result) && !isForceUseTag(invocation)) {
+            if (CollectionUtils.isEmpty(result) && !isForceUseTag(invocation,invokers)) {
                 result = filterInvoker(invokers, invoker -> StringUtils.isEmpty(invoker.getUrl().getParameter(TAG_KEY)));
             }
         } else {
@@ -188,8 +188,9 @@ public class TagRouter extends AbstractRouter implements ConfigurationListener {
         return tagRouterRule != null && tagRouterRule.isForce();
     }
 
-    private boolean isForceUseTag(Invocation invocation) {
-        return Boolean.valueOf(invocation.getAttachment(FORCE_USE_TAG, url.getParameter(FORCE_USE_TAG, "false")));
+    private <T>boolean isForceUseTag(Invocation invocation,List<Invoker<T>> invokers) {
+        boolean providerForceUseTag = invokers.stream().filter(invoker -> "true".equals((invoker.getUrl().getParameter(FORCE_USE_TAG)))).findAny().isPresent();
+        return providerForceUseTag ? providerForceUseTag : Boolean.valueOf(invocation.getAttachment(FORCE_USE_TAG, url.getParameter(FORCE_USE_TAG, "false")));
     }
 
     private <T> List<Invoker<T>> filterInvoker(List<Invoker<T>> invokers, Predicate<Invoker<T>> predicate) {


### PR DESCRIPTION
## What is the purpose of the change
Fix issue#9972


## Brief changelog
The isforceusetag method of tagrouter is modified to ensure that it can preferentially read the parameters of whether to force degradation from the provider.
修改了TagRouter的isForceUseTag方法，确保其能优先从提供方provider上读取是否强制降级的参数。


## Verifying this change


<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [ ] GitHub Actions works fine on your own branch.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
