### PR TITLE
[FAQ, CI] Apply Dubbo Error Code Inspector in GitHub Actions

### DIFF
--- a/.github/workflows/build-and-test-3.1.yml
+++ b/.github/workflows/build-and-test-3.1.yml
@@ -308,6 +308,6 @@ jobs:
 
       - name: "Run Error Code Inspecting"
         run: |
-          cd dubbo-test-tools
-          ./mvnw --batch-mode --no-snapshot-updates -e --no-transfer-progress --fail-fast package exec:java -Dmaven.test.skip=true -Dmaven.test.skip.exec=true -Ddubbo.eci.path=${{ github.workspace }}/dubbo
+          cd dubbo-test-tools/dubbo-error-code-inspector
+          ../mvnw --batch-mode --no-snapshot-updates -e --no-transfer-progress --fail-fast package exec:java -Dmaven.test.skip=true -Dmaven.test.skip.exec=true -Ddubbo.eci.path=${{ github.workspace }}/dubbo
           

--- a/.github/workflows/build-and-test-3.1.yml
+++ b/.github/workflows/build-and-test-3.1.yml
@@ -297,6 +297,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           path: "./dubbo"
+          
       - uses: actions/checkout@v2
         with:
           repository: 'win120a/dubbo-test-tools'
@@ -311,12 +312,17 @@ jobs:
       - name: "Compile Dubbo (Linux)"
         run: |
           cd ${{ github.workspace }}/dubbo
-          ./mvnw --batch-mode --no-snapshot-updates -e --no-transfer-progress --fail-fast clean install -DskipTests=true -DskipIntegrationTests=true -Dcheckstyle.skip=true -Dcheckstyle_unix.skip=true -Drat.skip=true -Dmaven.javadoc.skip=true
+          ./mvnw --batch-mode --no-snapshot-updates -e --no-transfer-progress --fail-fast -T 2C clean install -DskipTests=true -DskipIntegrationTests=true -Dcheckstyle.skip=true -Dcheckstyle_unix.skip=true -Drat.skip=true -Dmaven.javadoc.skip=true
 
       - name: "Run Error Code Inspecting"
         env:
           "dubbo.eci.report-as-error": false
         run: |
           cd ${{ github.workspace }}/dubbo-test-tools/dubbo-error-code-inspector
-          ../mvnw --batch-mode --no-snapshot-updates -e --no-transfer-progress --fail-fast package exec:java -Dmaven.test.skip=true -Dmaven.test.skip.exec=true -Ddubbo.eci.path=${{ github.workspace }}/dubbo
+          ../mvnw --batch-mode --no-snapshot-updates -e --no-transfer-progress --fail-fast -T 2C package exec:java -Dmaven.test.skip=true -Dmaven.test.skip.exec=true -Ddubbo.eci.path=${{ github.workspace }}/dubbo
           
+      - name: "Upload error code inspection result"
+        uses: actions/upload-artifact@v2
+        with:
+          name: "error-inspection-result"
+          path: ${{ github.workspace }}/dubbo-test-tools/dubbo-error-code-inspector/error-inspection-result.txt

--- a/.github/workflows/build-and-test-3.1.yml
+++ b/.github/workflows/build-and-test-3.1.yml
@@ -295,6 +295,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
         with:
           repository: 'win120a/dubbo-test-tools'
           ref: main
@@ -307,6 +308,6 @@ jobs:
 
       - name: "Run Error Code Inspecting"
         run: |
-          ls
-          ${{ github.workspace }}/dubbo-test-tools/mvnw --batch-mode --no-snapshot-updates -e --no-transfer-progress --fail-fast package exec:java -Dmaven.test.skip=true -Dmaven.test.skip.exec=true -Ddubbo.eci.path=${{ github.workspace }}/dubbo
+          cd dubbo-test-tools
+          ./mvnw --batch-mode --no-snapshot-updates -e --no-transfer-progress --fail-fast package exec:java -Dmaven.test.skip=true -Dmaven.test.skip.exec=true -Ddubbo.eci.path=${{ github.workspace }}/dubbo
           

