### PR TITLE
[CI] Bump the codecov action from v1 to v3.

### DIFF
--- a/.github/workflows/build-and-test-pr.yml
+++ b/.github/workflows/build-and-test-pr.yml
@@ -141,7 +141,7 @@ jobs:
         timeout-minutes: 70
         run: ./mvnw --batch-mode --no-snapshot-updates -e --no-transfer-progress --fail-fast clean test verify -Pjacoco -Dmaven.wagon.httpconnectionManager.ttlSeconds=120 -Dmaven.wagon.http.retryHandler.count=5 -DskipTests=false -DskipIntegrationTests=false -Dcheckstyle.skip=false -Dcheckstyle_unix.skip=false -Drat.skip=false -Dmaven.javadoc.skip=true -DembeddedZookeeperPath=${{ github.workspace }}/.tmp/zookeeper
       - name: "Upload coverage to Codecov"
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v3
 
   integration-test-prepare:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-and-test-scheduled-3.0.yml
+++ b/.github/workflows/build-and-test-scheduled-3.0.yml
@@ -161,7 +161,7 @@ jobs:
         if: ${{ startsWith( matrix.os, 'windows') }}
         run: ./mvnw --batch-mode --no-snapshot-updates -e --no-transfer-progress --fail-fast clean test verify -Pjacoco -D"http.keepAlive=false" -D"maven.wagon.http.pool=false" -D"maven.wagon.httpconnectionManager.ttlSeconds=120" -D"maven.wagon.http.retryHandler.count=5" -DskipTests=false -DskipIntegrationTests=true -D"checkstyle.skip=false" -D"checkstyle_unix.skip=true" -D"rat.skip=false" -D"maven.javadoc.skip=true" -D"embeddedZookeeperPath=${{ github.workspace }}/.tmp/zookeeper"
       - name: "Upload coverage to Codecov"
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v3
 
   integration-test-prepare:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-and-test-scheduled-3.1.yml
+++ b/.github/workflows/build-and-test-scheduled-3.1.yml
@@ -171,7 +171,7 @@ jobs:
         if: ${{ startsWith( matrix.os, 'windows') }}
         run: ./mvnw --batch-mode --no-snapshot-updates -e --no-transfer-progress --fail-fast clean test verify -Pjacoco -D"http.keepAlive=false" -D"maven.wagon.http.pool=false" -D"maven.wagon.httpconnectionManager.ttlSeconds=120" -D"maven.wagon.http.retryHandler.count=5" -DskipTests=false -DskipIntegrationTests=true -D"checkstyle.skip=false" -D"checkstyle_unix.skip=true" -D"rat.skip=false" -D"maven.javadoc.skip=true" -D"embeddedZookeeperPath=${{ github.workspace }}/.tmp/zookeeper"
       - name: "Upload coverage to Codecov"
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v3
 
   unit-test-fastjson2:
     needs: [build-source, unit-test-prepare]
@@ -211,7 +211,7 @@ jobs:
         if: ${{ startsWith( matrix.os, 'windows') }}
         run: ./mvnw --batch-mode --no-snapshot-updates -e --no-transfer-progress --fail-fast clean test verify -Pjacoco -D"http.keepAlive=false" -D"maven.wagon.http.pool=false" -D"maven.wagon.httpconnectionManager.ttlSeconds=120" -D"maven.wagon.http.retryHandler.count=5" -DskipTests=false -DskipIntegrationTests=true -D"checkstyle.skip=false" -D"checkstyle_unix.skip=true" -D"rat.skip=false" -D"maven.javadoc.skip=true" -D"embeddedZookeeperPath=${{ github.workspace }}/.tmp/zookeeper"
       - name: "Upload coverage to Codecov"
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v3
 
   integration-test-prepare:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-and-test-scheduled-3.2.yml
+++ b/.github/workflows/build-and-test-scheduled-3.2.yml
@@ -171,7 +171,7 @@ jobs:
         if: ${{ startsWith( matrix.os, 'windows') }}
         run: ./mvnw --batch-mode --no-snapshot-updates -e --no-transfer-progress --fail-fast clean test verify -Pjacoco -D"http.keepAlive=false" -D"maven.wagon.http.pool=false" -D"maven.wagon.httpconnectionManager.ttlSeconds=120" -D"maven.wagon.http.retryHandler.count=5" -DskipTests=false -DskipIntegrationTests=true -D"checkstyle.skip=false" -D"checkstyle_unix.skip=true" -D"rat.skip=false" -D"maven.javadoc.skip=true" -D"embeddedZookeeperPath=${{ github.workspace }}/.tmp/zookeeper"
       - name: "Upload coverage to Codecov"
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v3
 
   unit-test-fastjson2:
     needs: [build-source, unit-test-prepare]
