### PR TITLE
Support for Spring Framework 6 and Spring Boot 3

### DIFF
--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -76,6 +76,7 @@ header:
     - 'dubbo-common/src/main/java/org/apache/dubbo/common/utils/CIDRUtils.java'
     - 'dubbo-common/src/main/java/org/apache/dubbo/common/utils/Utf8Utils.java'
     - 'dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/EmbeddedZooKeeper.java'
+    - 'dubbo-test/dubbo-test-common/src/main/java/org/apache/dubbo/test/common/utils/TestSocketUtils.java'
 
   comment: on-failure
 

--- a/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/beans/factory/annotation/ReferenceAnnotationBeanPostProcessor.java
+++ b/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/beans/factory/annotation/ReferenceAnnotationBeanPostProcessor.java
@@ -307,9 +307,8 @@ public class ReferenceAnnotationBeanPostProcessor extends AbstractAnnotationBean
     }
 
     @Override
-    public PropertyValues postProcessPropertyValues(
-            PropertyValues pvs, PropertyDescriptor[] pds, Object bean, String beanName) throws BeansException {
-
+    public PropertyValues postProcessProperties(PropertyValues pvs, Object bean, String beanName)
+        throws BeansException {
         try {
             AnnotatedInjectionMetadata metadata = findInjectionMetadata(beanName, bean.getClass(), pvs);
             prepareInjection(metadata);
@@ -318,7 +317,7 @@ public class ReferenceAnnotationBeanPostProcessor extends AbstractAnnotationBean
             throw ex;
         } catch (Throwable ex) {
             throw new BeanCreationException(beanName, "Injection of @" + getAnnotationType().getSimpleName()
-                    + " dependencies is failed", ex);
+                + " dependencies is failed", ex);
         }
         return pvs;
     }
@@ -507,7 +506,7 @@ public class ReferenceAnnotationBeanPostProcessor extends AbstractAnnotationBean
 
     /**
      * Gets all beans of {@link ReferenceBean}
-     * @deprecated  use {@link ReferenceBeanManager.getReferences()} instead
+     * @deprecated use {@link ReferenceBeanManager.getReferences()} instead
      */
     @Deprecated
     public Collection<ReferenceBean<?>> getReferenceBeans() {

--- a/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/beans/factory/annotation/ReferenceAnnotationBeanPostProcessor.java
+++ b/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/beans/factory/annotation/ReferenceAnnotationBeanPostProcessor.java
@@ -51,6 +51,7 @@ import org.springframework.context.ApplicationContextAware;
 import org.springframework.core.annotation.AnnotationAttributes;
 import org.springframework.core.type.MethodMetadata;
 
+import java.beans.PropertyDescriptor;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Member;
 import java.util.Collection;
@@ -305,6 +306,21 @@ public class ReferenceAnnotationBeanPostProcessor extends AbstractAnnotationBean
         }
     }
 
+    /**
+     * Alternatives to the {@link #postProcessProperties(PropertyValues, Object, String)}, that removed as of Spring
+     * Framework 6.0.0, and in favor of {@link #postProcessProperties(PropertyValues, Object, String)}.
+     * <p>In order to be compatible with the lower version of Spring, it is still retained.
+     * @see #postProcessProperties
+     */
+    public PropertyValues postProcessPropertyValues(
+        PropertyValues pvs, PropertyDescriptor[] pds, Object bean, String beanName) throws BeansException {
+        return postProcessProperties(pvs, bean, beanName);
+    }
+
+    /**
+     * Alternatives to the {@link #postProcessPropertyValues(PropertyValues, PropertyDescriptor[], Object, String)}.
+     * @see #postProcessPropertyValues
+     */
     @Override
     public PropertyValues postProcessProperties(PropertyValues pvs, Object bean, String beanName)
         throws BeansException {

--- a/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/beans/factory/annotation/ReferenceAnnotationBeanPostProcessor.java
+++ b/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/beans/factory/annotation/ReferenceAnnotationBeanPostProcessor.java
@@ -51,7 +51,6 @@ import org.springframework.context.ApplicationContextAware;
 import org.springframework.core.annotation.AnnotationAttributes;
 import org.springframework.core.type.MethodMetadata;
 
-import java.beans.PropertyDescriptor;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Member;
 import java.util.Collection;
@@ -317,7 +316,7 @@ public class ReferenceAnnotationBeanPostProcessor extends AbstractAnnotationBean
             throw ex;
         } catch (Throwable ex) {
             throw new BeanCreationException(beanName, "Injection of @" + getAnnotationType().getSimpleName()
-                + " dependencies is failed", ex);
+                    + " dependencies is failed", ex);
         }
         return pvs;
     }
