### PR TITLE
Optimize the logic of zkDataListener

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/config/configcenter/TreePathDynamicConfiguration.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/config/configcenter/TreePathDynamicConfiguration.java
@@ -94,7 +94,7 @@ public abstract class TreePathDynamicConfiguration extends AbstractDynamicConfig
     @Override
     public final void addListener(String key, String group, ConfigurationListener listener) {
         String pathKey = buildPathKey(group, key);
-        doAddListener(pathKey, listener);
+        doAddListener(pathKey, listener, key, group);
     }
 
     @Override
@@ -111,7 +111,7 @@ public abstract class TreePathDynamicConfiguration extends AbstractDynamicConfig
 
     protected abstract Collection<String> doGetConfigKeys(String groupPath);
 
-    protected abstract void doAddListener(String pathKey, ConfigurationListener listener);
+    protected abstract void doAddListener(String pathKey, ConfigurationListener listener, String key, String group);
 
     protected abstract void doRemoveListener(String pathKey, ConfigurationListener listener);
 

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/config/configcenter/file/FileSystemDynamicConfiguration.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/config/configcenter/file/FileSystemDynamicConfiguration.java
@@ -402,7 +402,7 @@ public class FileSystemDynamicConfiguration extends TreePathDynamicConfiguration
     }
 
     @Override
