### PR TITLE
Adding error code to multiple classes in registry module.

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/logger/support/FailsafeErrorTypeAwareLogger.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/logger/support/FailsafeErrorTypeAwareLogger.java
@@ -66,6 +66,8 @@ public class FailsafeErrorTypeAwareLogger extends FailsafeLogger implements Erro
         } catch (NumberFormatException numberFormatException) {
             error("Invalid error code: " + code + ", the format of error code is: X-X (where X is a number).",
                 numberFormatException);
+
+            return "";
         }
 
         return String.format(INSTRUCTIONS_URL, errorCodeSegments[0], errorCodeSegments[1]);
@@ -80,6 +82,7 @@ public class FailsafeErrorTypeAwareLogger extends FailsafeLogger implements Erro
         try {
             getLogger().warn(appendContextMessageWithInstructions(code, cause, extendedInformation, msg));
         } catch (Throwable t) {
+            // ignored.
         }
     }
 
@@ -92,6 +95,7 @@ public class FailsafeErrorTypeAwareLogger extends FailsafeLogger implements Erro
         try {
             getLogger().warn(appendContextMessageWithInstructions(code, cause, extendedInformation, msg), e);
         } catch (Throwable t) {
+            // ignored.
         }
     }
 
@@ -104,6 +108,7 @@ public class FailsafeErrorTypeAwareLogger extends FailsafeLogger implements Erro
         try {
             getLogger().error(appendContextMessageWithInstructions(code, cause, extendedInformation, msg));
         } catch (Throwable t) {
+            // ignored.
         }
     }
 
@@ -116,6 +121,7 @@ public class FailsafeErrorTypeAwareLogger extends FailsafeLogger implements Erro
         try {
             getLogger().error(appendContextMessageWithInstructions(code, cause, extendedInformation, msg), e);
         } catch (Throwable t) {
+            // ignored.
         }
     }
 }

--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/AbstractServiceDiscovery.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/AbstractServiceDiscovery.java
@@ -17,7 +17,7 @@
 package org.apache.dubbo.registry.client;
 
 import org.apache.dubbo.common.URL;
-import org.apache.dubbo.common.logger.Logger;
+import org.apache.dubbo.common.logger.ErrorTypeAwareLogger;
 import org.apache.dubbo.common.logger.LoggerFactory;
 import org.apache.dubbo.common.threadpool.manager.FrameworkExecutorRepository;
 import org.apache.dubbo.common.utils.ConcurrentHashSet;
