### PR TITLE
fix(sec): upgrade org.eclipse.jetty:jetty-server to 9.4.41

### DIFF
--- a/dubbo-dependencies-bom/pom.xml
+++ b/dubbo-dependencies-bom/pom.xml
@@ -113,7 +113,7 @@
         <protobuf-java_version>3.11.0</protobuf-java_version>
         <javax_annotation-api_version>1.3.2</javax_annotation-api_version>
         <servlet_version>3.1.0</servlet_version>
-        <jetty_version>9.4.43.v20210629</jetty_version>
+        <jetty_version>9.4.41</jetty_version>
         <validation_new_version>3.0.1</validation_new_version>
         <validation_version>1.1.0.Final</validation_version>
         <hibernate_validator_version>5.4.3.Final</hibernate_validator_version>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.eclipse.jetty:jetty-server 9.4.38.v20210224
- [CVE-2021-34428](https://www.oscs1024.com/hd/CVE-2021-34428)


### What did I do？
Upgrade org.eclipse.jetty:jetty-server from 9.4.38.v20210224 to 9.4.41 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS