### PR TITLE
Replacing logger implementation of classes in registry module.

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/logger/support/FailsafeErrorTypeAwareLogger.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/logger/support/FailsafeErrorTypeAwareLogger.java
@@ -30,7 +30,7 @@ import java.util.regex.Pattern;
 public class FailsafeErrorTypeAwareLogger extends FailsafeLogger implements ErrorTypeAwareLogger {
 
     /**
-     * Mock address for formatting.
+     * Template address for formatting.
      */
     private static final String INSTRUCTIONS_URL = "https://dubbo.apache.org/faq/%d/%d";
 

--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/integration/AbstractConfiguratorListener.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/integration/AbstractConfiguratorListener.java
@@ -21,7 +21,7 @@ import org.apache.dubbo.common.config.configcenter.ConfigChangeType;
 import org.apache.dubbo.common.config.configcenter.ConfigChangedEvent;
 import org.apache.dubbo.common.config.configcenter.ConfigurationListener;
 import org.apache.dubbo.common.config.configcenter.DynamicConfiguration;
-import org.apache.dubbo.common.logger.Logger;
+import org.apache.dubbo.common.logger.ErrorTypeAwareLogger;
 import org.apache.dubbo.common.logger.LoggerFactory;
 import org.apache.dubbo.common.utils.StringUtils;
 import org.apache.dubbo.rpc.cluster.Configurator;
@@ -45,7 +45,7 @@ import static org.apache.dubbo.rpc.cluster.Constants.TYPE_KEY;
  * AbstractConfiguratorListener
  */
 public abstract class AbstractConfiguratorListener implements ConfigurationListener {
-    private static final Logger logger = LoggerFactory.getLogger(AbstractConfiguratorListener.class);
+    private static final ErrorTypeAwareLogger logger = LoggerFactory.getErrorTypeAwareLogger(AbstractConfiguratorListener.class);
 
     protected List<Configurator> configurators = Collections.emptyList();
     protected GovernanceRuleRepository ruleRepository;
@@ -107,8 +107,12 @@ public abstract class AbstractConfiguratorListener implements ConfigurationListe
             // parseConfigurators will recognize app/service config automatically.
             urls = ConfigParser.parseConfigurators(rawConfig);
         } catch (Exception e) {
-            logger.warn("Failed to parse raw dynamic config and it will not take effect, the raw config is: "
+            // 1-14 - Failed to parse raw dynamic config.
+
+            logger.warn("1-14", "", "",
+                "Failed to parse raw dynamic config and it will not take effect, the raw config is: "
                     + rawConfig + ", cause: " + e.getMessage());
+
             return false;
         }
         List<URL> safeUrls = urls.stream()

--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/integration/DynamicDirectory.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/integration/DynamicDirectory.java
@@ -20,7 +20,7 @@ import org.apache.dubbo.common.URL;
 import org.apache.dubbo.common.Version;
 import org.apache.dubbo.common.config.ConfigurationUtils;
 import org.apache.dubbo.common.extension.ExtensionLoader;
-import org.apache.dubbo.common.logger.Logger;
+import org.apache.dubbo.common.logger.ErrorTypeAwareLogger;
 import org.apache.dubbo.common.logger.LoggerFactory;
 import org.apache.dubbo.common.utils.CollectionUtils;
 import org.apache.dubbo.common.utils.NetUtils;
@@ -59,7 +59,7 @@ import static org.apache.dubbo.remoting.Constants.CHECK_KEY;
  */
 public abstract class DynamicDirectory<T> extends AbstractDirectory<T> implements NotifyListener {
 
-    private static final Logger logger = LoggerFactory.getLogger(DynamicDirectory.class);
+    private static final ErrorTypeAwareLogger logger = LoggerFactory.getErrorTypeAwareLogger(DynamicDirectory.class);
 
     protected final Cluster cluster;
 
@@ -204,7 +204,10 @@ public abstract class DynamicDirectory<T> extends AbstractDirectory<T> implement
             List<Invoker<T>> result = routerChain.route(getConsumerUrl(), invokers, invocation);
             return result == null ? BitList.emptyList() : result;
         } catch (Throwable t) {
-            logger.error("Failed to execute router: " + getUrl() + ", cause: " + t.getMessage(), t);
+            // 2-1 - Failed to execute routing.
+            logger.error("2-1", "", "",
+                "Failed to execute router: " + getUrl() + ", cause: " + t.getMessage(), t);
+
             return BitList.emptyList();
         }
     }
@@ -295,15 +298,20 @@ public abstract class DynamicDirectory<T> extends AbstractDirectory<T> implement
                 registry.unregister(getRegisteredConsumerUrl());
             }
         } catch (Throwable t) {
-            logger.warn("unexpected error when unregister service " + serviceKey + " from registry: " + registry.getUrl(), t);
+            // 1-8: Failed to unregister / unsubscribe url on destroy.
+            logger.warn("1-8", "", "",
+                "unexpected error when unregister service " + serviceKey + " from registry: " + registry.getUrl(), t);
         }
