### PR TITLE
Remove processing streamObserver in TripleInvoker#invokeUnary

### DIFF
--- a/dubbo-compiler/src/main/resources/Dubbo3TripleStub.mustache
+++ b/dubbo-compiler/src/main/resources/Dubbo3TripleStub.mustache
@@ -120,14 +120,6 @@ public final class {{className}} {
         public {{outputType}} {{methodName}}({{inputType}} request){
             return StubInvocationUtil.unaryCall(invoker, {{methodName}}Method, request);
         }
-
-        {{#javaDoc}}
-            {{{javaDoc}}}
-        {{/javaDoc}}
-        @Override
-        public void {{methodName}}({{inputType}} request, StreamObserver<{{outputType}}> responseObserver){
-            StubInvocationUtil.unaryCall(invoker, {{methodName}}Method , request, responseObserver);
-        }
     {{/unaryMethods}}
 
     {{#serverStreamingMethods}}

--- a/dubbo-compiler/src/main/resources/Dubbo3TripleStub.mustache
+++ b/dubbo-compiler/src/main/resources/Dubbo3TripleStub.mustache
@@ -120,6 +120,14 @@ public final class {{className}} {
         public {{outputType}} {{methodName}}({{inputType}} request){
             return StubInvocationUtil.unaryCall(invoker, {{methodName}}Method, request);
         }
+
+        {{#javaDoc}}
+            {{{javaDoc}}}
+        {{/javaDoc}}
+        @Override
+        public void {{methodName}}({{inputType}} request, StreamObserver<{{outputType}}> responseObserver){
+            StubInvocationUtil.unaryCall(invoker, {{methodName}}Method , request, responseObserver);
+        }
     {{/unaryMethods}}
 
     {{#serverStreamingMethods}}

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/stub/StubInvocationUtil.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/stub/StubInvocationUtil.java
@@ -31,6 +31,17 @@ public class StubInvocationUtil {
         return (R) call(invoker, methodDescriptor, new Object[]{request});
     }
 
+    public static <T, R> void unaryCall(Invoker<?> invoker, MethodDescriptor method, T request,
+        StreamObserver<R> responseObserver) {
+        try {
+            Object res = unaryCall(invoker, method, request);
+            responseObserver.onNext((R) res);
+        } catch (Exception e) {
+            responseObserver.onError(e);
+        }
+        responseObserver.onCompleted();
+    }
+
     public static <T, R> StreamObserver<T> biOrClientStreamCall(Invoker<?> invoker,
         MethodDescriptor method, StreamObserver<R> responseObserver) {
         return (StreamObserver<T>) call(invoker, method, new Object[]{responseObserver});

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/stub/StubInvocationUtil.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/stub/StubInvocationUtil.java
@@ -31,11 +31,6 @@ public class StubInvocationUtil {
         return (R) call(invoker, methodDescriptor, new Object[]{request});
     }
 
-    public static <T, R> void unaryCall(Invoker<?> invoker, MethodDescriptor method, T request,
-        StreamObserver<R> responseObserver) {
-        call(invoker, method, new Object[]{request, responseObserver});
-    }
-
     public static <T, R> StreamObserver<T> biOrClientStreamCall(Invoker<?> invoker,
         MethodDescriptor method, StreamObserver<R> responseObserver) {
         return (StreamObserver<T>) call(invoker, method, new Object[]{responseObserver});

--- a/dubbo-rpc/dubbo-rpc-api/src/test/java/org/apache/dubbo/rpc/stub/StubInvocationUtilTest.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/test/java/org/apache/dubbo/rpc/stub/StubInvocationUtilTest.java
@@ -117,61 +117,6 @@ class StubInvocationUtilTest {
     }
 
     @Test
-    void testUnaryCall() throws Throwable {
-        Invoker<DemoService> invoker = Mockito.mock(Invoker.class);
-        URL url = Mockito.mock(URL.class);
-        ConsumerModel consumerModel = Mockito.mock(ConsumerModel.class);
-        ServiceDescriptor serviceDescriptor = Mockito.mock(ServiceDescriptor.class);
-        when(consumerModel.getServiceModel()).thenReturn(serviceDescriptor);
-        when(url.getServiceModel())
-            .thenReturn(consumerModel);
-        when(url.getServiceInterface())
-            .thenReturn(DemoService.class.getName());
-        when(url.getProtocolServiceKey())
-            .thenReturn(DemoService.class.getName());
-        when(invoker.getUrl())
-            .thenReturn(url);
-        when(invoker.getInterface())
-            .thenReturn(DemoService.class);
-        Result result = Mockito.mock(Result.class);
-        String response = "response";
-        when(invoker.invoke(any(Invocation.class)))
-            .then(invocationOnMock -> {
-                Invocation invocation = (Invocation) invocationOnMock.getArguments()[0];
-                StreamObserver<Object> observer = (StreamObserver<Object>) invocation.getArguments()[1];
-                observer.onNext(response);
-                observer.onCompleted();
-                return result;
-            });
-        MethodDescriptor method = Mockito.mock(MethodDescriptor.class);
-        when(method.getParameterClasses())
-            .thenReturn(new Class[]{String.class});
-        when(method.getMethodName())
-            .thenReturn("sayHello");
-        String request = "request";
-        CountDownLatch latch = new CountDownLatch(1);
-        AtomicReference<Object> atomicReference = new AtomicReference<>();
-        StreamObserver<Object> responseObserver = new StreamObserver<Object>() {
-            @Override
-            public void onNext(Object data) {
-                atomicReference.set(data);
-            }
-
-            @Override
-            public void onError(Throwable throwable) {
-            }
-
-            @Override
-            public void onCompleted() {
-                latch.countDown();
-            }
-        };
-        StubInvocationUtil.unaryCall(invoker, method, request, responseObserver);
-        latch.await(1, TimeUnit.SECONDS);
-        Assertions.assertEquals(response, atomicReference.get());
-    }
-
-    @Test
     void biOrClientStreamCall() throws InterruptedException {
         Invoker<DemoService> invoker = Mockito.mock(Invoker.class);
         URL url = Mockito.mock(URL.class);


### PR DESCRIPTION
## What is the purpose of the change

Remove processing streamObserver in TripleInvoker#invokeUnary

## Brief changelog


## Verifying this change


<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [ ] GitHub Actions works fine on your own branch.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).

/cc @EarthChen 
