### PR TITLE
Replacing logger implementation of AbstractRegistry, AbstractRegistryFactory, and CacheableFailbackRegistry.

### DIFF
--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/support/AbstractRegistryFactory.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/support/AbstractRegistryFactory.java
@@ -18,7 +18,7 @@ package org.apache.dubbo.registry.support;
 
 import org.apache.dubbo.common.URL;
 import org.apache.dubbo.common.URLBuilder;
-import org.apache.dubbo.common.logger.Logger;
+import org.apache.dubbo.common.logger.ErrorTypeAwareLogger;
 import org.apache.dubbo.common.logger.LoggerFactory;
 import org.apache.dubbo.registry.Registry;
 import org.apache.dubbo.registry.RegistryFactory;
@@ -39,7 +39,7 @@ import static org.apache.dubbo.rpc.cluster.Constants.REFER_KEY;
  */
 public abstract class AbstractRegistryFactory implements RegistryFactory, ScopeModelAware {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(AbstractRegistryFactory.class);
+    private static final ErrorTypeAwareLogger LOGGER = LoggerFactory.getErrorTypeAwareLogger(AbstractRegistryFactory.class);
 
     private RegistryManager registryManager;
     protected ApplicationModel applicationModel;

--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/support/CacheableFailbackRegistry.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/support/CacheableFailbackRegistry.java
@@ -20,7 +20,7 @@ import org.apache.dubbo.common.URL;
 import org.apache.dubbo.common.URLBuilder;
 import org.apache.dubbo.common.URLStrParser;
 import org.apache.dubbo.common.config.ConfigurationUtils;
-import org.apache.dubbo.common.logger.Logger;
+import org.apache.dubbo.common.logger.ErrorTypeAwareLogger;
 import org.apache.dubbo.common.logger.LoggerFactory;
 import org.apache.dubbo.common.threadpool.manager.FrameworkExecutorRepository;
 import org.apache.dubbo.common.url.component.DubboServiceAddressURL;
@@ -65,7 +65,8 @@ import static org.apache.dubbo.common.constants.RegistryConstants.PROVIDERS_CATE
  * Useful for registries who's sdk returns raw string as provider instance, for example, zookeeper and etcd.
  */
 public abstract class CacheableFailbackRegistry extends FailbackRegistry {
-    private static final Logger logger = LoggerFactory.getLogger(CacheableFailbackRegistry.class);
+    private static final ErrorTypeAwareLogger logger = LoggerFactory.getErrorTypeAwareLogger(CacheableFailbackRegistry.class);
+
     private static String[] VARIABLE_KEYS = new String[]{ENCODED_TIMESTAMP_KEY, ENCODED_PID_KEY};
 
     protected Map<String, URLAddress> stringAddress = new ConcurrentHashMap<>();
@@ -96,7 +97,9 @@ public abstract class CacheableFailbackRegistry extends FailbackRegistry {
             try {
                 result = Integer.parseInt(str);
             } catch (NumberFormatException e) {
-                logger.warn("Invalid registry properties configuration key " + key + ", value " + str);
+                // 1-2 Invalid registry properties.
+                logger.warn("1-2", "", "",
+                    "Invalid registry properties configuration key " + key + ", value " + str);
             }
         }
         return result;
@@ -123,7 +126,9 @@ public abstract class CacheableFailbackRegistry extends FailbackRegistry {
                 }
             }
         } catch (Exception e) {
-            logger.warn("Failed to evict url for " + url.getServiceKey(), e);
+            // 1-3: URL evicting failed.
+            logger.warn("1-3", "", "",
+                "Failed to evict url for " + url.getServiceKey(), e);
         }
     }
 
