### PR TITLE
fix for issue#10283

### DIFF
--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/event/RetryServiceInstancesChangedEvent.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/event/RetryServiceInstancesChangedEvent.java
@@ -25,12 +25,19 @@ public class RetryServiceInstancesChangedEvent extends ServiceInstancesChangedEv
 
     private volatile long failureRecordTime;
 
-    public RetryServiceInstancesChangedEvent(String serviceName) {
+    private volatile int retryCount;
+
+    public RetryServiceInstancesChangedEvent(String serviceName, int retryCount) {
         super(serviceName, Collections.emptyList());// instance list has been stored by ServiceInstancesChangedListener
         this.failureRecordTime = System.currentTimeMillis();
+        this.retryCount = retryCount;
     }
 
     public long getFailureRecordTime() {
         return failureRecordTime;
+    }
+
+    public int getRetryCount() {
+        return retryCount;
     }
 }

--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/event/listener/ServiceInstancesChangedListener.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/event/listener/ServiceInstancesChangedListener.java
@@ -175,7 +175,6 @@ public class ServiceInstancesChangedListener {
                 }
 
                 retryFuture = scheduler.schedule(new AddressRefreshRetryTask(retryPermission, event.getServiceName(), retryCount), 10_000L, TimeUnit.MILLISECONDS);
-                logger.warn("Address refresh try task submitted");
             }
             // return if all metadata is empty, this notification will not take effect.
             if (emptyNum == revisionToInstances.size()) {
@@ -528,9 +527,14 @@ public class ServiceInstancesChangedListener {
         @Override
         public void run() {
             retryPermission.release();
+
             if (retryCount < 3) {
                 ServiceInstancesChangedListener.this.onEvent(retryEvent);
+                logger.warn("Address refresh try task submitted, retryCount:" + retryCount);
+                return;
             }
+
+            logger.info("Address refresh try task retryCount threshold reached");
         }
     }
 


### PR DESCRIPTION
问题链接：https://github.com/apache/dubbo/issues/10283
改动：问题原因是产生服务变动事件时，其中某个服务实例没有找到元数据信息就会触发延迟刷新，当元数据信息异常时就会一直重试，针对这个问题添加了重试机制，使一个变动事件最多重试三次。
