### PR TITLE
Add 'exclude' filtering policy for instance-level params

### DIFF
--- a/dubbo-metadata/dubbo-metadata-api/src/main/java/org/apache/dubbo/metadata/DefaultMetadataParamsFilter.java
+++ b/dubbo-metadata/dubbo-metadata-api/src/main/java/org/apache/dubbo/metadata/DefaultMetadataParamsFilter.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.metadata;
+
+import org.apache.dubbo.common.extension.Activate;
+
+import static org.apache.dubbo.common.constants.CommonConstants.MONITOR_KEY;
+import static org.apache.dubbo.common.constants.CommonConstants.PID_KEY;
+import static org.apache.dubbo.common.constants.CommonConstants.TIMESTAMP_KEY;
+import static org.apache.dubbo.common.constants.FilterConstants.VALIDATION_KEY;
+import static org.apache.dubbo.common.constants.QosConstants.ACCEPT_FOREIGN_IP;
+import static org.apache.dubbo.common.constants.QosConstants.QOS_ENABLE;
+import static org.apache.dubbo.common.constants.QosConstants.QOS_HOST;
+import static org.apache.dubbo.common.constants.QosConstants.QOS_PORT;
+import static org.apache.dubbo.remoting.Constants.BIND_IP_KEY;
+import static org.apache.dubbo.remoting.Constants.BIND_PORT_KEY;
+import static org.apache.dubbo.remoting.Constants.HEARTBEAT_TIMEOUT_KEY;
+import static org.apache.dubbo.rpc.Constants.INTERFACES;
+
+@Activate
+public class DefaultMetadataParamsFilter implements MetadataParamsFilter {
+    private final String[] excludedServiceParams;
+    private final String[] includedInstanceParams;
+
+    public DefaultMetadataParamsFilter() {
+        this.includedInstanceParams = new String[]{HEARTBEAT_TIMEOUT_KEY};
+        this.excludedServiceParams = new String[]{MONITOR_KEY, BIND_IP_KEY, BIND_PORT_KEY, QOS_ENABLE,
+            QOS_HOST, QOS_PORT, ACCEPT_FOREIGN_IP, VALIDATION_KEY, INTERFACES, PID_KEY, TIMESTAMP_KEY};
+    }
+
+    @Override
+    public String[] instanceParamsIncluded() {
+        return includedInstanceParams;
+    }
+
+    @Override
+    public String[] serviceParamsExcluded() {
+        return excludedServiceParams;
+    }
+}

--- a/dubbo-metadata/dubbo-metadata-api/src/main/java/org/apache/dubbo/metadata/MetadataInfo.java
+++ b/dubbo-metadata/dubbo-metadata-api/src/main/java/org/apache/dubbo/metadata/MetadataInfo.java
@@ -27,6 +27,8 @@ import org.apache.dubbo.common.utils.JsonUtils;
 import org.apache.dubbo.common.utils.StringUtils;
 
 import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -368,23 +370,45 @@ public class MetadataInfo implements Serializable {
             return;
         }
 
