### PR TITLE
[2.7] fix memory leak

### DIFF
--- a/dubbo-serialization/dubbo-serialization-hessian2/src/main/java/org/apache/dubbo/common/serialize/hessian2/Hessian2ObjectInput.java
+++ b/dubbo-serialization/dubbo-serialization-hessian2/src/main/java/org/apache/dubbo/common/serialize/hessian2/Hessian2ObjectInput.java
@@ -31,18 +31,12 @@ import java.lang.reflect.Type;
  */
 public class Hessian2ObjectInput implements ObjectInput, Cleanable {
 
-    private static ThreadLocal<Hessian2Input> INPUT_TL = ThreadLocal.withInitial(() -> {
-        Hessian2Input h2i = new Hessian2Input(null);
-        h2i.setSerializerFactory(Hessian2FactoryInitializer.getInstance().getSerializerFactory());
-        h2i.setCloseStreamOnClose(true);
-        return h2i;
-    });
-
     private final Hessian2Input mH2i;
 
     public Hessian2ObjectInput(InputStream is) {
-        mH2i = INPUT_TL.get();
-        mH2i.init(is);
+        mH2i = new Hessian2Input(is);
+        mH2i.setSerializerFactory(Hessian2FactoryInitializer.getInstance().getSerializerFactory());
+        mH2i.setCloseStreamOnClose(true);
     }
 
     @Override

--- a/dubbo-serialization/dubbo-serialization-hessian2/src/main/java/org/apache/dubbo/common/serialize/hessian2/Hessian2ObjectOutput.java
+++ b/dubbo-serialization/dubbo-serialization-hessian2/src/main/java/org/apache/dubbo/common/serialize/hessian2/Hessian2ObjectOutput.java
@@ -30,18 +30,12 @@ import java.io.OutputStream;
  */
 public class Hessian2ObjectOutput implements ObjectOutput, Cleanable {
 
-    private static ThreadLocal<Hessian2Output> OUTPUT_TL = ThreadLocal.withInitial(() -> {
-        Hessian2Output h2o = new Hessian2Output(null);
-        h2o.setSerializerFactory(Hessian2FactoryInitializer.getInstance().getSerializerFactory());
-        h2o.setCloseStreamOnClose(true);
-        return h2o;
-    });
-
     private final Hessian2Output mH2o;
 
     public Hessian2ObjectOutput(OutputStream os) {
-        mH2o = OUTPUT_TL.get();
-        mH2o.init(os);
+        mH2o = new Hessian2Output(os);
+        mH2o.setSerializerFactory(Hessian2FactoryInitializer.getInstance().getSerializerFactory());
+        mH2o.setCloseStreamOnClose(true);
     }
 
     @Override


### PR DESCRIPTION
## What is the purpose of the change
fix #10219

## Brief changelog
remove ``ThreadLocal`` from ``Hessian2ObjectInput`` and ``Hessian2ObjectOutput `` 

