### PR TITLE
Port Unification is disabled by default, and the spi key implemented by Netty4 port unification is changed

### DIFF
--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/ServiceConfig.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/ServiceConfig.java
@@ -599,23 +599,27 @@ public class ServiceConfig<T> extends ServiceConfigBase<T> {
                 // export to extra protocol is used in remote export
                 String extProtocol = url.getParameter("ext.protocol", "");
                 List<String> protocols = new ArrayList<>();
-                // export original url
-                url = URLBuilder.from(url).
-                    addParameter(IS_PU_SERVER_KEY, Boolean.TRUE.toString()).
-                    removeParameter("ext.protocol").
-                    build();
+
+                if (StringUtils.isNotBlank(extProtocol)) {
+                    // export original url
+                    url = URLBuilder.from(url).
+                        addParameter(IS_PU_SERVER_KEY, Boolean.TRUE.toString()).
+                        removeParameter("ext.protocol").
+                        build();
+                }
+
                 url = exportRemote(url, registryURLs);
                 if (!isGeneric(generic) && !getScopeModel().isInternal()) {
                     MetadataUtils.publishServiceDefinition(url, providerModel.getServiceModel(), getApplicationModel());
                 }
 
-                if (!extProtocol.equals("")) {
+                if (StringUtils.isNotBlank(extProtocol)) {
                     String[] extProtocols = extProtocol.split(",", -1);
                     protocols.addAll(Arrays.asList(extProtocols));
                 }
                 // export extra protocols
                 for(String protocol : protocols) {
-                    if(!protocol.equals("")){
+                    if(StringUtils.isNotBlank(protocol)){
                         URL localUrl = URLBuilder.from(url).
                             setProtocol(protocol).
                             build();

--- a/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/api/pu/PortUnificationTransporter.java
+++ b/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/api/pu/PortUnificationTransporter.java
@@ -25,7 +25,7 @@ import org.apache.dubbo.remoting.Client;
 import org.apache.dubbo.remoting.Constants;
 import org.apache.dubbo.remoting.RemotingException;
 
-@SPI(value = "netty", scope = ExtensionScope.FRAMEWORK)
+@SPI(value = "netty4", scope = ExtensionScope.FRAMEWORK)
 public interface PortUnificationTransporter {
 
     @Adaptive({Constants.SERVER_KEY, Constants.TRANSPORTER_KEY})

--- a/dubbo-remoting/dubbo-remoting-netty4/src/main/java/org/apache/dubbo/remoting/transport/netty4/NettyPortUnificationTransporter.java
+++ b/dubbo-remoting/dubbo-remoting-netty4/src/main/java/org/apache/dubbo/remoting/transport/netty4/NettyPortUnificationTransporter.java
@@ -25,7 +25,7 @@ import org.apache.dubbo.remoting.api.pu.PortUnificationTransporter;
 
 public class NettyPortUnificationTransporter implements PortUnificationTransporter {
 
-    public static final String NAME = "netty";
+    public static final String NAME = "netty4";
 
     @Override
     public AbstractPortUnificationServer bind(URL url, ChannelHandler handler) throws RemotingException {

--- a/dubbo-remoting/dubbo-remoting-netty4/src/main/resources/META-INF/dubbo/internal/org.apache.dubbo.remoting.api.pu.PortUnificationTransporter
+++ b/dubbo-remoting/dubbo-remoting-netty4/src/main/resources/META-INF/dubbo/internal/org.apache.dubbo.remoting.api.pu.PortUnificationTransporter
@@ -1,1 +1,1 @@
-netty=org.apache.dubbo.remoting.transport.netty4.NettyPortUnificationTransporter
+netty4=org.apache.dubbo.remoting.transport.netty4.NettyPortUnificationTransporter


### PR DESCRIPTION
Signed-off-by: crazyhzm <crazyhzm@gmail.com>

## What is the purpose of the change



## Brief changelog


## Verifying this change


<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [ ] GitHub Actions works fine on your own branch.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
