### PR TITLE
fix issue 10405: if the parameter contains Spaces, the invoke telnet command will fail.

### DIFF
--- a/dubbo-plugin/dubbo-qos/src/main/java/org/apache/dubbo/qos/command/decoder/TelnetCommandDecoder.java
+++ b/dubbo-plugin/dubbo-qos/src/main/java/org/apache/dubbo/qos/command/decoder/TelnetCommandDecoder.java
@@ -27,15 +27,23 @@ public class TelnetCommandDecoder {
         if (!StringUtils.isBlank(str)) {
             String[] array = str.split("(?<![\\\\]) ");
             if (array.length > 0) {
-                String name = array[0];
                 String[] targetArgs = new String[array.length - 1];
                 System.arraycopy(array, 1, targetArgs, 0, array.length - 1);
+                String name = array[0].trim();
+                if (name.equals("invoke") && array.length > 2) {
+                    targetArgs = reBuildInvokeCmdArgs(str);
+                }
                 commandContext = CommandContextFactory.newInstance( name, targetArgs,false);
                 commandContext.setOriginRequest(str);
             }
         }
 
         return commandContext;
+    }
+
+    private static String[] reBuildInvokeCmdArgs(String originCmd) {
+        String cmd = originCmd.trim();
+        return new String[] {cmd.substring(cmd.indexOf(" ") + 1).trim()};
     }
 
 }

--- a/dubbo-plugin/dubbo-qos/src/main/java/org/apache/dubbo/qos/command/decoder/TelnetCommandDecoder.java
+++ b/dubbo-plugin/dubbo-qos/src/main/java/org/apache/dubbo/qos/command/decoder/TelnetCommandDecoder.java
@@ -25,6 +25,7 @@ public class TelnetCommandDecoder {
     public static final CommandContext decode(String str) {
         CommandContext commandContext = null;
         if (!StringUtils.isBlank(str)) {
+            str = str.trim();
             String[] array = str.split("(?<![\\\\]) ");
             if (array.length > 0) {
                 String[] targetArgs = new String[array.length - 1];
@@ -41,8 +42,7 @@ public class TelnetCommandDecoder {
         return commandContext;
     }
 
-    private static String[] reBuildInvokeCmdArgs(String originCmd) {
-        String cmd = originCmd.trim();
+    private static String[] reBuildInvokeCmdArgs(String cmd) {
         return new String[] {cmd.substring(cmd.indexOf(" ") + 1).trim()};
     }
 


### PR DESCRIPTION
## What is the purpose of the change
Fixes #10405.

## Brief changelog
When use telnet command `invoke` that has args containing Space in method, no invalid parameters error will be reported.

## Verifying this change
Use telnet to connect to dubbo provider: `telnet {ip} {port}`.
Invoke the service exported with telnet command: `invoke {service name}.{method name}({args that contain Space})`

<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [x] Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [ ] GitHub Actions works fine on your own branch.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
