### PR TITLE
Adding error code to multiple classes in multiple modules.

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/config/configcenter/AbstractDynamicConfiguration.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/config/configcenter/AbstractDynamicConfiguration.java
@@ -17,7 +17,7 @@
 package org.apache.dubbo.common.config.configcenter;
 
 import org.apache.dubbo.common.URL;
-import org.apache.dubbo.common.logger.Logger;
+import org.apache.dubbo.common.logger.ErrorTypeAwareLogger;
 import org.apache.dubbo.common.logger.LoggerFactory;
 import org.apache.dubbo.common.utils.NamedThreadFactory;
 import org.apache.dubbo.common.utils.StringUtils;
@@ -75,7 +75,7 @@ public abstract class AbstractDynamicConfiguration implements DynamicConfigurati
     /**
      * Logger
      */
-    protected final Logger logger = LoggerFactory.getLogger(getClass());
+    protected final ErrorTypeAwareLogger logger = LoggerFactory.getErrorTypeAwareLogger(getClass());
 
     /**
      * The thread pool for workers who executes the tasks

--- a/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/beans/factory/config/DubboConfigDefaultPropertyValueBeanPostProcessor.java
+++ b/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/beans/factory/config/DubboConfigDefaultPropertyValueBeanPostProcessor.java
@@ -52,6 +52,7 @@ public class DubboConfigDefaultPropertyValueBeanPostProcessor extends GenericBea
      */
     public static final String BEAN_NAME = "dubboConfigDefaultPropertyValueBeanPostProcessor";
 
