### PR TITLE
Add payload config for <dubbo:service/>

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/config/AbstractServiceConfig.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/config/AbstractServiceConfig.java
@@ -102,6 +102,11 @@ public abstract class AbstractServiceConfig extends AbstractInterfaceConfig {
     protected String protocolIds;
 
     /**
+     * Max byte length of payload
+     */
+    protected Integer payload;
+
+    /**
      * Max allowed executing times
      */
     private Integer executes;
@@ -332,5 +337,13 @@ public abstract class AbstractServiceConfig extends AbstractInterfaceConfig {
     @Deprecated
     public void setExportAsync(Boolean exportAsync) {
         this.exportAsync = exportAsync;
+    }
+
+    public Integer getPayload() {
+        return payload;
+    }
+
+    public void setPayload(Integer payload) {
+        this.payload = payload;
     }
 }

--- a/dubbo-common/src/main/java/org/apache/dubbo/config/ProviderConfig.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/config/ProviderConfig.java
@@ -99,11 +99,6 @@ public class ProviderConfig extends AbstractServiceConfig {
     private String charset;
 
     /**
-     * Payload max length
-     */
-    private Integer payload;
-
-    /**
      * The network io buffer size
      */
     private Integer buffer;
@@ -292,14 +287,6 @@ public class ProviderConfig extends AbstractServiceConfig {
 
     public void setCharset(String charset) {
         this.charset = charset;
-    }
-
-    public Integer getPayload() {
-        return payload;
-    }
-
-    public void setPayload(Integer payload) {
-        this.payload = payload;
     }
 
     public Integer getBuffer() {

--- a/dubbo-common/src/main/java/org/apache/dubbo/config/annotation/DubboService.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/config/annotation/DubboService.java
@@ -317,4 +317,10 @@ public @interface DubboService {
      * Weather the service is export asynchronously
      */
     boolean exportAsync() default false;
+
+    /**
+     * Max byte length of payload. Default value: 8M.
+     * @return
+     */
+    int payload() default 8 * 1024 * 1024;
 }

--- a/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/ServiceConfigTest.java
+++ b/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/ServiceConfigTest.java
@@ -58,6 +58,7 @@ import static org.apache.dubbo.common.constants.CommonConstants.SIDE_KEY;
 import static org.apache.dubbo.config.Constants.SHUTDOWN_TIMEOUT_KEY;
 import static org.apache.dubbo.remoting.Constants.BIND_IP_KEY;
 import static org.apache.dubbo.remoting.Constants.BIND_PORT_KEY;
+import static org.apache.dubbo.remoting.Constants.PAYLOAD_KEY;
 import static org.apache.dubbo.rpc.Constants.GENERIC_KEY;
 import static org.apache.dubbo.rpc.cluster.Constants.EXPORT_KEY;
 import static org.hamcrest.CoreMatchers.containsString;
@@ -192,6 +193,53 @@ public class ServiceConfigTest {
 
         assertEquals(serviceVersion2, serviceVersion);
         assertEquals(group, group2);
+    }
+
+    @Test
+    public void testProtocolPayload() {
+        ProtocolConfig protocolConfig = new ProtocolConfig();
+        protocolConfig.setName("mockprotocol2");
+        protocolConfig.setPayload(1024);
+        service.setProtocol(protocolConfig);
+        service.export();
+        URL url = service.toUrl();
+        assertThat(url.getParameters(), hasEntry(PAYLOAD_KEY, "1024"));
+    }
+
+    @Test
+    public void testProviderPayload() {
+        service.getProvider().setPayload(1024);
+        service.export();
+        URL url = service.toUrl();
+        assertThat(url.getParameters(), hasEntry(PAYLOAD_KEY, "1024"));
+    }
+
+    @Test
+    public void testServicePayload() {
+        service.setPayload(1024);
+        service.export();
+        URL url = service.toUrl();
+        assertThat(url.getParameters(), hasEntry(PAYLOAD_KEY, "1024"));
+    }
+
+    @Test
+    public void testProviderPayloadMorePriorThanProyocol() {
+        ProtocolConfig protocolConfig = new ProtocolConfig();
+        protocolConfig.setName("mockprotocol2");
+        protocolConfig.setPayload(1024);
+        service.getProvider().setPayload(1042);
+        service.export();
+        URL url = service.toUrl();
+        assertThat(url.getParameters(), hasEntry(PAYLOAD_KEY, "1042"));
+    }
+
+    @Test
+    public void testServicePayloadMorePriorThanProvider() {
+        service.getProvider().setPayload(1024);
+        service.setPayload(1042);
+        service.export();
+        URL url = service.toUrl();
+        assertThat(url.getParameters(), hasEntry(PAYLOAD_KEY, "1042"));
     }
 
     @Test

--- a/dubbo-config/dubbo-config-spring/src/main/resources/META-INF/dubbo.xsd
+++ b/dubbo-config/dubbo-config-spring/src/main/resources/META-INF/dubbo.xsd
@@ -360,6 +360,11 @@
                             <![CDATA[ Weather the service is export asynchronously, default false. ]]></xsd:documentation>
                     </xsd:annotation>
                 </xsd:attribute>
+                <xsd:attribute name="payload" type="xsd:string">
+                    <xsd:annotation>
+                        <xsd:documentation><![CDATA[ The max byte length of payload. ]]></xsd:documentation>
+                    </xsd:annotation>
+                </xsd:attribute>
                 <xsd:anyAttribute namespace="##other" processContents="lax"/>
             </xsd:extension>
         </xsd:complexContent>
@@ -1523,11 +1528,6 @@
                 <xsd:attribute name="charset" type="xsd:string">
                     <xsd:annotation>
                         <xsd:documentation><![CDATA[ The protocol charset. ]]></xsd:documentation>
-                    </xsd:annotation>
-                </xsd:attribute>
-                <xsd:attribute name="payload" type="xsd:string">
-                    <xsd:annotation>
-                        <xsd:documentation><![CDATA[ The max payload. ]]></xsd:documentation>
                     </xsd:annotation>
                 </xsd:attribute>
                 <xsd:attribute name="buffer" type="xsd:string">

--- a/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/ConfigTest.java
+++ b/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/ConfigTest.java
@@ -368,6 +368,20 @@ public class ConfigTest {
     }
 
     @Test
+    public void testPayloadInProviderXml() {
+        ClassPathXmlApplicationContext providerContext = new ClassPathXmlApplicationContext(
+            resourcePath + "/demo-provider.xml",
+            resourcePath + "/demo-provider-properties.xml");
+        providerContext.start();
+        ProtocolConfig protocolConfig = providerContext.getBean(ProtocolConfig.class);
+        assertEquals(1024, protocolConfig.getPayload());
+        ProviderConfig providerConfig = providerContext.getBean(ProviderConfig.class);
+        assertEquals(1042, providerConfig.getPayload());
+        ServiceConfig serviceConfig = providerContext.getBean("org.apache.dubbo.config.spring.ServiceBean#0", ServiceConfig.class);
+        assertEquals(1402, serviceConfig.getPayload());
+    }
+
+    @Test
     @Disabled("waiting-to-fix")
     public void testAutowireAndAOP() throws Exception {
         ClassPathXmlApplicationContext providerContext = new ClassPathXmlApplicationContext(

--- a/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/JavaConfigBeanTest.java
+++ b/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/JavaConfigBeanTest.java
@@ -21,6 +21,7 @@ import org.apache.dubbo.config.ConsumerConfig;
 import org.apache.dubbo.config.ProtocolConfig;
 import org.apache.dubbo.config.ReferenceConfig;
 import org.apache.dubbo.config.RegistryConfig;
+import org.apache.dubbo.config.ServiceConfig;
 import org.apache.dubbo.config.annotation.DubboReference;
 import org.apache.dubbo.config.annotation.DubboService;
 import org.apache.dubbo.config.bootstrap.DubboBootstrap;
@@ -89,6 +90,10 @@ public class JavaConfigBeanTest {
             Assertions.assertEquals("dubbo", protocolConfig.getName());
             Assertions.assertEquals(2346, protocolConfig.getPort());
             Assertions.assertEquals(MY_PROTOCOL_ID, protocolConfig.getId());
+
+            ServiceConfig serviceConfig = consumerContext.getBean(ServiceConfig.class);
+            Assertions.assertEquals("demo", serviceConfig.getGroup());
+            Assertions.assertEquals(1024, serviceConfig.getPayload());
 
             ApplicationModel applicationModel = consumerContext.getBean(ApplicationModel.class);
             ModuleConfigManager moduleConfigManager = applicationModel.getDefaultModule().getConfigManager();
@@ -173,7 +178,7 @@ public class JavaConfigBeanTest {
     static class ProviderConfiguration {
 
         @Bean
-        @DubboService(group = "demo")
+        @DubboService(group = "demo", payload = 1024)
         public DemoService demoServiceImpl() {
             return new DemoServiceImpl();
         }

--- a/dubbo-config/dubbo-config-spring/src/test/resources/org/apache/dubbo/config/spring/demo-provider.xml
+++ b/dubbo-config/dubbo-config-spring/src/test/resources/org/apache/dubbo/config/spring/demo-provider.xml
@@ -27,10 +27,12 @@
     <dubbo:registry address="${dubbo.registry.address:foo-address}"/>
 
     <!-- service protocol configuration -->
-    <dubbo:protocol name="${dubbo.protocol.name:foo-protocol}" port="${dubbo.protocol.port:20881}"/>
+    <dubbo:protocol name="${dubbo.protocol.name:foo-protocol}" port="${dubbo.protocol.port:20881}" payload="1024"/>
+
+    <dubbo:provider payload="1042"/>
 
     <!-- service configuration -->
-    <dubbo:service interface="org.apache.dubbo.config.spring.api.DemoService" group="demo" version="1.2.3" ref="demoService"/>
+    <dubbo:service interface="org.apache.dubbo.config.spring.api.DemoService" group="demo" version="1.2.3" ref="demoService" payload="1402"/>
 
     <dubbo:service interface="org.apache.dubbo.config.spring.api.DemoService" group="demo" version="1.2.4" ref="demoService"/>
 


### PR DESCRIPTION
## What is the purpose of the change
Fixes a part of #10773

## Brief changelog
Support to specify payload limit for `<dubbo:service/>`. User can configure a different payload with the payload in `<dubbo:protocol>` or `<dubbo:provider>` for `<dubbo:service/>` if it is needed.

## Verifying this change
Run the related unit tests.

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [x] Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [ ] GitHub Actions works fine on your own branch.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
