### PR TITLE
[CI] Bump GitHub Actions Runner to Ubuntu 20.

### DIFF
--- a/.github/workflows/build-and-test-3.1.yml
+++ b/.github/workflows/build-and-test-3.1.yml
@@ -19,7 +19,7 @@ env:
 
 jobs:
   license:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - name: Check License

--- a/.github/workflows/build-and-test-3.1.yml
+++ b/.github/workflows/build-and-test-3.1.yml
@@ -19,7 +19,7 @@ env:
 
 jobs:
   build-source:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     outputs:
       version: ${{ steps.dubbo-version.outputs.version }}
     steps:
@@ -74,7 +74,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-18.04, windows-2019 ]
+        os: [ ubuntu-20.04, windows-2019 ]
         jdk: [ 8, 11, 17 ]
     env:
       DISABLE_FILE_SYSTEM_TEST: true
@@ -126,7 +126,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-18.04, windows-2019 ]
+        os: [ ubuntu-20.04, windows-2019 ]
         jdk: [ 8, 11, 17 ]
     env:
       DISABLE_FILE_SYSTEM_TEST: true
@@ -161,7 +161,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-18.04, windows-2019 ]
+        os: [ ubuntu-20.04, windows-2019 ]
         jdk: [ 8, 11, 17 ]
     env:
       DISABLE_FILE_SYSTEM_TEST: true
@@ -192,7 +192,7 @@ jobs:
         uses: codecov/codecov-action@v1
 
   integration-test-prepare:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     env:
       JOB_COUNT: 3
     steps:
@@ -211,8 +211,8 @@ jobs:
 
   integration-test-job:
     needs: [build-source, integration-test-prepare]
-    name: "Integration Test on ubuntu-18.04 (JobId: ${{matrix.job_id}})"
-    runs-on: ubuntu-18.04
+    name: "Integration Test on ubuntu-20.04 (JobId: ${{matrix.job_id}})"
+    runs-on: ubuntu-20.04
     timeout-minutes: 30
     env:
       JAVA_VER: 8
@@ -267,7 +267,7 @@ jobs:
   integration-test-result:
     needs: [integration-test-job]
     if: always()
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     env:
       JAVA_VER: 8
     steps:


### PR DESCRIPTION
#10663 中 “另外的修改” 部分。 / "Another changes" part in #10663 .

# 另外的修改 / Another Changes

## 中文
1. 由于 GitHub Actions 的 Ubuntu 18 运行器已经弃用 <sup>[1]</sup>。本 PR 修改了 Ubuntu 运行器的版本为 Ubuntu 20。

## English
1. Since Ubuntu 18 runner in GitHub Actions is deprecated <sup>[1]</sup>, this pull request also changes the version of Ubuntu runner to Ubuntu 20.

# 参考 / Reference
[1] https://github.blog/changelog/2022-08-09-github-actions-the-ubuntu-18-04-actions-runner-image-is-being-deprecated-and-will-be-removed-by-12-1-22/