+    @Override
     protected void processBeforeInitialization(AbstractConfig dubboConfigBean, String beanName) throws BeansException {
         // ignore auto generate bean name
         if (!beanName.contains("#")) {

--- a/dubbo-configcenter/dubbo-configcenter-apollo/src/main/java/org/apache/dubbo/configcenter/support/apollo/ApolloDynamicConfiguration.java
+++ b/dubbo-configcenter/dubbo-configcenter-apollo/src/main/java/org/apache/dubbo/configcenter/support/apollo/ApolloDynamicConfiguration.java
@@ -21,7 +21,7 @@ import org.apache.dubbo.common.config.configcenter.ConfigChangeType;
 import org.apache.dubbo.common.config.configcenter.ConfigChangedEvent;
 import org.apache.dubbo.common.config.configcenter.ConfigurationListener;
 import org.apache.dubbo.common.config.configcenter.DynamicConfiguration;
-import org.apache.dubbo.common.logger.Logger;
+import org.apache.dubbo.common.logger.ErrorTypeAwareLogger;
 import org.apache.dubbo.common.logger.LoggerFactory;
 import org.apache.dubbo.common.utils.StringUtils;
 
@@ -61,7 +61,7 @@ import static org.apache.dubbo.common.constants.CommonConstants.CONFIG_NAMESPACE
  * Please see http://dubbo.apache.org/zh-cn/docs/user/configuration/config-center.html for details.
  */
 public class ApolloDynamicConfiguration implements DynamicConfiguration {
-    private static final Logger logger = LoggerFactory.getLogger(ApolloDynamicConfiguration.class);
+    private static final ErrorTypeAwareLogger logger = LoggerFactory.getErrorTypeAwareLogger(ApolloDynamicConfiguration.class);
     private static final String APOLLO_ENV_KEY = "env";
     private static final String APOLLO_ADDR_KEY = "apollo.meta";
     private static final String APOLLO_CLUSTER_KEY = "apollo.cluster";
@@ -106,7 +106,10 @@ public class ApolloDynamicConfiguration implements DynamicConfiguration {
                 throw new IllegalStateException("Failed to connect to config center, the config center is Apollo, " +
                     "the address is: " + (StringUtils.isNotEmpty(configAddr) ? configAddr : configEnv));
             } else {
-                logger.warn("Failed to connect to config center, the config center is Apollo, " +
+                // 5-1 Failed to connect to configuration center.
+
+                logger.warn("5-1", "configuration server offline", "",
+                    "Failed to connect to config center, the config center is Apollo, " +
                     "the address is: " + (StringUtils.isNotEmpty(configAddr) ? configAddr : configEnv) +
                     ", will use the local cache value instead before eventually the connection is established.");
             }

--- a/dubbo-configcenter/dubbo-configcenter-zookeeper/src/main/java/org/apache/dubbo/configcenter/support/zookeeper/ZookeeperDynamicConfiguration.java
+++ b/dubbo-configcenter/dubbo-configcenter-zookeeper/src/main/java/org/apache/dubbo/configcenter/support/zookeeper/ZookeeperDynamicConfiguration.java
@@ -63,7 +63,16 @@ public class ZookeeperDynamicConfiguration extends TreePathDynamicConfiguration 
         zkClient = zookeeperTransporter.connect(url);
         boolean isConnected = zkClient.isConnected();
         if (!isConnected) {
-            throw new IllegalStateException("Failed to connect with zookeeper, pls check if url " + url + " is correct.");
+
+            IllegalStateException illegalStateException =
+                new IllegalStateException("Failed to connect with zookeeper, pls check if url " + url + " is correct.");
+
+            if (logger != null) {
+                logger.error("5-1", "configuration server offline", "",
+                    "Failed to connect with zookeeper", illegalStateException);
+            }
+
+            throw illegalStateException;
         }
     }
 

--- a/dubbo-metadata/dubbo-metadata-report-redis/src/main/java/org/apache/dubbo/metadata/store/redis/RedisMetadataReport.java
+++ b/dubbo-metadata/dubbo-metadata-report-redis/src/main/java/org/apache/dubbo/metadata/store/redis/RedisMetadataReport.java
@@ -52,8 +52,8 @@ import static org.apache.dubbo.metadata.MetadataConstants.META_DATA_STORE_TAG;
  */
 public class RedisMetadataReport extends AbstractMetadataReport {
 
-    private final static String REDIS_DATABASE_KEY = "database";
-    private final static Logger logger = LoggerFactory.getLogger(RedisMetadataReport.class);
+    private static final String REDIS_DATABASE_KEY = "database";
+    private static final Logger logger = LoggerFactory.getLogger(RedisMetadataReport.class);
 
     // protected , for test
     protected JedisPool pool;
@@ -66,7 +66,7 @@ public class RedisMetadataReport extends AbstractMetadataReport {
         super(url);
         timeout = url.getParameter(TIMEOUT_KEY, DEFAULT_TIMEOUT);
         if (url.getParameter(CLUSTER_KEY, false)) {
-            jedisClusterNodes = new HashSet<HostAndPort>();
+            jedisClusterNodes = new HashSet<>();
             List<URL> urls = url.getBackupUrls();
             for (URL tmpUrl : urls) {
                 jedisClusterNodes.add(new HostAndPort(tmpUrl.getHost(), tmpUrl.getPort()));
@@ -103,7 +103,7 @@ public class RedisMetadataReport extends AbstractMetadataReport {
         if (StringUtils.isEmpty(content)) {
             return Collections.emptyList();
         }
-        return new ArrayList<String>(Arrays.asList(URL.decode(content)));
+        return new ArrayList<>(Arrays.asList(URL.decode(content)));
     }
 
     @Override

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/proxy/javassist/JavassistProxyFactory.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/proxy/javassist/JavassistProxyFactory.java
@@ -19,7 +19,7 @@ package org.apache.dubbo.rpc.proxy.javassist;
 import org.apache.dubbo.common.URL;
 import org.apache.dubbo.common.bytecode.Proxy;
 import org.apache.dubbo.common.bytecode.Wrapper;
-import org.apache.dubbo.common.logger.Logger;
+import org.apache.dubbo.common.logger.ErrorTypeAwareLogger;
 import org.apache.dubbo.common.logger.LoggerFactory;
 import org.apache.dubbo.rpc.Invoker;
 import org.apache.dubbo.rpc.proxy.AbstractProxyFactory;
@@ -33,7 +33,7 @@ import java.util.Arrays;
  * JavassistRpcProxyFactory
  */
 public class JavassistProxyFactory extends AbstractProxyFactory {
-    private final static Logger logger = LoggerFactory.getLogger(JavassistProxyFactory.class);
+    private static final ErrorTypeAwareLogger logger = LoggerFactory.getErrorTypeAwareLogger(JavassistProxyFactory.class);
     private final JdkProxyFactory jdkProxyFactory = new JdkProxyFactory();
 
     @Override


### PR DESCRIPTION
另附迄今为止使用的错误码：
1-1: Address invalid. - 地址非法
1-2 Invalid registry properties. - 注册中心属性非法
1-3: URL evicting failed. - URL 销毁失败
1-4 Empty address. - 空地址
1-5 Received URL without any parameters. - 接收到没有任何参数的 URL
1-6 Error when clearing cached URLs. - 清空缓存 URL 出错
1-7: Failed to notify registry event. - 通知注册中心事件失败
1-8: Failed to unregister / unsubscribe url on destroy. - 销毁时注销（取消订阅）地址失败
1-9: failed to read / save registry cache file. - 读写注册关系缓存文件失败
1-10 Failed to delete lock file. - 删除锁文件失败。
1-11 Failed to obtain or create registry (service) object. - 注册服务实例创建失败
1-12 Failed to fetch (server) instance since the registry instances have been destroyed. - 由于 “注册服务” 的实例均已销毁，因此没法获取服务提供（或订阅）方的服务器地址。
1-13 - reach the most times of retry. 达到最多的重试次数。
1-14 - Failed to parse raw dynamic config. - 动态配置识别失败
1-15 - Failed to destroy service. - 销毁服务失败
1-16 - Unsupported category in NotifyListener - 存有不支持的类别（在 NotifyListener 中）
1-17 - Address refresh failed. - 地址刷新失败

2-1 - Failed to execute routing. - 路由选址执行失败。

3-1 - Failed to convert the URL address into Invokers. - 服务地址到 Invoker 对象的转换失败。

4-1 - Unsupported protocol - 不支持的协议。
4-2 - Can't find an instance URL using the default preferredProtocol. - 用指定的协议为条件找不到服务实例。

5-1 Failed to connect to configuration center. - 连接到注册中心失败。