### PR TITLE
Fix data being updated by default ticket

### DIFF
--- a/dubbo-metadata/dubbo-metadata-report-zookeeper/src/main/java/org/apache/dubbo/metadata/store/zookeeper/ZookeeperMetadataReport.java
+++ b/dubbo-metadata/dubbo-metadata-report-zookeeper/src/main/java/org/apache/dubbo/metadata/store/zookeeper/ZookeeperMetadataReport.java
@@ -198,7 +198,7 @@ public class ZookeeperMetadataReport extends AbstractMetadataReport {
                 throw new IllegalArgumentException("zookeeper publishConfigCas requires stat type ticket");
             }
             String pathKey = buildPathKey(group, key);
-            zkClient.createOrUpdate(pathKey, content, false, ticket == null ? 0 : ((Stat) ticket).getVersion());
+            zkClient.createOrUpdate(pathKey, content, false, ticket == null ? null : ((Stat) ticket).getVersion());
             return true;
         } catch (Exception e) {
             logger.warn(REGISTRY_ZOOKEEPER_EXCEPTION, "", "", "zookeeper publishConfigCas failed.", e);

--- a/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/zookeeper/AbstractZookeeperClient.java
+++ b/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/zookeeper/AbstractZookeeperClient.java
@@ -178,7 +178,7 @@ public abstract class AbstractZookeeperClient<TargetDataListener, TargetChildLis
     }
 
     @Override
