### PR TITLE
Fix memory alarm bug:Alarm when spare memory < 2M,not <2K

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/status/support/MemoryStatusChecker.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/status/support/MemoryStatusChecker.java
@@ -32,7 +32,7 @@ public class MemoryStatusChecker implements StatusChecker {
         long freeMemory = runtime.freeMemory();
         long totalMemory = runtime.totalMemory();
         long maxMemory = runtime.maxMemory();
-        boolean ok = (maxMemory - (totalMemory - freeMemory) > 2048); // Alarm when spare memory < 2M
+        boolean ok = (maxMemory - (totalMemory - freeMemory) > 2*1024*1024); // Alarm when spare memory < 2M
         String msg = "max:" + (maxMemory / 1024 / 1024) + "M,total:"
                 + (totalMemory / 1024 / 1024) + "M,used:" + ((totalMemory / 1024 / 1024) - (freeMemory / 1024 / 1024)) + "M,free:" + (freeMemory / 1024 / 1024) + "M";
         return new Status(ok ? Status.Level.OK : Status.Level.WARN, msg);


### PR DESCRIPTION
## What is the purpose of the change
Fix memory alarm bug:Alarm when spare memory < 2M,not <2K

## Brief changelog


## Verifying this change


<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [ ] GitHub Actions works fine on your own branch.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
