### PR TITLE
Optimize the logic of ConfigConfigurationAdapter to get prefixed meta…

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/config/AbstractConfig.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/config/AbstractConfig.java
@@ -634,7 +634,7 @@ public abstract class AbstractConfig implements Serializable {
 
                     // if old map is null, override with new map
                     if (oldMap == null) {
-                        invokeSetParameters(this.getClass(), this, newMap);
+                        invokeSetParameters(newMap, this);
                         continue;
                     }
 
@@ -646,7 +646,7 @@ public abstract class AbstractConfig implements Serializable {
                         newMap.putAll(oldMap);
                     }
 
-                    invokeSetParameters(this.getClass(), this, newMap);
+                    invokeSetParameters(newMap, this);
                 } else if (isNestedSetter(this, method)) {
                     // not support
                 }
@@ -782,7 +782,7 @@ public abstract class AbstractConfig implements Serializable {
 
                 // if old map is null, directly set params
                 if (oldMap == null) {
-                    invokeSetParameters(obj.getClass(), obj, newMap);
+                    invokeSetParameters(newMap, obj);
                     continue;
                 }
 
@@ -795,7 +795,7 @@ public abstract class AbstractConfig implements Serializable {
                     oldMap.forEach(newMap::putIfAbsent);
                 }
 
-                invokeSetParameters(obj.getClass(), obj, newMap);
+                invokeSetParameters(newMap, obj);
             } else if (isNestedSetter(obj, method)) {
                 try {
                     Class<?> clazz = method.getParameterTypes()[0];

--- a/dubbo-common/src/main/java/org/apache/dubbo/config/AbstractConfig.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/config/AbstractConfig.java
@@ -281,9 +281,6 @@ public abstract class AbstractConfig implements Serializable {
 
     private static void invokeSetParameters(Class c, Object o, Map map) {
         try {
-            if (CollectionUtils.isEmptyMap(map)) {
-                return;
-            }
             Method method = findMethodByMethodSignature(c, "setParameters", new String[]{Map.class.getName()});
             if (method != null && isParametersSetter(method)) {
                 method.invoke(o, map);

--- a/dubbo-common/src/main/java/org/apache/dubbo/config/ReferenceConfigBase.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/config/ReferenceConfigBase.java
@@ -149,6 +149,11 @@ public abstract class ReferenceConfigBase<T> extends AbstractReferenceConfig {
 
     @Override
     public Map<String, String> getMetaData() {
+        return getMetaData(null);
+    }
+
+    @Override
+    public Map<String, String> getMetaData(String prefix) {
         Map<String, String> metaData = new HashMap<>();
         ConsumerConfig consumer = this.getConsumer();
         // consumer should be initialized at preProcessRefresh()
@@ -156,8 +161,8 @@ public abstract class ReferenceConfigBase<T> extends AbstractReferenceConfig {
             throw new IllegalStateException("Consumer is not initialized");
         }
         // use consumer attributes as default value
-        appendAttributes(metaData, consumer);
-        appendAttributes(metaData, this);
+        appendAttributes(metaData, consumer, prefix);
+        appendAttributes(metaData, this, prefix);
         return metaData;
     }
 

--- a/dubbo-common/src/main/java/org/apache/dubbo/config/RegistryConfig.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/config/RegistryConfig.java
@@ -88,7 +88,7 @@ public class RegistryConfig extends AbstractConfig {
     private String zone;
 
     /**
-     * The group the services registry in
+     * The group that services registry in
      */
     private String group;
 
@@ -125,12 +125,12 @@ public class RegistryConfig extends AbstractConfig {
     private Boolean dynamic;
 
     /**
-     * Whether to export service on the register center
+     * Whether to allow exporting service on the register center
      */
     private Boolean register;
 
     /**
-     * Whether allow to subscribe service on the register center
+     * Whether to allow subscribing service on the register center
      */
     private Boolean subscribe;
 

--- a/dubbo-common/src/main/java/org/apache/dubbo/config/ServiceConfigBase.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/config/ServiceConfigBase.java
@@ -234,16 +234,21 @@ public abstract class ServiceConfigBase<T> extends AbstractServiceConfig {
 
     @Override
     public Map<String, String> getMetaData() {
+        return getMetaData(null);
+    }
+
+    @Override
+    public Map<String, String> getMetaData(String prefix) {
         Map<String, String> metaData = new HashMap<>();
         ProviderConfig provider = this.getProvider();
-        // provider should be inited at preProcessRefresh()
+        // provider should be initialized at preProcessRefresh()
         if (isRefreshed() && provider == null) {
             throw new IllegalStateException("Provider is not initialized");
         }
         // use provider attributes as default value
-        appendAttributes(metaData, provider);
+        appendAttributes(metaData, provider, prefix);
         // Finally, put the service's attributes, overriding previous attributes
-        appendAttributes(metaData, this);
+        appendAttributes(metaData, this, prefix);
         return metaData;
     }
 

--- a/dubbo-common/src/main/java/org/apache/dubbo/config/context/ConfigConfigurationAdapter.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/config/context/ConfigConfigurationAdapter.java
@@ -20,7 +20,6 @@ import org.apache.dubbo.common.config.Configuration;
 import org.apache.dubbo.common.utils.StringUtils;
 import org.apache.dubbo.config.AbstractConfig;
 
-import java.util.HashMap;
 import java.util.Map;
 
 /**

--- a/dubbo-common/src/main/java/org/apache/dubbo/config/context/ConfigConfigurationAdapter.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/config/context/ConfigConfigurationAdapter.java
@@ -31,14 +31,10 @@ public class ConfigConfigurationAdapter implements Configuration {
     private Map<String, String> metaData;
 
     public ConfigConfigurationAdapter(AbstractConfig config, String prefix) {
-        Map<String, String> configMetadata = config.getMetaData();
         if (StringUtils.hasText(prefix)) {
-            metaData = new HashMap<>(configMetadata.size(), 1.0f);
-            for (Map.Entry<String, String> entry : configMetadata.entrySet()) {
-                metaData.put(prefix + "." + entry.getKey(), entry.getValue());
-            }
+            metaData = config.getMetaData(prefix);
         } else {
-            metaData = configMetadata;
+            metaData = config.getMetaData();
         }
     }
 

--- a/dubbo-common/src/main/java/org/apache/dubbo/config/context/ConfigMode.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/config/context/ConfigMode.java
@@ -22,7 +22,7 @@ package org.apache.dubbo.config.context;
  */
 public enum ConfigMode {
     /**
-     * Strict mode: accept only one config for unique config type, throw exceptions if found more than one configs for an unique config type.
+     * Strict mode: accept only one config for unique config type, throw exceptions if found more than one config for a unique config type.
      */
     STRICT,
 

--- a/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/RegistryConfigTest.java
+++ b/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/RegistryConfigTest.java
@@ -65,9 +65,13 @@ public class RegistryConfigTest {
     @Test
     public void testAddress() throws Exception {
         RegistryConfig registry = new RegistryConfig();
-        registry.setAddress("localhost");
-        assertThat(registry.getAddress(), equalTo("localhost"));
-        Map<String, String> parameters = new HashMap<String, String>();
+        registry.setAddress("zookeeper://mrh:123@localhost:9103/registry?backup=localhost:9104&k1=v1");
+        assertThat(registry.getAddress(), equalTo("zookeeper://mrh:123@localhost:9103/registry?backup=localhost:9104&k1=v1"));
+        assertThat(registry.getProtocol(), equalTo("zookeeper"));
+        assertThat(registry.getUsername(), equalTo("mrh"));
+        assertThat(registry.getPassword(), equalTo("123"));
+        assertThat(registry.getParameters().get("k1"), equalTo("v1"));
+        Map<String, String> parameters = new HashMap<>();
         RegistryConfig.appendParameters(parameters, registry);
         assertThat(parameters, not(hasKey("address")));
     }


### PR DESCRIPTION
…data

## What is the purpose of the change

在原来`AbstractConfig#getMetaData()`方法的基础上，再添加一个带有`prefix`参数的重载的`getMetaData(String prefix)`方法。这样`ConfigConfigurationAdapter`在获取带前缀的元数据的时候直接调用此方法（`getMetaData(String prefix)`），不需要再像原来的逻辑 `getMetaData()` + 遍历`entry`对每个`key`拼上`prefix`。