-    public void createOrUpdate(String path, String content, boolean ephemeral, int version) {
+    public void createOrUpdate(String path, String content, boolean ephemeral, Integer version) {
         int i = path.lastIndexOf('/');
         if (i > 0) {
             create(path.substring(0, i), false, true);
@@ -224,9 +224,9 @@ public abstract class AbstractZookeeperClient<TargetDataListener, TargetChildLis
 
     protected abstract void createOrUpdateEphemeral(String path, String data);
 
-    protected abstract void createOrUpdatePersistent(String path, String data, int version);
+    protected abstract void createOrUpdatePersistent(String path, String data, Integer version);
 
-    protected abstract void createOrUpdateEphemeral(String path, String data, int version);
+    protected abstract void createOrUpdateEphemeral(String path, String data, Integer version);
 
     @Override
     public abstract boolean checkExists(String path);

--- a/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/zookeeper/ZookeeperClient.java
+++ b/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/zookeeper/ZookeeperClient.java
@@ -110,7 +110,7 @@ public interface ZookeeperClient {
      * @param ephemeral specify create mode of ZNode creation. true - EPHEMERAL, false - PERSISTENT.
      * @param ticket origin content version, if current version is not the specified version, throw exception
      */
-    void createOrUpdate(String path, String content, boolean ephemeral, int ticket);
+    void createOrUpdate(String path, String content, boolean ephemeral, Integer ticket);
 
     /**
      * Obtain the content of a ZNode.

--- a/dubbo-remoting/dubbo-remoting-zookeeper-curator5/src/main/java/org/apache/dubbo/remoting/zookeeper/curator5/Curator5ZookeeperClient.java
+++ b/dubbo-remoting/dubbo-remoting-zookeeper-curator5/src/main/java/org/apache/dubbo/remoting/zookeeper/curator5/Curator5ZookeeperClient.java
@@ -240,9 +240,9 @@ public class Curator5ZookeeperClient extends AbstractZookeeperClient<Curator5Zoo
     }
 
     @Override
-    protected void createOrUpdatePersistent(String path, String data, int version) {
+    protected void createOrUpdatePersistent(String path, String data, Integer version) {
         try {
-            if (checkExists(path)) {
+            if (checkExists(path) && version != null) {
                 update(path, data, version);
             } else {
                 createPersistent(path, data, false);
@@ -253,9 +253,9 @@ public class Curator5ZookeeperClient extends AbstractZookeeperClient<Curator5Zoo
     }
 
     @Override
-    protected void createOrUpdateEphemeral(String path, String data, int version) {
+    protected void createOrUpdateEphemeral(String path, String data, Integer version) {
         try {
-            if (checkExists(path)) {
+            if (checkExists(path) && version != null) {
                 update(path, data, version);
             } else {
                 createEphemeral(path, data, false);

--- a/dubbo-remoting/dubbo-remoting-zookeeper-curator5/src/test/java/org/apache/dubbo/remoting/zookeeper/curator5/Curator5ZookeeperClientTest.java
+++ b/dubbo-remoting/dubbo-remoting-zookeeper-curator5/src/test/java/org/apache/dubbo/remoting/zookeeper/curator5/Curator5ZookeeperClientTest.java
@@ -223,7 +223,8 @@ class Curator5ZookeeperClientTest {
     }
 
     @Test
-    void testPersistentCas() throws Exception {
+    void testPersistentCas1() throws Exception {
+        // test create failed when others create success
         String path = "/dubbo/mapping/org.apache.dubbo.demo.DemoService";
         AtomicReference<Runnable> runnable = new AtomicReference<>();
         Curator5ZookeeperClient curatorClient = new Curator5ZookeeperClient(URL.valueOf(zookeeperConnectionAddress1 + "/org.apache.dubbo.registry.RegistryService")) {
@@ -274,6 +275,20 @@ class Curator5ZookeeperClientTest {
         int version2 = ((Stat) configItem.getTicket()).getVersion();
         curatorClient.createOrUpdate(path, "version 2", false, version2);
         Assertions.assertEquals("version 2", curatorClient.getContent(path));
+
+        curatorClient.close();
+    }
+
+    @Test
+    void testPersistentCas2() throws Exception {
+        // test update failed when others create success
+        String path = "/dubbo/mapping/org.apache.dubbo.demo.DemoService";
+        Curator5ZookeeperClient curatorClient = new Curator5ZookeeperClient(URL.valueOf(zookeeperConnectionAddress1 + "/org.apache.dubbo.registry.RegistryService"));
+        curatorClient.delete(path);
+
+        curatorClient.createOrUpdate(path, "version x", false);
+        Assertions.assertThrows(IllegalStateException.class, () -> curatorClient.createOrUpdate(path, "version 1", false, null));
+        Assertions.assertEquals("version x", curatorClient.getContent(path));
 
         curatorClient.close();
     }
@@ -333,7 +348,8 @@ class Curator5ZookeeperClientTest {
     }
 
     @Test
-    void testEphemeralCas() throws Exception {
+    void testEphemeralCas1() throws Exception {
+        // test create failed when others create success
         String path = "/dubbo/mapping/org.apache.dubbo.demo.DemoService";
         AtomicReference<Runnable> runnable = new AtomicReference<>();
         Curator5ZookeeperClient curatorClient = new Curator5ZookeeperClient(URL.valueOf(zookeeperConnectionAddress1 + "/org.apache.dubbo.registry.RegistryService")) {
@@ -384,6 +400,20 @@ class Curator5ZookeeperClientTest {
         int version2 = ((Stat) configItem.getTicket()).getVersion();
         curatorClient.createOrUpdate(path, "version 2", true, version2);
         Assertions.assertEquals("version 2", curatorClient.getContent(path));
+
+        curatorClient.close();
+    }
+
+    @Test
+    void testEphemeralCas2() throws Exception {
+        // test update failed when others create success
+        String path = "/dubbo/mapping/org.apache.dubbo.demo.DemoService";
+        Curator5ZookeeperClient curatorClient = new Curator5ZookeeperClient(URL.valueOf(zookeeperConnectionAddress1 + "/org.apache.dubbo.registry.RegistryService"));
+        curatorClient.delete(path);
+
+        curatorClient.createOrUpdate(path, "version x", true);
+        Assertions.assertThrows(IllegalStateException.class, () -> curatorClient.createOrUpdate(path, "version 1", true, null));
+        Assertions.assertEquals("version x", curatorClient.getContent(path));
 
         curatorClient.close();
     }

--- a/dubbo-remoting/dubbo-remoting-zookeeper/src/main/java/org/apache/dubbo/remoting/zookeeper/curator/CuratorZookeeperClient.java
+++ b/dubbo-remoting/dubbo-remoting-zookeeper/src/main/java/org/apache/dubbo/remoting/zookeeper/curator/CuratorZookeeperClient.java
@@ -244,9 +244,9 @@ public class CuratorZookeeperClient extends AbstractZookeeperClient<CuratorZooke
     }
 
     @Override
-    protected void createOrUpdatePersistent(String path, String data, int version) {
+    protected void createOrUpdatePersistent(String path, String data, Integer version) {
         try {
-            if (checkExists(path)) {
+            if (checkExists(path) && version != null) {
                 update(path, data, version);
             } else {
                 createPersistent(path, data, false);
@@ -257,9 +257,9 @@ public class CuratorZookeeperClient extends AbstractZookeeperClient<CuratorZooke
     }
 
     @Override
-    protected void createOrUpdateEphemeral(String path, String data, int version) {
+    protected void createOrUpdateEphemeral(String path, String data, Integer version) {
         try {
-            if (checkExists(path)) {
+            if (checkExists(path) && version != null) {
                 update(path, data, version);
             } else {
                 createEphemeral(path, data, false);

--- a/dubbo-remoting/dubbo-remoting-zookeeper/src/test/java/org/apache/dubbo/remoting/zookeeper/curator/CuratorZookeeperClientTest.java
+++ b/dubbo-remoting/dubbo-remoting-zookeeper/src/test/java/org/apache/dubbo/remoting/zookeeper/curator/CuratorZookeeperClientTest.java
@@ -248,7 +248,8 @@ class CuratorZookeeperClientTest {
 
 
     @Test
-    void testPersistentCas() throws Exception {
+    void testPersistentCas1() throws Exception {
+        // test create failed when others create success
         String path = "/dubbo/mapping/org.apache.dubbo.demo.DemoService";
         AtomicReference<Runnable> runnable = new AtomicReference<>();
         CuratorZookeeperClient curatorClient = new CuratorZookeeperClient(URL.valueOf(zookeeperConnectionAddress1 + "/org.apache.dubbo.registry.RegistryService")) {
@@ -299,6 +300,20 @@ class CuratorZookeeperClientTest {
         int version2 = ((Stat) configItem.getTicket()).getVersion();
         curatorClient.createOrUpdate(path, "version 2", false, version2);
         Assertions.assertEquals("version 2", curatorClient.getContent(path));
+
+        curatorClient.close();
+    }
+
+    @Test
+    void testPersistentCas2() throws Exception {
+        // test update failed when others create success
+        String path = "/dubbo/mapping/org.apache.dubbo.demo.DemoService";
+        CuratorZookeeperClient curatorClient = new CuratorZookeeperClient(URL.valueOf(zookeeperConnectionAddress1 + "/org.apache.dubbo.registry.RegistryService"));
+        curatorClient.delete(path);
+
+        curatorClient.createOrUpdate(path, "version x", false);
+        Assertions.assertThrows(IllegalStateException.class, () -> curatorClient.createOrUpdate(path, "version 1", false, null));
+        Assertions.assertEquals("version x", curatorClient.getContent(path));
 
         curatorClient.close();
     }
@@ -358,7 +373,8 @@ class CuratorZookeeperClientTest {
     }
 
     @Test
-    void testEphemeralCas() throws Exception {
+    void testEphemeralCas1() throws Exception {
+        // test create failed when others create success
         String path = "/dubbo/mapping/org.apache.dubbo.demo.DemoService";
         AtomicReference<Runnable> runnable = new AtomicReference<>();
         CuratorZookeeperClient curatorClient = new CuratorZookeeperClient(URL.valueOf(zookeeperConnectionAddress1 + "/org.apache.dubbo.registry.RegistryService")) {
@@ -409,6 +425,20 @@ class CuratorZookeeperClientTest {
         int version2 = ((Stat) configItem.getTicket()).getVersion();
         curatorClient.createOrUpdate(path, "version 2", true, version2);
         Assertions.assertEquals("version 2", curatorClient.getContent(path));
+
+        curatorClient.close();
+    }
+
+    @Test
+    void testEphemeralCas2() throws Exception {
+        // test update failed when others create success
+        String path = "/dubbo/mapping/org.apache.dubbo.demo.DemoService";
+        CuratorZookeeperClient curatorClient = new CuratorZookeeperClient(URL.valueOf(zookeeperConnectionAddress1 + "/org.apache.dubbo.registry.RegistryService"));
+        curatorClient.delete(path);
+
+        curatorClient.createOrUpdate(path, "version x", true);
+        Assertions.assertThrows(IllegalStateException.class, () -> curatorClient.createOrUpdate(path, "version 1", true, null));
+        Assertions.assertEquals("version x", curatorClient.getContent(path));
 
         curatorClient.close();
     }


### PR DESCRIPTION
## What is the purpose of the change

```java
            zkClient.createOrUpdate(pathKey, content, false, ticket == null ? 0 : ((Stat) ticket).getVersion());
```

When the ticket is null because the original data was empty, setting the ticket to `0` will overwrite new data created by other processes.

## Brief changelog


## Verifying this change


<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [ ] GitHub Actions works fine on your own branch.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
