### PR TITLE
Fix potential NPE of ZookeeperDynamicConfiguration#doRemoveListener method

### DIFF
--- a/dubbo-configcenter/dubbo-configcenter-zookeeper/src/main/java/org/apache/dubbo/configcenter/support/zookeeper/ZookeeperDynamicConfiguration.java
+++ b/dubbo-configcenter/dubbo-configcenter-zookeeper/src/main/java/org/apache/dubbo/configcenter/support/zookeeper/ZookeeperDynamicConfiguration.java
@@ -146,7 +146,7 @@ public class ZookeeperDynamicConfiguration extends TreePathDynamicConfiguration 
     @Override
     protected void doRemoveListener(String pathKey, ConfigurationListener listener) {
         ZookeeperDataListener zookeeperDataListener = cacheListener.removeListener(pathKey, listener);
-        if (CollectionUtils.isEmpty(zookeeperDataListener.getListeners())) {
+        if (zookeeperDataListener != null && CollectionUtils.isEmpty(zookeeperDataListener.getListeners())) {
             zkClient.removeDataListener(pathKey, zookeeperDataListener);
         }
     }


### PR DESCRIPTION
针对 #10445 做的修复，自己debug test case遇见的NPE问题（case `MultiInstanceTest#testDefaultConsumerApplication`）

消费者在双订阅场景下，应用程序正常关闭的时候，内部会调用 `MigrationInvoker#destroy`，该方法内部会调用`invoker.destroy() `和 `serviceDiscoveryInvoker.destroy()` ，同时两个invoker都有自己的routerChain对象，也会执行各自`routerChain#destroy`方法，该方法内部会遍历 stateRouters 并调用 `router.stop()` ，部分router会调用`ZookeeperDynamicConfiguration#doRemoveListener` 。

但因为两个routerChain里面的`TagStateRouter、ServiceStateRouter、AppStateRouter`都是一个对象引用（因为他们的SPI工厂都用了缓存），所以两个routerChain各自添加这三个router的时候，只注册了一次监听器(主要是ServiceStateRouter和AppStateRouter)，即调用了一次`doAddListener`方法；而两个routerChain各自销毁的时候对这三个router重复调用了各自的`router.stop()`方法，即调用两次`doRemoveListener`方法，第二次没有判空引发NPE。