### PR TITLE
Fix the problem of partial setXXX method injection of spi class

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/config/Environment.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/config/Environment.java
@@ -112,6 +112,7 @@ public class Environment extends LifecycleAdapter implements ApplicationExt {
      * @deprecated only for ut
      */
     @Deprecated
+    @DisableInject
     public void setLocalMigrationRule(String localMigrationRule) {
         this.localMigrationRule = localMigrationRule;
     }

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/config/ModuleEnvironment.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/config/ModuleEnvironment.java
@@ -132,21 +132,25 @@ public class ModuleEnvironment extends Environment implements ModuleExt {
     }
 
     @Override
+    @DisableInject
     public void setLocalMigrationRule(String localMigrationRule) {
         applicationDelegate.setLocalMigrationRule(localMigrationRule);
     }
 
     @Override
+    @DisableInject
     public void setExternalConfigMap(Map<String, String> externalConfiguration) {
         applicationDelegate.setExternalConfigMap(externalConfiguration);
     }
 
     @Override
+    @DisableInject
     public void setAppExternalConfigMap(Map<String, String> appExternalConfiguration) {
         applicationDelegate.setAppExternalConfigMap(appExternalConfiguration);
     }
 
     @Override
+    @DisableInject
     public void setAppConfigMap(Map<String, String> appConfiguration) {
         applicationDelegate.setAppConfigMap(appConfiguration);
     }

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/extension/ExtensionLoader.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/extension/ExtensionLoader.java
@@ -853,8 +853,7 @@ public class ExtensionLoader<T> {
 
                 // When spiXXX implements ScopeModelAware, ExtensionAccessorAware,
                 // the setXXX of ScopeModelAware and ExtensionAccessorAware does not need to be injected
-                if (method.getDeclaringClass() == ScopeModelAware.class ||
-                    method.getDeclaringClass() == ExtensionAccessorAware.class) {
+                if (method.getDeclaringClass() == ScopeModelAware.class) {
                     continue;
                 }
                 if (instance instanceof ScopeModelAware || instance instanceof ExtensionAccessorAware) {

--- a/dubbo-common/src/main/java/org/apache/dubbo/config/context/ModuleConfigManager.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/config/context/ModuleConfigManager.java
@@ -16,6 +16,7 @@
  */
 package org.apache.dubbo.config.context;
 
+import org.apache.dubbo.common.context.ModuleExt;
 import org.apache.dubbo.common.extension.DisableInject;
 import org.apache.dubbo.common.logger.Logger;
 import org.apache.dubbo.common.logger.LoggerFactory;
@@ -50,9 +51,11 @@ import static org.apache.dubbo.config.AbstractConfig.getTagName;
 /**
  * Manage configs of module
  */
-public class ModuleConfigManager extends AbstractConfigManager {
+public class ModuleConfigManager extends AbstractConfigManager implements ModuleExt {
 
     private static final Logger logger = LoggerFactory.getLogger(ModuleConfigManager.class);
+
+    public static final String NAME = "moduleConfig";
 
     private Map<String, AbstractInterfaceConfig> serviceConfigCache = new ConcurrentHashMap<>();
     private final ConfigManager applicationConfigManager;

--- a/dubbo-common/src/main/java/org/apache/dubbo/rpc/model/ApplicationModel.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/rpc/model/ApplicationModel.java
@@ -203,6 +203,9 @@ public class ApplicationModel extends ScopeModel {
             LOGGER.info(getDesc() + " is created");
         }
         initialize();
+        Assert.notNull(getApplicationServiceRepository(), "ApplicationServiceRepository can not be null");
+        Assert.notNull(getApplicationConfigManager(), "ApplicationConfigManager can not be null");
+        Assert.assertTrue(getApplicationConfigManager().isInitialized(), "ApplicationConfigManager can not be initialized");
     }
 
     @Override

--- a/dubbo-common/src/main/java/org/apache/dubbo/rpc/model/FrameworkModel.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/rpc/model/FrameworkModel.java
@@ -123,7 +123,6 @@ public class FrameworkModel extends ScopeModel {
         // notify destroy and clean framework resources
         // see org.apache.dubbo.config.deploy.FrameworkModelCleaner
         notifyDestroy();
-        checkApplicationDestroy();
 
         if (LOGGER.isInfoEnabled()) {
             LOGGER.info(getDesc() + " is destroyed");

--- a/dubbo-common/src/main/java/org/apache/dubbo/rpc/model/ModuleModel.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/rpc/model/ModuleModel.java
@@ -61,9 +61,6 @@ public class ModuleModel extends ScopeModel {
         }
 
         initialize();
-        Assert.notNull(serviceRepository, "ModuleServiceRepository can not be null");
-        Assert.notNull(moduleConfigManager, "ModuleConfigManager can not be null");
-        Assert.assertTrue(moduleConfigManager.isInitialized(), "ModuleConfigManager can not be initialized");
 
         // notify application check state
         ApplicationDeployer applicationDeployer = applicationModel.getDeployer();
@@ -76,8 +73,6 @@ public class ModuleModel extends ScopeModel {
     protected void initialize() {
         super.initialize();
         this.serviceRepository = new ModuleServiceRepository(this);
-        this.moduleConfigManager = new ModuleConfigManager(this);
-        this.moduleConfigManager.initialize();
 
         initModuleExt();
 
@@ -158,6 +153,10 @@ public class ModuleModel extends ScopeModel {
     }
 
     public ModuleConfigManager getConfigManager() {
+        if (moduleConfigManager == null) {
+            moduleConfigManager = (ModuleConfigManager) this.getExtensionLoader(ModuleExt.class)
+                .getExtension(ModuleConfigManager.NAME);
+        }
         return moduleConfigManager;
     }
 

--- a/dubbo-common/src/main/java/org/apache/dubbo/rpc/model/ModuleModel.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/rpc/model/ModuleModel.java
@@ -61,6 +61,9 @@ public class ModuleModel extends ScopeModel {
         }
 
         initialize();
+        Assert.notNull(getServiceRepository(), "ModuleServiceRepository can not be null");
+        Assert.notNull(getConfigManager(), "ModuleConfigManager can not be null");
+        Assert.assertTrue(getConfigManager().isInitialized(), "ModuleConfigManager can not be initialized");
 
         // notify application check state
         ApplicationDeployer applicationDeployer = applicationModel.getDeployer();

--- a/dubbo-common/src/main/java/org/apache/dubbo/rpc/model/ScopeModel.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/rpc/model/ScopeModel.java
@@ -242,7 +242,7 @@ public abstract class ScopeModel implements ExtensionAccessor {
     }
 
     /**
-     * @return the describe string of this scope model
+     * @return to describe string of this scope model
      */
     public String getDesc() {
         if (this.desc == null) {

--- a/dubbo-common/src/main/resources/META-INF/dubbo/internal/org.apache.dubbo.common.context.ModuleExt
+++ b/dubbo-common/src/main/resources/META-INF/dubbo/internal/org.apache.dubbo.common.context.ModuleExt
@@ -1,1 +1,2 @@
 moduleEnvironment=org.apache.dubbo.common.config.ModuleEnvironment
+moduleConfig=org.apache.dubbo.config.context.ModuleConfigManager

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/extension/ExtensionDirectorTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/extension/ExtensionDirectorTest.java
@@ -37,10 +37,6 @@ public class ExtensionDirectorTest {
     String testAppSrvName = "testAppSrv";
     String testMdSrvName = "testMdSrv";
 
-    String testAppProviderName = "testAppProvider";
-    String testModuleProviderName = "testModuleProvider";
-    String testFrameworkProviderName = "testFrameworkProvider";
-
     @Test
     public void testInheritanceAndScope() {
 
@@ -144,16 +140,16 @@ public class ExtensionDirectorTest {
 
     @Test
     public void testModelDataIsolation() {
-//Model Tree
-//├─frameworkModel1
-//│  ├─applicationModel11
-//│  │  ├─moduleModel111
-//│  │  └─moduleModel112
-//│  └─applicationModel12
-//│     └─moduleModel121
-//└─frameworkModel2
-//   └─applicationModel21
-//      └─moduleModel211
+        //Model Tree
+        //├─frameworkModel1
+        //│  ├─applicationModel11
+        //│  │  ├─moduleModel111
+        //│  │  └─moduleModel112
+        //│  └─applicationModel12
+        //│     └─moduleModel121
+        //└─frameworkModel2
+        //   └─applicationModel21
+        //      └─moduleModel211
 
         FrameworkModel frameworkModel1 = new FrameworkModel();
         ApplicationModel applicationModel11 = new ApplicationModel(frameworkModel1);

--- a/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/extension/SpringExtensionInjector.java
+++ b/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/extension/SpringExtensionInjector.java
@@ -16,7 +16,6 @@
  */
 package org.apache.dubbo.config.spring.extension;
 
-import org.apache.dubbo.common.context.Lifecycle;
 import org.apache.dubbo.common.extension.ExtensionAccessor;
 import org.apache.dubbo.common.extension.ExtensionInjector;
 import org.apache.dubbo.common.extension.SPI;
@@ -29,7 +28,7 @@ import java.util.Arrays;
 /**
  * SpringExtensionInjector
  */
-public class SpringExtensionInjector implements ExtensionInjector, Lifecycle {
+public class SpringExtensionInjector implements ExtensionInjector {
 
     private ApplicationContext context;
 
@@ -91,18 +90,5 @@ public class SpringExtensionInjector implements ExtensionInjector, Lifecycle {
                     Arrays.toString(beanNamesForType));
         }
         return beanFactory.getBean(beanNamesForType[0], type);
-    } 
-
-    @Override
-    public void initialize() throws IllegalStateException {
-    }
-
-    @Override
-    public void start() throws IllegalStateException {
-        // no op
-    }
-
-    @Override
-    public void destroy() {
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

When spiXXX implements ScopeModelAware, ExtensionAccessorAware, the setXXX of ScopeModelAware and ExtensionAccessorAware does not need to be injected(ExtensionDirectorTest#testInjection can be reproduced)

