### PR TITLE
Add code that shows error code 2-2, 1-9, 5-1 with code optimization.

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/threadpool/manager/FrameworkExecutorRepository.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/threadpool/manager/FrameworkExecutorRepository.java
@@ -91,7 +91,7 @@ public class FrameworkExecutorRepository implements Disposable {
 
     /**
      * Returns a scheduler from the scheduler list, call this method whenever you need a scheduler for a cron job.
-     * If your cron cannot burden the possible schedule delay caused by sharing the same scheduler, please consider define a dedicate one.
+     * If your cron cannot burden the possible schedule delay caused by sharing the same scheduler, please consider define a dedicated one.
      *
      * @return ScheduledExecutorService
      */

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/utils/UrlUtils.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/utils/UrlUtils.java
@@ -64,9 +64,16 @@ import static org.apache.dubbo.common.constants.RegistryConstants.SERVICE_REGIST
 public class UrlUtils {
 
     /**
+     * Forbids the instantiation.
+     */
+    private UrlUtils() {
+        throw new UnsupportedOperationException("No instance of 'UrlUtils' for you! ");
+    }
+
+    /**
      * in the url string,mark the param begin
      */
-    private final static String URL_PARAM_STARTING_SYMBOL = "?";
+    private static final String URL_PARAM_STARTING_SYMBOL = "?";
 
     public static URL parseURL(String address, Map<String, String> defaults) {
         if (StringUtils.isEmpty(address)) {
@@ -212,7 +219,8 @@ public class UrlUtils {
     }
 
     public static Map<String, String> convertSubscribe(Map<String, String> subscribe) {
-        Map<String, String> newSubscribe = new HashMap<String, String>();
+        Map<String, String> newSubscribe = new HashMap<>();
+
         for (Map.Entry<String, String> entry : subscribe.entrySet()) {
             String serviceName = entry.getKey();
             String serviceQuery = entry.getValue();
@@ -234,11 +242,13 @@ public class UrlUtils {
                 newSubscribe.put(serviceName, serviceQuery);
             }
         }
+
         return newSubscribe;
     }
 
     public static Map<String, Map<String, String>> revertRegister(Map<String, Map<String, String>> register) {
-        Map<String, Map<String, String>> newRegister = new HashMap<String, Map<String, String>>();
+        Map<String, Map<String, String>> newRegister = new HashMap<>();
+
         for (Map.Entry<String, Map<String, String>> entry : register.entrySet()) {
             String serviceName = entry.getKey();
             Map<String, String> serviceUrls = entry.getValue();
@@ -265,11 +275,14 @@ public class UrlUtils {
                 newRegister.put(serviceName, serviceUrls);
             }
         }
+
         return newRegister;
     }
 
     public static Map<String, String> revertSubscribe(Map<String, String> subscribe) {
-        Map<String, String> newSubscribe = new HashMap<String, String>();
+
+        Map<String, String> newSubscribe = new HashMap<>();
+
         for (Map.Entry<String, String> entry : subscribe.entrySet()) {
             String serviceName = entry.getKey();
             String serviceQuery = entry.getValue();
@@ -385,32 +398,47 @@ public class UrlUtils {
     public static boolean isMatch(URL consumerUrl, URL providerUrl) {
         String consumerInterface = consumerUrl.getServiceInterface();
         String providerInterface = providerUrl.getServiceInterface();
-        //FIXME accept providerUrl with '*' as interface name, after carefully thought about all possible scenarios I think it's ok to add this condition.
+
+        // FIXME accept providerUrl with '*' as interface name, after carefully thought about all possible scenarios I think it's ok to add this condition.
+
+        // Return false if the consumer interface is not equals the provider interface,
+        // except one of the interface configurations is equals '*' (i.e. any value).
         if (!(ANY_VALUE.equals(consumerInterface)
             || ANY_VALUE.equals(providerInterface)
             || StringUtils.isEquals(consumerInterface, providerInterface))) {
             return false;
         }
 
-        if (!isMatchCategory(providerUrl.getCategory(DEFAULT_CATEGORY),
-            consumerUrl.getCategory(DEFAULT_CATEGORY))) {
+        // If the category of provider URL does not match the category of consumer URL.
+        // Usually, the provider URL's category is empty, and the default category ('providers') is present.
+        // Hence, the category of the provider URL is 'providers'.
+        // Through observing of the Zookeeper registry, I found that the category of the consumer URL is 'consumers'.
+        if (!isMatchCategory(providerUrl.getCategory(DEFAULT_CATEGORY), consumerUrl.getCategory(DEFAULT_CATEGORY))) {
             return false;
         }
+
+        // If the provider is not enabled, return false.
         if (!providerUrl.getParameter(ENABLED_KEY, true)
             && !ANY_VALUE.equals(consumerUrl.getParameter(ENABLED_KEY))) {
             return false;
         }
 
+        // Obtain consumer's group, version and classifier.
         String consumerGroup = consumerUrl.getGroup();
         String consumerVersion = consumerUrl.getVersion();
         String consumerClassifier = consumerUrl.getParameter(CLASSIFIER_KEY, ANY_VALUE);
 
+        // Obtain provider's group, version and classifier.
         String providerGroup = providerUrl.getGroup();
         String providerVersion = providerUrl.getVersion();
         String providerClassifier = providerUrl.getParameter(CLASSIFIER_KEY, ANY_VALUE);
-        return (ANY_VALUE.equals(consumerGroup) || StringUtils.isEquals(consumerGroup, providerGroup) || StringUtils.isContains(consumerGroup, providerGroup))
-            && (ANY_VALUE.equals(consumerVersion) || StringUtils.isEquals(consumerVersion, providerVersion))
-            && (consumerClassifier == null || ANY_VALUE.equals(consumerClassifier) || StringUtils.isEquals(consumerClassifier, providerClassifier));
+
+        // If Group, Version, Classifier all matches, return true.
+        boolean groupMatches = ANY_VALUE.equals(consumerGroup) || StringUtils.isEquals(consumerGroup, providerGroup) || StringUtils.isContains(consumerGroup, providerGroup);
+        boolean versionMatches = ANY_VALUE.equals(consumerVersion) || StringUtils.isEquals(consumerVersion, providerVersion);
+        boolean classifierMatches = consumerClassifier == null || ANY_VALUE.equals(consumerClassifier) || StringUtils.isEquals(consumerClassifier, providerClassifier);
+
+        return groupMatches && versionMatches && classifierMatches;
     }
 
     public static boolean isMatchGlobPattern(String pattern, String value, URL param) {

--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/ReferenceConfig.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/ReferenceConfig.java
@@ -566,7 +566,9 @@ public class ReferenceConfig<T> extends ReferenceConfigBase<T> {
 
     private void checkInvokerAvailable() throws IllegalStateException {
         if (shouldCheck() && !invoker.isAvailable()) {
-            throw new IllegalStateException("Failed to check the status of the service "
+            // 2-2 - No provider available.
+
+            IllegalStateException illegalStateException = new IllegalStateException("Failed to check the status of the service "
                     + interfaceName
                     + ". No provider available for the service "
                     + (group == null ? "" : group + "/")
@@ -576,6 +578,10 @@ public class ReferenceConfig<T> extends ReferenceConfigBase<T> {
                     + invoker.getUrl()
                     + " to the consumer "
                     + NetUtils.getLocalHost() + " use dubbo version " + Version.getVersion());
+
+            logger.error("2-2", "provider not started", "", "No provider available.", illegalStateException);
+
+            throw illegalStateException;
         }
     }
 

--- a/dubbo-plugin/dubbo-qos/src/main/java/org/apache/dubbo/qos/probe/impl/ProviderReadinessProbe.java
+++ b/dubbo-plugin/dubbo-qos/src/main/java/org/apache/dubbo/qos/probe/impl/ProviderReadinessProbe.java
@@ -51,7 +51,9 @@ public class ProviderReadinessProbe implements ReadinessProbe {
                 continue;
             }
             hasService = true;
-            anyOnline = anyOnline || providerModel.getStatedUrl().stream().anyMatch(ProviderModel.RegisterStatedURL::isRegistered);
+            anyOnline = anyOnline ||
+                providerModel.getStatedUrl().isEmpty() ||
+                providerModel.getStatedUrl().stream().anyMatch(ProviderModel.RegisterStatedURL::isRegistered);
         }
 
         // no service => check pass

--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/metadata/ServiceInstanceHostPortCustomizer.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/metadata/ServiceInstanceHostPortCustomizer.java
@@ -75,7 +75,7 @@ public class ServiceInstanceHostPortCustomizer implements ServiceInstanceCustomi
                     // 4-2 - Can't find an instance URL using the default preferredProtocol.
 
                     logger.warn("4-2", "typo in preferred protocol", "",
-                        "Can't find an instance URL  using the default preferredProtocol \"" + preferredProtocol + "\", " +
+                        "Can't find an instance URL using the default preferredProtocol \"" + preferredProtocol + "\", " +
                         "falling back to the strategy that pick the first found protocol. " +
                         "Please try modifying the config of dubbo.application.protocol");
 

--- a/dubbo-registry/dubbo-registry-api/src/test/java/org/apache/dubbo/registry/CacheableFailbackRegistryTest.java
+++ b/dubbo-registry/dubbo-registry-api/src/test/java/org/apache/dubbo/registry/CacheableFailbackRegistryTest.java
@@ -34,7 +34,7 @@ import static org.apache.dubbo.common.constants.RegistryConstants.EMPTY_PROTOCOL
 import static org.apache.dubbo.common.constants.RegistryConstants.ENABLE_EMPTY_PROTECTION_KEY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class CacheableFailbackRegistryTest {
+class CacheableFailbackRegistryTest {
 
     static String service;
     static URL serviceUrl;
@@ -70,7 +70,7 @@ public class CacheableFailbackRegistryTest {
     }
 
     @Test
-    public void testFullURLCache() {
+    void testFullURLCache() {
         final AtomicReference<Integer> resCount = new AtomicReference<>(0);
         registry = new MockCacheableRegistryImpl(registryUrl);
         URL url = URLStrParser.parseEncodedStr(urlStr);
@@ -101,7 +101,7 @@ public class CacheableFailbackRegistryTest {
     }
 
     @Test
-    public void testURLAddressCache() {
+    void testURLAddressCache() {
         final AtomicReference<Integer> resCount = new AtomicReference<>(0);
         registry = new MockCacheableRegistryImpl(registryUrl);
         URL url = URLStrParser.parseEncodedStr(urlStr);
@@ -127,7 +127,7 @@ public class CacheableFailbackRegistryTest {
     }
 
     @Test
-    public void testURLParamCache() {
+    void testURLParamCache() {
         final AtomicReference<Integer> resCount = new AtomicReference<>(0);
         registry = new MockCacheableRegistryImpl(registryUrl);
         URL url = URLStrParser.parseEncodedStr(urlStr);
@@ -153,7 +153,7 @@ public class CacheableFailbackRegistryTest {
     }
 
     @Test
-    public void testRemove() {
+    void testRemove() {
         final AtomicReference<Integer> resCount = new AtomicReference<>(0);
         registry = new MockCacheableRegistryImpl(registryUrl);
         URL url = URLStrParser.parseEncodedStr(urlStr);
@@ -193,7 +193,7 @@ public class CacheableFailbackRegistryTest {
     }
 
     @Test
-    public void testEmptyProtection() {
+    void testEmptyProtection() {
         final AtomicReference<Integer> resCount = new AtomicReference<>(0);
         final AtomicReference<List<URL>> currentUrls = new AtomicReference<>();
         final List<URL> EMPTY_LIST = new ArrayList<>();
@@ -239,6 +239,4 @@ public class CacheableFailbackRegistryTest {
         assertEquals(EMPTY_LIST, currentUrls.get());
 
     }
-
-
 }

--- a/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/zookeeper/ZookeeperClient.java
+++ b/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/zookeeper/ZookeeperClient.java
@@ -47,18 +47,28 @@ public interface ZookeeperClient {
     List<String> addChildListener(String path, ChildListener listener);
 
     /**
-     * @param path    directory. All child of path will be listened.
-     * @param listener
+     * Attach data listener to current Zookeeper client.
+     *
+     * @param path    directory. All children of path will be listened.
+     * @param listener The data listener object.
      */
     void addDataListener(String path, DataListener listener);
 
     /**
-     * @param path    directory. All child of path will be listened.
-     * @param listener
-     * @param executor another thread
+     * Attach data listener to current Zookeeper client. The listener will be executed using the given executor.
+     *
+     * @param path    directory. All children of path will be listened.
+     * @param listener The data listener object.
+     * @param executor the executor that will execute the listener.
      */
     void addDataListener(String path, DataListener listener, Executor executor);
 
+    /**
+     * Detach data listener.
+     *
+     * @param path    directory. All listener of children of the path will be detached.
+     * @param listener The data listener object.
+     */
     void removeDataListener(String path, DataListener listener);
 
     void removeChildListener(String path, ChildListener listener);

--- a/dubbo-remoting/dubbo-remoting-zookeeper-curator5/src/main/java/org/apache/dubbo/remoting/zookeeper/curator5/Curator5ZookeeperClient.java
+++ b/dubbo-remoting/dubbo-remoting-zookeeper-curator5/src/main/java/org/apache/dubbo/remoting/zookeeper/curator5/Curator5ZookeeperClient.java
@@ -18,7 +18,7 @@ package org.apache.dubbo.remoting.zookeeper.curator5;
 
 import org.apache.dubbo.common.URL;
 import org.apache.dubbo.common.config.configcenter.ConfigItem;
-import org.apache.dubbo.common.logger.Logger;
+import org.apache.dubbo.common.logger.ErrorTypeAwareLogger;
 import org.apache.dubbo.common.logger.LoggerFactory;
 import org.apache.dubbo.remoting.zookeeper.AbstractZookeeperClient;
 import org.apache.dubbo.remoting.zookeeper.ChildListener;
@@ -59,7 +59,7 @@ import static org.apache.dubbo.common.constants.CommonConstants.TIMEOUT_KEY;
 
 public class Curator5ZookeeperClient extends AbstractZookeeperClient<Curator5ZookeeperClient.NodeCacheListenerImpl, Curator5ZookeeperClient.CuratorWatcherImpl> {
 
-    protected static final Logger logger = LoggerFactory.getLogger(Curator5ZookeeperClient.class);
+    protected static final ErrorTypeAwareLogger logger = LoggerFactory.getErrorTypeAwareLogger(Curator5ZookeeperClient.class);
 
     private static final Charset CHARSET = StandardCharsets.UTF_8;
     private final CuratorFramework client;
@@ -94,9 +94,17 @@ public class Curator5ZookeeperClient extends AbstractZookeeperClient<Curator5Zoo
             client.getConnectionStateListenable().addListener(new CuratorConnectionStateListener(url));
             client.start();
             boolean connected = client.blockUntilConnected(timeout, TimeUnit.MILLISECONDS);
+
             if (!connected) {
-                throw new IllegalStateException("zookeeper not connected");
+                IllegalStateException illegalStateException = new IllegalStateException("zookeeper not connected");
+
+                // 5-1 Failed to connect to configuration center.
+                logger.error("5-1", "Zookeeper server offline", "",
+                    "Failed to connect with zookeeper", illegalStateException);
+
+                throw new IllegalStateException();
             }
+
         } catch (Exception e) {
             throw new IllegalStateException(e.getMessage(), e);
         }

--- a/dubbo-remoting/dubbo-remoting-zookeeper-curator5/src/main/java/org/apache/dubbo/remoting/zookeeper/curator5/Curator5ZookeeperClient.java
+++ b/dubbo-remoting/dubbo-remoting-zookeeper-curator5/src/main/java/org/apache/dubbo/remoting/zookeeper/curator5/Curator5ZookeeperClient.java
@@ -102,7 +102,7 @@ public class Curator5ZookeeperClient extends AbstractZookeeperClient<Curator5Zoo
                 logger.error("5-1", "Zookeeper server offline", "",
                     "Failed to connect with zookeeper", illegalStateException);
 
-                throw new IllegalStateException();
+                throw illegalStateException;
             }
 
         } catch (Exception e) {

--- a/dubbo-remoting/dubbo-remoting-zookeeper/src/main/java/org/apache/dubbo/remoting/zookeeper/curator/CuratorZookeeperClient.java
+++ b/dubbo-remoting/dubbo-remoting-zookeeper/src/main/java/org/apache/dubbo/remoting/zookeeper/curator/CuratorZookeeperClient.java
@@ -106,7 +106,7 @@ public class CuratorZookeeperClient extends AbstractZookeeperClient<CuratorZooke
                 logger.error("5-1", "Zookeeper server offline", "",
                     "Failed to connect with zookeeper", illegalStateException);
 
-                throw new IllegalStateException();
+                throw illegalStateException;
             }
 
             CuratorWatcherImpl.closed = false;

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/Protocol.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/Protocol.java
@@ -25,7 +25,35 @@ import java.util.Collections;
 import java.util.List;
 
 /**
- * Protocol. (API/SPI, Singleton, ThreadSafe)
+ * RPC Protocol extension interface, which encapsulates the details of remote invocation. <br /><br />
+ *
+ * <p>Conventions:
+ *
+ * <li>
+ *     When user invokes the 'invoke()' method in object that the method 'refer()' returns,
+ *     the protocol needs to execute the 'invoke()' method of Invoker object that received by 'export()' method,
+ *     which should have the same URL.
+ * </li>
+ *
+ * <li>
+ *     Invoker that returned by 'refer()' is implemented by the protocol. The remote invocation request should be sent by that Invoker.
+ * </li>
+ *
+ * <li>
+ *     The invoker that 'export()' receives will be implemented by framework. Protocol implementation should not care with that.
+ * </li>
+ *
+ * <p>Attentions:
+ *
+ * <li>
+ *     The Protocol implementation does not care the transparent proxy. The invoker will be converted to business interface by other layer.
+ * </li>
+ *
+ * <li>
+ *     The protocol doesn't need to be backed by TCP connection. It can also be backed by file sharing or inter-process communication.
+ * </li>
+ *
+ * (API/SPI, Singleton, ThreadSafe)
  */
 @SPI(value = "dubbo", scope = ExtensionScope.FRAMEWORK)
 public interface Protocol {


### PR DESCRIPTION
另附迄今为止使用的错误码：
0-1: Thread pool is EXHAUSTED! - 线程池资源耗尽。
0-2 - Property type mismatch. - 属性类型不匹配

1-1: Address invalid. - 地址非法
1-2 - （空缺）
1-3: URL evicting failed. - URL 销毁失败
1-4 Empty address. - 空地址
1-5 Received URL without any parameters. - 接收到没有任何参数的 URL
1-6 Error when clearing cached URLs. - 清空缓存 URL 出错
1-7: Failed to notify registry event. - 通知注册中心事件失败
1-8: Failed to unregister / unsubscribe url on destroy. - 销毁时注销（取消订阅）地址失败
1-9: failed to read / save registry cache file. - 读写注册关系缓存文件失败
1-10 Failed to delete lock file. - 删除锁文件失败。
1-11 Failed to obtain or create registry (service) object. - 注册服务实例创建失败
1-12 Failed to fetch (server) instance since the registry instances have been destroyed. - 由于 “注册服务” 的实例均已销毁，因此没法获取服务提供（或订阅）方的服务器地址。
1-13 - reach the most times of retry. 达到最多的重试次数。
1-14 - Failed to parse raw dynamic config. - 动态配置识别失败
1-15 - Failed to destroy service. - 销毁服务失败
1-16 - Unsupported category in NotifyListener - 存有不支持的类别（在 NotifyListener 中）
1-17 - Address refresh failed. - 地址刷新失败

2-1 - Failed to execute routing. - 路由选址执行失败。
2-2 - No provider available - 没有可用的提供端。

3-1 - Failed to convert the URL address into Invokers. - 服务地址到 Invoker 对象的转换失败。

4-1 - Unsupported protocol - 不支持的协议。
4-2 - Can't find an instance URL using the default preferredProtocol. - 用指定的协议为条件找不到服务实例。

5-1 Failed to connect to configuration center. - 连接到注册中心失败。

6-1 - Failed to connect to provider server by other reason. - 因其它原因连接不上 Provider。
6-2 - Client-side timeout. - 客户端超时