### PR TITLE
Add error code 2-2, 6-1, 6-2, 0-1.

### DIFF
--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/directory/AbstractDirectory.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/directory/AbstractDirectory.java
@@ -20,7 +20,7 @@ import org.apache.dubbo.common.URL;
 import org.apache.dubbo.common.Version;
 import org.apache.dubbo.common.config.Configuration;
 import org.apache.dubbo.common.config.ConfigurationUtils;
-import org.apache.dubbo.common.logger.Logger;
+import org.apache.dubbo.common.logger.ErrorTypeAwareLogger;
 import org.apache.dubbo.common.logger.LoggerFactory;
 import org.apache.dubbo.common.threadpool.manager.FrameworkExecutorRepository;
 import org.apache.dubbo.common.utils.ConcurrentHashSet;
@@ -71,7 +71,7 @@ import static org.apache.dubbo.rpc.cluster.Constants.REFER_KEY;
 public abstract class AbstractDirectory<T> implements Directory<T> {
 
     // logger
-    private static final Logger logger = LoggerFactory.getLogger(AbstractDirectory.class);
+    private static final ErrorTypeAwareLogger logger = LoggerFactory.getErrorTypeAwareLogger(AbstractDirectory.class);
 
     private final URL url;
 
@@ -193,7 +193,10 @@ public abstract class AbstractDirectory<T> implements Directory<T> {
 
         List<Invoker<T>> routedResult = doList(availableInvokers, invocation);
         if (routedResult.isEmpty()) {
-            logger.warn("No provider available after connectivity filter for the service " + getConsumerUrl().getServiceKey()
+            // 2-2 - No provider available.
+
+            logger.warn("2-2", "provider server or registry center crashed", "",
+                "No provider available after connectivity filter for the service " + getConsumerUrl().getServiceKey()
                 + " All validInvokers' size: " + validInvokers.size()
                 + " All routed invokers' size: " + routedResult.size()
                 + " All invokers' size: " + invokers.size()

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/threadpool/support/AbortPolicyWithReport.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/threadpool/support/AbortPolicyWithReport.java
@@ -84,6 +84,7 @@ public class AbortPolicyWithReport extends ThreadPoolExecutor.AbortPolicy {
                 e.getTaskCount(), e.getCompletedTaskCount(), e.isShutdown(), e.isTerminated(), e.isTerminating(),
                 url.getProtocol(), url.getIp(), url.getPort());
 
+        // 0-1 - Thread pool is EXHAUSTED!
         logger.warn("0-1", "too much client requesting provider", "", msg);
 
         dumpJStack();

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/threadpool/support/AbortPolicyWithReport.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/threadpool/support/AbortPolicyWithReport.java
@@ -14,10 +14,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.dubbo.common.threadpool.support;
 
 import org.apache.dubbo.common.URL;
-import org.apache.dubbo.common.logger.Logger;
+import org.apache.dubbo.common.logger.ErrorTypeAwareLogger;
 import org.apache.dubbo.common.logger.LoggerFactory;
 import org.apache.dubbo.common.threadpool.event.ThreadPoolExhaustedEvent;
 import org.apache.dubbo.common.threadpool.event.ThreadPoolExhaustedListener;
@@ -47,7 +48,7 @@ import static org.apache.dubbo.common.constants.CommonConstants.OS_WIN_PREFIX;
  */
 public class AbortPolicyWithReport extends ThreadPoolExecutor.AbortPolicy {
 
-    protected static final Logger logger = LoggerFactory.getLogger(AbortPolicyWithReport.class);
+    protected static final ErrorTypeAwareLogger logger = LoggerFactory.getErrorTypeAwareLogger(AbortPolicyWithReport.class);
 
     private final String threadName;
 
@@ -82,9 +83,12 @@ public class AbortPolicyWithReport extends ThreadPoolExecutor.AbortPolicy {
                 e.getLargestPoolSize(),
                 e.getTaskCount(), e.getCompletedTaskCount(), e.isShutdown(), e.isTerminated(), e.isTerminating(),
                 url.getProtocol(), url.getIp(), url.getPort());
-        logger.warn(msg);
+
+        logger.warn("0-1", "too much client requesting provider", "", msg);
+
         dumpJStack();
         dispatchThreadPoolExhaustedEvent(msg);
+
         throw new RejectedExecutionException(msg);
     }
 

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/threadpool/support/eager/EagerThreadPool.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/threadpool/support/eager/EagerThreadPool.java
@@ -51,7 +51,7 @@ public class EagerThreadPool implements ThreadPool {
         int alive = url.getParameter(ALIVE_KEY, DEFAULT_ALIVE);
 
         // init queue and executor
-        TaskQueue<Runnable> taskQueue = new TaskQueue<Runnable>(queues <= 0 ? 1 : queues);
+        TaskQueue<Runnable> taskQueue = new TaskQueue<>(queues <= 0 ? 1 : queues);
         EagerThreadPoolExecutor executor = new EagerThreadPoolExecutor(cores,
                 threads,
                 alive,

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/threadpool/support/fixed/FixedThreadPool.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/threadpool/support/fixed/FixedThreadPool.java
@@ -22,6 +22,7 @@ import org.apache.dubbo.common.threadpool.MemorySafeLinkedBlockingQueue;
 import org.apache.dubbo.common.threadpool.ThreadPool;
 import org.apache.dubbo.common.threadpool.support.AbortPolicyWithReport;
 
+import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.Executor;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.SynchronousQueue;
@@ -47,10 +48,18 @@ public class FixedThreadPool implements ThreadPool {
         String name = url.getParameter(THREAD_NAME_KEY, (String) url.getAttribute(THREAD_NAME_KEY, DEFAULT_THREAD_NAME));
         int threads = url.getParameter(THREADS_KEY, DEFAULT_THREADS);
         int queues = url.getParameter(QUEUES_KEY, DEFAULT_QUEUES);
-        return new ThreadPoolExecutor(threads, threads, 0, TimeUnit.MILLISECONDS,
-                queues == 0 ? new SynchronousQueue<Runnable>() :
-                        (queues < 0 ? new MemorySafeLinkedBlockingQueue<Runnable>()
-                                : new LinkedBlockingQueue<Runnable>(queues)),
+
+        BlockingQueue<Runnable> queue;
+
+        if (queues == 0) {
+            queue = new SynchronousQueue<>();
+        } else if (queues < 0) {
+            queue = new MemorySafeLinkedBlockingQueue<>();
+        } else {
+            queue = new LinkedBlockingQueue<>(queues);
+        }
+
+        return new ThreadPoolExecutor(threads, threads, 0, TimeUnit.MILLISECONDS, queue,
                 new NamedInternalThreadFactory(name, true), new AbortPolicyWithReport(name, url));
     }
 

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/threadpool/support/fixed/FixedThreadPool.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/threadpool/support/fixed/FixedThreadPool.java
@@ -49,17 +49,17 @@ public class FixedThreadPool implements ThreadPool {
         int threads = url.getParameter(THREADS_KEY, DEFAULT_THREADS);
         int queues = url.getParameter(QUEUES_KEY, DEFAULT_QUEUES);
 
-        BlockingQueue<Runnable> queue;
+        BlockingQueue<Runnable> blockingQueue;
 
         if (queues == 0) {
-            queue = new SynchronousQueue<>();
+            blockingQueue = new SynchronousQueue<>();
         } else if (queues < 0) {
-            queue = new MemorySafeLinkedBlockingQueue<>();
+            blockingQueue = new MemorySafeLinkedBlockingQueue<>();
         } else {
-            queue = new LinkedBlockingQueue<>(queues);
+            blockingQueue = new LinkedBlockingQueue<>(queues);
         }
 
-        return new ThreadPoolExecutor(threads, threads, 0, TimeUnit.MILLISECONDS, queue,
+        return new ThreadPoolExecutor(threads, threads, 0, TimeUnit.MILLISECONDS, blockingQueue,
                 new NamedInternalThreadFactory(name, true), new AbortPolicyWithReport(name, url));
     }
 

--- a/dubbo-remoting/dubbo-remoting-netty/src/main/java/org/apache/dubbo/remoting/transport/netty/NettyClient.java
+++ b/dubbo-remoting/dubbo-remoting-netty/src/main/java/org/apache/dubbo/remoting/transport/netty/NettyClient.java
@@ -121,13 +121,26 @@ public class NettyClient extends AbstractClient {
                     }
                 }
             } else if (future.getCause() != null) {
-                throw new RemotingException(this, "client(url: " + getUrl() + ") failed to connect to server "
-                        + getRemoteAddress() + ", error message is:" + future.getCause().getMessage(), future.getCause());
+                Throwable cause = future.getCause();
+
+                RemotingException remotingException = new RemotingException(this, "client(url: " + getUrl() + ") failed to connect to server "
+                        + getRemoteAddress() + ", error message is:" + cause.getMessage(), cause);
+
+                // 6-1 - Failed to connect to provider server by other reason.
+                logger.error("6-1", "network disconnected", "", "Failed to connect to provider server by other reason.", cause);
+
+                throw remotingException;
             } else {
-                throw new RemotingException(this, "client(url: " + getUrl() + ") failed to connect to server "
+
+                RemotingException remotingException = new RemotingException(this, "client(url: " + getUrl() + ") failed to connect to server "
                         + getRemoteAddress() + " client-side timeout "
                         + getConnectTimeout() + "ms (elapsed: " + (System.currentTimeMillis() - start) + "ms) from netty client "
                         + NetUtils.getLocalHost() + " using dubbo version " + Version.getVersion());
+
+                // 6-2 - Client-side timeout.
+                logger.error("6-2", "provider crash", "", "Client-side timeout.", remotingException);
+
+                throw remotingException;
             }
         } finally {
             if (!isConnected()) {

--- a/dubbo-remoting/dubbo-remoting-netty/src/main/java/org/apache/dubbo/remoting/transport/netty/NettyClient.java
+++ b/dubbo-remoting/dubbo-remoting-netty/src/main/java/org/apache/dubbo/remoting/transport/netty/NettyClient.java
@@ -18,7 +18,7 @@ package org.apache.dubbo.remoting.transport.netty;
 
 import org.apache.dubbo.common.URL;
 import org.apache.dubbo.common.Version;
-import org.apache.dubbo.common.logger.Logger;
+import org.apache.dubbo.common.logger.ErrorTypeAwareLogger;
 import org.apache.dubbo.common.logger.LoggerFactory;
 import org.apache.dubbo.common.utils.NamedThreadFactory;
 import org.apache.dubbo.common.utils.NetUtils;
@@ -44,7 +44,7 @@ import java.util.concurrent.TimeUnit;
  */
 public class NettyClient extends AbstractClient {
 
-    private static final Logger logger = LoggerFactory.getLogger(NettyClient.class);
+    private static final ErrorTypeAwareLogger logger = LoggerFactory.getErrorTypeAwareLogger(NettyClient.class);
 
     // ChannelFactory's closure has a DirectMemory leak, using static to avoid
     // https://issues.jboss.org/browse/NETTY-424

--- a/dubbo-remoting/dubbo-remoting-netty4/src/main/java/org/apache/dubbo/remoting/transport/netty4/NettyClient.java
+++ b/dubbo-remoting/dubbo-remoting-netty4/src/main/java/org/apache/dubbo/remoting/transport/netty4/NettyClient.java
@@ -16,11 +16,10 @@
  */
 package org.apache.dubbo.remoting.transport.netty4;
 
-import io.netty.util.concurrent.EventExecutorGroup;
 import org.apache.dubbo.common.URL;
 import org.apache.dubbo.common.Version;
 import org.apache.dubbo.common.config.ConfigurationUtils;
-import org.apache.dubbo.common.logger.Logger;
+import org.apache.dubbo.common.logger.ErrorTypeAwareLogger;
 import org.apache.dubbo.common.logger.LoggerFactory;
 import org.apache.dubbo.common.resource.GlobalResourceInitializer;
 import org.apache.dubbo.common.utils.NetUtils;
@@ -42,6 +41,7 @@ import io.netty.channel.EventLoopGroup;
 import io.netty.channel.socket.SocketChannel;
 import io.netty.handler.proxy.Socks5ProxyHandler;
 import io.netty.handler.timeout.IdleStateHandler;
+import io.netty.util.concurrent.EventExecutorGroup;
 
 import java.net.InetSocketAddress;
 
@@ -62,7 +62,7 @@ public class NettyClient extends AbstractClient {
 
     private static final String DEFAULT_SOCKS_PROXY_PORT = "1080";
 
-    private static final Logger logger = LoggerFactory.getLogger(NettyClient.class);
+    private static final ErrorTypeAwareLogger logger = LoggerFactory.getErrorTypeAwareLogger(NettyClient.class);
 
     /**
      * netty client bootstrap

--- a/dubbo-serialization/dubbo-serialization-fastjson2/src/main/java/org/apache/dubbo/common/serialize/fastjson2/Fastjson2CreatorManager.java
+++ b/dubbo-serialization/dubbo-serialization-fastjson2/src/main/java/org/apache/dubbo/common/serialize/fastjson2/Fastjson2CreatorManager.java
@@ -31,7 +31,7 @@ public class Fastjson2CreatorManager implements ScopeClassLoaderListener<Framewo
     /**
      * An empty classLoader used when classLoader is system classLoader. Prevent the NPE.
      */
-    private final static ClassLoader SYSTEM_CLASSLOADER_KEY = new ClassLoader() {};
+    private static final ClassLoader SYSTEM_CLASSLOADER_KEY = new ClassLoader() {};
 
     private final Map<ClassLoader, ObjectReaderCreatorASM> readerMap = new ConcurrentHashMap<>();
     private final Map<ClassLoader, ObjectWriterCreatorASM> writerMap = new ConcurrentHashMap<>();

--- a/dubbo-serialization/dubbo-serialization-jdk/src/main/java/org/apache/dubbo/common/serialize/java/JavaObjectInput.java
+++ b/dubbo-serialization/dubbo-serialization-jdk/src/main/java/org/apache/dubbo/common/serialize/java/JavaObjectInput.java
@@ -27,7 +27,7 @@ import java.lang.reflect.Type;
  * Java object input implementation
  */
 public class JavaObjectInput extends NativeJavaObjectInput {
-    public final static int MAX_BYTE_ARRAY_LENGTH = 8 * 1024 * 1024;
+    public static final int MAX_BYTE_ARRAY_LENGTH = 8 * 1024 * 1024;
 
     public JavaObjectInput(InputStream is) throws IOException {
         super(new ObjectInputStream(is));

--- a/dubbo-serialization/dubbo-serialization-jdk/src/main/java/org/apache/dubbo/common/serialize/java/JavaSerialization.java
+++ b/dubbo-serialization/dubbo-serialization-jdk/src/main/java/org/apache/dubbo/common/serialize/java/JavaSerialization.java
@@ -39,7 +39,7 @@ import static org.apache.dubbo.common.serialize.Constants.JAVA_SERIALIZATION_ID;
  */
 public class JavaSerialization implements Serialization {
     private static final Logger logger = LoggerFactory.getLogger(JavaSerialization.class);
-    private final static AtomicBoolean warn = new AtomicBoolean(false);
+    private static final AtomicBoolean warn = new AtomicBoolean(false);
 
     @Override
     public byte getContentTypeId() {

--- a/dubbo-serialization/dubbo-serialization-jdk/src/main/java/org/apache/dubbo/common/serialize/nativejava/NativeJavaSerialization.java
+++ b/dubbo-serialization/dubbo-serialization-jdk/src/main/java/org/apache/dubbo/common/serialize/nativejava/NativeJavaSerialization.java
@@ -41,7 +41,7 @@ import static org.apache.dubbo.common.serialize.Constants.NATIVE_JAVA_SERIALIZAT
  */
 public class NativeJavaSerialization implements Serialization {
     private static final Logger logger = LoggerFactory.getLogger(JavaSerialization.class);
-    private final static AtomicBoolean warn = new AtomicBoolean(false);
+    private static final AtomicBoolean warn = new AtomicBoolean(false);
 
     @Override
     public byte getContentTypeId() {


### PR DESCRIPTION
另附迄今为止使用的错误码：
0-1: Thread pool is EXHAUSTED! - 线程池资源耗尽。

1-1: Address invalid. - 地址非法
1-2 Invalid registry properties. - 注册中心属性非法
1-3: URL evicting failed. - URL 销毁失败
1-4 Empty address. - 空地址
1-5 Received URL without any parameters. - 接收到没有任何参数的 URL
1-6 Error when clearing cached URLs. - 清空缓存 URL 出错
1-7: Failed to notify registry event. - 通知注册中心事件失败
1-8: Failed to unregister / unsubscribe url on destroy. - 销毁时注销（取消订阅）地址失败
1-9: failed to read / save registry cache file. - 读写注册关系缓存文件失败
1-10 Failed to delete lock file. - 删除锁文件失败。
1-11 Failed to obtain or create registry (service) object. - 注册服务实例创建失败
1-12 Failed to fetch (server) instance since the registry instances have been destroyed. - 由于 “注册服务” 的实例均已销毁，因此没法获取服务提供（或订阅）方的服务器地址。
1-13 - reach the most times of retry. 达到最多的重试次数。
1-14 - Failed to parse raw dynamic config. - 动态配置识别失败
1-15 - Failed to destroy service. - 销毁服务失败
1-16 - Unsupported category in NotifyListener - 存有不支持的类别（在 NotifyListener 中）
1-17 - Address refresh failed. - 地址刷新失败

2-1 - Failed to execute routing. - 路由选址执行失败。
2-2 - No provider available - 没有可用的提供端。

3-1 - Failed to convert the URL address into Invokers. - 服务地址到 Invoker 对象的转换失败。

4-1 - Unsupported protocol - 不支持的协议。
4-2 - Can't find an instance URL using the default preferredProtocol. - 用指定的协议为条件找不到服务实例。

5-1 Failed to connect to configuration center. - 连接到注册中心失败。

6-1 - Failed to connect to provider server by other reason. - 因其它原因连接不上 Provider。
6-2 - Client-side timeout. - 客户端超时