### PR TITLE
fix issue: resolve the conficts between Dubbo shutdown hook and Spring.

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/rpc/model/ModuleModel.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/rpc/model/ModuleModel.java
@@ -46,7 +46,7 @@ public class ModuleModel extends ScopeModel {
     private ModuleServiceRepository serviceRepository;
     private ModuleConfigManager moduleConfigManager;
     private ModuleDeployer deployer;
-    private boolean bindSpring = false;
+    private boolean lifeCycleManagedExternally = false;
 
     public ModuleModel(ApplicationModel applicationModel) {
         this(applicationModel, false);
@@ -198,11 +198,11 @@ public class ModuleModel extends ScopeModel {
         return consumerModel;
     }
 
-    public boolean isBindSpring() {
-        return bindSpring;
+    public boolean isLifeCycleManagedExternally() {
+        return lifeCycleManagedExternally;
     }
 
-    public void setBindSpring(boolean bindSpring) {
-        this.bindSpring = bindSpring;
+    public void setLifeCycleManagedExternally(boolean lifeCycleManagedExternally) {
+        this.lifeCycleManagedExternally = lifeCycleManagedExternally;
     }
 }

--- a/dubbo-common/src/main/java/org/apache/dubbo/rpc/model/ModuleModel.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/rpc/model/ModuleModel.java
@@ -46,6 +46,7 @@ public class ModuleModel extends ScopeModel {
     private ModuleServiceRepository serviceRepository;
     private ModuleConfigManager moduleConfigManager;
     private ModuleDeployer deployer;
+    private boolean bindSpring = false;
 
     public ModuleModel(ApplicationModel applicationModel) {
         this(applicationModel, false);
@@ -195,5 +196,13 @@ public class ModuleModel extends ScopeModel {
         logger.info("Dynamically registering consumer model " + serviceKey + " into model " + this.getDesc());
         serviceRepository.registerConsumer(consumerModel);
         return consumerModel;
+    }
+
+    public boolean isBindSpring() {
+        return bindSpring;
+    }
+
+    public void setBindSpring(boolean bindSpring) {
+        this.bindSpring = bindSpring;
     }
 }

--- a/dubbo-common/src/test/java/org/apache/dubbo/rpc/model/ModuleModelTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/rpc/model/ModuleModelTest.java
@@ -40,6 +40,7 @@ public class ModuleModelTest {
         Assertions.assertEquals(moduleModel.getApplicationModel(), applicationModel);
         Assertions.assertTrue(applicationModel.getPubModuleModels().contains(moduleModel));
         Assertions.assertNotNull(moduleModel.getInternalId());
+        Assertions.assertFalse(moduleModel.isLifeCycleManagedExternally());
 
         Assertions.assertNotNull(moduleModel.getExtensionDirector());
         Assertions.assertNotNull(moduleModel.getBeanFactory());

--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/DubboShutdownHook.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/DubboShutdownHook.java
@@ -22,13 +22,10 @@ import org.apache.dubbo.common.logger.ErrorTypeAwareLogger;
 import org.apache.dubbo.common.logger.LoggerFactory;
 import org.apache.dubbo.common.utils.Assert;
 import org.apache.dubbo.rpc.model.ApplicationModel;
-import org.apache.dubbo.rpc.model.ModelConstants;
 import org.apache.dubbo.rpc.model.ModuleModel;
 
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.List;
-import java.util.Map;
 
 import static org.apache.dubbo.common.constants.LoggerCodeConstants.CONFIG_FAILED_SHUTDOWN_HOOK;
 

--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/DubboShutdownHook.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/DubboShutdownHook.java
@@ -85,7 +85,7 @@ public class DubboShutdownHook extends Thread {
         boolean hasModuleBindSpring = false;
         // check if any modules are bound to Spring
         for (ModuleModel module: applicationModel.getModuleModels()) {
-            if (module.isBindSpring()) {
+            if (module.isLifeCycleManagedExternally()) {
                 hasModuleBindSpring = true;
                 break;
             }
@@ -98,6 +98,7 @@ public class DubboShutdownHook extends Thread {
                  * To avoid shutdown conflicts between Dubbo and Spring,
                  * wait for the modules bound to Spring to be handled by Spring util timeout.
                  */
+                logger.info("Waiting for modules managed by Spring to be shut down.");
                 while (!applicationModel.isDestroyed() && hasModuleBindSpring
                     && (System.currentTimeMillis() - start) < timeout) {
                     try {
@@ -105,7 +106,7 @@ public class DubboShutdownHook extends Thread {
                         hasModuleBindSpring = false;
                         if (!applicationModel.isDestroyed()) {
                             for (ModuleModel module: applicationModel.getModuleModels()) {
-                                if (module.isBindSpring()) {
+                                if (module.isLifeCycleManagedExternally()) {
                                     hasModuleBindSpring = true;
                                     break;
                                 }
@@ -118,6 +119,8 @@ public class DubboShutdownHook extends Thread {
             }
         }
         if (!applicationModel.isDestroyed()) {
+            logger.info("Dubbo shuts down application " +
+                "after Spring fails to do in time or doesn't do it completely.");
             applicationModel.destroy();
         }
     }

--- a/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/DubboShutdownHookTest.java
+++ b/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/DubboShutdownHookTest.java
@@ -1,0 +1,66 @@
+package org.apache.dubbo.config;
+
+import org.apache.dubbo.common.constants.CommonConstants;
+import org.apache.dubbo.rpc.model.ApplicationModel;
+import org.apache.dubbo.rpc.model.FrameworkModel;
+import org.apache.dubbo.rpc.model.ModuleModel;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.TimeUnit;
+
+import static java.util.Arrays.asList;
+
+public class DubboShutdownHookTest {
+    private DubboShutdownHook dubboShutdownHook;
+    private ApplicationModel applicationModel;
+
+    @BeforeEach
+    public void init() {
+        SysProps.setProperty(CommonConstants.IGNORE_LISTEN_SHUTDOWN_HOOK, "false");
+        FrameworkModel frameworkModel = new FrameworkModel();
+        applicationModel = new ApplicationModel(frameworkModel);
+        ModuleModel moduleModel = applicationModel.newModule();
+        dubboShutdownHook = new DubboShutdownHook(applicationModel);
+    }
+
+    @AfterEach
+    public void clear() {
+        SysProps.clear();
+    }
+
+    @Test
+    public void testDubboShutdownHook() {
+        Assertions.assertNotNull(dubboShutdownHook);
+        Assertions.assertLinesMatch(asList("DubboShutdownHook"), asList(dubboShutdownHook.getName()));
+        Assertions.assertFalse(dubboShutdownHook.getRegistered());
+    }
+
+    @Test
+    public void testDestoryNoModuleManagedExternally() {
+        dubboShutdownHook.run();
+        boolean hasModuleManagedExternally = false;
+        for (ModuleModel moduleModel : applicationModel.getModuleModels()) {
+            if (moduleModel.isLifeCycleManagedExternally()) {
+                hasModuleManagedExternally = true;
+                break;
+            }
+        }
+        Assertions.assertFalse(hasModuleManagedExternally);
+        Assertions.assertTrue(applicationModel.isDestroyed());
+    }
+
+    @Test
+    public void testDestoryWithModuleManagedExternally() throws InterruptedException {
+        applicationModel.getModuleModels().get(0).setLifeCycleManagedExternally(true);
+        new Thread(() -> {
+            applicationModel.getModuleModels().get(0).destroy();
+        }).start();
+        TimeUnit.MILLISECONDS.sleep(10);
+        dubboShutdownHook.run();
+        Assertions.assertTrue(applicationModel.isDestroyed());
+    }
+}

--- a/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/DubboShutdownHookTest.java
+++ b/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/DubboShutdownHookTest.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.dubbo.config;
 
 import org.apache.dubbo.common.constants.CommonConstants;

--- a/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/DubboShutdownHookTest.java
+++ b/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/DubboShutdownHookTest.java
@@ -41,7 +41,6 @@ public class DubboShutdownHookTest {
 
     @Test
     public void testDestoryNoModuleManagedExternally() {
-        dubboShutdownHook.run();
         boolean hasModuleManagedExternally = false;
         for (ModuleModel moduleModel : applicationModel.getModuleModels()) {
             if (moduleModel.isLifeCycleManagedExternally()) {
@@ -50,6 +49,7 @@ public class DubboShutdownHookTest {
             }
         }
         Assertions.assertFalse(hasModuleManagedExternally);
+        dubboShutdownHook.run();
         Assertions.assertTrue(applicationModel.isDestroyed());
     }
 

--- a/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/context/DubboSpringInitializer.java
+++ b/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/context/DubboSpringInitializer.java
@@ -138,6 +138,7 @@ public class DubboSpringInitializer {
 
         // mark context as bound
         context.markAsBound();
+        moduleModel.setBindSpring(true);
 
         // register common beans
         DubboBeanUtils.registerCommonBeans(registry);

--- a/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/context/DubboSpringInitializer.java
+++ b/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/context/DubboSpringInitializer.java
@@ -138,7 +138,7 @@ public class DubboSpringInitializer {
 
         // mark context as bound
         context.markAsBound();
-        moduleModel.setBindSpring(true);
+        moduleModel.setLifeCycleManagedExternally(true);
 
         // register common beans
         DubboBeanUtils.registerCommonBeans(registry);


### PR DESCRIPTION
## What is the purpose of the change
Fixes #10709

## Brief changelog
Mark Dubbo Module if is spring managed. Wait the module bound to Spring to be handled by Spring before Dubbo shutdown hook executing.

## Verifying this change


## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [ ] GitHub Actions works fine on your own branch.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