-        filters.forEach(filter -> {
-            String[] included = filter.instanceParamsIncluded();
-            if (ArrayUtils.isEmpty(included)) {
-                /*
-                 * Does not put any parameter in instance if not specified.
-                 * It will bring no functional suppression as long as all params will appear in service metadata.
-                 */
-            } else {
-                for (String p : included) {
-                    String value = url.getParameter(p);
-                    if (value != null) {
-                        String oldValue = instanceParams.put(p, value);
-                        if (oldValue != null && !oldValue.equals(value)) {
-                            throw new IllegalStateException(String.format("Inconsistent instance metadata found in different services: %s, %s", oldValue, value));
-                        }
-                    }
+        String[] included, excluded;
+        if (filters.size() == 1) {
+            MetadataParamsFilter filter = filters.get(0);
+            included = filter.instanceParamsIncluded();
+            excluded = filter.instanceParamsExcluded();
+        } else {
+            Set<String> includedList = new HashSet<>();
+            Set<String> excludedList = new HashSet<>();
+            filters.forEach(filter -> {
+                if (ArrayUtils.isNotEmpty(filter.instanceParamsIncluded())) {
+                    includedList.addAll(Arrays.asList(filter.instanceParamsIncluded()));
                 }
+                if (ArrayUtils.isNotEmpty(filter.instanceParamsExcluded())) {
+                    excludedList.addAll(Arrays.asList(filter.instanceParamsExcluded()));
+                }
+            });
+            included = includedList.toArray(new String[0]);
+            excluded = excludedList.toArray(new String[0]);
+        }
+
+        Map<String, String> tmpInstanceParams = new HashMap<>();
+        if (ArrayUtils.isNotEmpty(included)) {
+            for (String p : included) {
+                String value = url.getParameter(p);
+                if (value != null) {
+                    tmpInstanceParams.put(p, value);
+                }
+            }
+        } else if (ArrayUtils.isNotEmpty(excluded)) {
+            tmpInstanceParams.putAll(url.getParameters());
+            for (String p : excluded) {
+                tmpInstanceParams.remove(p);
+            }
+        }
+
+        tmpInstanceParams.forEach((key, value) -> {
+            String oldValue = instanceParams.put(key, value);
+            if (oldValue != null && !oldValue.equals(value)) {
+                throw new IllegalStateException(String.format("Inconsistent instance metadata found in different services: %s, %s", oldValue, value));
             }
         });
     }
@@ -451,34 +475,7 @@ public class MetadataInfo implements Serializable {
         public ServiceInfo(URL url, List<MetadataParamsFilter> filters) {
             this(url.getServiceInterface(), url.getGroup(), url.getVersion(), url.getProtocol(), url.getPath(), null);
             this.url = url;
-            Map<String, String> params = new HashMap<>();
-            if (filters.size() == 0) {
-                params.putAll(url.getParameters());
-                for (String key : KEYS_TO_REMOVE) {
-                    params.remove(key);
-                }
-            }
-            for (MetadataParamsFilter filter : filters) {
-                String[] paramsIncluded = filter.serviceParamsIncluded();
-                if (ArrayUtils.isNotEmpty(paramsIncluded)) {
-                    for (String p : paramsIncluded) {
-                        String value = url.getParameter(p);
-                        if (StringUtils.isNotEmpty(value) && params.get(p) == null) {
-                            params.put(p, value);
-                        }
-                        String[] methods = url.getParameter(METHODS_KEY, (String[]) null);
-                        if (methods != null) {
-                            for (String method : methods) {
-                                String mValue = url.getMethodParameterStrict(method, p);
-                                if (StringUtils.isNotEmpty(mValue)) {
-                                    params.put(method + DOT_SEPARATOR + p, mValue);
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-            this.params = params;
+            Map<String, String> params = extractServiceParams(url, filters);
             // initialize method params caches.
             this.methodParams = URLParam.initMethodParameters(params);
             this.consumerMethodParams = URLParam.initMethodParameters(consumerParams);
@@ -494,6 +491,75 @@ public class MetadataInfo implements Serializable {
 
             this.serviceKey = buildServiceKey(name, group, version);
             this.matchKey = buildMatchKey();
+        }
+
+        private Map<String, String> extractServiceParams(URL url, List<MetadataParamsFilter> filters) {
+            Map<String, String> params = new HashMap<>();
+            if (filters.size() == 0) {
+                params.putAll(url.getParameters());
+                for (String key : KEYS_TO_REMOVE) {
+                    params.remove(key);
+                }
+            }
+
+            String[] included, excluded;
+            if (filters.size() == 1) {
+                included = filters.get(0).serviceParamsIncluded();
+                excluded = filters.get(0).serviceParamsExcluded();
+            } else {
+                Set<String> includedList = new HashSet<>();
+                Set<String> excludedList = new HashSet<>();
+                for (MetadataParamsFilter filter : filters) {
+                    if (ArrayUtils.isNotEmpty(filter.serviceParamsIncluded())) {
+                        includedList.addAll(Arrays.asList(filter.serviceParamsIncluded()));
+                    }
+                    if (ArrayUtils.isNotEmpty(filter.serviceParamsExcluded())) {
+                        excludedList.addAll(Arrays.asList(filter.serviceParamsExcluded()));
+                    }
+                }
+                included = includedList.toArray(new String[0]);
+                excluded = excludedList.toArray(new String[0]);
+            }
+
+            if (ArrayUtils.isNotEmpty(included)) {
+                String[] methods = url.getParameter(METHODS_KEY, (String[]) null);
+                for (String p : included) {
+                    String value = url.getParameter(p);
+                    if (StringUtils.isNotEmpty(value) && params.get(p) == null) {
+                        params.put(p, value);
+                    }
+                    appendMethodParams(url, params, methods, p);
+                }
+            } else if (ArrayUtils.isNotEmpty(excluded)) {
+                for (Map.Entry<String, String> entry : url.getParameters().entrySet()) {
+                    String key = entry.getKey();
+                    String value = entry.getValue();
+                    boolean shouldAdd = true;
+                    for (String excludeKey : excluded) {
+                        if (key.equalsIgnoreCase(excludeKey) || key.contains("." + excludeKey)) {
+                            shouldAdd = false;
+                            break;
+                        }
+                    }
+                    if (shouldAdd) {
+                        params.put(key, value);
+                    }
+                }
+            }
+
+            this.params = params;
+            return params;
+        }
+
+        private void appendMethodParams(URL url, Map<String, String> params, String[] methods, String p) {
+            if (methods != null) {
+                for (String method : methods) {
+                    String mValue = url.getMethodParameterStrict(method, p);
+                    if (StringUtils.isNotEmpty(mValue)) {
+                        params.put(method + DOT_SEPARATOR + p, mValue);
+                    }
+                }
+            }
         }
 
         /**

--- a/dubbo-metadata/dubbo-metadata-api/src/main/java/org/apache/dubbo/metadata/MetadataInfo.java
+++ b/dubbo-metadata/dubbo-metadata-api/src/main/java/org/apache/dubbo/metadata/MetadataInfo.java
@@ -27,7 +27,6 @@ import org.apache.dubbo.common.utils.JsonUtils;
 import org.apache.dubbo.common.utils.StringUtils;
 
 import java.io.Serializable;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;

--- a/dubbo-metadata/dubbo-metadata-api/src/main/java/org/apache/dubbo/metadata/MetadataInfo.java
+++ b/dubbo-metadata/dubbo-metadata-api/src/main/java/org/apache/dubbo/metadata/MetadataInfo.java
@@ -47,18 +47,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import static org.apache.dubbo.common.constants.CommonConstants.DOT_SEPARATOR;
 import static org.apache.dubbo.common.constants.CommonConstants.GROUP_CHAR_SEPARATOR;
 import static org.apache.dubbo.common.constants.CommonConstants.METHODS_KEY;
-import static org.apache.dubbo.common.constants.CommonConstants.MONITOR_KEY;
-import static org.apache.dubbo.common.constants.CommonConstants.PID_KEY;
-import static org.apache.dubbo.common.constants.CommonConstants.TIMESTAMP_KEY;
-import static org.apache.dubbo.common.constants.FilterConstants.VALIDATION_KEY;
-import static org.apache.dubbo.common.constants.QosConstants.ACCEPT_FOREIGN_IP;
-import static org.apache.dubbo.common.constants.QosConstants.QOS_ENABLE;
-import static org.apache.dubbo.common.constants.QosConstants.QOS_HOST;
-import static org.apache.dubbo.common.constants.QosConstants.QOS_PORT;
 import static org.apache.dubbo.metadata.RevisionResolver.EMPTY_REVISION;
-import static org.apache.dubbo.remoting.Constants.BIND_IP_KEY;
-import static org.apache.dubbo.remoting.Constants.BIND_PORT_KEY;
-import static org.apache.dubbo.rpc.Constants.INTERFACES;
 
 public class MetadataInfo implements Serializable {
     public static final MetadataInfo EMPTY = new MetadataInfo();
@@ -466,9 +455,6 @@ public class MetadataInfo implements Serializable {
 
         private transient URL url;
 
-        private final static String[] KEYS_TO_REMOVE = {MONITOR_KEY, BIND_IP_KEY, BIND_PORT_KEY, QOS_ENABLE,
-            QOS_HOST, QOS_PORT, ACCEPT_FOREIGN_IP, VALIDATION_KEY, INTERFACES, PID_KEY, TIMESTAMP_KEY};
-
         public ServiceInfo() {}
 
         public ServiceInfo(URL url, List<MetadataParamsFilter> filters) {
@@ -494,12 +480,6 @@ public class MetadataInfo implements Serializable {
 
         private Map<String, String> extractServiceParams(URL url, List<MetadataParamsFilter> filters) {
             Map<String, String> params = new HashMap<>();
-            if (filters.size() == 0) {
-                params.putAll(url.getParameters());
-                for (String key : KEYS_TO_REMOVE) {
-                    params.remove(key);
-                }
-            }
 
             String[] included, excluded;
             if (filters.size() == 1) {

--- a/dubbo-metadata/dubbo-metadata-api/src/main/java/org/apache/dubbo/metadata/MetadataParamsFilter.java
+++ b/dubbo-metadata/dubbo-metadata-api/src/main/java/org/apache/dubbo/metadata/MetadataParamsFilter.java
@@ -18,6 +18,17 @@ package org.apache.dubbo.metadata;
 
 import org.apache.dubbo.common.extension.SPI;
 
+/**
+ * This filter applies an either 'include' or 'exclude' policy with 'include' having higher priority.
+ * That means if 'include' is specified then params specified in 'exclude' will be ignored
+ *
+ * If multiple Filter extensions are provided, then,
+ * 1. All params specified as should be included within different Filter extension instances will determine the params that will finally be used.
+ * 2. If none of the Filter extensions specified any params as should be included, then the final effective params would be those left after removed all the params specified as should be excluded.
+ *
+ * It is recommended for most users to use 'exclude' policy for service params and 'include' policy for instance params.
+ * Please use 'params-filter=-default, -filterName1, filterName2' to activate or deactivate filter extensions.
+ */
 @SPI
 public interface MetadataParamsFilter {
 
@@ -28,10 +39,24 @@ public interface MetadataParamsFilter {
     */
    String[] serviceParamsIncluded();
 
+    /**
+     * params that need to be excluded before sending to metadata center
+     *
+     * @return arrays of keys
+     */
+    String[] serviceParamsExcluded();
+
    /**
     * params that need to be sent to registry center
     *
     * @return arrays of keys
     */
    String[] instanceParamsIncluded();
+
+    /**
+     * params that need to be excluded before sending to registry center
+     *
+     * @return arrays of keys
+     */
+    String[] instanceParamsExcluded();
 }

--- a/dubbo-metadata/dubbo-metadata-api/src/main/java/org/apache/dubbo/metadata/MetadataParamsFilter.java
+++ b/dubbo-metadata/dubbo-metadata-api/src/main/java/org/apache/dubbo/metadata/MetadataParamsFilter.java
@@ -37,26 +37,34 @@ public interface MetadataParamsFilter {
     *
     * @return arrays of keys
     */
-   String[] serviceParamsIncluded();
+   default String[] serviceParamsIncluded() {
+       return new String[0];
+   }
 
     /**
      * params that need to be excluded before sending to metadata center
      *
      * @return arrays of keys
      */
-    String[] serviceParamsExcluded();
+    default String[] serviceParamsExcluded() {
+        return new String[0];
+    }
 
-   /**
-    * params that need to be sent to registry center
-    *
-    * @return arrays of keys
-    */
-   String[] instanceParamsIncluded();
+    /**
+     * params that need to be sent to registry center
+     *
+     * @return arrays of keys
+     */
+    default String[] instanceParamsIncluded() {
+        return new String[0];
+    }
 
     /**
      * params that need to be excluded before sending to registry center
      *
      * @return arrays of keys
      */
-    String[] instanceParamsExcluded();
+    default String[] instanceParamsExcluded() {
+        return new String[0];
+    }
 }

--- a/dubbo-metadata/dubbo-metadata-api/src/main/java/org/apache/dubbo/metadata/ServiceNameMapping.java
+++ b/dubbo-metadata/dubbo-metadata-api/src/main/java/org/apache/dubbo/metadata/ServiceNameMapping.java
@@ -90,9 +90,9 @@ public interface ServiceNameMapping extends Destroyable {
     }
 
     /**
-     * Init the mapping data from local storage and url parameter.
+     * Init mapping from local storage and url parameter.
      *
-     * @return app list that current interface maps to, in sequence determined by:
+     * @return app list the current interface maps to, in sequence determined by:
      * 1. PROVIDED_BY specified by user
      * 2. snapshot in local file
      */

--- a/dubbo-metadata/dubbo-metadata-api/src/main/resources/META-INF/dubbo/internal/org.apache.dubbo.metadata.MetadataParamsFilter
+++ b/dubbo-metadata/dubbo-metadata-api/src/main/resources/META-INF/dubbo/internal/org.apache.dubbo.metadata.MetadataParamsFilter
@@ -1,0 +1,1 @@
+default=org.apache.dubbo.metadata.DefaultMetadataParamsFilter

--- a/dubbo-metadata/dubbo-metadata-api/src/main/resources/META-INF/dubbo/internal/org.apache.dubbo.metadata.MetadataParamsFilter
+++ b/dubbo-metadata/dubbo-metadata-api/src/main/resources/META-INF/dubbo/internal/org.apache.dubbo.metadata.MetadataParamsFilter
@@ -1,1 +1,1 @@
-default=org.apache.dubbo.metadata.DefaultMetadataParamsFilter
+dubbo=org.apache.dubbo.metadata.DefaultMetadataParamsFilter

--- a/dubbo-metadata/dubbo-metadata-api/src/test/java/org/apache/dubbo/metadata/MetadataInfoTest.java
+++ b/dubbo-metadata/dubbo-metadata-api/src/test/java/org/apache/dubbo/metadata/MetadataInfoTest.java
@@ -91,8 +91,7 @@ public class MetadataInfoTest {
         metadataInfo.addService(url3);
         MetadataInfo.ServiceInfo serviceInfo3 = metadataInfo.getServiceInfo(url3.getProtocolServiceKey());
         assertNotNull(serviceInfo3);
-        // '5 + 1' because 'sayHello.timeout' will also be excluded
-        assertEquals(url3.getAllParameters().size() - (5 + 1), serviceInfo3.getParams().size());
+        assertEquals(14, serviceInfo3.getParams().size());
         assertNotNull(serviceInfo3.getParams().get(INTERFACE_KEY));
         assertNotNull(serviceInfo3.getParams().get(APPLICATION_KEY));
         assertNotNull(serviceInfo3.getParams().get(VERSION_KEY));

--- a/dubbo-metadata/dubbo-metadata-api/src/test/java/org/apache/dubbo/metadata/MetadataInfoTest.java
+++ b/dubbo-metadata/dubbo-metadata-api/src/test/java/org/apache/dubbo/metadata/MetadataInfoTest.java
@@ -51,6 +51,12 @@ public class MetadataInfoTest {
         "&metadata-type=remote&methods=sayHello&pid=36621&release=&revision=1.0.0&service-name-mapping=true" +
         "&side=provider&timeout=5000&timestamp=1629970068002&version=1.0.0&params-filter=customized,-excluded");
 
+    private static URL url3 = URL.valueOf("dubbo://30.225.21.30:20880/org.apache.dubbo.registry.service.DemoService?" +
+        "REGISTRY_CLUSTER=registry1&anyhost=true&application=demo-provider2&delay=5000&deprecated=false&dubbo=2.0.2" +
+        "&dynamic=true&generic=false&group=greeting&interface=org.apache.dubbo.registry.service.DemoService" +
+        "&metadata-type=remote&methods=sayHello&sayHello.timeout=7000&pid=36621&release=&revision=1.0.0&service-name-mapping=true" +
+        "&side=provider&timeout=5000&timestamp=1629970068002&version=1.0.0&params-filter=-customized,excluded");
+
     @Test
     public void testEmptyRevision() {
         MetadataInfo metadataInfo = new MetadataInfo("demo");
@@ -60,7 +66,7 @@ public class MetadataInfoTest {
     }
 
     @Test
-    public void testParamsFiltered() {
+    public void testParamsFilterIncluded() {
         MetadataInfo metadataInfo = new MetadataInfo("demo");
 
         // export normal url again
@@ -75,6 +81,25 @@ public class MetadataInfoTest {
         assertNotNull(serviceInfo2.getParams().get(GROUP_KEY));
         assertNotNull(serviceInfo2.getParams().get(TIMEOUT_KEY));
         assertEquals("7000", serviceInfo2.getMethodParameter("sayHello", TIMEOUT_KEY, "1000"));
+    }
+
+    @Test
+    public void testParamsFilterExcluded() {
+        MetadataInfo metadataInfo = new MetadataInfo("demo");
+
+        // export normal url again
+        metadataInfo.addService(url3);
+        MetadataInfo.ServiceInfo serviceInfo3 = metadataInfo.getServiceInfo(url3.getProtocolServiceKey());
+        assertNotNull(serviceInfo3);
+        // '5 + 1' because 'sayHello.timeout' will also be excluded
+        assertEquals(url3.getAllParameters().size() - (5 + 1), serviceInfo3.getParams().size());
+        assertNotNull(serviceInfo3.getParams().get(INTERFACE_KEY));
+        assertNotNull(serviceInfo3.getParams().get(APPLICATION_KEY));
+        assertNotNull(serviceInfo3.getParams().get(VERSION_KEY));
+        assertNull(serviceInfo3.getParams().get(GROUP_KEY));
+        assertNull(serviceInfo3.getParams().get(TIMEOUT_KEY));
+        assertNull(serviceInfo3.getParams().get("delay"));
+        assertEquals("1000", serviceInfo3.getMethodParameter("sayHello", TIMEOUT_KEY, "1000"));
     }
 
     @Test

--- a/dubbo-metadata/dubbo-metadata-api/src/test/java/org/apache/dubbo/metadata/filter/CustomizedParamsFilter.java
+++ b/dubbo-metadata/dubbo-metadata-api/src/test/java/org/apache/dubbo/metadata/filter/CustomizedParamsFilter.java
@@ -24,7 +24,7 @@ import static org.apache.dubbo.common.constants.CommonConstants.GROUP_KEY;
 import static org.apache.dubbo.common.constants.CommonConstants.TIMEOUT_KEY;
 import static org.apache.dubbo.common.constants.CommonConstants.VERSION_KEY;
 
-@Activate
+@Activate(order = 3) // Will take effect after ExcludedParamsFilter
 public class CustomizedParamsFilter implements MetadataParamsFilter {
 
     @Override
@@ -32,11 +32,21 @@ public class CustomizedParamsFilter implements MetadataParamsFilter {
         return new String[]{APPLICATION_KEY, TIMEOUT_KEY, GROUP_KEY, VERSION_KEY};
     }
 
+    @Override
+    public String[] serviceParamsExcluded() {
+        return new String[0];
+    }
+
     /**
      * Not included in this test
      */
     @Override
     public String[] instanceParamsIncluded() {
+        return new String[0];
+    }
+
+    @Override
+    public String[] instanceParamsExcluded() {
         return new String[0];
     }
 }

--- a/dubbo-metadata/dubbo-metadata-api/src/test/java/org/apache/dubbo/metadata/filter/ExcludedParamsFilter.java
+++ b/dubbo-metadata/dubbo-metadata-api/src/test/java/org/apache/dubbo/metadata/filter/ExcludedParamsFilter.java
@@ -19,14 +19,21 @@ package org.apache.dubbo.metadata.filter;
 import org.apache.dubbo.common.extension.Activate;
 import org.apache.dubbo.metadata.MetadataParamsFilter;
 
+import static org.apache.dubbo.common.constants.CommonConstants.GROUP_KEY;
 import static org.apache.dubbo.common.constants.CommonConstants.INTERFACE_KEY;
+import static org.apache.dubbo.common.constants.CommonConstants.TIMEOUT_KEY;
 
-@Activate
+@Activate(order = 1) // Will take effect before ExcludedParamsFilter
 public class ExcludedParamsFilter implements MetadataParamsFilter {
 
     @Override
     public String[] serviceParamsIncluded() {
-        return new String[]{INTERFACE_KEY};
+        return new String[0];
+    }
+
+    @Override
+    public String[] serviceParamsExcluded() {
+        return new String[]{TIMEOUT_KEY, GROUP_KEY, "delay"};
     }
 
     /**
@@ -34,6 +41,11 @@ public class ExcludedParamsFilter implements MetadataParamsFilter {
      */
     @Override
     public String[] instanceParamsIncluded() {
+        return new String[0];
+    }
+
+    @Override
+    public String[] instanceParamsExcluded() {
         return new String[0];
     }
 }

--- a/dubbo-metadata/dubbo-metadata-api/src/test/java/org/apache/dubbo/metadata/filter/ExcludedParamsFilter.java
+++ b/dubbo-metadata/dubbo-metadata-api/src/test/java/org/apache/dubbo/metadata/filter/ExcludedParamsFilter.java
@@ -20,7 +20,6 @@ import org.apache.dubbo.common.extension.Activate;
 import org.apache.dubbo.metadata.MetadataParamsFilter;
 
 import static org.apache.dubbo.common.constants.CommonConstants.GROUP_KEY;
-import static org.apache.dubbo.common.constants.CommonConstants.INTERFACE_KEY;
 import static org.apache.dubbo.common.constants.CommonConstants.TIMEOUT_KEY;
 
 @Activate(order = 1) // Will take effect before ExcludedParamsFilter

--- a/dubbo-metadata/dubbo-metadata-api/src/test/java/org/apache/dubbo/metadata/filter/ExcludedParamsFilter2.java
+++ b/dubbo-metadata/dubbo-metadata-api/src/test/java/org/apache/dubbo/metadata/filter/ExcludedParamsFilter2.java
@@ -14,28 +14,27 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.dubbo.registry.client.metadata.store;
+package org.apache.dubbo.metadata.filter;
 
 import org.apache.dubbo.common.extension.Activate;
 import org.apache.dubbo.metadata.MetadataParamsFilter;
 
-import static org.apache.dubbo.common.constants.CommonConstants.APPLICATION_KEY;
 import static org.apache.dubbo.common.constants.CommonConstants.GROUP_KEY;
 import static org.apache.dubbo.common.constants.CommonConstants.SIDE_KEY;
 import static org.apache.dubbo.common.constants.CommonConstants.TIMEOUT_KEY;
-import static org.apache.dubbo.common.constants.CommonConstants.VERSION_KEY;
+import static org.apache.dubbo.rpc.Constants.DEPRECATED_KEY;
 
-@Activate
-public class CustomizedParamsFilter implements MetadataParamsFilter {
+@Activate(order = 2) // Will take effect before ExcludedParamsFilter
+public class ExcludedParamsFilter2 implements MetadataParamsFilter {
 
     @Override
     public String[] serviceParamsIncluded() {
-        return new String[]{APPLICATION_KEY, TIMEOUT_KEY, GROUP_KEY, VERSION_KEY};
+        return new String[0];
     }
 
     @Override
     public String[] serviceParamsExcluded() {
-        return new String[0];
+        return new String[]{DEPRECATED_KEY, SIDE_KEY};
     }
 
     /**
@@ -43,7 +42,7 @@ public class CustomizedParamsFilter implements MetadataParamsFilter {
      */
     @Override
     public String[] instanceParamsIncluded() {
-        return new String[]{SIDE_KEY};
+        return new String[0];
     }
 
     @Override

--- a/dubbo-metadata/dubbo-metadata-api/src/test/java/org/apache/dubbo/metadata/filter/ExcludedParamsFilter2.java
+++ b/dubbo-metadata/dubbo-metadata-api/src/test/java/org/apache/dubbo/metadata/filter/ExcludedParamsFilter2.java
@@ -19,9 +19,7 @@ package org.apache.dubbo.metadata.filter;
 import org.apache.dubbo.common.extension.Activate;
 import org.apache.dubbo.metadata.MetadataParamsFilter;
 
-import static org.apache.dubbo.common.constants.CommonConstants.GROUP_KEY;
 import static org.apache.dubbo.common.constants.CommonConstants.SIDE_KEY;
-import static org.apache.dubbo.common.constants.CommonConstants.TIMEOUT_KEY;
 import static org.apache.dubbo.rpc.Constants.DEPRECATED_KEY;
 
 @Activate(order = 2) // Will take effect before ExcludedParamsFilter

--- a/dubbo-metadata/dubbo-metadata-api/src/test/resources/META-INF/dubbo/internal/org.apache.dubbo.metadata.MetadataParamsFilter
+++ b/dubbo-metadata/dubbo-metadata-api/src/test/resources/META-INF/dubbo/internal/org.apache.dubbo.metadata.MetadataParamsFilter
@@ -1,2 +1,3 @@
 customized=org.apache.dubbo.metadata.filter.CustomizedParamsFilter
 excluded=org.apache.dubbo.metadata.filter.ExcludedParamsFilter
+excluded2=org.apache.dubbo.metadata.filter.ExcludedParamsFilter2

--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/metadata/ServiceInstanceMetadataUtils.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/metadata/ServiceInstanceMetadataUtils.java
@@ -90,8 +90,6 @@ public class ServiceInstanceMetadataUtils {
 
     public static final String METADATA_CLUSTER_PROPERTY_NAME = "dubbo.metadata.cluster";
 
-    public static final String INSTANCE_REVISION_UPDATED_KEY = "dubbo.instance.revision.updated";
-
     public static final Gson gson = new Gson();
 
     public static String getMetadataServiceParameter(URL url) {

--- a/dubbo-registry/dubbo-registry-api/src/test/java/org/apache/dubbo/registry/client/metadata/ServiceInstanceMetadataCustomizerTest.java
+++ b/dubbo-registry/dubbo-registry-api/src/test/java/org/apache/dubbo/registry/client/metadata/ServiceInstanceMetadataCustomizerTest.java
@@ -46,7 +46,7 @@ public class ServiceInstanceMetadataCustomizerTest {
 
 
     /**
-     * Only 'include' specified in Customized Filter will take effect
+     * Only 'include' policy spicified in Customized Filter will take effect
      */
     @Test
     public void testCustomizeWithIncludeFilters() {
@@ -66,7 +66,7 @@ public class ServiceInstanceMetadataCustomizerTest {
     }
 
     /**
-     * Only 'include' specified in Customized Filter will take effect
+     * Only 'exclude' policies specified in Exclude Filters will take effect
      */
     @Test
     public void testCustomizeWithExcludeFilters() {
@@ -76,7 +76,7 @@ public class ServiceInstanceMetadataCustomizerTest {
 
         DefaultServiceInstance serviceInstance1 = new DefaultServiceInstance("ServiceInstanceMetadataCustomizerTest", applicationModel);
         MetadataInfo metadataInfo = new MetadataInfo();
-        metadataInfo.addService(URL.valueOf("tri://127.1.1.1:50052/org.apache.dubbo.demo.GreetingService?application=ServiceInstanceMetadataCustomizerTest&env=test&side=provider&group=test&params-filter=-customized"));
+        metadataInfo.addService(URL.valueOf("tri://127.1.1.1:50052/org.apache.dubbo.demo.GreetingService?application=ServiceInstanceMetadataCustomizerTest&env=test&side=provider&group=test&params-filter=-customized,-dubbo"));
         serviceInstance1.setServiceMetadata(metadataInfo);
         serviceInstanceMetadataCustomizer.customize(serviceInstance1, applicationModel);
         Assertions.assertEquals(2, serviceInstance1.getMetadata().size());

--- a/dubbo-registry/dubbo-registry-api/src/test/java/org/apache/dubbo/registry/client/metadata/ServiceInstanceMetadataCustomizerTest.java
+++ b/dubbo-registry/dubbo-registry-api/src/test/java/org/apache/dubbo/registry/client/metadata/ServiceInstanceMetadataCustomizerTest.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.registry.client.metadata;
+
+import org.apache.dubbo.common.URL;
+import org.apache.dubbo.config.ApplicationConfig;
+import org.apache.dubbo.metadata.MetadataInfo;
+import org.apache.dubbo.registry.client.DefaultServiceInstance;
+import org.apache.dubbo.rpc.model.ApplicationModel;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.apache.dubbo.common.constants.CommonConstants.SIDE_KEY;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.spy;
+
+public class ServiceInstanceMetadataCustomizerTest {
+    private static ServiceInstanceMetadataCustomizer serviceInstanceMetadataCustomizer;
+
+    @BeforeAll
+    public static void setUp() {
+        serviceInstanceMetadataCustomizer = new ServiceInstanceMetadataCustomizer();
+    }
+
+    @AfterAll
+    public static void clearUp() {
+        ApplicationModel.reset();
+    }
+
+
+    /**
+     * Only 'include' specified in Customized Filter will take effect
+     */
+    @Test
+    public void testCustomizeWithIncludeFilters() {
+        ApplicationModel applicationModel = spy(ApplicationModel.defaultModel());
+        ApplicationConfig applicationConfig = new ApplicationConfig("aa");
+        doReturn(applicationConfig).when(applicationModel).getCurrentConfig();
+
+        DefaultServiceInstance serviceInstance1 = new DefaultServiceInstance("ServiceInstanceMetadataCustomizerTest", applicationModel);
+        MetadataInfo metadataInfo = new MetadataInfo();
+        metadataInfo.addService(URL.valueOf("tri://127.1.1.1:50052/org.apache.dubbo.demo.GreetingService?application=ServiceInstanceMetadataCustomizerTest&env=test&side=provider&group=test"));
+        serviceInstance1.setServiceMetadata(metadataInfo);
+        serviceInstanceMetadataCustomizer.customize(serviceInstance1, applicationModel);
+        Assertions.assertEquals(1, serviceInstance1.getMetadata().size());
+        Assertions.assertEquals("provider", serviceInstance1.getMetadata(SIDE_KEY));
+        Assertions.assertNull( serviceInstance1.getMetadata("env"));
+        Assertions.assertNull( serviceInstance1.getMetadata("application"));
+    }
+
+    /**
+     * Only 'include' specified in Customized Filter will take effect
+     */
+    @Test
+    public void testCustomizeWithExcludeFilters() {
+        ApplicationModel applicationModel = spy(ApplicationModel.defaultModel());
+        ApplicationConfig applicationConfig = new ApplicationConfig("aa");
+        doReturn(applicationConfig).when(applicationModel).getCurrentConfig();
+
+        DefaultServiceInstance serviceInstance1 = new DefaultServiceInstance("ServiceInstanceMetadataCustomizerTest", applicationModel);
+        MetadataInfo metadataInfo = new MetadataInfo();
+        metadataInfo.addService(URL.valueOf("tri://127.1.1.1:50052/org.apache.dubbo.demo.GreetingService?application=ServiceInstanceMetadataCustomizerTest&env=test&side=provider&group=test&params-filter=-customized"));
+        serviceInstance1.setServiceMetadata(metadataInfo);
+        serviceInstanceMetadataCustomizer.customize(serviceInstance1, applicationModel);
+        Assertions.assertEquals(2, serviceInstance1.getMetadata().size());
+        Assertions.assertEquals("ServiceInstanceMetadataCustomizerTest", serviceInstance1.getMetadata("application"));
+        Assertions.assertEquals("test", serviceInstance1.getMetadata("env"));
+
+        Assertions.assertNull( serviceInstance1.getMetadata("side"));
+        Assertions.assertNull( serviceInstance1.getMetadata("group"));
+    }
+}

--- a/dubbo-registry/dubbo-registry-api/src/test/java/org/apache/dubbo/registry/client/metadata/store/ExcludedParamsFilter.java
+++ b/dubbo-registry/dubbo-registry-api/src/test/java/org/apache/dubbo/registry/client/metadata/store/ExcludedParamsFilter.java
@@ -19,14 +19,19 @@ package org.apache.dubbo.registry.client.metadata.store;
 import org.apache.dubbo.common.extension.Activate;
 import org.apache.dubbo.metadata.MetadataParamsFilter;
 
-import static org.apache.dubbo.common.constants.CommonConstants.INTERFACE_KEY;
+import static org.apache.dubbo.common.constants.CommonConstants.SIDE_KEY;
 
 @Activate
 public class ExcludedParamsFilter implements MetadataParamsFilter {
 
     @Override
     public String[] serviceParamsIncluded() {
-        return new String[]{INTERFACE_KEY};
+        return new String[0];
+    }
+
+    @Override
+    public String[] serviceParamsExcluded() {
+        return new String[0];
     }
 
     /**
@@ -35,5 +40,10 @@ public class ExcludedParamsFilter implements MetadataParamsFilter {
     @Override
     public String[] instanceParamsIncluded() {
         return new String[0];
+    }
+
+    @Override
+    public String[] instanceParamsExcluded() {
+        return new String[]{SIDE_KEY};
     }
 }

--- a/dubbo-registry/dubbo-registry-api/src/test/java/org/apache/dubbo/registry/client/metadata/store/ExcludedParamsFilter2.java
+++ b/dubbo-registry/dubbo-registry-api/src/test/java/org/apache/dubbo/registry/client/metadata/store/ExcludedParamsFilter2.java
@@ -19,18 +19,15 @@ package org.apache.dubbo.registry.client.metadata.store;
 import org.apache.dubbo.common.extension.Activate;
 import org.apache.dubbo.metadata.MetadataParamsFilter;
 
-import static org.apache.dubbo.common.constants.CommonConstants.APPLICATION_KEY;
 import static org.apache.dubbo.common.constants.CommonConstants.GROUP_KEY;
 import static org.apache.dubbo.common.constants.CommonConstants.SIDE_KEY;
-import static org.apache.dubbo.common.constants.CommonConstants.TIMEOUT_KEY;
-import static org.apache.dubbo.common.constants.CommonConstants.VERSION_KEY;
 
 @Activate
-public class CustomizedParamsFilter implements MetadataParamsFilter {
+public class ExcludedParamsFilter2 implements MetadataParamsFilter {
 
     @Override
     public String[] serviceParamsIncluded() {
-        return new String[]{APPLICATION_KEY, TIMEOUT_KEY, GROUP_KEY, VERSION_KEY};
+        return new String[0];
     }
 
     @Override
@@ -43,11 +40,11 @@ public class CustomizedParamsFilter implements MetadataParamsFilter {
      */
     @Override
     public String[] instanceParamsIncluded() {
-        return new String[]{SIDE_KEY};
+        return new String[0];
     }
 
     @Override
     public String[] instanceParamsExcluded() {
-        return new String[0];
+        return new String[]{GROUP_KEY, "params-filter"};
     }
 }

--- a/dubbo-registry/dubbo-registry-api/src/test/java/org/apache/dubbo/registry/client/metadata/store/ExcludedParamsFilter2.java
+++ b/dubbo-registry/dubbo-registry-api/src/test/java/org/apache/dubbo/registry/client/metadata/store/ExcludedParamsFilter2.java
@@ -20,7 +20,6 @@ import org.apache.dubbo.common.extension.Activate;
 import org.apache.dubbo.metadata.MetadataParamsFilter;
 
 import static org.apache.dubbo.common.constants.CommonConstants.GROUP_KEY;
-import static org.apache.dubbo.common.constants.CommonConstants.SIDE_KEY;
 
 @Activate
 public class ExcludedParamsFilter2 implements MetadataParamsFilter {

--- a/dubbo-registry/dubbo-registry-api/src/test/resources/META-INF/dubbo/org.apache.dubbo.metadata.MetadataParamsFilter
+++ b/dubbo-registry/dubbo-registry-api/src/test/resources/META-INF/dubbo/org.apache.dubbo.metadata.MetadataParamsFilter
@@ -1,2 +1,3 @@
 customized=org.apache.dubbo.registry.client.metadata.store.CustomizedParamsFilter
 excluded=org.apache.dubbo.registry.client.metadata.store.ExcludedParamsFilter
+excluded2=org.apache.dubbo.registry.client.metadata.store.ExcludedParamsFilter2

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/protocol/AbstractProxyProtocol.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/protocol/AbstractProxyProtocol.java
@@ -137,15 +137,21 @@ public abstract class AbstractProxyProtocol extends AbstractProtocol {
                 super.destroy();
                 target.destroy();
                 invokers.remove(this);
+                AbstractProxyProtocol.this.destroyInternal(url);
             }
         };
         invokers.add(invoker);
         return invoker;
     }
 
+    // used to destroy unused clients and other resource
+    protected void destroyInternal(URL url) {
+        // subclass override
+    }
+
     protected RpcException getRpcException(Class<?> type, URL url, Invocation invocation, Throwable e) {
         RpcException re = new RpcException("Failed to invoke remote service: " + type + ", method: "
-                + invocation.getMethodName() + ", cause: " + e.getMessage(), e);
+            + invocation.getMethodName() + ", cause: " + e.getMessage(), e);
         re.setCode(getErrorCode(e));
         return re;
     }


### PR DESCRIPTION
related issue #9990

New definition of ParamsFilter is as below

```java
/**
 * This filter applies an either 'include' or 'exclude' policy with 'include' having higher priority.
 * That means if 'include' is specified then params specified in 'exclude' will be ignored
 *
 * If multiple Filter extensions are provided, then,
 * 1. All params specified as should be included within different Filter extension instances will determine the params that will finally be used.
 * 2. If none of the Filter extensions specified any params as should be included, then the final effective params would be those left after removed all the params specified as should be excluded.
 *
 * It is recommended for most users to use 'exclude' policy for service params and 'include' policy for instance params.
 * Please use 'params-filter=-default, -filterName1, filterName2' to activate or deactivate filter extensions.
 */
@SPI
public interface MetadataParamsFilter {

    */
   String[] serviceParamsIncluded();

    /**
     * params that need to be excluded before sending to metadata center
     *
     * @return arrays of keys
     */
    String[] serviceParamsExcluded();

   /**
    * params that need to be sent to registry center
    *
    * @return arrays of keys
    */
   String[] instanceParamsIncluded();

    /**
     * params that need to be excluded before sending to registry center
     *
     * @return arrays of keys
     */
    String[] instanceParamsExcluded();
}
```