### PR TITLE
Fix ConcurrentModification when initializing concurrently

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/config/ConfigurationUtils.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/config/ConfigurationUtils.java
@@ -239,7 +239,11 @@ public final class ConfigurationUtils {
         }
 
         if (CollectionUtils.isNotEmptyMap(configMap)) {
-            for(Map.Entry<String, V> entry : configMap.entrySet()) {
+            Map<String,V> copy ;
+            synchronized (configMap){
+                copy = new HashMap<>(configMap);
+            }
+            for(Map.Entry<String, V> entry : copy.entrySet()) {
                 String key = entry.getKey();
                 V val = entry.getValue();
                 if (StringUtils.startsWithIgnoreCase(key, prefix)
@@ -276,7 +280,11 @@ public final class ConfigurationUtils {
         if (!prefix.endsWith(".")) {
             prefix += ".";
         }
-        for (Map.Entry<String, V> entry : configMap.entrySet()) {
+        Map<String,V> copy ;
+        synchronized (configMap){
+            copy = new HashMap<>(configMap);
+        }
+        for (Map.Entry<String, V> entry : copy.entrySet()) {
             String key = entry.getKey();
             if (StringUtils.startsWithIgnoreCase(key, prefix)
                 && key.length() > prefix.length()
@@ -311,7 +319,11 @@ public final class ConfigurationUtils {
         }
         Set<String> ids = new LinkedHashSet<>();
         for (Map<String, V> configMap : configMaps) {
-            for (Map.Entry<String, V> entry : configMap.entrySet()) {
+            Map<String,V> copy ;
+            synchronized (configMap){
+                copy = new HashMap<>(configMap);
+            }
+            for (Map.Entry<String, V> entry : copy.entrySet()) {
                 String key = entry.getKey();
                 V val = entry.getValue();
                 if (StringUtils.startsWithIgnoreCase(key, prefix)


### PR DESCRIPTION
## What is the purpose of the change

Fix `ConcurrentModificationException` when initializing dubbo concurrently.

Scenario:
Assume there are two beans `A` and `B`

1. `A` is iterating `PropertiesConfiguration` for `prefix` configs.
2. `B` is writing its `Registry/Application/Protocol Config` to `PropertiesConfiguration`

Cuz it is not thread-safe when iterating `HashTable` with `put` concurrently, a `ConcurrentModificationException` will be thrown by `HashTable`.


## Brief changelog

Return a copied `Map` under `sync` block.

## Verifying this change


<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [ ] GitHub Actions works fine on your own branch.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
