### PR TITLE
Add some code about error code 1-1, 4-1 with code optimization.

### DIFF
--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/RouterChain.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/RouterChain.java
@@ -241,6 +241,7 @@ public class RouterChain<T> {
         RouterSnapshotNode<T> commonRouterNode = new RouterSnapshotNode<T>("CommonRouter", resultInvokers.clone());
         parentNode.appendNode(commonRouterNode);
         List<Invoker<T>> commonRouterResult = resultInvokers;
+
         // 2. route common router
         for (Router router : routers) {
             // Copy resultInvokers to a arrayList. BitList not support

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/URL.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/URL.java
@@ -146,7 +146,12 @@ class URL implements Serializable {
     public URL(URLAddress urlAddress, URLParam urlParam, Map<String, Object> attributes) {
         this.urlAddress = urlAddress;
         this.urlParam = null == urlParam ? URLParam.parse(new HashMap<>()) : urlParam;
-        this.attributes = (attributes != null ? attributes.isEmpty() ? null : attributes : null);
+
+        if (attributes != null && !attributes.isEmpty()) {
+            this.attributes = attributes;
+        } else {
+            this.attributes = null;
+        }
     }
 
     public URL(String protocol, String host, int port) {

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/extension/ExtensionLoader.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/extension/ExtensionLoader.java
@@ -524,8 +524,9 @@ public class ExtensionLoader<T> {
     }
 
     /**
-     * Find the extension with the given name. If the specified name is not found, then {@link IllegalStateException}
-     * will be thrown.
+     * Find the extension with the given name.
+     *
+     * @throws IllegalStateException If the specified extension is not found.
      */
     public T getExtension(String name) {
         T extension = getExtension(name, true);

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/url/component/URLParam.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/url/component/URLParam.java
@@ -978,7 +978,7 @@ public class URLParam {
      *
      * @param params   params map added into URLParam
      * @param rawParam original rawParam string, directly add to rawParam field,
-     *                 will not effect real key-pairs store in URLParam.
+     *                 will not affect real key-pairs store in URLParam.
      *                 Please make sure it can correspond with params or will
      *                 cause unexpected result when calling {@link URLParam#getRawParam()}
      *                 and {@link URLParam#toString()} ()}. If you not sure, you can call

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/utils/UrlUtils.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/utils/UrlUtils.java
@@ -412,7 +412,7 @@ public class UrlUtils {
         // If the category of provider URL does not match the category of consumer URL.
         // Usually, the provider URL's category is empty, and the default category ('providers') is present.
         // Hence, the category of the provider URL is 'providers'.
-        // Through observing of the Zookeeper registry, I found that the category of the consumer URL is 'consumers'.
+        // Through observing of debugging process, I found that the category of the consumer URL is 'providers,configurators,routers'.
         if (!isMatchCategory(providerUrl.getCategory(DEFAULT_CATEGORY), consumerUrl.getCategory(DEFAULT_CATEGORY))) {
             return false;
         }

--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/ServiceDiscoveryRegistryDirectory.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/ServiceDiscoveryRegistryDirectory.java
@@ -294,10 +294,15 @@ public class ServiceDiscoveryRegistryDirectory<T> extends DynamicDirectory<T> {
                 continue;
             }
             if (!getUrl().getOrDefaultFrameworkModel().getExtensionLoader(Protocol.class).hasExtension(instanceAddressURL.getProtocol())) {
-                logger.error(new IllegalStateException("Unsupported protocol " + instanceAddressURL.getProtocol() +
+
+                // 4-1 - Unsupported protocol
+
+                logger.error("4-1", "protocol extension does not installed", "", "Unsupported protocol.",
+                    new IllegalStateException("Unsupported protocol " + instanceAddressURL.getProtocol() +
                     " in notified url: " + instanceAddressURL + " from registry " + getUrl().getAddress() +
                     " to consumer " + NetUtils.getLocalHost() + ", supported protocol: " +
                     getUrl().getOrDefaultFrameworkModel().getExtensionLoader(Protocol.class).getSupportedExtensions()));
+
                 continue;
             }
 


### PR DESCRIPTION
另附迄今为止使用的错误码：
0-1: Thread pool is EXHAUSTED! - 线程池资源耗尽。
0-2 - Property type mismatch. - 属性类型不匹配

1-1: Address invalid. - 地址非法（服务版本或分组不匹配）
1-2 - （空缺）
1-3: URL evicting failed. - URL 销毁失败
1-4 Empty address. - 空地址
1-5 Received URL without any parameters. - 接收到没有任何参数的 URL
1-6 Error when clearing cached URLs. - 清空缓存 URL 出错
1-7: Failed to notify registry event. - 通知注册中心事件失败
1-8: Failed to unregister / unsubscribe url on destroy. - 销毁时注销（取消订阅）地址失败
1-9: failed to read / save registry cache file. - 读写注册关系缓存文件失败
1-10 Failed to delete lock file. - 删除锁文件失败。
1-11 Failed to obtain or create registry (service) object. - 注册服务实例创建失败
1-12 Failed to fetch (server) instance since the registry instances have been destroyed. - 由于 “注册服务” 的实例均已销毁，因此没法获取服务提供（或订阅）方的服务器地址。
1-13 - reach the most times of retry. 达到最多的重试次数。
1-14 - Failed to parse raw dynamic config. - 动态配置识别失败
1-15 - Failed to destroy service. - 销毁服务失败
1-16 - Unsupported category in NotifyListener - 存有不支持的类别（在 NotifyListener 中）
1-17 - Address refresh failed. - 地址刷新失败

2-1 - Failed to execute routing. - 路由选址执行失败。
2-2 - No provider available - 没有可用的提供端。

3-1 - Failed to convert the URL address into Invokers. - 服务地址到 Invoker 对象的转换失败。

4-1 - Unsupported protocol - 不支持的协议。
4-2 - Can't find an instance URL using the default preferredProtocol. - 用指定的协议为条件找不到服务实例。

5-1 Failed to connect to configuration center. - 连接到注册中心失败。

6-1 - Failed to connect to provider server by other reason. - 因其它原因连接不上 Provider。
6-2 - Client-side timeout. - 客户端超时