### PR TITLE
fix for issue 10303

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/URL.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/URL.java
@@ -135,7 +135,7 @@ class URL implements Serializable {
 
     protected URL() {
         this.urlAddress = null;
-        this.urlParam = null;
+        this.urlParam = URLParam.parse(new HashMap<>());
         this.attributes = null;
     }
 
@@ -145,7 +145,7 @@ class URL implements Serializable {
 
     public URL(URLAddress urlAddress, URLParam urlParam, Map<String, Object> attributes) {
         this.urlAddress = urlAddress;
-        this.urlParam = urlParam;
+        this.urlParam = null == urlParam ? URLParam.parse(new HashMap<>()) : urlParam;
         this.attributes = (attributes != null ? attributes.isEmpty() ? null : attributes : null);
     }
 

--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/InstanceAddressURL.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/InstanceAddressURL.java
@@ -55,7 +55,7 @@ public class InstanceAddressURL extends URL {
     private volatile transient Set<String> providerFirstParams;
     // one instance address url serves only one protocol.
     private final transient String protocol;
-    
+
     protected InstanceAddressURL() {
         this(null, null, null);
     }
@@ -242,6 +242,10 @@ public class InstanceAddressURL extends URL {
         }
 
         MetadataInfo.ServiceInfo serviceInfo = getServiceInfo(protocolServiceKey);
+        if (null == serviceInfo) {
+            return getParameter(key);
+        }
+
         String value = serviceInfo.getMethodParameter(method, key, null);
         if (StringUtils.isNotEmpty(value)) {
             return value;
@@ -307,6 +311,10 @@ public class InstanceAddressURL extends URL {
             return false;
         }
 
+        if (null == serviceInfo) {
+            return false;
+        }
+
         return serviceInfo.hasMethodParameter(method, key);
     }
 
@@ -344,6 +352,10 @@ public class InstanceAddressURL extends URL {
         }
 
         MetadataInfo.ServiceInfo serviceInfo = getServiceInfo(protocolServiceKey);
+        if (null == serviceInfo) {
+            return false;
+        }
+
         return serviceInfo.hasMethodParameter(method);
     }
 
@@ -427,7 +439,11 @@ public class InstanceAddressURL extends URL {
             return this;
         }
 
-       getServiceInfo(protocolServiceKey).addParameter(key, value);
+        MetadataInfo.ServiceInfo serviceInfo = getServiceInfo(protocolServiceKey);
+        if (null != serviceInfo) {
+            serviceInfo.addParameter(key, value);
+        }
+
         return this;
     }
 
@@ -436,12 +452,20 @@ public class InstanceAddressURL extends URL {
             return this;
         }
 
-        getServiceInfo(protocolServiceKey).addParameterIfAbsent(key, value);
+        MetadataInfo.ServiceInfo serviceInfo = getServiceInfo(protocolServiceKey);
+        if (null != serviceInfo) {
+            serviceInfo.addParameterIfAbsent(key, value);
+        }
+
         return this;
     }
 
     public URL addConsumerParams(String protocolServiceKey, Map<String, String> params) {
-        getServiceInfo(protocolServiceKey).addConsumerParams(params);
+        MetadataInfo.ServiceInfo serviceInfo = getServiceInfo(protocolServiceKey);
+        if (null != serviceInfo) {
+            serviceInfo.addConsumerParams(params);
+        }
+
         return this;
     }
 
@@ -456,7 +480,12 @@ public class InstanceAddressURL extends URL {
         String suffix = "." + key;
         String protocolServiceKey = getProtocolServiceKey();
         if (StringUtils.isNotEmpty(protocolServiceKey)) {
-            for (String fullKey : getServiceInfo(protocolServiceKey).getAllParams().keySet()) {
+            MetadataInfo.ServiceInfo serviceInfo = getServiceInfo(protocolServiceKey);
+            if (null == serviceInfo) {
+                return null;
+            }
+
+            for (String fullKey : serviceInfo.getAllParams().keySet()) {
                 if (fullKey.endsWith(suffix)) {
                     return getParameter(fullKey);
                 }
@@ -477,7 +506,9 @@ public class InstanceAddressURL extends URL {
 
     @Override
     protected Map<String, Number> getServiceNumbers(String protocolServiceKey) {
-        return getServiceInfo(protocolServiceKey).getNumbers();
+        MetadataInfo.ServiceInfo serviceInfo = getServiceInfo(protocolServiceKey);
+
+        return null == serviceInfo ? new ConcurrentHashMap<>() : serviceInfo.getNumbers();
     }
 
     @Override
@@ -494,7 +525,8 @@ public class InstanceAddressURL extends URL {
 
     @Override
     protected Map<String, Map<String, Number>> getServiceMethodNumbers(String protocolServiceKey) {
-        return getServiceInfo(protocolServiceKey).getMethodNumbers();
+        MetadataInfo.ServiceInfo serviceInfo = getServiceInfo(protocolServiceKey);
+        return null == serviceInfo ? new ConcurrentHashMap<>() : serviceInfo.getMethodNumbers();
     }
 
     @Override

--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/ServiceDiscoveryRegistryDirectory.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/ServiceDiscoveryRegistryDirectory.java
@@ -24,6 +24,7 @@ import org.apache.dubbo.common.logger.LoggerFactory;
 import org.apache.dubbo.common.utils.Assert;
 import org.apache.dubbo.common.utils.CollectionUtils;
 import org.apache.dubbo.common.utils.NetUtils;
+import org.apache.dubbo.metadata.MetadataInfo;
 import org.apache.dubbo.registry.AddressListener;
 import org.apache.dubbo.registry.Constants;
 import org.apache.dubbo.registry.ProviderFirstParams;
@@ -324,7 +325,7 @@ public class ServiceDiscoveryRegistryDirectory<T> extends DynamicDirectory<T> {
         }
 
         if (oldURL instanceof OverrideInstanceAddressURL || newURL instanceof OverrideInstanceAddressURL) {
-            if(!(oldURL instanceof OverrideInstanceAddressURL && newURL instanceof OverrideInstanceAddressURL)) {
+            if (!(oldURL instanceof OverrideInstanceAddressURL && newURL instanceof OverrideInstanceAddressURL)) {
                 // sub-class changed
                 return true;
             } else {
@@ -334,8 +335,12 @@ public class ServiceDiscoveryRegistryDirectory<T> extends DynamicDirectory<T> {
             }
         }
 
-        return !oldURL.getMetadataInfo().getValidServiceInfo(getConsumerUrl().getProtocolServiceKey())
-            .equals(newURL.getMetadataInfo().getValidServiceInfo(getConsumerUrl().getProtocolServiceKey()));
+        MetadataInfo.ServiceInfo oldServiceInfo = oldURL.getMetadataInfo().getValidServiceInfo(getConsumerUrl().getProtocolServiceKey());
+        if (null == oldServiceInfo) {
+            return false;
+        }
+
+        return !oldServiceInfo.equals(newURL.getMetadataInfo().getValidServiceInfo(getConsumerUrl().getProtocolServiceKey()));
     }
 
     private List<Invoker<T>> toMergeInvokerList(List<Invoker<T>> invokers) {


### PR DESCRIPTION
fix for java.lang.NullPointerException

底层调用方法：
org.apache.dubbo.metadata.MetadataInfo#getValidServiceInfo 

调用方：
org.apache.dubbo.registry.client.InstanceAddressURL#getServiceInfo
org.apache.dubbo.registry.client.ServiceDiscoveryRegistryDirectory#urlChanged

问题原因：底层调用方法会返回null，调用方没有判空，导致有可能造成空指针
解决方式：调用方增加判空逻辑
