### PR TITLE
Support for ibm J9 

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/status/support/LoadStatusChecker.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/status/support/LoadStatusChecker.java
@@ -27,12 +27,10 @@ import org.apache.dubbo.common.system.OperatingSystemBeanManager;
 @Activate
 public class LoadStatusChecker implements StatusChecker {
 
-    private static final double NA_VAL = -1d;
-
     @Override
     public Status check() {
         double load = OperatingSystemBeanManager.getOperatingSystemBean().getSystemLoadAverage();
-        if (load == NA_VAL) {
+        if (load == -1) {
             load = OperatingSystemBeanManager.getSystemCpuUsage();
         }
 

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/status/support/LoadStatusChecker.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/status/support/LoadStatusChecker.java
@@ -19,10 +19,7 @@ package org.apache.dubbo.common.status.support;
 import org.apache.dubbo.common.extension.Activate;
 import org.apache.dubbo.common.status.Status;
 import org.apache.dubbo.common.status.StatusChecker;
-
-import java.lang.management.ManagementFactory;
-import java.lang.management.OperatingSystemMXBean;
-import java.lang.reflect.Method;
+import org.apache.dubbo.common.system.OperatingSystemBeanManager;
 
 /**
  * Load Status
@@ -30,24 +27,27 @@ import java.lang.reflect.Method;
 @Activate
 public class LoadStatusChecker implements StatusChecker {
 
+    private static final double NA_VAL = -1d;
+
     @Override
     public Status check() {
-        OperatingSystemMXBean operatingSystemMXBean = ManagementFactory.getOperatingSystemMXBean();
-        double load;
-        try {
-            Method method = OperatingSystemMXBean.class.getMethod("getSystemLoadAverage", new Class<?>[0]);
-            load = (Double) method.invoke(operatingSystemMXBean, new Object[0]);
-            if (load == -1) {
-                com.sun.management.OperatingSystemMXBean bean =
-                        (com.sun.management.OperatingSystemMXBean) operatingSystemMXBean;
-                load = bean.getSystemCpuLoad();
-            }
-        } catch (Throwable e) {
-            load = -1;
+        double load = OperatingSystemBeanManager.getOperatingSystemBean().getSystemLoadAverage();
+        if (load == NA_VAL) {
+            load = OperatingSystemBeanManager.getSystemCpuUsage();
         }
-        int cpu = operatingSystemMXBean.getAvailableProcessors();
-        return new Status(load < 0 ? Status.Level.UNKNOWN : (load < cpu ? Status.Level.OK : Status.Level.WARN),
-                (load < 0 ? "" : "load:" + load + ",") + "cpu:" + cpu);
-    }
 
+        int cpu = OperatingSystemBeanManager.getOperatingSystemBean().getAvailableProcessors();
+        Status.Level level;
+        if (load < 0) {
+            level = Status.Level.UNKNOWN;
+        } else if (load < cpu) {
+            level = Status.Level.OK;
+        } else {
+            level = Status.Level.WARN;
+        }
+
+        String message = (load < 0 ? "" : "load:" + load + ",") + "cpu:" + cpu;
+        return new Status(level, message);
+    }
 }
+

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/system/OperatingSystemBeanManager.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/system/OperatingSystemBeanManager.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.dubbo.common.system;
+
+import org.apache.dubbo.common.logger.Logger;
+import org.apache.dubbo.common.logger.LoggerFactory;
+import org.apache.dubbo.common.utils.MethodUtils;
+
+import java.lang.management.ManagementFactory;
+import java.lang.management.OperatingSystemMXBean;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * OperatingSystemBeanManager related.
+ */
+public class OperatingSystemBeanManager {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(OperatingSystemBeanManager.class);
+
+    /**
+     * com.ibm for J9
+     * com.sun for HotSpot
+     */
+    private static final List<String> OPERATING_SYSTEM_BEAN_CLASS_NAMES = Arrays.asList(
+            "com.sun.management.OperatingSystemMXBean", "com.ibm.lang.management.OperatingSystemMXBean");
+
+    private static final OperatingSystemMXBean OPERATING_SYSTEM_BEAN;
+
+    private static final Class<?> OPERATING_SYSTEM_BEAN_CLASS;
+
+    private static final Method SYSTEM_CPU_USAGE_METHOD;
+
+    private static final Method PROCESS_CPU_USAGE_METHOD;
+
+    static {
+        OPERATING_SYSTEM_BEAN = ManagementFactory.getOperatingSystemMXBean();
+        OPERATING_SYSTEM_BEAN_CLASS = loadOne(OPERATING_SYSTEM_BEAN_CLASS_NAMES);
+        SYSTEM_CPU_USAGE_METHOD = deduceMethod("getSystemCpuLoad");
+        PROCESS_CPU_USAGE_METHOD = deduceMethod("getProcessCpuLoad");
+    }
+
+    private OperatingSystemBeanManager() {}
+
+    public static OperatingSystemMXBean getOperatingSystemBean() {
+        return OPERATING_SYSTEM_BEAN;
+    }
+
+    public static double getSystemCpuUsage() {
+        return MethodUtils.invokeAndReturnDouble(SYSTEM_CPU_USAGE_METHOD, OPERATING_SYSTEM_BEAN);
+    }
+
+    public static double getProcessCpuUsage() {
+        return MethodUtils.invokeAndReturnDouble(PROCESS_CPU_USAGE_METHOD, OPERATING_SYSTEM_BEAN);
+    }
+
+    private static Class<?> loadOne(List<String> classNames) {
+        for (String className : classNames) {
+            try {
+                return Class.forName(className);
+            } catch (ClassNotFoundException e) {
+                LOGGER.warn("[OperatingSystemBeanManager] Failed to load operating system bean class.", e);
+            }
+        }
+        return null;
+    }
+
+    private static Method deduceMethod(String name) {
+        if (Objects.isNull(OPERATING_SYSTEM_BEAN_CLASS)) {
+            return null;
+        }
+        try {
+            OPERATING_SYSTEM_BEAN_CLASS.cast(OPERATING_SYSTEM_BEAN);
+            return OPERATING_SYSTEM_BEAN_CLASS.getDeclaredMethod(name);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+}

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/utils/MethodUtils.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/utils/MethodUtils.java
@@ -427,4 +427,35 @@ public interface MethodUtils {
 
         return fieldName;
     }
+
+    /**
+     * Invoke and return double value.
+     *
+     * @param method method
+     * @param targetObj the object the method is invoked from
+     * @return double value
+     */
+    static double invokeAndReturnDouble(Method method, Object targetObj) {
+        try {
+            return method != null ? (double) method.invoke(targetObj) : Double.NaN;
+        } catch (Exception e) {
+            return Double.NaN;
+        }
+    }
+
+    /**
+     * Invoke and return long value.
+     *
+     * @param method method
+     * @param targetObj the object the method is invoked from
+     * @return long value
+     */
+    static long invokeAndReturnLong(Method method, Object targetObj) {
+        try {
+            return method != null ? (long) method.invoke(targetObj) : -1;
+        } catch (Exception e) {
+            return -1;
+        }
+    }
 }
+


### PR DESCRIPTION
Now system metrics are obtained from com.sun.management.OperatingSystemMXBean for HotSpot JVM, but these are in com.ibm.lang.management.OperatingSystemMXBean for Ibm J9, so need to deduce the target source.