### PR TITLE
fix bug of  "Failed to start when metadata-report.cycle-report=false is set"

### DIFF
--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/utils/ConfigValidationUtils.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/utils/ConfigValidationUtils.java
@@ -503,6 +503,10 @@ public class ConfigValidationUtils {
             return;
         }
 
+        if (metadataReportConfig.getCycleReport() != null && !metadataReportConfig.getCycleReport()) {
+            return;
+        }
+
         String address = metadataReportConfig.getAddress();
         String protocol = metadataReportConfig.getProtocol();
 

--- a/dubbo-metadata/dubbo-metadata-api/src/main/java/org/apache/dubbo/metadata/report/MetadataReportInstance.java
+++ b/dubbo-metadata/dubbo-metadata-api/src/main/java/org/apache/dubbo/metadata/report/MetadataReportInstance.java
@@ -76,7 +76,9 @@ public class MetadataReportInstance implements Disposable {
 
         MetadataReportFactory metadataReportFactory = applicationModel.getExtensionLoader(MetadataReportFactory.class).getAdaptiveExtension();
         for (MetadataReportConfig metadataReportConfig : metadataReportConfigs) {
-            init(metadataReportConfig, metadataReportFactory);
+            if (metadataReportConfig.getCycleReport() != null && metadataReportConfig.getCycleReport()) {
+                init(metadataReportConfig, metadataReportFactory);
+            }
         }
     }
 


### PR DESCRIPTION
## What is the purpose of the change
Issue Number: close #11096 
It should be a bug brought by pr #9820

## Brief changelog
Add the judgment of the attribute cycle-report.

Currently this attribute is not used, but the documentation suggests that if this attribute is false, metadata will not be checked.  https://dubbo.apache.org/zh/docsv2.7/user/references/metadata/


## Verifying this change
The demo of issue #11096 can be started normally when apply this pr.

<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [x] Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [ ] GitHub Actions works fine on your own branch.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