+
         // unsubscribe.
         try {
             if (getSubscribeUrl() != null && registry != null && registry.isAvailable()) {
                 registry.unsubscribe(getSubscribeUrl(), this);
             }
         } catch (Throwable t) {
-            logger.warn("unexpected error when unsubscribe service " + serviceKey + " from registry: " + registry.getUrl(), t);
+            // 1-8: Failed to unregister / unsubscribe url on destroy.
+            logger.warn("1-8", "", "",
+                "unexpected error when unsubscribe service " + serviceKey + " from registry: " + registry.getUrl(), t);
         }
 
         ExtensionLoader<AddressListener> addressListenerExtensionLoader = getUrl().getOrDefaultModuleModel().getExtensionLoader(AddressListener.class);
@@ -318,7 +326,9 @@ public abstract class DynamicDirectory<T> extends AbstractDirectory<T> implement
             try {
                 destroyAllInvokers();
             } catch (Throwable t) {
-                logger.warn("Failed to destroy service " + serviceKey, t);
+                // 1-15 - Failed to destroy service.
+                logger.warn("1-15", "", "",
+                    "Failed to destroy service " + serviceKey, t);
             }
             routerChain.destroy();
             invokersChangedListener = null;
@@ -333,7 +343,9 @@ public abstract class DynamicDirectory<T> extends AbstractDirectory<T> implement
         try {
             destroyAllInvokers();
         } catch (Throwable t) {
-            logger.warn("Failed to destroy service " + serviceKey, t);
+            // 1-15 - Failed to destroy service.
+            logger.warn("1-15", "", "",
+                "Failed to destroy service " + serviceKey, t);
         }
     }
 

--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/integration/RegistryDirectory.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/integration/RegistryDirectory.java
@@ -20,7 +20,7 @@ import org.apache.dubbo.common.URL;
 import org.apache.dubbo.common.URLBuilder;
 import org.apache.dubbo.common.config.configcenter.DynamicConfiguration;
 import org.apache.dubbo.common.extension.ExtensionLoader;
-import org.apache.dubbo.common.logger.Logger;
+import org.apache.dubbo.common.logger.ErrorTypeAwareLogger;
 import org.apache.dubbo.common.logger.LoggerFactory;
 import org.apache.dubbo.common.url.component.DubboServiceAddressURL;
 import org.apache.dubbo.common.url.component.ServiceAddressURL;