@@ -211,7 +211,7 @@ jobs:
         if: ${{ startsWith( matrix.os, 'windows') }}
         run: ./mvnw --batch-mode --no-snapshot-updates -e --no-transfer-progress --fail-fast clean test verify -Pjacoco -D"http.keepAlive=false" -D"maven.wagon.http.pool=false" -D"maven.wagon.httpconnectionManager.ttlSeconds=120" -D"maven.wagon.http.retryHandler.count=5" -DskipTests=false -DskipIntegrationTests=true -D"checkstyle.skip=false" -D"checkstyle_unix.skip=true" -D"rat.skip=false" -D"maven.javadoc.skip=true" -D"embeddedZookeeperPath=${{ github.workspace }}/.tmp/zookeeper"
       - name: "Upload coverage to Codecov"
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v3
 
   integration-test-prepare:
     runs-on: ubuntu-latest

--- a/.github/workflows/release-test-3.1.yml
+++ b/.github/workflows/release-test-3.1.yml
@@ -166,7 +166,7 @@ jobs:
         if: ${{ startsWith( matrix.os, 'windows') }}
         run: ./mvnw --batch-mode --no-snapshot-updates -e --no-transfer-progress --fail-fast clean test verify -Pjacoco -D"http.keepAlive=false" -D"maven.wagon.http.pool=false" -D"maven.wagon.httpconnectionManager.ttlSeconds=120" -D"maven.wagon.http.retryHandler.count=5" -DskipTests=false -DskipIntegrationTests=true -D"checkstyle.skip=false" -D"checkstyle_unix.skip=true" -D"rat.skip=false" -D"maven.javadoc.skip=true" -D"embeddedZookeeperPath=${{ github.workspace }}/.tmp/zookeeper"
       - name: "Upload coverage to Codecov"
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v3
 
   unit-test-fastjson2:
     needs: [build-source, unit-test-prepare]
@@ -204,7 +204,7 @@ jobs:
         if: ${{ startsWith( matrix.os, 'windows') }}
         run: ./mvnw --batch-mode --no-snapshot-updates -e --no-transfer-progress --fail-fast clean test verify -Pjacoco -D"http.keepAlive=false" -D"maven.wagon.http.pool=false" -D"maven.wagon.httpconnectionManager.ttlSeconds=120" -D"maven.wagon.http.retryHandler.count=5" -DskipTests=false -DskipIntegrationTests=true -D"checkstyle.skip=false" -D"checkstyle_unix.skip=true" -D"rat.skip=false" -D"maven.javadoc.skip=true" -D"embeddedZookeeperPath=${{ github.workspace }}/.tmp/zookeeper"
       - name: "Upload coverage to Codecov"
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v3
 
   integration-test-prepare:
     runs-on: ubuntu-20.04

--- a/.github/workflows/release-test-3.1.yml
+++ b/.github/workflows/release-test-3.1.yml
@@ -23,23 +23,24 @@ env:
 
 jobs:
   license:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Check License
         uses: apache/skywalking-eyes@main
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   build-source:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.dubbo-version.outputs.version }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           path: dubbo
-      - uses: actions/setup-java@v1
+      - uses: actions/setup-java@v3
         with:
+          distribution: 'zulu'
           java-version: 8
       - uses: actions/cache@v2
         name: "Cache local Maven repository"
@@ -89,7 +90,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-20.04, windows-2019 ]
+        os: [ ubuntu-latest, windows-2019 ]
     env:
       ZOOKEEPER_VERSION: 3.6.3
     steps:
@@ -139,16 +140,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-20.04, windows-2019 ]
+        os: [ ubuntu-latest, windows-2019 ]
         jdk: [ 8, 11, 17, 19 ]
     env:
       DISABLE_FILE_SYSTEM_TEST: true
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: "Set up JDK ${{ matrix.jdk }}"
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
           java-version: ${{ matrix.jdk }}
+          distribution: 'zulu'
       - uses: actions/cache@v2
         name: "Cache local Maven repository"
         with:
@@ -175,17 +177,18 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-20.04, windows-2019 ]
+        os: [ ubuntu-latest, windows-2019 ]
         jdk: [ 8, 11, 17, 19 ]
     env:
       DISABLE_FILE_SYSTEM_TEST: true
       DUBBO_DEFAULT_SERIALIZATION: fastjson2
       MAVEN_SUREFIRE_ADD_OPENS: true
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: "Set up JDK ${{ matrix.jdk }}"
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
+          distribution: 'zulu'
           java-version: ${{ matrix.jdk }}
       - uses: actions/cache@v2
         name: "Cache local Maven repository"
@@ -207,11 +210,11 @@ jobs:
         uses: codecov/codecov-action@v3
 
   integration-test-prepare:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env:
       JOB_COUNT: 3
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           repository: 'apache/dubbo-samples'
           ref: master
