### PR TITLE
[3.0] fix UT regex spell mistake

### DIFF
--- a/dubbo-common/src/test/java/org/apache/dubbo/common/utils/NetUtilsInterfaceDisplayNameHasMetaCharactersTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/utils/NetUtilsInterfaceDisplayNameHasMetaCharactersTest.java
@@ -29,7 +29,7 @@ import static org.apache.dubbo.common.constants.CommonConstants.DUBBO_NETWORK_IG
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class NetUtilsInterfaceDisplayNameHasMetaCharactersTest {
-    private static final String IGNORED_DISPLAY_NAME_HAS_METACHARACTERS = "Mock(R) ^$*+?.|-[0-9] Adapter";
+    private static final String IGNORED_DISPLAY_NAME_HAS_METACHARACTERS = "Mock(R) ^$*+[?].|-[0-9] Adapter";
     private static final String SELECTED_DISPLAY_NAME = "Selected Adapter";
     private static final String SELECTED_HOST_ADDR = "192.168.0.1";
 


### PR DESCRIPTION
fix regex spell mistake

<img width="1538" alt="截屏2022-05-16 下午2 14 41" src="https://user-images.githubusercontent.com/17539174/168534169-36adf890-17b5-4e50-acdd-7e7353e303e6.png">