@@ -81,7 +81,7 @@ import static org.apache.dubbo.rpc.model.ScopeModelUtil.getModuleModel;
  * RegistryDirectory
  */
 public class RegistryDirectory<T> extends DynamicDirectory<T> {
-    private static final Logger logger = LoggerFactory.getLogger(RegistryDirectory.class);
+    private static final ErrorTypeAwareLogger logger = LoggerFactory.getErrorTypeAwareLogger(RegistryDirectory.class);
 
     private final ConsumerConfigurationListener consumerConfigurationListener;
     private ReferenceConfigurationListener referenceConfigurationListener;
@@ -246,7 +246,7 @@ public class RegistryDirectory<T> extends DynamicDirectory<T> {
             }
             Map<URL, Invoker<T>> newUrlInvokerMap = toInvokers(oldUrlInvokerMap, invokerUrls);// Translate url list to Invoker map
 
-            /**
+            /*
              * If the calculation is wrong, it is not processed.
              *
              * 1. The protocol configured by the client is inconsistent with the protocol of the server.

--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/integration/RegistryProtocol.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/integration/RegistryProtocol.java
@@ -19,7 +19,7 @@ package org.apache.dubbo.registry.integration;
 import org.apache.dubbo.common.URL;
 import org.apache.dubbo.common.config.ConfigurationUtils;
 import org.apache.dubbo.common.config.configcenter.DynamicConfiguration;
-import org.apache.dubbo.common.logger.Logger;
+import org.apache.dubbo.common.logger.ErrorTypeAwareLogger;
 import org.apache.dubbo.common.logger.LoggerFactory;
 import org.apache.dubbo.common.threadpool.manager.FrameworkExecutorRepository;
 import org.apache.dubbo.common.timer.HashedWheelTimer;
@@ -143,7 +143,8 @@ public class RegistryProtocol implements Protocol, ScopeModelAware {
         APPLICATION_KEY, VERSION_KEY, GROUP_KEY, DUBBO_VERSION_KEY, RELEASE_KEY
     };
 
-    private final static Logger logger = LoggerFactory.getLogger(RegistryProtocol.class);
+    private static final ErrorTypeAwareLogger logger = LoggerFactory.getErrorTypeAwareLogger(RegistryProtocol.class);
+
     private final Map<String, ServiceConfigurationListener> serviceConfigurationListeners = new ConcurrentHashMap<>();
     //To solve the problem of RMI repeated exposure port conflicts, the services that have been exposed are no longer exposed.
     //provider url <--> exporter

--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/retry/AbstractRetryTask.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/retry/AbstractRetryTask.java
@@ -18,7 +18,7 @@
 package org.apache.dubbo.registry.retry;
 
 import org.apache.dubbo.common.URL;
-import org.apache.dubbo.common.logger.Logger;
+import org.apache.dubbo.common.logger.ErrorTypeAwareLogger;
 import org.apache.dubbo.common.logger.LoggerFactory;
 import org.apache.dubbo.common.timer.Timeout;
 import org.apache.dubbo.common.timer.Timer;
@@ -38,7 +38,7 @@ import static org.apache.dubbo.registry.Constants.REGISTRY_RETRY_TIMES_KEY;
  */
 public abstract class AbstractRetryTask implements TimerTask {
 
-    protected final Logger logger = LoggerFactory.getLogger(getClass());
+    protected final ErrorTypeAwareLogger logger = LoggerFactory.getErrorTypeAwareLogger(getClass());
 
     /**
      * url for retry task
@@ -113,8 +113,12 @@ public abstract class AbstractRetryTask implements TimerTask {
             return;
         }
         if (times > retryTimes) {
-            // reach the most times of retry.
-            logger.warn("Final failed to execute task " + taskName + ", url: " + url + ", retry " + retryTimes + " times.");
+            // 1-13 - failed to execute the retrying task.
+
+            logger.warn(
+                "1-13", "registry center offline", "Check the registry server.",
+                "Final failed to execute task " + taskName + ", url: " + url + ", retry " + retryTimes + " times.");
+
             return;
         }
         if (logger.isInfoEnabled()) {
@@ -123,7 +127,12 @@ public abstract class AbstractRetryTask implements TimerTask {
         try {
             doRetry(url, registry, timeout);
         } catch (Throwable t) { // Ignore all the exceptions and wait for the next retry
-            logger.warn("Failed to execute task " + taskName + ", url: " + url + ", waiting for again, cause:" + t.getMessage(), t);
+
+            // 1-13 - failed to execute the retrying task.
+
+            logger.warn("1-13", "registry center offline", "Check the registry server.",
+                "Failed to execute task " + taskName + ", url: " + url + ", waiting for again, cause:" + t.getMessage(), t);
+
             // reput this task when catch exception.
             reput(timeout, retryPeriod);
         }

--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/support/AbstractRegistryFactory.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/support/AbstractRegistryFactory.java
@@ -98,7 +98,9 @@ public abstract class AbstractRegistryFactory implements RegistryFactory, ScopeM
             if (check) {
                 throw new RuntimeException("Can not create registry " + url, e);
             } else {
-                LOGGER.warn("Failed to obtain or create registry ", e);
+                // 1-11 Failed to obtain or create registry (service) object.
+                LOGGER.warn("1-11", "", "",
+                    "Failed to obtain or create registry ", e);
             }
         } finally {
             // Release the lock

--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/support/RegistryManager.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/support/RegistryManager.java
@@ -17,7 +17,7 @@
 package org.apache.dubbo.registry.support;
 
 import org.apache.dubbo.common.URL;
-import org.apache.dubbo.common.logger.Logger;
+import org.apache.dubbo.common.logger.ErrorTypeAwareLogger;
 import org.apache.dubbo.common.logger.LoggerFactory;
 import org.apache.dubbo.registry.NotifyListener;
 import org.apache.dubbo.registry.Registry;
@@ -40,7 +40,7 @@ import java.util.stream.Collectors;
  * Application Level, used to collect Registries
  */
 public class RegistryManager {
-    private static final Logger LOGGER = LoggerFactory.getLogger(RegistryManager.class);
+    private static final ErrorTypeAwareLogger LOGGER = LoggerFactory.getErrorTypeAwareLogger(RegistryManager.class);
 
     private ApplicationModel applicationModel;
 
@@ -124,8 +124,11 @@ public class RegistryManager {
 
     protected Registry getDefaultNopRegistryIfDestroyed() {
         if (destroyed.get()) {
-            LOGGER.warn("All registry instances have been destroyed, failed to fetch any instance. " +
+            // 1-12 Failed to fetch (server) instance since the registry instances have been destroyed.
+            LOGGER.warn("1-12", "misuse of the methods", "",
+                "All registry instances have been destroyed, failed to fetch any instance. " +
                 "Usually, this means no need to try to do unnecessary redundant resource clearance, all registries has been taken care of.");
+
             return DEFAULT_NOP_REGISTRY;
         }
         return null;


### PR DESCRIPTION
## Brief changelog
更换 RegistryManager、AbstractRegistryFactory 以及 registry 模块下 retry 包、integration 包下部分类的日志实现。并添加了错误码。

Replace logging implementation with Error-Type-Aware Logger in RegistryManager, AbstractRegistryFactory. Classes in retry package and integration package are also replaced, with error codes added.

另附迄今为止使用的错误码：
1-1: Address invalid. - 地址非法
1-2 Invalid registry properties. - 注册中心属性非法
1-3: URL evicting failed. - URL 销毁失败
1-4 Empty address. - 空地址
1-5 Received URL without any parameters. - 接收到没有任何参数的 URL
1-6 Error when clearing cached URLs. - 清空缓存 URL 出错
1-7: Failed to notify registry event. - 通知注册中心事件失败
1-8: Failed to unregister / unsubscribe url on destroy. - 销毁时注销（取消订阅）地址失败
1-9: failed to read / save registry cache file. - 读写注册关系缓存文件失败
1-10 Failed to delete lock file. - 删除锁文件失败。
1-11 Failed to obtain or create registry (service) object. - 注册服务实例创建失败
1-12 Failed to fetch (server) instance since the registry instances have been destroyed. - 由于 “注册服务” 的实例均已销毁，因此没法获取服务提供（或订阅）方的服务器地址。
1-13 - reach the most times of retry. 达到最多的重试次数。
1-14 - Failed to parse raw dynamic config. - 动态配置识别失败
1-15 - Failed to destroy service. - 销毁服务失败

2-1 - Failed to execute routing. - 路由选址执行失败。