### PR TITLE
Fix #9829, SimpleReferenceCache bug to cause genericInvoke high latency

### DIFF
--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/utils/SimpleReferenceCache.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/utils/SimpleReferenceCache.java
@@ -107,14 +107,12 @@ public class SimpleReferenceCache implements ReferenceCache {
     public <T> T get(ReferenceConfigBase<T> rc) {
         String key = generator.generateKey(rc);
         Class<?> type = rc.getInterfaceClass();
-        Object proxy = rc.get();
-
-        references.computeIfAbsent(rc, _rc -> {
+        Object proxy = references.computeIfAbsent(rc, _rc -> {
             List<ReferenceConfigBase<?>> referencesOfType = referenceTypeMap.computeIfAbsent(type, _t -> Collections.synchronizedList(new ArrayList<>()));
             referencesOfType.add(rc);
             List<ReferenceConfigBase<?>> referenceConfigList = referenceKeyMap.computeIfAbsent(key, _k -> Collections.synchronizedList(new ArrayList<>()));
             referenceConfigList.add(rc);
-            return proxy;
+            return _rc.get();
         });
 
         return (T) proxy;


### PR DESCRIPTION
related issue https://github.com/apache/dubbo/issues/9829

This patch is more like a code optimization, it cannot fully solve the issue mentioned in #9829. We cannot  simply change the mapping key for now. So the best way to solve it is to try to reuse ReferenceConfig all the time.