### PR TITLE
Fix the warning problem when invokerUrls is checked

### DIFF
--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/integration/RegistryDirectory.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/integration/RegistryDirectory.java
@@ -232,7 +232,7 @@ public class RegistryDirectory<T> extends DynamicDirectory<T> {
             // use local reference to avoid NPE as this.cachedInvokerUrls will be set null by destroyAllInvokers().
             Set<URL> localCachedInvokerUrls = this.cachedInvokerUrls;
             if (invokerUrls.isEmpty()) {
-                if(localCachedInvokerUrls != null){
+                if(CollectionUtils.isNotEmpty(localCachedInvokerUrls)){
                     // 1-4 Empty address.
                     logger.warn(REGISTRY_EMPTY_ADDRESS, "configuration ", "",
                         "Service" + serviceKey + " received empty address list with no EMPTY protocol set, trigger empty protection.");

--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/integration/RegistryDirectory.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/integration/RegistryDirectory.java
@@ -231,14 +231,14 @@ public class RegistryDirectory<T> extends DynamicDirectory<T> {
             }
             // use local reference to avoid NPE as this.cachedInvokerUrls will be set null by destroyAllInvokers().
             Set<URL> localCachedInvokerUrls = this.cachedInvokerUrls;
-            if (invokerUrls.isEmpty() && localCachedInvokerUrls != null) {
+            if (invokerUrls.isEmpty()) {
+                if(localCachedInvokerUrls != null){
+                    // 1-4 Empty address.
+                    logger.warn(REGISTRY_EMPTY_ADDRESS, "configuration ", "",
+                        "Service" + serviceKey + " received empty address list with no EMPTY protocol set, trigger empty protection.");
 
-                // 1-4 Empty address.
-                logger.warn(REGISTRY_EMPTY_ADDRESS, "configuration ", "",
-                    "Service" + serviceKey + " received empty address list with no EMPTY protocol set, trigger empty protection.");
-
-                invokerUrls.addAll(localCachedInvokerUrls);
-
+                    invokerUrls.addAll(localCachedInvokerUrls);
+                }
             } else {
                 localCachedInvokerUrls = new HashSet<>();
                 localCachedInvokerUrls.addAll(invokerUrls);//Cached invoker urls, convenient for comparison


### PR DESCRIPTION
## What is the purpose of the change

Fix the warning problem when invokerUrls is checked

## Brief changelog

dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/integration/RegistryDirectory.java

## Verifying this change

<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [x] Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [x] GitHub Actions works fine on your own branch.
- [x] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
