### PR TITLE
Multiple dubboServices dynamically configure monitoring coverage

### DIFF
--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/integration/RegistryProtocol.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/integration/RegistryProtocol.java
@@ -59,8 +59,17 @@ import org.apache.dubbo.rpc.model.ScopeModelUtil;
 import org.apache.dubbo.rpc.protocol.InvokerWrapper;
 import org.apache.dubbo.rpc.support.ProtocolUtils;
 
-import java.util.*;
-import java.util.concurrent.*;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 
 import static org.apache.dubbo.common.constants.CommonConstants.APPLICATION_KEY;
 import static org.apache.dubbo.common.constants.CommonConstants.CLUSTER_KEY;

--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/integration/RegistryProtocol.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/integration/RegistryProtocol.java
@@ -228,7 +228,7 @@ public class RegistryProtocol implements Protocol, ScopeModelAware {
         final URL overrideSubscribeUrl = getSubscribedOverrideUrl(providerUrl);
         final OverrideListener overrideSubscribeListener = new OverrideListener(overrideSubscribeUrl, originInvoker);
         Map<URL, NotifyListener> overrideListeners = getProviderConfigurationListener(providerUrl).getOverrideListeners();
-        overrideListeners.put(registryUrl, overrideSubscribeListener);
+        overrideListeners.put(providerUrl, overrideSubscribeListener);
 
         providerUrl = overrideUrlWithConfig(providerUrl, overrideSubscribeListener);
         //export invoker

--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/integration/RegistryProtocol.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/integration/RegistryProtocol.java
@@ -59,10 +59,7 @@ import org.apache.dubbo.rpc.model.ScopeModelUtil;
 import org.apache.dubbo.rpc.protocol.InvokerWrapper;
 import org.apache.dubbo.rpc.support.ProtocolUtils;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.concurrent.*;
 
 import static org.apache.dubbo.common.constants.CommonConstants.APPLICATION_KEY;
@@ -835,7 +832,10 @@ public class RegistryProtocol implements Protocol, ScopeModelAware {
 
         @Override
         protected void notifyOverrides() {
-            overrideListeners.values().forEach(listener -> ((OverrideListener) listener).doOverrideIfNecessary());
+            Collection<List<NotifyListener>> listenersList = overrideListeners.values();
+            for (List<NotifyListener> listeners : listenersList) {
+                listeners.forEach(listener -> ((OverrideListener) listener).doOverrideIfNecessary());
+            }
         }
 
         public Map<URL, List<NotifyListener>> getOverrideListeners() {

--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/integration/RegistryProtocol.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/integration/RegistryProtocol.java
@@ -767,6 +767,10 @@ public class RegistryProtocol implements Protocol, ScopeModelAware {
             }
         }
 
+        public boolean isMatchedSubscribeUrl(URL targetSubscribeUrl) {
+            return this.subscribeUrl.equals(targetSubscribeUrl);
+        }
+
         private List<URL> getMatchedUrls(List<URL> configuratorUrls, URL currentSubscribe) {
             List<URL> result = new ArrayList<>();
             for (URL url : configuratorUrls) {
@@ -906,7 +910,12 @@ public class RegistryProtocol implements Protocol, ScopeModelAware {
                     if (listeners != null) {
                         if (!registry.isServiceDiscovery()) {
                             for (NotifyListener listener : listeners) {
-                                registry.unsubscribe(subscribeUrl, listener);
+                                if (listener instanceof OverrideListener) {
+                                    OverrideListener overrideListener = (OverrideListener) listener;
+                                    if (overrideListener.isMatchedSubscribeUrl(this.subscribeUrl)) {
+                                        registry.unsubscribe(subscribeUrl, listener);
+                                    }
+                                }
                             }
                         }
                         ApplicationModel applicationModel = getApplicationModel(registerUrl.getScopeModel());

--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/integration/RegistryProtocol.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/integration/RegistryProtocol.java
@@ -61,13 +61,11 @@ import org.apache.dubbo.rpc.support.ProtocolUtils;
 
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 


### PR DESCRIPTION
Fix the OverrideListener coverage problem of multiple dubboServices when exporting dubbo applications. Because registryUrl is used as the key, only one dubboService can listen to the configuration when the dynamic configuration is issued.

Fix #10670