@@ -226,8 +229,8 @@ jobs:
 
   integration-test-job:
     needs: [build-source, integration-test-prepare]
-    name: "Integration Test on ubuntu-20.04 (JobId: ${{matrix.job_id}})"
-    runs-on: ubuntu-20.04
+    name: "Integration Test on ubuntu-latest (JobId: ${{matrix.job_id}})"
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     env:
       JAVA_VER: 8
@@ -237,7 +240,7 @@ jobs:
       matrix:
         job_id: [1, 2, 3]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           repository: 'apache/dubbo-samples'
           ref: master
@@ -263,9 +266,10 @@ jobs:
           name: test-list
           path: test/jobs/
       - name: "Set up JDK 8"
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
           java-version: 8
+          distribution: 'zulu'
       - name: "Init Candidate Versions"
         run: |
           DUBBO_VERSION="${{needs.build-source.outputs.version}}"
@@ -286,11 +290,11 @@ jobs:
   integration-test-result:
     needs: [integration-test-job]
     if: always()
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env:
       JAVA_VER: 8
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           repository: 'apache/dubbo-samples'
           ref: master
@@ -306,20 +310,21 @@ jobs:
   error-code-inspecting:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           path: "./dubbo"
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           repository: 'apache/dubbo-test-tools'
           ref: main
           path: "./dubbo-test-tools"
 
       - name: "Set up JDK 17"
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
           java-version: 17
+          distribution: 'zulu'
 
       - name: "Compile Dubbo (Linux)"
         run: |

--- a/.github/workflows/release-test-3.1.yml
+++ b/.github/workflows/release-test-3.1.yml
@@ -81,7 +81,7 @@ jobs:
         id: dubbo-version
         run: |
           REVISION=`awk '/<revision>[^<]+<\/revision>/{gsub(/<revision>|<\/revision>/,"",$1);print $1;exit;}' ./dubbo/pom.xml`
-          echo "::set-output name=version::$REVISION"
+          echo "version=$REVISION" >> $GITHUB_OUTPUT
           echo "dubbo version: $REVISION"
 
   unit-test-prepare:

--- a/.github/workflows/release-test-3.1.yml
+++ b/.github/workflows/release-test-3.1.yml
@@ -42,7 +42,7 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: 8
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         name: "Cache local Maven repository"
         with:
           path: ~/.m2/repository
@@ -51,7 +51,7 @@ jobs:
             ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
             ${{ runner.os }}-maven-
       - name: "Dubbo cache"
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.m2/repository/org/apache/dubbo
           key: ${{ runner.os }}-dubbo-snapshot-${{ github.sha }}-${{ github.run_id }}
@@ -90,11 +90,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, windows-2019 ]
+        os: [ ubuntu-latest, windows-latest ]
     env:
       ZOOKEEPER_VERSION: 3.6.3
     steps:
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         name: "Cache zookeeper binary archive"
         id: "cache-zookeeper"
         with:
@@ -140,7 +140,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, windows-2019 ]
+        os: [ ubuntu-latest, windows-latest ]
         jdk: [ 8, 11, 17, 19 ]
     env:
       DISABLE_FILE_SYSTEM_TEST: true
@@ -151,7 +151,7 @@ jobs:
         with:
           java-version: ${{ matrix.jdk }}
           distribution: 'zulu'
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         name: "Cache local Maven repository"
         with:
           path: ~/.m2/repository
@@ -177,7 +177,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, windows-2019 ]
+        os: [ ubuntu-latest, windows-latest ]
         jdk: [ 8, 11, 17, 19 ]
     env:
       DISABLE_FILE_SYSTEM_TEST: true
@@ -190,7 +190,7 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: ${{ matrix.jdk }}
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         name: "Cache local Maven repository"
         with:
           path: ~/.m2/repository
@@ -245,7 +245,7 @@ jobs:
           repository: 'apache/dubbo-samples'
           ref: master
       - name: "Cache local Maven repository"
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}-${{ github.run_id }}
@@ -253,7 +253,7 @@ jobs:
             ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
             ${{ runner.os }}-maven-
       - name: "Restore Dubbo cache"
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.m2/repository/org/apache/dubbo
           key: ${{ runner.os }}-dubbo-snapshot-${{ github.sha }}-${{ github.run_id }}


### PR DESCRIPTION
## What is the purpose of the change
With Node.js 12.x has been out of support <sup>[1]</sup>, it's recommended for us to upgrade all GitHub Actions to the version that uses Node.js 16.x.

[1] https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

Due to the statement in #10788 : 

_The codecov actions will not be updated in this PR since I don't have the token to test. It will be updated by a separate PR._

This PR does the remaining thing.


## Brief changelog
Update some actions versions in workflow files.
