### PR TITLE
Abstract the disableAutoFlowControl method of CallStreamObserver

### DIFF
--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/ClientStreamObserver.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/ClientStreamObserver.java
@@ -29,6 +29,8 @@ public interface ClientStreamObserver<T> extends CallStreamObserver<T> {
      * request()} may not be called before the call is started, a number of initial requests may be
      * specified.
      */
-    void disableAutoRequest();
+    default void disableAutoRequest() {
+        disableAutoFlowControl();
+    }
 
 }

--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/ServerStreamObserver.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/ServerStreamObserver.java
@@ -21,7 +21,8 @@ import org.apache.dubbo.rpc.protocol.tri.observer.CallStreamObserver;
 
 public interface ServerStreamObserver<T> extends CallStreamObserver<T> {
 
-
-    void disableAutoInboundFlowControl();
+    default void disableAutoInboundFlowControl() {
+        disableAutoFlowControl();
+    }
 
 }

--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/observer/CallStreamObserver.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/observer/CallStreamObserver.java
@@ -43,5 +43,12 @@ public interface CallStreamObserver<T> extends StreamObserver<T> {
      */
     void setCompression(String compression);
 
+    /**
+     * Swaps to manual flow control where no message will be delivered to {@link
+     * StreamObserver#onNext(Object)} unless it is {@link #request request()}ed. Since {@code
+     * request()} may not be called before the call is started, a number of initial requests may be
+     * specified.
+     */
+    void disableAutoFlowControl();
 
 }

--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/observer/ClientCallToObserverAdapter.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/observer/ClientCallToObserverAdapter.java
@@ -77,6 +77,11 @@ public class ClientCallToObserverAdapter<T> extends CancelableStreamObserver<T> 
 
     @Override
     public void disableAutoRequest() {
+        disableAutoFlowControl();
+    }
+
+    @Override
+    public void disableAutoFlowControl() {
         call.setAutoRequest(false);
     }
 }

--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/observer/ClientCallToObserverAdapter.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/observer/ClientCallToObserverAdapter.java
@@ -76,11 +76,6 @@ public class ClientCallToObserverAdapter<T> extends CancelableStreamObserver<T> 
     }
 
     @Override
-    public void disableAutoRequest() {
-        disableAutoFlowControl();
-    }
-
-    @Override
     public void disableAutoFlowControl() {
         call.setAutoRequest(false);
     }

--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/observer/ServerCallToObserverAdapter.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/observer/ServerCallToObserverAdapter.java
@@ -106,6 +106,11 @@ public class ServerCallToObserverAdapter<T> extends CancelableStreamObserver<T> 
 
     @Override
     public void disableAutoInboundFlowControl() {
+        disableAutoFlowControl();
+    }
+
+    @Override
+    public void disableAutoFlowControl() {
         call.disableAutoRequestN();
     }
 

--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/observer/ServerCallToObserverAdapter.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/observer/ServerCallToObserverAdapter.java
@@ -105,11 +105,6 @@ public class ServerCallToObserverAdapter<T> extends CancelableStreamObserver<T> 
     }
 
     @Override
-    public void disableAutoInboundFlowControl() {
-        disableAutoFlowControl();
-    }
-
-    @Override
     public void disableAutoFlowControl() {
         call.disableAutoRequestN();
     }


### PR DESCRIPTION
## What is the purpose of the change

Abstract the disableAutoFlowControl method of CallStreamObserver, because ClientStreamObserver#disableAutoRequest and ServerStreamObserver#disableAutoInboundFlowControl are both similar.

/cc @EarthChen 

## Brief changelog


## Verifying this change


<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [ ] GitHub Actions works fine on your own branch.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