--- a/.github/workflows/build-and-test-3.1.yml
+++ b/.github/workflows/build-and-test-3.1.yml
@@ -298,7 +298,7 @@ jobs:
         with:
           repository: 'win120a/dubbo-test-tools'
           ref: main
-          path: "/dubbo-test-tools"
+          path: "./dubbo-test-tools"
 
       - name: "Run Error Code Inspecting"
         run: |

--- a/.github/workflows/build-and-test-3.1.yml
+++ b/.github/workflows/build-and-test-3.1.yml
@@ -307,5 +307,6 @@ jobs:
 
       - name: "Run Error Code Inspecting"
         run: |
+          ls
           ${{ github.workspace }}/dubbo-test-tools/mvnw --batch-mode --no-snapshot-updates -e --no-transfer-progress --fail-fast package exec:java -Dmaven.test.skip=true -Dmaven.test.skip.exec=true -Ddubbo.eci.path=${{ github.workspace }}/dubbo
           

--- a/.github/workflows/build-and-test-3.1.yml
+++ b/.github/workflows/build-and-test-3.1.yml
@@ -295,7 +295,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-        path: "./dubbo
+        path: "./dubbo"
       - uses: actions/checkout@v2
         with:
           repository: 'win120a/dubbo-test-tools'

--- a/.github/workflows/build-and-test-3.1.yml
+++ b/.github/workflows/build-and-test-3.1.yml
@@ -306,7 +306,7 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 17
-      - name: "Listings":
+      - name: "Listings"
         run: |
           ls
           ls ./dubbo

--- a/.github/workflows/build-and-test-3.1.yml
+++ b/.github/workflows/build-and-test-3.1.yml
@@ -300,7 +300,7 @@ jobs:
           
       - uses: actions/checkout@v2
         with:
-          repository: 'win120a/dubbo-test-tools'
+          repository: 'apache/dubbo-test-tools'
           ref: main
           path: "./dubbo-test-tools"
 

--- a/.github/workflows/build-and-test-3.1.yml
+++ b/.github/workflows/build-and-test-3.1.yml
@@ -295,7 +295,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-        path: "./dubbo"
+        with:
+          path: "./dubbo"
       - uses: actions/checkout@v2
         with:
           repository: 'win120a/dubbo-test-tools'

--- a/.github/workflows/build-and-test-3.1.yml
+++ b/.github/workflows/build-and-test-3.1.yml
@@ -282,3 +282,16 @@ jobs:
           path: test/jobs/
       - name: "Merge test result"
         run: ./test/scripts/merge-test-results.sh
+
+  error-code-inspecting:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          repository: 'win120a/dubbo-test-tools'
+          ref: main
+
+      - name: "Run Error Code Inspecting"
+        run: |
+          ${{ github.workspace }}/dubbo-test-tools/mvnw --batch-mode --no-snapshot-updates -e --no-transfer-progress --fail-fast package exec:java -Dmaven.test.skip=true -Dmaven.test.skip.exec=true -Ddubbo.eci.path=${{ github.workspace }}/dubbo
+          

--- a/.github/workflows/build-and-test-3.1.yml
+++ b/.github/workflows/build-and-test-3.1.yml
@@ -298,6 +298,7 @@ jobs:
         with:
           repository: 'win120a/dubbo-test-tools'
           ref: main
+          path: "/dubbo-test-tools"
 
       - name: "Run Error Code Inspecting"
         run: |

--- a/.github/workflows/build-and-test-3.1.yml
+++ b/.github/workflows/build-and-test-3.1.yml
@@ -307,13 +307,16 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 17
-      - name: "Listings"
+          
+      - name: "Compile Dubbo (Linux)"
         run: |
