### PR TITLE
Change error code 1-2 to 0-2, add code of logging error code 2-2, optimize javadoc, and add unit tests in Configuration.

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/config/Configuration.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/config/Configuration.java
@@ -16,6 +16,9 @@
  */
 package org.apache.dubbo.common.config;
 
+import org.apache.dubbo.common.logger.ErrorTypeAwareLogger;
+import org.apache.dubbo.common.logger.LoggerFactory;
+
 import java.util.NoSuchElementException;
 
 import static org.apache.dubbo.common.config.ConfigurationUtils.isEmptyValue;
@@ -24,6 +27,9 @@ import static org.apache.dubbo.common.config.ConfigurationUtils.isEmptyValue;
  * Configuration interface, to fetch the value for the specified key.
  */
 public interface Configuration {
+
+    ErrorTypeAwareLogger interfaceLevelLogger = LoggerFactory.getErrorTypeAwareLogger(Configuration.class);
+
     /**
      * Get a string associated with the given configuration key.
      *
@@ -66,6 +72,11 @@ public interface Configuration {
         try {
             return convert(Integer.class, key, defaultValue);
         } catch (NumberFormatException e) {
+            // 0-2 Property type mismatch.
+            interfaceLevelLogger.error("0-2", "typo in property value",
+                "This property requires an integer value.",
+                "Actual Class: " + getClass().getName(), e);
+
             throw new IllegalStateException('\'' + key + "' doesn't map to a Integer object", e);
         }
     }

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/config/InmemoryConfigurationTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/config/InmemoryConfigurationTest.java
@@ -16,6 +16,8 @@
  */
 package org.apache.dubbo.common.config;
 
+import org.apache.dubbo.common.beanutil.JavaBeanAccessor;
+
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -23,9 +25,10 @@ import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.NoSuchElementException;
 
 /**
- * The type Inmemory configuration test.
+ * Unit test of class InmemoryConfiguration, and interface Configuration.
  */
 class InmemoryConfigurationTest {
 
@@ -41,7 +44,6 @@ class InmemoryConfigurationTest {
      */
     @BeforeEach
     public void init() {
-
         memConfig = new InmemoryConfiguration();
     }
 
@@ -49,7 +51,7 @@ class InmemoryConfigurationTest {
      * Test get mem property.
      */
     @Test
-    public void testGetMemProperty() {
+    void testGetMemProperty() {
         Assertions.assertNull(memConfig.getInternalProperty(MOCK_KEY));
         Assertions.assertFalse(memConfig.containsKey(MOCK_KEY));
         Assertions.assertNull(memConfig.getString(MOCK_KEY));
@@ -65,7 +67,7 @@ class InmemoryConfigurationTest {
      * Test get properties.
      */
     @Test
-    public void testGetProperties() {
+    void testGetProperties() {
         Assertions.assertNull(memConfig.getInternalProperty(MOCK_ONE_KEY));
         Assertions.assertNull(memConfig.getInternalProperty(MOCK_TWO_KEY));
         Map<String, String> proMap = new HashMap<>();
@@ -84,7 +86,7 @@ class InmemoryConfigurationTest {
     }
 
     @Test
-    public void testGetInt() {
+    void testGetInt() {
         memConfig.addProperty("a", "1");
         Assertions.assertEquals(1, memConfig.getInt("a"));
         Assertions.assertEquals(Integer.valueOf(1), memConfig.getInteger("a", 2));
@@ -92,11 +94,61 @@ class InmemoryConfigurationTest {
     }
 
     @Test
-    public void getBoolean() {
+    void getBoolean() {
         memConfig.addProperty("a", Boolean.TRUE.toString());
         Assertions.assertTrue(memConfig.getBoolean("a"));
         Assertions.assertFalse(memConfig.getBoolean("b", false));
         Assertions.assertTrue(memConfig.getBoolean("b", Boolean.TRUE));
+    }
+
+    @Test
+    void testIllegalType() {
+        memConfig.addProperty("it", "aaa");
+
+        Assertions.assertThrows(IllegalStateException.class, () -> memConfig.getInteger("it", 1));
+        Assertions.assertThrows(IllegalStateException.class, () -> memConfig.getInt("it", 1));
+        Assertions.assertThrows(IllegalStateException.class, () -> memConfig.getInt("it"));
+    }
+
+    @Test
+    void testDoesNotExist() {
+        Assertions.assertThrows(NoSuchElementException.class, () -> memConfig.getInt("ne"));
+        Assertions.assertThrows(NoSuchElementException.class, () -> memConfig.getBoolean("ne"));
+    }
+
+    @Test
+    void testConversions() {
+        memConfig.addProperty("long", "2147483648");
+        memConfig.addProperty("byte", "127");
+        memConfig.addProperty("short", "32767");
+        memConfig.addProperty("float", "3.14");
+        memConfig.addProperty("double", "3.14159265358979323846264338327950");
+        memConfig.addProperty("enum", "FIELD");
+
+        Object longObject = memConfig.convert(Long.class, "long", 1L);
+        Object byteObject = memConfig.convert(Byte.class, "byte", (byte) 1);
+        Object shortObject = memConfig.convert(Short.class, "short", (short) 1);
+        Object floatObject = memConfig.convert(Float.class, "float", 3.14F);
+        Object doubleObject = memConfig.convert(Double.class, "double", 3.14159265358979323846264338327950);
+        JavaBeanAccessor javaBeanAccessor = memConfig.convert(JavaBeanAccessor.class, "enum", JavaBeanAccessor.ALL);
+
+        Assertions.assertEquals(Long.class, longObject.getClass());
+        Assertions.assertEquals(2147483648L, longObject);
+
+        Assertions.assertEquals(Byte.class, byteObject.getClass());
+        Assertions.assertEquals((byte) 127, byteObject);
+
+        Assertions.assertEquals(Short.class, shortObject.getClass());
+        Assertions.assertEquals((short) 32767, shortObject);
+
+        Assertions.assertEquals(Float.class, floatObject.getClass());
+        Assertions.assertEquals(3.14F, floatObject);
+
+        Assertions.assertEquals(Double.class, doubleObject.getClass());
+        Assertions.assertEquals(3.14159265358979323846264338327950, doubleObject);
+
+        Assertions.assertEquals(JavaBeanAccessor.class, javaBeanAccessor.getClass());
+        Assertions.assertEquals(JavaBeanAccessor.FIELD, javaBeanAccessor);
     }
 
     /**

--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/support/AbstractRegistryFactory.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/support/AbstractRegistryFactory.java
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.dubbo.registry.support;
 
 import org.apache.dubbo.common.URL;
@@ -69,9 +70,11 @@ public abstract class AbstractRegistryFactory implements RegistryFactory, ScopeM
             .removeAttribute(EXPORT_KEY)
             .removeAttribute(REFER_KEY)
             .build();
+
         String key = createRegistryCacheKey(url);
         Registry registry = null;
         boolean check = url.getParameter(CHECK_KEY, true) && url.getPort() != 0;
+
         // Lock the registry access process to ensure a single instance of the registry
         registryManager.getRegistryLock().lock();
         try {
@@ -81,11 +84,13 @@ public abstract class AbstractRegistryFactory implements RegistryFactory, ScopeM
             if (null != defaultNopRegistry) {
                 return defaultNopRegistry;
             }
+
             registry = registryManager.getRegistry(key);
             if (registry != null) {
                 return registry;
             }
-            //create registry by spi/ioc
+
+            // create registry by spi/ioc
             registry = createRegistry(url);
             if (check && registry == null) {
                 throw new IllegalStateException("Can not create registry " + url);

--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/support/CacheableFailbackRegistry.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/support/CacheableFailbackRegistry.java
@@ -97,8 +97,8 @@ public abstract class CacheableFailbackRegistry extends FailbackRegistry {
             try {
                 result = Integer.parseInt(str);
             } catch (NumberFormatException e) {
-                // 1-2 Invalid registry properties.
-                logger.warn("1-2", "", "",
+                // 0-2 Invalid registry properties.
+                logger.warn("0-2", "typo in property value", "This property requires an integer value.",
                     "Invalid registry properties configuration key " + key + ", value " + str);
             }
         }
@@ -135,9 +135,11 @@ public abstract class CacheableFailbackRegistry extends FailbackRegistry {
     protected List<URL> toUrlsWithoutEmpty(URL consumer, Collection<String> providers) {
         // keep old urls
         Map<String, ServiceAddressURL> oldURLs = stringUrls.get(consumer);
+
         // create new urls
         Map<String, ServiceAddressURL> newURLs = new HashMap<>((int) (providers.size() / 0.75f + 1));
         URL copyOfConsumer = removeParamsFromConsumer(consumer);
+
         if (oldURLs == null) {
             for (String rawProvider : providers) {
                 rawProvider = stripOffVariableKeys(rawProvider);
@@ -178,6 +180,7 @@ public abstract class CacheableFailbackRegistry extends FailbackRegistry {
     protected List<URL> toUrlsWithEmpty(URL consumer, String path, Collection<String> providers) {
         List<URL> urls = new ArrayList<>(1);
         boolean isProviderPath = path.endsWith(PROVIDERS_CATEGORY);
+
         if (isProviderPath) {
             if (CollectionUtils.isNotEmpty(providers)) {
                 urls = toUrlsWithoutEmpty(consumer, providers);

--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/support/CacheableFailbackRegistry.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/support/CacheableFailbackRegistry.java
@@ -98,6 +98,7 @@ public abstract class CacheableFailbackRegistry extends FailbackRegistry {
                 result = Integer.parseInt(str);
             } catch (NumberFormatException e) {
                 // 0-2 Property type mismatch.
+
                 logger.warn("0-2", "typo in property value", "This property requires an integer value.",
                     "Invalid registry properties configuration key " + key + ", value " + str);
             }

--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/support/CacheableFailbackRegistry.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/support/CacheableFailbackRegistry.java
@@ -97,7 +97,7 @@ public abstract class CacheableFailbackRegistry extends FailbackRegistry {
             try {
                 result = Integer.parseInt(str);
             } catch (NumberFormatException e) {
-                // 0-2 Invalid registry properties.
+                // 0-2 Property type mismatch.
                 logger.warn("0-2", "typo in property value", "This property requires an integer value.",
                     "Invalid registry properties configuration key " + key + ", value " + str);
             }

--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/support/FailbackRegistry.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/support/FailbackRegistry.java
@@ -40,7 +40,8 @@ import static org.apache.dubbo.registry.Constants.DEFAULT_REGISTRY_RETRY_PERIOD;
 import static org.apache.dubbo.registry.Constants.REGISTRY_RETRY_PERIOD_KEY;
 
 /**
- * FailbackRegistry. (SPI, Prototype, ThreadSafe)
+ * A template implementation of registry service that provides auto-retry ability.
+ * (SPI, Prototype, ThreadSafe)
  */
 public abstract class FailbackRegistry extends AbstractRegistry {
 

--- a/dubbo-registry/dubbo-registry-zookeeper/src/main/java/org/apache/dubbo/registry/zookeeper/ZookeeperRegistry.java
+++ b/dubbo-registry/dubbo-registry-zookeeper/src/main/java/org/apache/dubbo/registry/zookeeper/ZookeeperRegistry.java
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.dubbo.registry.zookeeper;
 
 import org.apache.dubbo.common.URL;
@@ -81,7 +82,7 @@ public class ZookeeperRegistry extends CacheableFailbackRegistry {
         this.zkClient = zookeeperTransporter.connect(url);
         this.zkClient.addStateListener((state) -> {
             if (state == StateListener.RECONNECTED) {
-                logger.warn("Trying to fetch the latest urls, in case there're provider changes during connection loss.\n" +
+                logger.warn("Trying to fetch the latest urls, in case there are provider changes during connection loss.\n" +
                     " Since ephemeral ZNode will not get deleted for a connection lose, " +
                     "there's no need to re-register url of this instance.");
                 ZookeeperRegistry.this.fetchLatestAddresses();

--- a/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/zookeeper/ZookeeperClient.java
+++ b/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/zookeeper/ZookeeperClient.java
@@ -22,10 +22,24 @@ import org.apache.dubbo.common.config.configcenter.ConfigItem;
 import java.util.List;
 import java.util.concurrent.Executor;
 
+/**
+ * Common abstraction of Zookeeper client.
+ */
 public interface ZookeeperClient {
 
+    /**
+     * Create ZNode in Zookeeper.
+     *
+     * @param path path to ZNode
+     * @param ephemeral specify create mode of ZNode creation. true - EPHEMERAL, false - PERSISTENT.
+     */
     void create(String path, boolean ephemeral);
 
+    /**
+     * Delete ZNode.
+     *
+     * @param path path to ZNode
+     */
     void delete(String path);
 
     List<String> getChildren(String path);
@@ -33,13 +47,13 @@ public interface ZookeeperClient {
     List<String> addChildListener(String path, ChildListener listener);
 
     /**
-     * @param path:    directory. All child of path will be listened.
+     * @param path    directory. All child of path will be listened.
      * @param listener
      */
     void addDataListener(String path, DataListener listener);
 
     /**
-     * @param path:    directory. All child of path will be listened.
+     * @param path    directory. All child of path will be listened.
      * @param listener
      * @param executor another thread
      */
@@ -53,16 +67,37 @@ public interface ZookeeperClient {
 
     void removeStateListener(StateListener listener);
 
+    /**
+     * Check the Zookeeper client whether connected to server or not.
+     *
+     * @return true if connected
+     */
     boolean isConnected();
 
+    /**
+     * Close connection to Zookeeper server (cluster).
+     */
     void close();
 
     URL getUrl();
 
+    /**
+     * Create ZNode in Zookeeper with content specified.
+     *
+     * @param path path to ZNode
+     * @param content the content of ZNode
+     * @param ephemeral specify create mode of ZNode creation. true - EPHEMERAL, false - PERSISTENT.
+     */
     void create(String path, String content, boolean ephemeral);
 
     void createOrUpdate(String path, String content, boolean ephemeral, int ticket);
 
+    /**
+     * Obtain the content of a ZNode.
+     *
+     * @param path path to ZNode
+     * @return content of ZNode
+     */
     String getContent(String path);
 
     ConfigItem getConfigItem(String path);


### PR DESCRIPTION
另附迄今为止使用的错误码：
0-1: Thread pool is EXHAUSTED! - 线程池资源耗尽。
0-2 - Property type mismatch. - 属性类型不匹配

1-1: Address invalid. - 地址非法
1-2 - （空缺）
1-3: URL evicting failed. - URL 销毁失败
1-4 Empty address. - 空地址
1-5 Received URL without any parameters. - 接收到没有任何参数的 URL
1-6 Error when clearing cached URLs. - 清空缓存 URL 出错
1-7: Failed to notify registry event. - 通知注册中心事件失败
1-8: Failed to unregister / unsubscribe url on destroy. - 销毁时注销（取消订阅）地址失败
1-9: failed to read / save registry cache file. - 读写注册关系缓存文件失败
1-10 Failed to delete lock file. - 删除锁文件失败。
1-11 Failed to obtain or create registry (service) object. - 注册服务实例创建失败
1-12 Failed to fetch (server) instance since the registry instances have been destroyed. - 由于 “注册服务” 的实例均已销毁，因此没法获取服务提供（或订阅）方的服务器地址。
1-13 - reach the most times of retry. 达到最多的重试次数。
1-14 - Failed to parse raw dynamic config. - 动态配置识别失败
1-15 - Failed to destroy service. - 销毁服务失败
1-16 - Unsupported category in NotifyListener - 存有不支持的类别（在 NotifyListener 中）
1-17 - Address refresh failed. - 地址刷新失败

2-1 - Failed to execute routing. - 路由选址执行失败。
2-2 - No provider available - 没有可用的提供端。

3-1 - Failed to convert the URL address into Invokers. - 服务地址到 Invoker 对象的转换失败。

4-1 - Unsupported protocol - 不支持的协议。
4-2 - Can't find an instance URL using the default preferredProtocol. - 用指定的协议为条件找不到服务实例。

5-1 Failed to connect to configuration center. - 连接到注册中心失败。

6-1 - Failed to connect to provider server by other reason. - 因其它原因连接不上 Provider。
6-2 - Client-side timeout. - 客户端超时