### PR TITLE
fix: nacos开启权限校验后,dubbo服务缺失username和password导致注册失败

### DIFF
--- a/dubbo-registry/dubbo-registry-nacos/src/main/java/com/alibaba/dubbo/registry/nacos/NacosRegistryFactory.java
+++ b/dubbo-registry/dubbo-registry-nacos/src/main/java/com/alibaba/dubbo/registry/nacos/NacosRegistryFactory.java
@@ -69,6 +69,7 @@ public class NacosRegistryFactory extends AbstractRegistryFactory {
     private Properties buildNacosProperties(URL url) {
         Properties properties = new Properties();
         setServerAddr(url, properties);
+        setSecurityInfo(url, properties);
         setProperties(url, properties);
         return properties;
     }
@@ -103,5 +104,10 @@ public class NacosRegistryFactory extends AbstractRegistryFactory {
         if (StringUtils.isNotEmpty(propertyValue)) {
             properties.setProperty(propertyName, propertyValue);
         }
+    }
+
+    private void setSecurityInfo(URL url, Properties properties) {
+        properties.setProperty("username", StringUtils.isNotEmpty(url.getUsername()) ? url.getUsername() : "");
+        properties.setProperty("password", StringUtils.isNotEmpty(url.getPassword()) ? url.getPassword() : "");
     }
 }


### PR DESCRIPTION
## What is the purpose of the change
修复nacos开启权限校验后,dubbo服务缺失username和password导致注册失败，在NacosRegistryFactory中的buildNacosProperties里面增加这部分内容


## Brief changelog


## Verifying this change

