### PR TITLE
[3.0] fix #10035 ,In DubboService.java loadbalance does not have a correct default value

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/config/annotation/DubboService.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/config/annotation/DubboService.java
@@ -18,6 +18,7 @@ package org.apache.dubbo.config.annotation;
 
 
 import org.apache.dubbo.common.constants.ClusterRules;
+import org.apache.dubbo.common.constants.LoadbalanceRules;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
@@ -205,7 +206,7 @@ public @interface DubboService {
      *
      * you can use {@link org.apache.dubbo.common.constants.LoadbalanceRules#RANDOM} ……
      */
-    String loadbalance() default ClusterRules.EMPTY;
+    String loadbalance() default LoadbalanceRules.EMPTY;
 
     /**
      * Whether to enable async invocation, default value is false


### PR DESCRIPTION
fix #10035 

change "DubboService#loadbalance() default ClusterRules.EMPTY"  to " loadbalance() default LoadbalanceRules.EMPTY"
