### PR TITLE
feat: add apache/skywalking-eyes/header@main and EndBug/add-and-commit@v4 github action

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,3 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 coverage:
   status:
     # pull-requests only

--- a/.github/workflows/build-and-test-3.1.yml
+++ b/.github/workflows/build-and-test-3.1.yml
@@ -3,7 +3,7 @@ name: Build and Test For Dubbo 3.1
 on: [push, pull_request, workflow_dispatch]
 
 permissions:
-  contents: read
+  contents: write
 
 env:
   FORK_COUNT: 2
@@ -18,6 +18,22 @@ env:
     '
 
 jobs:
+  license:
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Fix License Header
+        uses: apache/skywalking-eyes/header@main
+        with:
+          mode: fix
+      - name: Apply License Header Changes
+        uses: EndBug/add-and-commit@v4
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          author_name: License Bot
+          author_email: license_bot@github.com
+          message: 'Automatic application of license header'
   build-source:
     runs-on: ubuntu-18.04
     outputs:

--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -1,0 +1,82 @@
+header:
+  license:
+    spdx-id: Apache-2.0
+    content: |
+      Licensed to the Apache Software Foundation (ASF) under one or more
+      contributor license agreements.  See the NOTICE file distributed with
+      this work for additional information regarding copyright ownership.
+      The ASF licenses this file to You under the Apache License, Version 2.0
+      (the "License"); you may not use this file except in compliance with
+      the License.  You may obtain a copy of the License at
+      
+          http://www.apache.org/licenses/LICENSE-2.0
+      
+      Unless required by applicable law or agreed to in writing, software
+      distributed under the License is distributed on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      See the License for the specific language governing permissions and
+      limitations under the License.
+
+  paths-ignore:
+    - '**/*.versionsBackup'
+    - '**/.idea/'
+    - '**/*.iml'
+    - '**/.settings/*'
+    - '**/.classpath'
+    - '**/.project'
+    - '**/target/**'
+    - '**/generated/**'
+    - '**/*.log'
+    - '**/codestyle/*'
+    - '**/resources/META-INF/**'
+    - '**/resources/mockito-extensions/**'
+    - '**/*.proto'
+    - '**/*.cache'
+    - '**/*.txt'
+    - '**/*.load'
+    - '**/*.flex'
+    - '**/*.fc'
+    - '**/*.javascript'
+    - '**/*.properties'
+    - '**/*.thrift'
+    - '**/*.sh'
+    - '**/*.bat'
+    - '**/*.md'
+    - '**/*.svg'
+    - '**/*.png'
+    - '**/*.json'
+    - '**/*.conf'
+    - '**/*.ftl'
+    - '**/*.tpl'
+    - '**/*.factories'
+    - '**/*.handlers'
+    - '**/*.schemas'
+    - '**/*.nojekyll'
+    - '.git/'
+    - '.github/**'
+    - '**/.gitignore'
+    - '**/.helmignore'
+    - '.repository/'
+    - 'compiler/**'
+    - '.gitmodules'
+    - '.mvn'
+    - 'mvnw'
+    - 'mvnw.cmd'
+    - 'LICENSE'
+    - 'NOTICE'
+    - 'CNAME'
+    - 'Jenkinsfile'
+    - '**/vendor/**'
+    - 'dubbo-common/src/main/java/org/apache/dubbo/common/threadlocal/InternalThreadLocal.java'
+    - 'dubbo-common/src/main/java/org/apache/dubbo/common/threadlocal/InternalThreadLocalMap.java'
+    - 'dubbo-common/src/main/java/org/apache/dubbo/common/timer/HashedWheelTimer.java'
+    - 'dubbo-common/src/main/java/org/apache/dubbo/common/timer/Timeout.java'
+    - 'dubbo-common/src/main/java/org/apache/dubbo/common/timer/Timer.java'
+    - 'dubbo-common/src/main/java/org/apache/dubbo/common/timer/TimerTask.java'
+    - 'dubbo-common/src/main/java/org/apache/dubbo/common/utils/CIDRUtils.java'
+    - 'dubbo-common/src/main/java/org/apache/dubbo/common/utils/Utf8Utils.java'
+    - 'dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/EmbeddedZooKeeper.java'
+
+  comment: on-failure
+
+  license-location-threshold: 130

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 sudo: false # faster builds
 os: linux
 dist: focal


### PR DESCRIPTION
## What is the purpose of the change

Try using GitHub action to check and automatically add ASF license header.

This PR contains two commits, the first commit is submitted by me, the content is to add GitHub action and configuration file .licenserc.yaml, and the second commit is to use License Bot/license_bot@github.com account in GitHub action automatically submitted.

As you can see, the two files .codecov.yml and .travis.yml have no ASF license header added, so the GitHub action automatically adds the ASF license header and commits it. It is worth noting that this requires the GitHub action. The configuration item permissions.contents has been changed from read to write. I'm not very sure whether this change will bring some bad consequences, but everything is normal at present.

Another point to note is that there are some files in the source code that reference other open source licenses, so you need to ignore the check for these files, such as dubbo-common/src/main/java/org/apache/dubbo/common/threadlocal /InternalThreadLocal.java, the complete list can be viewed in the header.paths-ignore configuration of the .licenserc.yaml file. Because of this, if we introduce other open source licenses in the future development process, we need to add them to the header.paths-ignore configuration item of the .licenserc.yaml file to ignore, otherwise the ASF license header may be duplicated or added incorrectly. this is a hidden danger.

Including if you add an ASF license header containing a spelling error, the GitHub action will also repeatedly add the ASF license header and commit by mistake, so either do not add the ASF license header and be automatically added by the GitHub action, or add the exact ASF license header.

The account for committing in GitHub action is License Bot/license_bot@github.com. If there are any that do not meet the requirements, you can replace them with others. This account does not seem to have an avatar.

In short, this can save us the step of copying and pasting the ASF license header for each new file, which can be said to improve the efficiency of research and development.

Finally, thanks.

## Brief changelog


## Verifying this change

Maybe you can look at the log of the GitHub action below to verify some:

[https://github.com/sunchaser-lilu/dubbo/actions/runs/3110713547/jobs/5042180021](https://github.com/sunchaser-lilu/dubbo/actions/runs/3110713547/jobs/5042180021)

<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [x] Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [x] GitHub Actions works fine on your own branch.
- [x] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