@@ -48,7 +48,7 @@ import static org.apache.dubbo.registry.client.metadata.ServiceInstanceMetadataU
  * Each service discovery is bond to one application.
  */
 public abstract class AbstractServiceDiscovery implements ServiceDiscovery {
-    private final Logger logger = LoggerFactory.getLogger(AbstractServiceDiscovery.class);
+    private final ErrorTypeAwareLogger logger = LoggerFactory.getErrorTypeAwareLogger(AbstractServiceDiscovery.class);
     private volatile boolean isDestroy;
 
     protected final String serviceName;

--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/FileSystemServiceDiscovery.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/FileSystemServiceDiscovery.java
@@ -22,7 +22,7 @@
 //import org.apache.dubbo.common.config.configcenter.ConfigChangedEvent;
 //import org.apache.dubbo.common.config.configcenter.file.FileSystemDynamicConfiguration;
 //import org.apache.dubbo.common.lang.ShutdownHookCallbacks;
-//import org.apache.dubbo.common.logger.Logger;
+//import org.apache.dubbo.common.logger.ErrorTypeAwareLogger;
 //import org.apache.dubbo.common.logger.LoggerFactory;
 //import org.apache.dubbo.common.utils.StringUtils;
 //
@@ -53,7 +53,7 @@
 // */
 //public class FileSystemServiceDiscovery extends AbstractServiceDiscovery {
 //
-//    private final Logger logger = LoggerFactory.getLogger(getClass());
+//    private final ErrorTypeAwareLogger logger = LoggerFactory.getErrorTypeAwareLogger(getClass());
 //
 //    private final Map<File, FileLock> fileLocksCache = new ConcurrentHashMap<>();
 //

--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/ReflectionBasedServiceDiscovery.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/ReflectionBasedServiceDiscovery.java
@@ -18,7 +18,7 @@ package org.apache.dubbo.registry.client;
 
 import org.apache.dubbo.common.URL;
 import org.apache.dubbo.common.constants.CommonConstants;
-import org.apache.dubbo.common.logger.Logger;
+import org.apache.dubbo.common.logger.ErrorTypeAwareLogger;
 import org.apache.dubbo.common.logger.LoggerFactory;
 import org.apache.dubbo.common.utils.NamedThreadFactory;
 import org.apache.dubbo.common.utils.NetUtils;
@@ -54,7 +54,7 @@ import java.util.concurrent.TimeUnit;
 
 public class ReflectionBasedServiceDiscovery extends AbstractServiceDiscovery {
 
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private final ErrorTypeAwareLogger logger = LoggerFactory.getErrorTypeAwareLogger(getClass());
 
     /**
      * Echo check if consumer is still work

--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/ReflectionBasedServiceDiscovery.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/ReflectionBasedServiceDiscovery.java
@@ -160,7 +160,12 @@ public class ReflectionBasedServiceDiscovery extends AbstractServiceDiscovery {
                 try {
                     entry.getValue().onEvent(metadataString);
                 } catch (RpcException e) {
-                    logger.warn("Notify to consumer error. Possible cause: consumer is offline.");
+                    // 1-7 - Failed to notify registry event.
+                    // The updating of metadata to consumer is a type of registry event.
+
+                    logger.warn("1-7", "consumer is offline", "",
+                        "Notify to consumer error, removing listener.");
+
                     // remove listener if consumer is offline
                     iterator.remove();
                 }

--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/ServiceDiscoveryRegistry.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/ServiceDiscoveryRegistry.java
@@ -17,7 +17,7 @@
 package org.apache.dubbo.registry.client;
 
 import org.apache.dubbo.common.URL;
-import org.apache.dubbo.common.logger.Logger;
+import org.apache.dubbo.common.logger.ErrorTypeAwareLogger;
 import org.apache.dubbo.common.logger.LoggerFactory;
 import org.apache.dubbo.common.utils.CollectionUtils;
 import org.apache.dubbo.metadata.AbstractServiceNameMapping;
@@ -66,7 +66,7 @@ import static org.apache.dubbo.registry.client.ServiceDiscoveryFactory.getExtens
  */
 public class ServiceDiscoveryRegistry extends FailbackRegistry {
 
-    protected final Logger logger = LoggerFactory.getLogger(getClass());
+    protected final ErrorTypeAwareLogger logger = LoggerFactory.getErrorTypeAwareLogger(getClass());
 
     private final ServiceDiscovery serviceDiscovery;
 
@@ -348,7 +348,7 @@ public class ServiceDiscoveryRegistry extends FailbackRegistry {
     }
 
     private class DefaultMappingListener implements MappingListener {
-        private final Logger logger = LoggerFactory.getLogger(DefaultMappingListener.class);
+        private final ErrorTypeAwareLogger logger = LoggerFactory.getErrorTypeAwareLogger(DefaultMappingListener.class);
         private final URL url;
         private Set<String> oldApps;
         private NotifyListener listener;

--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/event/listener/ServiceInstancesChangedListener.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/event/listener/ServiceInstancesChangedListener.java
@@ -177,9 +177,13 @@ public class ServiceInstancesChangedListener {
                 retryFuture = scheduler.schedule(new AddressRefreshRetryTask(retryPermission, event.getServiceName()), 10_000L, TimeUnit.MILLISECONDS);
                 logger.warn("Address refresh try task submitted");
             }
+
             // return if all metadata is empty, this notification will not take effect.
             if (emptyNum == revisionToInstances.size()) {
-                logger.error("Address refresh failed because of Metadata Server failure, wait for retry or new address refresh event.");
+                // 1-17 - Address refresh failed.
+                logger.error("1-17", "metadata Server failure", "",
+                    "Address refresh failed because of Metadata Server failure, wait for retry or new address refresh event.");
+
                 return;
             }
         }

--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/metadata/MetadataServiceDelegation.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/metadata/MetadataServiceDelegation.java
@@ -17,7 +17,7 @@
 package org.apache.dubbo.registry.client.metadata;
 
 import org.apache.dubbo.common.URL;
-import org.apache.dubbo.common.logger.Logger;
+import org.apache.dubbo.common.logger.ErrorTypeAwareLogger;
 import org.apache.dubbo.common.logger.LoggerFactory;
 import org.apache.dubbo.common.resource.Disposable;
 import org.apache.dubbo.common.utils.StringUtils;
@@ -50,7 +50,8 @@ import static org.apache.dubbo.common.utils.CollectionUtils.isEmpty;
  * Implementation providing remote RPC service to facilitate the query of metadata information.
  */
 public class MetadataServiceDelegation implements MetadataService, Disposable {
-    Logger logger = LoggerFactory.getLogger(getClass());
+    ErrorTypeAwareLogger logger = LoggerFactory.getErrorTypeAwareLogger(getClass());
+
     private final ApplicationModel applicationModel;
     private final RegistryManager registryManager;
     private ConcurrentMap<String, InstanceMetadataChangedListener> instanceMetadataChangedListenerMap = new ConcurrentHashMap<>();

--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/metadata/MetadataServiceNameMapping.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/metadata/MetadataServiceNameMapping.java
@@ -18,7 +18,7 @@ package org.apache.dubbo.registry.client.metadata;
 
 import org.apache.dubbo.common.URL;
 import org.apache.dubbo.common.config.configcenter.ConfigItem;
-import org.apache.dubbo.common.logger.Logger;
+import org.apache.dubbo.common.logger.ErrorTypeAwareLogger;
 import org.apache.dubbo.common.logger.LoggerFactory;
 import org.apache.dubbo.common.utils.CollectionUtils;
 import org.apache.dubbo.common.utils.StringUtils;
@@ -40,7 +40,7 @@ import static org.apache.dubbo.common.constants.CommonConstants.DEFAULT_KEY;
 
 public class MetadataServiceNameMapping extends AbstractServiceNameMapping {
 
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private final ErrorTypeAwareLogger logger = LoggerFactory.getErrorTypeAwareLogger(getClass());
 
     private static final List<String> IGNORED_SERVICE_INTERFACES = Collections.singletonList(MetadataService.class.getName());
 

--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/metadata/ServiceInstanceHostPortCustomizer.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/metadata/ServiceInstanceHostPortCustomizer.java
@@ -72,10 +72,10 @@ public class ServiceInstanceHostPortCustomizer implements ServiceInstanceCustomi
                 
                 if (host == null || port == -1) {
 
-                    // 4-2 - The default preferredProtocol is not found.
+                    // 4-2 - Can't find an instance URL using the default preferredProtocol.
 
-                    logger.warn("4-2", "typo in protocol", "",
-                        "The default preferredProtocol \"" + preferredProtocol + "\" is not found, " +
+                    logger.warn("4-2", "typo in preferred protocol", "",
+                        "Can't find an instance URL  using the default preferredProtocol \"" + preferredProtocol + "\", " +
                         "falling back to the strategy that pick the first found protocol. " +
                         "Please try modifying the config of dubbo.application.protocol");
 

--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/metadata/ServiceInstanceHostPortCustomizer.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/metadata/ServiceInstanceHostPortCustomizer.java
@@ -71,7 +71,14 @@ public class ServiceInstanceHostPortCustomizer implements ServiceInstanceCustomi
                 }
                 
                 if (host == null || port == -1) {
-                    logger.warn("The default preferredProtocol \"" + preferredProtocol + "\" is not found, fall back to the strategy that pick the first found protocol. Please try to modify the config of dubbo.application.protocol");
+
+                    // 4-2 - The default preferredProtocol is not found.
+
+                    logger.warn("4-2", "typo in protocol", "",
+                        "The default preferredProtocol \"" + preferredProtocol + "\" is not found, " +
+                        "falling back to the strategy that pick the first found protocol. " +
+                        "Please try modifying the config of dubbo.application.protocol");
+
                     URL url = urls.iterator().next();
                     host = url.getHost();
                     port = url.getPort();

--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/migration/MigrationInvoker.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/migration/MigrationInvoker.java
@@ -255,7 +255,7 @@ public class MigrationInvoker<T> implements MigrationClusterInvoker<T> {
             try {
                 Thread.sleep(delay * 1000L);
             } catch (InterruptedException e) {
-                logger.error("Interrupter when waiting for address notify!" + e);
+                logger.error("Interrupted when waiting for address notify!" + e);
             }
         } else {
             // do not wait address notify by default
@@ -264,7 +264,7 @@ public class MigrationInvoker<T> implements MigrationClusterInvoker<T> {
         try {
             latch.await(delay, TimeUnit.SECONDS);
         } catch (InterruptedException e) {
-            logger.error("Interrupter when waiting for address notify!" + e);
+            logger.error("Interrupted when waiting for address notify!" + e);
         }
     }
 

--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/support/AbstractRegistry.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/support/AbstractRegistry.java
@@ -433,7 +433,7 @@ public abstract class AbstractRegistry implements Registry {
                         notify(url, listener, filterEmpty(url, urls));
                     } catch (Throwable t) {
                         // 1-7: Failed to notify registry event.
-                        logger.error("1-7", "", "",
+                        logger.error("1-7", "consumer is offline", "",
                             "Failed to notify registry event, urls: " + urls + ", cause: " + t.getMessage(), t);
                     }
                 }


### PR DESCRIPTION
## Brief changelog
对 Registry 模块中多个类中加入错误码。

另附迄今为止使用的错误码：
1-1: Address invalid. - 地址非法
1-2 Invalid registry properties. - 注册中心属性非法
1-3: URL evicting failed. - URL 销毁失败
1-4 Empty address. - 空地址
1-5 Received URL without any parameters. - 接收到没有任何参数的 URL
1-6 Error when clearing cached URLs. - 清空缓存 URL 出错
1-7: Failed to notify registry event. - 通知注册中心事件失败
1-8: Failed to unregister / unsubscribe url on destroy. - 销毁时注销（取消订阅）地址失败
1-9: failed to read / save registry cache file. - 读写注册关系缓存文件失败
1-10 Failed to delete lock file. - 删除锁文件失败。
1-11 Failed to obtain or create registry (service) object. - 注册服务实例创建失败
1-12 Failed to fetch (server) instance since the registry instances have been destroyed. - 由于 “注册服务” 的实例均已销毁，因此没法获取服务提供（或订阅）方的服务器地址。
1-13 - reach the most times of retry. 达到最多的重试次数。
1-14 - Failed to parse raw dynamic config. - 动态配置识别失败
1-15 - Failed to destroy service. - 销毁服务失败
1-16 - Unsupported category in NotifyListener - 存有不支持的类别（在 NotifyListener 中）
1-17 - Address refresh failed. - 地址刷新失败

2-1 - Failed to execute routing. - 路由选址执行失败。

3-1 - Failed to convert the URL address into Invokers. - 服务地址到 Invoker 对象的转换失败。

4-1 - Unsupported protocol - 不支持的协议。
4-2 - Can't find an instance URL using the default preferredProtocol. - 用指定的协议为条件找不到服务实例。