### PR TITLE
feat: replace kube-apiserver watch with informer

### DIFF
--- a/dubbo-dependencies-bom/pom.xml
+++ b/dubbo-dependencies-bom/pom.xml
@@ -157,7 +157,7 @@
         <eureka.version>1.9.12</eureka.version>
 
         <!-- Fabric8 for Kubernetes -->
-        <fabric8_kubernetes_version>5.3.2</fabric8_kubernetes_version>
+        <fabric8_kubernetes_version>6.1.1</fabric8_kubernetes_version>
 
         <!-- Alibaba -->
         <alibaba_spring_context_support_version>1.0.8</alibaba_spring_context_support_version>

--- a/dubbo-kubernetes/src/test/java/org/apache/dubbo/registry/kubernetes/KubernetesServiceDiscoveryTest.java
+++ b/dubbo-kubernetes/src/test/java/org/apache/dubbo/registry/kubernetes/KubernetesServiceDiscoveryTest.java
@@ -14,185 +14,220 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-//package org.apache.dubbo.registry.kubernetes;
-//
-//import org.apache.dubbo.common.URL;
-//import org.apache.dubbo.registry.client.DefaultServiceInstance;
-//import org.apache.dubbo.registry.client.ServiceInstance;
-//import org.apache.dubbo.registry.client.event.ServiceInstancesChangedEvent;
-//import org.apache.dubbo.registry.client.event.listener.ServiceInstancesChangedListener;
-//import org.apache.dubbo.registry.kubernetes.util.KubernetesClientConst;
-//import org.apache.dubbo.rpc.model.ApplicationModel;
-//import org.apache.dubbo.rpc.model.ScopeModelUtil;
-//
-//import io.fabric8.kubernetes.api.model.Endpoints;
-//import io.fabric8.kubernetes.api.model.EndpointsBuilder;
-//import io.fabric8.kubernetes.api.model.Pod;
-//import io.fabric8.kubernetes.api.model.PodBuilder;
-//import io.fabric8.kubernetes.api.model.Service;
-//import io.fabric8.kubernetes.api.model.ServiceBuilder;
-//import io.fabric8.kubernetes.client.Config;
-//import io.fabric8.kubernetes.client.NamespacedKubernetesClient;
-//import io.fabric8.kubernetes.client.server.mock.KubernetesServer;
-//import org.junit.jupiter.api.AfterEach;
-//import org.junit.jupiter.api.Assertions;
-//import org.junit.jupiter.api.BeforeEach;
-//import org.junit.jupiter.api.Test;
-//import org.junit.jupiter.api.extension.ExtendWith;
-//import org.mockito.ArgumentCaptor;
-//import org.mockito.Mockito;
-//import org.mockito.junit.jupiter.MockitoExtension;
-//
-//import java.util.HashMap;
-//import java.util.HashSet;
-//import java.util.Map;
-//
-//@ExtendWith({MockitoExtension.class})
-//public class KubernetesServiceDiscoveryTest {
-//    public KubernetesServer mockServer = new KubernetesServer(false, true);
-//
-//    private NamespacedKubernetesClient mockClient;
-//
-//    private ServiceInstancesChangedListener mockListener = Mockito.mock(ServiceInstancesChangedListener.class);
-//
-//    private URL serverUrl;
-//
-//    private Map<String, String> selector;
-//
-//    @BeforeEach
-//    public void setUp() {
-//        mockServer.before();
-//        mockClient = mockServer.getClient();
-//
-//        serverUrl = URL.valueOf(mockClient.getConfiguration().getMasterUrl())
-//            .setProtocol("kubernetes")
-//            .addParameter(KubernetesClientConst.USE_HTTPS, "false")
-//            .addParameter(KubernetesClientConst.HTTP2_DISABLE, "true");
-//        serverUrl.setScopeModel(ApplicationModel.defaultModel());
-//
-//        System.setProperty(Config.KUBERNETES_AUTH_TRYKUBECONFIG_SYSTEM_PROPERTY, "false");
-//        System.setProperty(Config.KUBERNETES_AUTH_TRYSERVICEACCOUNT_SYSTEM_PROPERTY, "false");
-//
-//        selector = new HashMap<>(4);
-//        selector.put("l", "v");
-//        Pod pod = new PodBuilder()
-//            .withNewMetadata().withName("TestServer").withLabels(selector).endMetadata()
-//            .build();
-//
-//        Service service = new ServiceBuilder()
-//            .withNewMetadata().withName("TestService").endMetadata()
-//            .withNewSpec().withSelector(selector).endSpec().build();
-//
-//        Endpoints endPoints = new EndpointsBuilder()
-//            .withNewMetadata().withName("TestService").endMetadata()
-//            .addNewSubset()
-//            .addNewAddress().withIp("ip1")
-//            .withNewTargetRef().withUid("uid1").withName("TestServer").endTargetRef().endAddress()
-//            .addNewPort("Test", "Test", 12345, "TCP").endSubset()
-//            .build();
-//
-//        mockClient.pods().create(pod);
-//        mockClient.services().create(service);
-//        mockClient.endpoints().create(endPoints);
-//    }
-//
-//    @AfterEach
-//    public void destroy() {
-//        mockServer.after();
-//    }
-//
-//    @Test
-//    public void testEndpointsUpdate() throws Exception {
-//
-//        KubernetesServiceDiscovery serviceDiscovery = new KubernetesServiceDiscovery();
-//        serviceDiscovery.initialize(serverUrl);
-//
-//        serviceDiscovery.setCurrentHostname("TestServer");
-//        serviceDiscovery.setKubernetesClient(mockClient);
-//
-//        ServiceInstance serviceInstance = new DefaultServiceInstance("TestService", "Test", 12345, ScopeModelUtil.getApplicationModel(serviceDiscovery.getUrl().getScopeModel()));
-//        serviceDiscovery.register(serviceInstance);
-//
-//        HashSet<String> serviceList = new HashSet<>(4);
-//        serviceList.add("TestService");
-//        Mockito.when(mockListener.getServiceNames()).thenReturn(serviceList);
-//        Mockito.doNothing().when(mockListener).onEvent(Mockito.any());
-//
-//        serviceDiscovery.addServiceInstancesChangedListener(mockListener);
-//        mockClient.endpoints().withName("TestService")
-//            .edit(endpoints ->
-//                new EndpointsBuilder(endpoints)
-//                    .editFirstSubset()
-//                    .addNewAddress()
-//                    .withIp("ip2")
-//                    .withNewTargetRef().withUid("uid2").withName("TestServer").endTargetRef()
-//                    .endAddress().endSubset()
-//                    .build());
-//
-//        Thread.sleep(5000);
-//        ArgumentCaptor<ServiceInstancesChangedEvent> eventArgumentCaptor =
-//            ArgumentCaptor.forClass(ServiceInstancesChangedEvent.class);
-//        Mockito.verify(mockListener, Mockito.times(2)).onEvent(eventArgumentCaptor.capture());
-//        Assertions.assertEquals(2, eventArgumentCaptor.getValue().getServiceInstances().size());
-//
-//        serviceDiscovery.unregister(serviceInstance);
-//
-//        serviceDiscovery.destroy();
-//    }
-//
-//    @Test
-//    public void testPodsUpdate() throws Exception {
-//
-//        KubernetesServiceDiscovery serviceDiscovery = new KubernetesServiceDiscovery();
-//        serviceDiscovery.initialize(serverUrl);
-//
-//        serviceDiscovery.setCurrentHostname("TestServer");
-//        serviceDiscovery.setKubernetesClient(mockClient);
-//
-//        ServiceInstance serviceInstance = new DefaultServiceInstance("TestService", "Test", 12345, ScopeModelUtil.getApplicationModel(serviceDiscovery.getUrl().getScopeModel()));
-//        serviceDiscovery.register(serviceInstance);
-//
-//        HashSet<String> serviceList = new HashSet<>(4);
-//        serviceList.add("TestService");
-//        Mockito.when(mockListener.getServiceNames()).thenReturn(serviceList);
-//        Mockito.doNothing().when(mockListener).onEvent(Mockito.any());
-//
-//        serviceDiscovery.addServiceInstancesChangedListener(mockListener);
-//
-//        serviceInstance = new DefaultServiceInstance("TestService", "Test12345", 12345, ScopeModelUtil.getApplicationModel(serviceDiscovery.getUrl().getScopeModel()));
-//        serviceDiscovery.update(serviceInstance);
-//
-//        Thread.sleep(5000);
-//        ArgumentCaptor<ServiceInstancesChangedEvent> eventArgumentCaptor =
-//            ArgumentCaptor.forClass(ServiceInstancesChangedEvent.class);
-//        Mockito.verify(mockListener, Mockito.times(1)).onEvent(eventArgumentCaptor.capture());
-//        Assertions.assertEquals(1, eventArgumentCaptor.getValue().getServiceInstances().size());
-//
-//        serviceDiscovery.unregister(serviceInstance);
-//
-//        serviceDiscovery.destroy();
-//    }
-//
-//    @Test
-//    public void testGetInstance() throws Exception {
-//        KubernetesServiceDiscovery serviceDiscovery = new KubernetesServiceDiscovery();
-//        serviceDiscovery.initialize(serverUrl);
-//
-//        serviceDiscovery.setCurrentHostname("TestServer");
-//        serviceDiscovery.setKubernetesClient(mockClient);
-//
-//        ServiceInstance serviceInstance = new DefaultServiceInstance("TestService", "Test", 12345, ScopeModelUtil.getApplicationModel(serviceDiscovery.getUrl().getScopeModel()));
-//        serviceDiscovery.register(serviceInstance);
-//
-//        serviceDiscovery.update(serviceInstance);
-//
-//        Assertions.assertEquals(1, serviceDiscovery.getServices().size());
-//        Assertions.assertEquals(1, serviceDiscovery.getInstances("TestService").size());
-//
-//        Assertions.assertEquals(serviceInstance, serviceDiscovery.getLocalInstance());
-//
-//        serviceDiscovery.unregister(serviceInstance);
-//
-//        serviceDiscovery.destroy();
-//    }
-//}
+package org.apache.dubbo.registry.kubernetes;
+
+import org.apache.dubbo.common.URL;
+import org.apache.dubbo.config.ApplicationConfig;
+import org.apache.dubbo.registry.client.DefaultServiceInstance;
+import org.apache.dubbo.registry.client.ServiceInstance;
+import org.apache.dubbo.registry.client.event.ServiceInstancesChangedEvent;
+import org.apache.dubbo.registry.client.event.listener.ServiceInstancesChangedListener;
+import org.apache.dubbo.registry.kubernetes.util.KubernetesClientConst;
+import org.apache.dubbo.rpc.model.ApplicationModel;
+import org.apache.dubbo.rpc.model.ScopeModelUtil;
+
+import io.fabric8.kubernetes.api.model.Endpoints;
+import io.fabric8.kubernetes.api.model.EndpointsBuilder;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodBuilder;
+import io.fabric8.kubernetes.api.model.Service;
+import io.fabric8.kubernetes.api.model.ServiceBuilder;
+import io.fabric8.kubernetes.client.Config;
+import io.fabric8.kubernetes.client.NamespacedKubernetesClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+
+import static org.apache.dubbo.registry.kubernetes.util.KubernetesClientConst.NAMESPACE;
+
+@ExtendWith({MockitoExtension.class})
+public class KubernetesServiceDiscoveryTest {
+    private static final String SERVICE_NAME = "TestService";
+
+    private static final String POD_NAME = "TestServer";
+
+    public KubernetesServer mockServer = new KubernetesServer(false, true);
+
+    private NamespacedKubernetesClient mockClient;
+
+    private ServiceInstancesChangedListener mockListener = Mockito.mock(ServiceInstancesChangedListener.class);
+
+    private URL serverUrl;
+
+    private Map<String, String> selector;
+
+    private KubernetesServiceDiscovery serviceDiscovery;
+
+
+    @BeforeEach
+    public void setUp() {
+        mockServer.before();
+        mockClient = mockServer.getClient().inNamespace("dubbo-demo");
+
+        ApplicationModel applicationModel = ApplicationModel.defaultModel();
+        applicationModel.getApplicationConfigManager().setApplication(new ApplicationConfig());
+
+        serverUrl = URL.valueOf(mockClient.getConfiguration().getMasterUrl())
+                .setProtocol("kubernetes")
+                .addParameter(NAMESPACE, "dubbo-demo")
+                .addParameter(KubernetesClientConst.USE_HTTPS, "false")
+                .addParameter(KubernetesClientConst.HTTP2_DISABLE, "true");
+        serverUrl.setScopeModel(applicationModel);
+
+        this.serviceDiscovery = new KubernetesServiceDiscovery(applicationModel, serverUrl);
+
+        System.setProperty(Config.KUBERNETES_AUTH_TRYKUBECONFIG_SYSTEM_PROPERTY, "false");
+        System.setProperty(Config.KUBERNETES_AUTH_TRYSERVICEACCOUNT_SYSTEM_PROPERTY, "false");
+
+        selector = new HashMap<>(4);
+        selector.put("l", "v");
+        Pod pod = new PodBuilder()
+                .withNewMetadata().withName(POD_NAME).withLabels(selector).endMetadata()
+                .build();
+
+        Service service = new ServiceBuilder()
+                .withNewMetadata().withName(SERVICE_NAME).endMetadata()
+                .withNewSpec().withSelector(selector).endSpec().build();
+
+        Endpoints endPoints = new EndpointsBuilder()
+                .withNewMetadata().withName(SERVICE_NAME).endMetadata()
+                .addNewSubset()
+                .addNewAddress().withIp("ip1")
+                .withNewTargetRef().withUid("uid1").withName(POD_NAME).endTargetRef().endAddress()
+                .addNewPort("Test", "Test", 12345, "TCP").endSubset()
+                .build();
+
+        mockClient.pods().resource(pod).create();
+        mockClient.services().resource(service).create();
+        mockClient.endpoints().resource(endPoints).create();
+    }
+
+    @AfterEach
+    public void destroy() throws Exception {
+        serviceDiscovery.destroy();
+        mockClient.close();
+        mockServer.after();
+    }
+
+    @Test
+    public void testEndpointsUpdate() throws Exception {
+        serviceDiscovery.setCurrentHostname(POD_NAME);
+        serviceDiscovery.setKubernetesClient(mockClient);
+
+        ServiceInstance serviceInstance = new DefaultServiceInstance(SERVICE_NAME, "Test", 12345, ScopeModelUtil.getApplicationModel(serviceDiscovery.getUrl().getScopeModel()));
+
+        serviceDiscovery.doRegister(serviceInstance);
+
+        HashSet<String> serviceList = new HashSet<>(4);
+        serviceList.add(SERVICE_NAME);
+        Mockito.when(mockListener.getServiceNames()).thenReturn(serviceList);
+        Mockito.doNothing().when(mockListener).onEvent(Mockito.any());
+
+        serviceDiscovery.addServiceInstancesChangedListener(mockListener);
+        mockClient.endpoints().withName(SERVICE_NAME)
+                .edit(endpoints ->
+                        new EndpointsBuilder(endpoints)
+                                .editFirstSubset()
+                                .addNewAddress()
+                                .withIp("ip2")
+                                .withNewTargetRef().withUid("uid2").withName(POD_NAME).endTargetRef()
+                                .endAddress().endSubset()
+                                .build());
+
+        Thread.sleep(2000);
+        ArgumentCaptor<ServiceInstancesChangedEvent> eventArgumentCaptor =
+                ArgumentCaptor.forClass(ServiceInstancesChangedEvent.class);
+        Mockito.verify(mockListener, Mockito.times(2)).onEvent(eventArgumentCaptor.capture());
+        Assertions.assertEquals(2, eventArgumentCaptor.getValue().getServiceInstances().size());
+
+        serviceDiscovery.doUnregister(serviceInstance);
+    }
+
+    @Test
+    public void testPodsUpdate() throws Exception {
+        serviceDiscovery.setCurrentHostname(POD_NAME);
+        serviceDiscovery.setKubernetesClient(mockClient);
+
+        ServiceInstance serviceInstance = new DefaultServiceInstance(SERVICE_NAME, "Test", 12345, ScopeModelUtil.getApplicationModel(serviceDiscovery.getUrl().getScopeModel()));
+
+        serviceDiscovery.doRegister(serviceInstance);
+
+        HashSet<String> serviceList = new HashSet<>(4);
+        serviceList.add(SERVICE_NAME);
+        Mockito.when(mockListener.getServiceNames()).thenReturn(serviceList);
+        Mockito.doNothing().when(mockListener).onEvent(Mockito.any());
+
+        serviceDiscovery.addServiceInstancesChangedListener(mockListener);
+
+        serviceInstance = new DefaultServiceInstance(SERVICE_NAME, "Test12345", 12345, ScopeModelUtil.getApplicationModel(serviceDiscovery.getUrl().getScopeModel()));
+        serviceDiscovery.doUpdate(serviceInstance);
+
+        Thread.sleep(2000);
+        ArgumentCaptor<ServiceInstancesChangedEvent> eventArgumentCaptor =
+                ArgumentCaptor.forClass(ServiceInstancesChangedEvent.class);
+        Mockito.verify(mockListener, Mockito.times(1)).onEvent(eventArgumentCaptor.capture());
+        Assertions.assertEquals(1, eventArgumentCaptor.getValue().getServiceInstances().size());
+
+        serviceDiscovery.doUnregister(serviceInstance);
+    }
+
+    @Test
+    public void testServiceUpdate() throws Exception {
+        serviceDiscovery.setCurrentHostname(POD_NAME);
+        serviceDiscovery.setKubernetesClient(mockClient);
+
+        ServiceInstance serviceInstance = new DefaultServiceInstance(SERVICE_NAME, "Test", 12345, ScopeModelUtil.getApplicationModel(serviceDiscovery.getUrl().getScopeModel()));
+
+        serviceDiscovery.doRegister(serviceInstance);
+
+        HashSet<String> serviceList = new HashSet<>(4);
+        serviceList.add(SERVICE_NAME);
+        Mockito.when(mockListener.getServiceNames()).thenReturn(serviceList);
+        Mockito.doNothing().when(mockListener).onEvent(Mockito.any());
+
+        serviceDiscovery.addServiceInstancesChangedListener(mockListener);
+
+        selector.put("app", "test");
+        mockClient.services().withName(SERVICE_NAME)
+                .edit(service -> new ServiceBuilder(service)
+                        .editSpec()
+                        .addToSelector(selector)
+                        .endSpec()
+                        .build());
+
+        Thread.sleep(2000);
+        ArgumentCaptor<ServiceInstancesChangedEvent> eventArgumentCaptor =
+                ArgumentCaptor.forClass(ServiceInstancesChangedEvent.class);
+        Mockito.verify(mockListener, Mockito.times(1)).onEvent(eventArgumentCaptor.capture());
+        Assertions.assertEquals(1, eventArgumentCaptor.getValue().getServiceInstances().size());
+
+        serviceDiscovery.doUnregister(serviceInstance);
+    }
+
+    @Test
+    public void testGetInstance() {
+        serviceDiscovery.setCurrentHostname(POD_NAME);
+        serviceDiscovery.setKubernetesClient(mockClient);
+
+        ServiceInstance serviceInstance = new DefaultServiceInstance(SERVICE_NAME, "Test", 12345, ScopeModelUtil.getApplicationModel(serviceDiscovery.getUrl().getScopeModel()));
+
+        serviceDiscovery.doRegister(serviceInstance);
+
+        serviceDiscovery.doUpdate(serviceInstance);
+
+        Assertions.assertEquals(1, serviceDiscovery.getServices().size());
+        Assertions.assertEquals(1, serviceDiscovery.getInstances(SERVICE_NAME).size());
+
+        serviceDiscovery.doUnregister(serviceInstance);
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change
Fix: #10535 

Replace the watch mechanism with a high-performance informer mechanism.

Informer maintains a memory cache, which can return the results of List/Get requests more quickly and reduce direct calls to kubenetes API.

## Brief changelog

- Update fabric8_kubernetes_version from v5.3.2 to v6.1.1 because of adding informer api.
- Replace all watch APIs.

## Verifying this change

org.apache.dubbo.registry.kubernetes.KubernetesServiceDiscoveryTest can verify.

<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [x] Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [ ] GitHub Actions works fine on your own branch.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
