### PR TITLE
解决dubbo3.0.7使用protobuf序列化方式报错

### DIFF
--- a/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/transport/CodecSupport.java
+++ b/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/transport/CodecSupport.java
@@ -26,6 +26,7 @@ import org.apache.dubbo.common.serialize.ObjectOutput;
 import org.apache.dubbo.common.serialize.Serialization;
 import org.apache.dubbo.common.utils.CollectionUtils;
 import org.apache.dubbo.remoting.Constants;
+import org.apache.dubbo.rpc.model.ApplicationModel;
 import org.apache.dubbo.rpc.model.FrameworkModel;
 import org.apache.dubbo.rpc.model.FrameworkServiceRepository;
 
@@ -51,7 +52,7 @@ public class CodecSupport {
     private static final ThreadLocal<byte[]> TL_BUFFER = ThreadLocal.withInitial(() -> new byte[1024]);
 
     static {
-        ExtensionLoader<Serialization> extensionLoader = FrameworkModel.defaultModel().getExtensionLoader(Serialization.class);
+        ExtensionLoader<Serialization> extensionLoader = ApplicationModel.defaultModel().getExtensionLoader(Serialization.class);
         Set<String> supportedExtensions = extensionLoader.getSupportedExtensions();
         for (String name : supportedExtensions) {
             Serialization serialization = extensionLoader.getExtension(name);


### PR DESCRIPTION

## What is the purpose of the change
dubbo version：3.0.7
dubbo-serialization-protobuf：2.7.15
我使用最新的dubbo 3.0.7，想使用protobuf，但是最新的版本是2.7.15

使用过程中发现，由于dubbo 3.0.7版本中关于对protobuf序列化的支持，相关的实现移动到了dubbo-serialization-protobuf中，在调用过程中出现异常

CodecSupport初始化时静态块执行过程中出现空指针

ExtensionLoader<Serialization> extensionLoader = FrameworkModel.defaultModel().getExtensionLoader(Serialization.class);
Set<String> supportedExtensions = extensionLoader.getSupportedExtensions();

由于Serialization spi接口同时出现于dubbo和dubbo-serialization-api:2.7.14中，导致类冲突，dubbo-serialization-api中的Serialization接口scope=ExtensionScope.APPLICATION，导致这里获取为null，修改为ApplicationModel获取

## Verifying this change
本地修改后编译代码可以成功获取到


<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [x] Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [ ] GitHub Actions works fine on your own branch.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
