### PR TITLE
Adds error code which represents internal errors. (Partial backport of #10691)

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/constants/LoggerCodeConstants.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/constants/LoggerCodeConstants.java
@@ -164,4 +164,9 @@ public interface LoggerCodeConstants {
 
     String TRANSPORT_CLIENT_CONNECT_TIMEOUT = "6-2";
 
+    // Internal unknown error.
+
+    String INTERNAL_ERROR = "99-0";
+
+    String INTERNAL_INTERRUPTED = "99-1";
 }


### PR DESCRIPTION
## What is the purpose of the change
Partial backport of #10691, which adds error code which represents internal errors.


## Brief changelog
Add some error codes in `dubbo-common/src/main/java/org/apache/dubbo/common/constants/LoggerCodeConstants.java`.