-    protected void doAddListener(String pathKey, ConfigurationListener listener) {
+    protected void doAddListener(String pathKey, ConfigurationListener listener, String key, String group) {
         doInListener(pathKey, (configFilePath, listeners) -> {
             if (listeners.isEmpty()) { // If no element, it indicates watchService was registered before
                 ThrowableConsumer.execute(configFilePath, configFile -> {

--- a/dubbo-configcenter/dubbo-configcenter-zookeeper/src/main/java/org/apache/dubbo/configcenter/support/zookeeper/ZookeeperDataListener.java
+++ b/dubbo-configcenter/dubbo-configcenter-zookeeper/src/main/java/org/apache/dubbo/configcenter/support/zookeeper/ZookeeperDataListener.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.configcenter.support.zookeeper;
+
+import org.apache.dubbo.common.config.configcenter.ConfigChangeType;
+import org.apache.dubbo.common.config.configcenter.ConfigChangedEvent;
+import org.apache.dubbo.common.config.configcenter.ConfigurationListener;
+import org.apache.dubbo.common.utils.CollectionUtils;
+import org.apache.dubbo.remoting.zookeeper.DataListener;
+import org.apache.dubbo.remoting.zookeeper.EventType;
+
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArraySet;
+
+/**
+ * one path has multi configurationListeners
+ */
+public class ZookeeperDataListener implements DataListener {
+    private String path;
+    private String key;
+    private String group;
+    private Set<ConfigurationListener> listeners;
+
+    public ZookeeperDataListener(String path, String key, String group) {
+        this.path = path;
+        this.key = key;
+        this.group = group;
+        this.listeners = new CopyOnWriteArraySet<>();
+    }
+
+    public void addListener(ConfigurationListener configurationListener) {
+        listeners.add(configurationListener);
+    }
+
+    public void removeListener(ConfigurationListener configurationListener) {
+        listeners.remove(configurationListener);
+    }
+
+    public Set<ConfigurationListener> getListeners() {
+        return listeners;
+    }
+
+    @Override
+    public void dataChanged(String path, Object value, EventType eventType) {
+        if (!this.path.equals(path)) {
+            return;
+        }
+        ConfigChangeType changeType;
+        if (EventType.NodeCreated.equals(eventType)) {
+            changeType = ConfigChangeType.ADDED;
+        } else if (value == null) {
+            changeType = ConfigChangeType.DELETED;
+        } else {
+            changeType = ConfigChangeType.MODIFIED;
+        }
+        ConfigChangedEvent configChangeEvent = new ConfigChangedEvent(key, group, (String) value, changeType);
+        if (CollectionUtils.isNotEmpty(listeners)) {
+            listeners.forEach(listener -> listener.process(configChangeEvent));
+        }
+    }
+
+}

--- a/dubbo-configcenter/dubbo-configcenter-zookeeper/src/main/java/org/apache/dubbo/configcenter/support/zookeeper/ZookeeperDynamicConfiguration.java
+++ b/dubbo-configcenter/dubbo-configcenter-zookeeper/src/main/java/org/apache/dubbo/configcenter/support/zookeeper/ZookeeperDynamicConfiguration.java
@@ -29,15 +29,12 @@ import org.apache.dubbo.remoting.zookeeper.ZookeeperTransporter;
 import org.apache.zookeeper.data.Stat;
 
 import java.util.Collection;
-import java.util.Set;
+import java.util.Map;
 import java.util.concurrent.Executor;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
-/**
- *
- */
 public class ZookeeperDynamicConfiguration extends TreePathDynamicConfiguration {
 
     private Executor executor;
@@ -51,7 +48,7 @@ public class ZookeeperDynamicConfiguration extends TreePathDynamicConfiguration 
     ZookeeperDynamicConfiguration(URL url, ZookeeperTransporter zookeeperTransporter) {
         super(url);
 
-        this.cacheListener = new CacheListener(rootPath);
+        this.cacheListener = new CacheListener();
 
         final String threadName = this.getClass().getSimpleName();
         this.executor = new ThreadPoolExecutor(DEFAULT_ZK_EXECUTOR_THREADS_NUM, DEFAULT_ZK_EXECUTOR_THREADS_NUM,
@@ -78,6 +75,13 @@ public class ZookeeperDynamicConfiguration extends TreePathDynamicConfiguration 
 
     @Override
     protected void doClose() throws Exception {
+        // remove data listener
+        Map<String, ZookeeperDataListener> pathKeyListeners = cacheListener.getPathKeyListeners();
+        for (Map.Entry<String, ZookeeperDataListener> entry : pathKeyListeners.entrySet()) {
+            zkClient.removeDataListener(entry.getKey(), entry.getValue());
+        }
+        cacheListener.clear();
+
         // zkClient is shared in framework, should not close it here
         // zkClient.close();
         // See: org.apache.dubbo.remoting.zookeeper.AbstractZookeeperTransporter#destroy()
@@ -129,17 +133,21 @@ public class ZookeeperDynamicConfiguration extends TreePathDynamicConfiguration 
     }
 
     @Override
-    protected void doAddListener(String pathKey, ConfigurationListener listener) {
-        cacheListener.addListener(pathKey, listener);
-        zkClient.addDataListener(pathKey, cacheListener, executor);
+    protected void doAddListener(String pathKey, ConfigurationListener listener, String key, String group) {
+        ZookeeperDataListener cachedListener = cacheListener.getCachedListener(pathKey);
+        if (cachedListener != null) {
+            cachedListener.addListener(listener);
+        } else {
+            ZookeeperDataListener addedListener = cacheListener.addListener(pathKey, listener, key, group);
+            zkClient.addDataListener(pathKey, addedListener, executor);
+        }
     }
 
     @Override
     protected void doRemoveListener(String pathKey, ConfigurationListener listener) {
-        cacheListener.removeListener(pathKey, listener);
-        Set<ConfigurationListener> configurationListeners = cacheListener.getConfigurationListeners(pathKey);
-        if (CollectionUtils.isEmpty(configurationListeners)) {
-            zkClient.removeDataListener(pathKey, cacheListener);
+        ZookeeperDataListener zookeeperDataListener = cacheListener.removeListener(pathKey, listener);
+        if (CollectionUtils.isEmpty(zookeeperDataListener.getListeners())) {
+            zkClient.removeDataListener(pathKey, zookeeperDataListener);
         }
     }
 }

--- a/dubbo-configcenter/dubbo-configcenter-zookeeper/src/main/java/org/apache/dubbo/configcenter/support/zookeeper/ZookeeperDynamicConfigurationFactory.java
+++ b/dubbo-configcenter/dubbo-configcenter-zookeeper/src/main/java/org/apache/dubbo/configcenter/support/zookeeper/ZookeeperDynamicConfigurationFactory.java
@@ -19,13 +19,9 @@ package org.apache.dubbo.configcenter.support.zookeeper;
 import org.apache.dubbo.common.URL;
 import org.apache.dubbo.common.config.configcenter.AbstractDynamicConfigurationFactory;
 import org.apache.dubbo.common.config.configcenter.DynamicConfiguration;
-import org.apache.dubbo.common.extension.DisableInject;
 import org.apache.dubbo.remoting.zookeeper.ZookeeperTransporter;
 import org.apache.dubbo.rpc.model.ApplicationModel;
 
-/**
- *
- */
 public class ZookeeperDynamicConfigurationFactory extends AbstractDynamicConfigurationFactory {
 
     private ZookeeperTransporter zookeeperTransporter;
@@ -35,11 +31,6 @@ public class ZookeeperDynamicConfigurationFactory extends AbstractDynamicConfigu
     public ZookeeperDynamicConfigurationFactory(ApplicationModel applicationModel) {
         this.applicationModel = applicationModel;
         this.zookeeperTransporter = ZookeeperTransporter.getExtension(applicationModel);
-    }
-
-    @DisableInject
-    public void setZookeeperTransporter(ZookeeperTransporter zookeeperTransporter) {
-        this.zookeeperTransporter = zookeeperTransporter;
     }
 
     @Override


### PR DESCRIPTION
**现状**
目前ZK监听的逻辑是，所有的ConfigurationListener都在CacheListener中维护。

给ZK添加监听器的时候，每个path对应一个CuratorZookeeperClient.NodeCacheListenerImpl，且所有的NodeCacheListenerImpl都是映射的同一个CacheListener。每当有任意一个path的监听事件发生的时候，都需要在CacheListener根据path取出对应的Set<ConfigurationListener>，并每次都需要解析出group和key，然后调用ConfigurationListener#process。

**调整**
现在增加ZookeeperDataListener，使得一个NodeCacheListenerImpl只对应一个ZookeeperDataListener，这样path事件触发直接获取ZookeeperDataListener的Set<ConfigurationListener>，然后调用ConfigurationListener#process。使得path、NodeCacheListenerImpl、ZookeeperDataListener三者一一对应，关系更明确、独立。

TreePathDynamicConfiguration#doAddListener方法冗余传递key和group，用以赋值到ZookeeperDataListener的属性中，这样每次事件发生的时候不需要再像原有逻辑那样根据rootPath以及path来解析key和group。

CacheListener内部只维护path和ZookeeperDataListener的映射关系，事件监听逻辑即dataChanged方法挪到了 ZookeeperDataListener 。