### PR TITLE
fix discovery paramater "protocol" works abnormally in port reuse

### DIFF
--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/DefaultServiceInstance.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/DefaultServiceInstance.java
@@ -71,7 +71,7 @@ public class DefaultServiceInstance implements ServiceInstance {
     private transient Map<String, String> extendParams;
     private transient List<Endpoint> endpoints;
     private transient ApplicationModel applicationModel;
-    private transient InstanceAddressURL instanceAddressURL = null;
+    private transient Map<String, InstanceAddressURL> instanceAddressURL;
 
     public DefaultServiceInstance() {
     }
@@ -291,10 +291,15 @@ public class DefaultServiceInstance implements ServiceInstance {
 
     @Override
     public InstanceAddressURL toURL(String protocol) {
-        if (instanceAddressURL == null) {
-            instanceAddressURL = new InstanceAddressURL(this, serviceMetadata, protocol);
+        if(instanceAddressURL == null) {
+            instanceAddressURL = new HashMap<>();
         }
-        return instanceAddressURL;
+        InstanceAddressURL result = instanceAddressURL.getOrDefault(protocol, null);
+        if (result == null) {
+            instanceAddressURL.put(protocol, new InstanceAddressURL(this, serviceMetadata, protocol));
+            result = instanceAddressURL.get(protocol);
+        }
+        return result;
     }
 
     @Override


### PR DESCRIPTION
## What is the purpose of the change

1. fix application based service discovery failed in port reuse 


## Brief changelog


## Verifying this change


<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [ ] GitHub Actions works fine on your own branch.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