-          ls
-          ls ./dubbo
-          ls ./dubbo-test-tools
+          cd ${{ github.workspace }}/dubbo
+          ./mvnw --batch-mode --no-snapshot-updates -e --no-transfer-progress --fail-fast clean install -DskipTests=true -DskipIntegrationTests=true -Dcheckstyle.skip=true -Dcheckstyle_unix.skip=true -Drat.skip=true -Dmaven.javadoc.skip=true
+
       - name: "Run Error Code Inspecting"
+        env:
+          "dubbo.eci.report-as-error": false
         run: |
-          cd dubbo-test-tools/dubbo-error-code-inspector
+          cd ${{ github.workspace }}/dubbo-test-tools/dubbo-error-code-inspector
           ../mvnw --batch-mode --no-snapshot-updates -e --no-transfer-progress --fail-fast package exec:java -Dmaven.test.skip=true -Dmaven.test.skip.exec=true -Ddubbo.eci.path=${{ github.workspace }}/dubbo
           

--- a/.github/workflows/build-and-test-3.1.yml
+++ b/.github/workflows/build-and-test-3.1.yml
@@ -295,6 +295,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        path: "./dubbo
       - uses: actions/checkout@v2
         with:
           repository: 'win120a/dubbo-test-tools'
@@ -305,7 +306,11 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 17
-
+      - name: "Listings":
+        run: |
+          ls
+          ls ./dubbo
+          ls ./dubbo-test-tools
       - name: "Run Error Code Inspecting"
         run: |
           cd dubbo-test-tools/dubbo-error-code-inspector

--- a/.github/workflows/build-and-test-3.1.yml
+++ b/.github/workflows/build-and-test-3.1.yml
@@ -300,6 +300,11 @@ jobs:
           ref: main
           path: "./dubbo-test-tools"
 
+      - name: "Set up JDK 17"
+        uses: actions/setup-java@v1
+        with:
+          java-version: 17
+
       - name: "Run Error Code Inspecting"
         run: |
           ${{ github.workspace }}/dubbo-test-tools/mvnw --batch-mode --no-snapshot-updates -e --no-transfer-progress --fail-fast package exec:java -Dmaven.test.skip=true -Dmaven.test.skip.exec=true -Ddubbo.eci.path=${{ github.workspace }}/dubbo


### PR DESCRIPTION
# 相关 PR / Related PRs
原先的 PR / Legacy PR: #10663 
检查机制的实现的 PR / The inspector code implementation: https://github.com/apache/dubbo-test-tools/pull/1

# 介绍 / Introduction

这个 PR 实现了在 GitHub Actions 中 warn, error 链接指向的检查机制。

This pull request implements the mechanism that checks (document links of) error code in logger invocations.

# 功能 / Features
## 中文
1. 代码中全部错误码的提取 （见下述截图中的 All Error Codes 部分）
2. 错误码文档链接失效的判定 （见下述截图中的 Error codes which document links are not reachable 部分）
3. 未用错误码的 Logger 方法的提示 （见下述截图中的 Illegal logger method invocations 部分）
4. GitHub Actions 的自动检查。（目前不会抛出异常。其会将结果上传到 GitHub 的 Artifacts。）

## English
1. Error code extraction. ('All Error Codes' in screenshot)
2. Link testing of document of error codes. ('Error codes which document links are not reachable' in screenshot)
3. Hint of logger method invocations which don't use error code. ('Illegal logger method invocations' in screenshot)
4. Automatic checking in GitHub Actions. (Currently it does not throw exception. It will upload result to artifacts in GitHub Actions.)

# Actions 的运行截图 / Screenshot in GitHub Actions
![eci-1](https://user-images.githubusercontent.com/4351489/192001227-36315550-60e4-4846-9550-d4cd1e2363c5.jpg)

# 运行 / Run
## GitHub Actions 自动运行 / Automatically run in GitHub Actions
GitHub Actions 会在代码推送时自动运行本程序。可以到 Artifacts 下载 GitHub Actions 的运行结果。文件名为 `error-inspection-result.txt`。

This program will be executed by GitHub Actions when someone pushes patches. The result can be downloaded in 'Artifacts' section. The file name of report is `error-inspection-result.txt`.