### PR TITLE
fix: metadata service port error when config DUBBO_PORT_TO_REGISTRY env

### DIFF
--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/metadata/ConfigurableMetadataServiceExporter.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/metadata/ConfigurableMetadataServiceExporter.java
@@ -45,6 +45,7 @@ import static org.apache.dubbo.common.constants.CommonConstants.METADATA_SERVICE
 import static org.apache.dubbo.common.constants.CommonConstants.METADATA_SERVICE_PROTOCOL_KEY;
 import static org.apache.dubbo.common.constants.CommonConstants.THREADPOOL_KEY;
 import static org.apache.dubbo.common.constants.CommonConstants.THREADS_KEY;
+import static org.apache.dubbo.remoting.Constants.BIND_PORT_KEY;
 
 /**
  * Export metadata service
@@ -122,8 +123,12 @@ public class ConfigurableMetadataServiceExporter {
                     // metadata service may export before normal service export, it.hasNext() will return false.
                     // so need use specified protocol port.
                     if (it.hasNext()) {
-                        String addr = it.next().getAddress();
-                        String rawPort = addr.substring(addr.indexOf(":") + 1);
+                        ProtocolServer server = it.next();
+                        String rawPort = server.getUrl().getParameter(BIND_PORT_KEY);
+                        if (rawPort == null) {
+                            String addr = server.getAddress();
+                            rawPort = addr.substring(addr.indexOf(":") + 1);
+                        }
                         protocolConfig.setPort(Integer.parseInt(rawPort));
                     } else {
                         Integer protocolPort = getProtocolConfig(specifiedProtocol).getPort();


### PR DESCRIPTION
当配置了`DUBBO_PORT_TO_REGISTRY `环境变量来改变注册端口时，会导致提供者无法提供服务(100%复现)，异常信息如下：
```
Not found exported service: hello-rpc/org.apache.dubbo.metadata.MetadataService:1.0.0:20880 in 
[hello-rpc/org.apache.dubbo.metadata.MetadataService:1.0.0:20885, com.example.dubbo3test.service.HelloService:20880], 
may be version or group mismatch , channel: consumer: /172.10.40.224:63160 --> provider: /172.10.40.224:20880, message:RpcInvocation [methodName=getMetadataInfo, parameterTypes=[class java.lang.String], arguments=[], attachments={input=231, path=org.apache.dubbo.metadata.MetadataService, dubbo=2.0.2, version=1.0.0, timeout=5000, group=hello-rpc}], dubbo version: 3.0.10, current host: 172.10.40.224
```
MetadataService的端口数据不正确(应该使用bindPort而不是registryPort)导致找不到对应的`exported service`。