### PR TITLE
fix(sec): upgrade org.apache.tomcat.embed:tomcat-embed-core to 8.5.78

### DIFF
--- a/dubbo-dependencies-bom/pom.xml
+++ b/dubbo-dependencies-bom/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -13,16 +14,14 @@
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   See the License for the specific language governing permissions and
   limitations under the License.
-  -->
-
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  --><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
         <groupId>org.apache</groupId>
         <artifactId>apache</artifactId>
         <version>27</version>
-        <relativePath />
+        <relativePath/>
     </parent>
 
     <groupId>org.apache.dubbo</groupId>
@@ -138,7 +137,7 @@
 
         <rs_api_version>2.0</rs_api_version>
         <resteasy_version>3.0.19.Final</resteasy_version>
-        <tomcat_embed_version>8.5.69</tomcat_embed_version>
+        <tomcat_embed_version>8.5.78</tomcat_embed_version>
         <jetcd_version>0.5.3</jetcd_version>
         <nacos_version>2.1.0</nacos_version>
         <grpc.version>1.47.0</grpc.version>


### PR DESCRIPTION
### What happened？
There are 12 security vulnerabilities found in org.apache.tomcat.embed:tomcat-embed-core 8.5.43
- [CVE-2019-17563](https://www.oscs1024.com/hd/CVE-2019-17563)
- [CVE-2020-13934](https://www.oscs1024.com/hd/CVE-2020-13934)
- [CVE-2020-13943](https://www.oscs1024.com/hd/CVE-2020-13943)
- [CVE-2020-17527(critical)](https://www.oscs1024.com/hd/CVE-2020-17527)
- [CVE-2020-9484](https://www.oscs1024.com/hd/CVE-2020-9484)
- [CVE-2020-11996](https://www.oscs1024.com/hd/CVE-2020-11996)
- [CVE-2021-30640](https://www.oscs1024.com/hd/CVE-2021-30640)
- [CVE-2021-24122](https://www.oscs1024.com/hd/CVE-2021-24122)
- [CVE-2021-25122](https://www.oscs1024.com/hd/CVE-2021-25122)
- [CVE-2021-25329](https://www.oscs1024.com/hd/CVE-2021-25329)
- [CVE-2021-41079](https://www.oscs1024.com/hd/CVE-2021-41079)
- [CVE-2021-33037](https://www.oscs1024.com/hd/CVE-2021-33037)


### What did I do？
Upgrade org.apache.tomcat.embed:tomcat-embed-core from 8.5.43 to 8.5.78 for vulnerability fix