@@ -138,7 +143,10 @@ public abstract class CacheableFailbackRegistry extends FailbackRegistry {
                 rawProvider = stripOffVariableKeys(rawProvider);
                 ServiceAddressURL cachedURL = createURL(rawProvider, copyOfConsumer, getExtraParameters());
                 if (cachedURL == null) {
-                    logger.warn("Invalid address, failed to parse into URL " + rawProvider);
+                    // 1-1: Address invalid.
+                    logger.warn("1-1", "", "",
+                        "Invalid address, failed to parse into URL " + rawProvider);
+
                     continue;
                 }
                 newURLs.put(rawProvider, cachedURL);
@@ -151,7 +159,9 @@ public abstract class CacheableFailbackRegistry extends FailbackRegistry {
                 if (cachedURL == null) {
                     cachedURL = createURL(rawProvider, copyOfConsumer, getExtraParameters());
                     if (cachedURL == null) {
-                        logger.warn("Invalid address, failed to parse into URL " + rawProvider);
+                        logger.warn("1-1", "", "",
+                            "Invalid address, failed to parse into URL " + rawProvider);
+
                         continue;
                     }
                 }
@@ -186,7 +196,8 @@ public abstract class CacheableFailbackRegistry extends FailbackRegistry {
             String category = i < 0 ? path : path.substring(i + 1);
             if (!PROVIDERS_CATEGORY.equals(category) || !getUrl().getParameter(ENABLE_EMPTY_PROTECTION_KEY, true)) {
                 if (PROVIDERS_CATEGORY.equals(category)) {
-                    logger.warn("Service " + consumer.getServiceKey() + " received empty address list and empty protection is disabled, will clear current available addresses");
+                    logger.warn("1-4", "", "",
+                        "Service " + consumer.getServiceKey() + " received empty address list and empty protection is disabled, will clear current available addresses");
                 }
                 URL empty = URLBuilder.from(consumer)
                     .setProtocol(EMPTY_PROTOCOL)
@@ -208,7 +219,10 @@ public abstract class CacheableFailbackRegistry extends FailbackRegistry {
         }
         String[] parts = URLStrParser.parseRawURLToArrays(rawProvider, paramStartIdx);
         if (parts.length <= 1) {
-            logger.warn("Received url without any parameters " + rawProvider);
+            // 1-5 Received URL without any parameters.
+            logger.warn("1-5", "", "",
+                "Received url without any parameters " + rawProvider);
+
             return DubboServiceAddressURL.valueOf(rawProvider, consumerURL);
         }
 
@@ -341,7 +355,11 @@ public abstract class CacheableFailbackRegistry extends FailbackRegistry {
                     }
                 }
             } catch (Throwable t) {
-                logger.error("Error occurred when clearing cached URLs", t);
+                // 1-6 Error when clearing cached URLs.
+
+                logger.error("1-6", "", "",
+                    "Error occurred when clearing cached URLs", t);
+
             } finally {
                 semaphore.release();
             }


### PR DESCRIPTION
## Brief changelog

更换 AbstractRegistry、AbstractRegistryFactory 和 CacheableFailbackRegistry 的日志实现。

Replace logging implementation with Error-Type-Aware Logger in AbstractRegistry, AbstractRegistryFactory, and CacheableFailbackRegistry.

在 CacheFailbackRegistry 加入错误码。
Adds error code in invocation of logger in CacheFailbackRegistry.

另附使用的错误码：
1-1: Address invalid. - 地址非法
1-2 Invalid registry properties. - 注册中心属性非法
1-3: URL evicting failed. - URL 销毁失败
1-4 Empty address. - 空地址
1-5 Received URL without any parameters. - 接收到没有任何参数的 URL
1-6 Error when clearing cached URLs. - 清空缓存 URL 出错
1-7: Failed to notify registry event. - 通知注册中心事件失败
1-8: Failed to unregister / unsubscribe url on destroy. - 销毁时注销（取消订阅）地址失败
1-9: failed to read / save registry cache file. - 读写注册关系缓存文件失败
1-10 Failed to delete lock file. - 删除锁文件失败。
