### PR TITLE
Fix ApplicationConfig.enableFileCache default value is not true (#10880)

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/config/ApplicationConfig.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/config/ApplicationConfig.java
@@ -244,6 +244,9 @@ public class ApplicationConfig extends AbstractConfig {
         if (executorManagementMode == null) {
             executorManagementMode = EXECUTOR_MANAGEMENT_MODE_DEFAULT;
         }
+        if (enableFileCache == null) {
+            enableFileCache = Boolean.TRUE;
+        }
     }
 
     @Parameter(key = APPLICATION_KEY, required = true)

--- a/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/ApplicationConfigTest.java
+++ b/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/ApplicationConfigTest.java
@@ -29,7 +29,9 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.apache.dubbo.common.constants.CommonConstants.APPLICATION_KEY;
+import static org.apache.dubbo.common.constants.CommonConstants.DUBBO;
 import static org.apache.dubbo.common.constants.CommonConstants.DUMP_DIRECTORY;
+import static org.apache.dubbo.common.constants.CommonConstants.EXECUTOR_MANAGEMENT_MODE_DEFAULT;
 import static org.apache.dubbo.common.constants.QosConstants.ACCEPT_FOREIGN_IP;
 import static org.apache.dubbo.common.constants.QosConstants.QOS_ENABLE;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -330,6 +332,22 @@ class ApplicationConfigTest {
         Assertions.assertEquals("127.0.0.1", applicationConfig.getQosHost());
         Assertions.assertEquals(2345, applicationConfig.getQosPort());
         Assertions.assertEquals("demo-app", applicationConfig.getName());
+
+        DubboBootstrap.getInstance().destroy();
+    }
+
+    @Test
+    void testDefaultValue() {
+        SysProps.setProperty("dubbo.application.NAME", "demo-app");
+
+        DubboBootstrap.getInstance()
+            .initialize();
+
+        ApplicationConfig applicationConfig = DubboBootstrap.getInstance().getApplication();
+
+        Assertions.assertEquals(DUBBO, applicationConfig.getProtocol());
+        Assertions.assertEquals(EXECUTOR_MANAGEMENT_MODE_DEFAULT, applicationConfig.getExecutorManagementMode());
+        Assertions.assertEquals(Boolean.TRUE, applicationConfig.getEnableFileCache());
 
         DubboBootstrap.getInstance().destroy();
     }

--- a/dubbo-config/dubbo-config-api/src/test/resources/dubbo.properties
+++ b/dubbo-config/dubbo-config-api/src/test/resources/dubbo.properties
@@ -1,4 +1,3 @@
 dubbo.override.key2=properties
 dubbo.override.protocol=properties
-dubbo.application.enable-file-cache=false
 dubbo.service.shutdown.wait=200


### PR DESCRIPTION
## What is the purpose of the change
fix #10880


## Brief changelog
Set  `true`  as  default value  of ApplicationConfig.enableFileCache  

## Verifying this change

<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [x] Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [x] GitHub Actions works fine on your own branch.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