@@ -506,7 +505,7 @@ public class ReferenceAnnotationBeanPostProcessor extends AbstractAnnotationBean
 
     /**
      * Gets all beans of {@link ReferenceBean}
-     * @deprecated use {@link ReferenceBeanManager.getReferences()} instead
+     * @deprecated use {@link ReferenceBeanManager#getReferences()} instead
      */
     @Deprecated
     public Collection<ReferenceBean<?>> getReferenceBeans() {

--- a/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/EmbeddedZooKeeper.java
+++ b/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/EmbeddedZooKeeper.java
@@ -17,12 +17,12 @@ package org.apache.dubbo.config.spring;
 
 import org.apache.dubbo.common.logger.ErrorTypeAwareLogger;
 import org.apache.dubbo.common.logger.LoggerFactory;
+import org.apache.dubbo.test.common.utils.TestSocketUtils;
 import org.apache.zookeeper.server.ServerConfig;
 import org.apache.zookeeper.server.ZooKeeperServerMain;
 import org.apache.zookeeper.server.quorum.QuorumPeerConfig;
 import org.springframework.context.SmartLifecycle;
 import org.springframework.util.ErrorHandler;
-import org.springframework.util.SocketUtils;
 
 import java.io.File;
 import java.lang.reflect.Method;
@@ -83,7 +83,7 @@ public class EmbeddedZooKeeper implements SmartLifecycle {
      * Construct an EmbeddedZooKeeper with a random port.
      */
     public EmbeddedZooKeeper() {
-        clientPort = SocketUtils.findAvailableTcpPort();
+        clientPort = TestSocketUtils.findAvailableTcpPort();
     }
 
     /**

--- a/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/issues/issue6000/adubbo/HelloDubbo.java
+++ b/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/issues/issue6000/adubbo/HelloDubbo.java
@@ -18,14 +18,14 @@ package org.apache.dubbo.config.spring.issues.issue6000.adubbo;
 
 import org.apache.dubbo.config.spring.api.HelloService;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-
-import javax.annotation.Resource;
 
 @Component
 public class HelloDubbo {
     HelloService helloService;
-    @Resource
+
+    @Autowired
     public void setHelloService(HelloService helloService) {
         this.helloService = helloService;
     }

--- a/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/reference/ReferenceKeyTest.java
+++ b/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/reference/ReferenceKeyTest.java
@@ -164,7 +164,7 @@ public class ReferenceKeyTest {
             Map<String, ReferenceBean> referenceBeanMap = context.getBeansOfType(ReferenceBean.class);
             Assertions.fail("Reference bean check failed");
         } catch (BeansException e) {
-            Assertions.assertTrue(e.getMessage().contains("Duplicate spring bean name: demoService"), getStackTrace(e));
+            Assertions.assertTrue(getStackTrace(e).contains("Duplicate spring bean name: demoService"));
         }
     }
 

--- a/dubbo-config/pom.xml
+++ b/dubbo-config/pom.xml
@@ -41,5 +41,11 @@
             <version>${project.parent.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.dubbo</groupId>
+            <artifactId>dubbo-test-common</artifactId>
+            <version>${project.parent.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/dubbo-spring-boot/dubbo-spring-boot-actuator/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/dubbo-spring-boot/dubbo-spring-boot-actuator/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+org.apache.dubbo.spring.boot.actuate.autoconfigure.DubboEndpointAnnotationAutoConfiguration

--- a/dubbo-spring-boot/dubbo-spring-boot-autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/dubbo-spring-boot/dubbo-spring-boot-autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+org.apache.dubbo.spring.boot.autoconfigure.DubboRelaxedBinding2AutoConfiguration

--- a/dubbo-spring-boot/dubbo-spring-boot-compatible/actuator/src/main/resources/META-INF/spring/org.springframework.boot.actuate.autoconfigure.web.ManagementContextConfiguration.imports
+++ b/dubbo-spring-boot/dubbo-spring-boot-compatible/actuator/src/main/resources/META-INF/spring/org.springframework.boot.actuate.autoconfigure.web.ManagementContextConfiguration.imports
@@ -1,0 +1,1 @@
+org.apache.dubbo.spring.boot.actuate.autoconfigure.DubboMvcEndpointManagementContextConfiguration

--- a/dubbo-spring-boot/dubbo-spring-boot-compatible/actuator/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/dubbo-spring-boot/dubbo-spring-boot-compatible/actuator/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,3 @@
+org.apache.dubbo.spring.boot.actuate.autoconfigure.DubboEndpointAutoConfiguration
+org.apache.dubbo.spring.boot.actuate.autoconfigure.DubboHealthIndicatorAutoConfiguration
+org.apache.dubbo.spring.boot.actuate.autoconfigure.DubboEndpointMetadataAutoConfiguration

--- a/dubbo-spring-boot/dubbo-spring-boot-compatible/autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/dubbo-spring-boot/dubbo-spring-boot-compatible/autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,3 @@
+org.apache.dubbo.spring.boot.autoconfigure.DubboAutoConfiguration
+org.apache.dubbo.spring.boot.autoconfigure.DubboRelaxedBindingAutoConfiguration
+org.apache.dubbo.spring.boot.autoconfigure.DubboListenerAutoConfiguration

--- a/dubbo-test/dubbo-test-common/src/main/java/org/apache/dubbo/test/common/utils/TestSocketUtils.java
+++ b/dubbo-test/dubbo-test-common/src/main/java/org/apache/dubbo/test/common/utils/TestSocketUtils.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2002-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.test.common.utils;
+
+import java.net.InetAddress;
+import java.net.ServerSocket;
+import java.security.SecureRandom;
+
+import javax.net.ServerSocketFactory;
+
+import org.apache.dubbo.common.utils.Assert;
+
+/**
+ * Simple utility for finding available TCP ports on {@code localhost} for use in
+ * integration testing scenarios.
+ *
+ * <p>{@code TestSocketUtils} can be used in integration tests which start an
+ * external server on an available random port. However, these utilities make no
+ * guarantee about the subsequent availability of a given port and are therefore
+ * unreliable. Instead of using {@code TestSocketUtils} to find an available local
+ * port for a server, it is recommended that you rely on a server's ability to
+ * start on a random <em>ephemeral</em> port that it selects or is assigned by the
+ * operating system. To interact with that server, you should query the server
+ * for the port it is currently using.
+ *
+ * @since 3.2
+ */
+public class TestSocketUtils {
+
+    /**
+     * The minimum value for port ranges used when finding an available TCP port.
+     */
+    static final int PORT_RANGE_MIN = 1024;
+
+    /**
+     * The maximum value for port ranges used when finding an available TCP port.
+     */
+    static final int PORT_RANGE_MAX = 65535;
+
+    private static final int PORT_RANGE_PLUS_ONE = PORT_RANGE_MAX - PORT_RANGE_MIN + 1;
+
+    private static final int MAX_ATTEMPTS = 1_000;
+
+    private static final SecureRandom random = new SecureRandom();
+
+    private static final TestSocketUtils INSTANCE = new TestSocketUtils();
+
+    private TestSocketUtils() {
+    }
+
+    /**
+     * Find an available TCP port randomly selected from the range [1024, 65535].
+     * @return an available TCP port number
+     * @throws IllegalStateException if no available port could be found
+     */
+    public static int findAvailableTcpPort() {
+        return INSTANCE.findAvailableTcpPortInternal();
+    }
+
+
+    /**
+     * Internal implementation of {@link #findAvailableTcpPort()}.
+     * <p>Package-private solely for testing purposes.
+     */
+    int findAvailableTcpPortInternal() {
+        int candidatePort;
+        int searchCounter = 0;
+        do {
+            Assert.assertTrue(++searchCounter <= MAX_ATTEMPTS, String.format(
+                "Could not find an available TCP port in the range [%d, %d] after %d attempts",
+                PORT_RANGE_MIN, PORT_RANGE_MAX, MAX_ATTEMPTS));
+            candidatePort = PORT_RANGE_MIN + random.nextInt(PORT_RANGE_PLUS_ONE);
+        }
+        while (!isPortAvailable(candidatePort));
+
+        return candidatePort;
+    }
+
+    /**
+     * Determine if the specified TCP port is currently available on {@code localhost}.
+     * <p>Package-private solely for testing purposes.
+     */
+    boolean isPortAvailable(int port) {
+        try {
+            ServerSocket serverSocket = ServerSocketFactory.getDefault()
+                .createServerSocket(port, 1, InetAddress.getByName("localhost"));
+            serverSocket.close();
+            return true;
+        }
+        catch (Exception ex) {
+            return false;
+        }
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -327,6 +327,7 @@
                                         **/org/apache/dubbo/common/utils/Utf8Utils.java,
                                         **/org/apache/dubbo/common/serialize/protobuf/support/wrapper/MapValue.java,
                                         **/org/apache/dubbo/common/serialize/protobuf/support/wrapper/ThrowablePB.java,
+                                        **/org/apache/dubbo/test/common/utils/TestSocketUtils.java,
                                         **/org/apache/dubbo/triple/TripleWrapper.java,
                                         **/istio/v1/auth/**/*,
                                         **/com/google/rpc/*,


### PR DESCRIPTION
This commit is closing [gh-10565](https://github.com/apache/dubbo/issues/10565) 

## What is the purpose of the change
- [x] Support for Spring Framework 6.0.0
- [x] Support for Spring Boot 3.0.0
  - Support new Auto-configuration mechanism in Spring Boot 3
  Since Spring Boot 3, loading Auto-configuration classes is supported with `.imports` files only.
  In order to be compatible with the lower version of Spring Boot, we have retained the `spring.factories` file
- [x] Enhance `ReferenceAnnotationBeanPostProcessor` to be compatible with Spring & Spring Boot lower versions
- [x] Introduce `TestSocketUtils` to replace `SocketUtils`

<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [x] Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [x] GitHub Actions works fine on your own branch.
- [x] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
