### PR TITLE
Change constant name of error code 0-2, merge 4-19 to 0-2. Add error code of 'port is overridden' hint.

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/config/Configuration.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/config/Configuration.java
@@ -22,7 +22,7 @@ import org.apache.dubbo.common.logger.LoggerFactory;
 import java.util.NoSuchElementException;
 
 import static org.apache.dubbo.common.config.ConfigurationUtils.isEmptyValue;
-import static org.apache.dubbo.common.constants.LoggerCodeConstants.COMMON_PROPERTY_MISSPELLING;
+import static org.apache.dubbo.common.constants.LoggerCodeConstants.COMMON_PROPERTY_TYPE_MISMATCH;
 
 /**
  * Configuration interface, to fetch the value for the specified key.
@@ -74,7 +74,7 @@ public interface Configuration {
             return convert(Integer.class, key, defaultValue);
         } catch (NumberFormatException e) {
             // 0-2 Property type mismatch.
-            interfaceLevelLogger.error(COMMON_PROPERTY_MISSPELLING, "typo in property value",
+            interfaceLevelLogger.error(COMMON_PROPERTY_TYPE_MISMATCH, "typo in property value",
                 "This property requires an integer value.",
                 "Actual Class: " + getClass().getName(), e);
 

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/constants/LoggerCodeConstants.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/constants/LoggerCodeConstants.java
@@ -25,7 +25,7 @@ public interface LoggerCodeConstants {
     // common module
     String COMMON_THREAD_POOL_EXHAUSTED = "0-1";
 
-    String COMMON_PROPERTY_MISSPELLING = "0-2";
+    String COMMON_PROPERTY_TYPE_MISMATCH = "0-2";
 
     String COMMON_CACHE_PATH_INACCESSIBLE = "0-3";
 

--- a/dubbo-common/src/main/java/org/apache/dubbo/config/context/AbstractConfigManager.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/config/context/AbstractConfigManager.java
@@ -60,7 +60,7 @@ import static java.lang.Boolean.TRUE;
 import static java.util.Collections.emptyMap;
 import static java.util.Optional.ofNullable;
 import static org.apache.dubbo.common.constants.CommonConstants.DUBBO;
-import static org.apache.dubbo.common.constants.LoggerCodeConstants.COMMON_PROPERTY_MISSPELLING;
+import static org.apache.dubbo.common.constants.LoggerCodeConstants.COMMON_PROPERTY_TYPE_MISMATCH;
 import static org.apache.dubbo.common.constants.LoggerCodeConstants.COMMON_UNEXPECTED_EXCEPTION;
 import static org.apache.dubbo.config.AbstractConfig.getTagName;
 
@@ -121,7 +121,7 @@ public abstract class AbstractConfigManager extends LifecycleAdapter {
             }
         } catch (Exception e) {
             String msg = "Illegal '" + ConfigKeys.DUBBO_CONFIG_MODE + "' config value [" + configModeStr + "], available values " + Arrays.toString(ConfigMode.values());
-            logger.error(COMMON_PROPERTY_MISSPELLING, "", "", msg, e);
+            logger.error(COMMON_PROPERTY_TYPE_MISMATCH, "", "", msg, e);
             throw new IllegalArgumentException(msg, e);
         }
 
@@ -506,7 +506,7 @@ public abstract class AbstractConfigManager extends LifecycleAdapter {
                     this.addConfig(config);
                     tmpConfigs.add(config);
                 } catch (Exception e) {
-                    logger.error(COMMON_PROPERTY_MISSPELLING, "", "", "load config failed, id: " + id + ", type:" + cls.getSimpleName(), e);
+                    logger.error(COMMON_PROPERTY_TYPE_MISMATCH, "", "", "load config failed, id: " + id + ", type:" + cls.getSimpleName(), e);
                     throw new IllegalStateException("load config failed, id: " + id + ", type:" + cls.getSimpleName());
                 } finally {
                     if (addDefaultNameConfig && key != null) {

--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/metadata/ProtocolPortsMetadataCustomizer.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/metadata/ProtocolPortsMetadataCustomizer.java
@@ -25,6 +25,7 @@ import org.apache.dubbo.registry.client.ServiceInstance;
 import org.apache.dubbo.registry.client.ServiceInstanceCustomizer;
 import org.apache.dubbo.rpc.Protocol;
 import org.apache.dubbo.rpc.model.ApplicationModel;
+import org.apache.dubbo.common.constants.LoggerCodeConstants;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -55,7 +56,7 @@ public class ProtocolPortsMetadataCustomizer implements ServiceInstanceCustomize
             Integer oldPort = protocols.get(protocol);
             int newPort = url.getPort();
             if (oldPort != null) {
-                LOGGER.warn("same protocol " + "[" + protocol + "]" + " listen on different ports " + "[" + oldPort + "," + newPort + "]" + " will override with each other" +
+                LOGGER.warn(LoggerCodeConstants.PROTOCOL_INCORRECT_PARAMETER_VALUES, "same protocol " + "[" + protocol + "]" + " listen on different ports " + "[" + oldPort + "," + newPort + "]" + " will override with each other" +
                     ".Override port [" + oldPort + "] with port [" + newPort + "]");
             }
             protocols.put(protocol, newPort);

--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/metadata/ProtocolPortsMetadataCustomizer.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/metadata/ProtocolPortsMetadataCustomizer.java
@@ -56,8 +56,8 @@ public class ProtocolPortsMetadataCustomizer implements ServiceInstanceCustomize
             Integer oldPort = protocols.get(protocol);
             int newPort = url.getPort();
             if (oldPort != null) {
-                LOGGER.warn(LoggerCodeConstants.PROTOCOL_INCORRECT_PARAMETER_VALUES, "same protocol " + "[" + protocol + "]" + " listen on different ports " + "[" + oldPort + "," + newPort + "]" + " will override with each other" +
-                    ".Override port [" + oldPort + "] with port [" + newPort + "]");
+                LOGGER.warn(LoggerCodeConstants.PROTOCOL_INCORRECT_PARAMETER_VALUES, "the protocol is listening multiple ports", "", "Same protocol " + "[" + protocol + "]" + " listens on different ports " + "[" + oldPort + "," + newPort + "]" + " will override with each other" +
+                    ". The port [" + oldPort + "] is overridden with port [" + newPort + "].");
             }
             protocols.put(protocol, newPort);
         });

--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/migration/DefaultMigrationAddressComparator.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/migration/DefaultMigrationAddressComparator.java
@@ -29,7 +29,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
-import static org.apache.dubbo.common.constants.LoggerCodeConstants.PROTOCOL_INCORRECT_PARAMETER_VALUES;
+import static org.apache.dubbo.common.constants.LoggerCodeConstants.COMMON_PROPERTY_TYPE_MISMATCH;
 
 public class DefaultMigrationAddressComparator implements MigrationAddressComparator {
     private static final ErrorTypeAwareLogger logger = LoggerFactory.getErrorTypeAwareLogger(DefaultMigrationAddressComparator.class);
@@ -75,7 +75,7 @@ public class DefaultMigrationAddressComparator implements MigrationAddressCompar
         try {
             threshold = Float.parseFloat(rawThreshold);
         } catch (Exception e) {
-            logger.error(PROTOCOL_INCORRECT_PARAMETER_VALUES, "", "", "Invalid migration threshold " + rawThreshold);
+            logger.error(COMMON_PROPERTY_TYPE_MISMATCH, "", "", "Invalid migration threshold " + rawThreshold);
             threshold = DEFAULT_THREAD;
         }
 

--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/migration/MigrationRuleListener.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/migration/MigrationRuleListener.java
@@ -50,7 +50,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.apache.dubbo.common.constants.LoggerCodeConstants.COMMON_THREAD_INTERRUPTED_EXCEPTION;
-import static org.apache.dubbo.common.constants.LoggerCodeConstants.PROTOCOL_INCORRECT_PARAMETER_VALUES;
+import static org.apache.dubbo.common.constants.LoggerCodeConstants.COMMON_PROPERTY_TYPE_MISMATCH;
 import static org.apache.dubbo.common.constants.LoggerCodeConstants.REGISTRY_EMPTY_ADDRESS;
 import static org.apache.dubbo.common.constants.LoggerCodeConstants.REGISTRY_UNEXPECTED_EXCEPTION;
 import static org.apache.dubbo.common.constants.RegistryConstants.INIT;
@@ -135,7 +135,7 @@ public class MigrationRuleListener implements RegistryProtocolListener, Configur
         try {
             delay = Integer.parseInt(delayStr);
         } catch (Exception e) {
-            logger.warn(PROTOCOL_INCORRECT_PARAMETER_VALUES, "", "", "Invalid migration delay param " + delayStr);
+            logger.warn(COMMON_PROPERTY_TYPE_MISMATCH, "", "", "Invalid migration delay param " + delayStr);
         }
         return delay;
     }
@@ -146,7 +146,7 @@ public class MigrationRuleListener implements RegistryProtocolListener, Configur
         if (StringUtils.isEmpty(rawRule)) {
             // fail back to startup status
             rawRule = INIT;
-            //logger.warn(PROTOCOL_INCORRECT_PARAMETER_VALUES, "", "", "Received empty migration rule, will ignore.");
+            //logger.warn(COMMON_PROPERTY_TYPE_MISMATCH, "", "", "Received empty migration rule, will ignore.");
         }
         try {
             ruleQueue.put(rawRule);
@@ -226,7 +226,7 @@ public class MigrationRuleListener implements RegistryProtocolListener, Configur
             try {
                 tmpRule = MigrationRule.parse(rawRule);
             } catch (Exception e) {
-                logger.error(PROTOCOL_INCORRECT_PARAMETER_VALUES, "", "", "Failed to parse migration rule...", e);
+                logger.error(COMMON_PROPERTY_TYPE_MISMATCH, "", "", "Failed to parse migration rule...", e);
             }
         }
         return tmpRule;

--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/support/CacheableFailbackRegistry.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/support/CacheableFailbackRegistry.java
@@ -59,7 +59,7 @@ import static org.apache.dubbo.common.constants.CommonConstants.PROTOCOL_SEPARAT
 import static org.apache.dubbo.common.constants.LoggerCodeConstants.REGISTRY_ADDRESS_INVALID;
 import static org.apache.dubbo.common.constants.LoggerCodeConstants.REGISTRY_EMPTY_ADDRESS;
 import static org.apache.dubbo.common.constants.LoggerCodeConstants.REGISTRY_FAILED_URL_EVICTING;
-import static org.apache.dubbo.common.constants.LoggerCodeConstants.COMMON_PROPERTY_MISSPELLING;
+import static org.apache.dubbo.common.constants.LoggerCodeConstants.COMMON_PROPERTY_TYPE_MISMATCH;
 import static org.apache.dubbo.common.constants.LoggerCodeConstants.REGISTRY_NO_PARAMETERS_URL;
 import static org.apache.dubbo.common.constants.LoggerCodeConstants.REGISTRY_FAILED_CLEAR_CACHED_URLS;
 import static org.apache.dubbo.common.constants.RegistryConstants.CATEGORY_KEY;
@@ -114,7 +114,7 @@ public abstract class CacheableFailbackRegistry extends FailbackRegistry {
             } catch (NumberFormatException e) {
                 // 0-2 Property type mismatch.
 
-                logger.warn(COMMON_PROPERTY_MISSPELLING, "typo in property value", "This property requires an integer value.",
+                logger.warn(COMMON_PROPERTY_TYPE_MISMATCH, "typo in property value", "This property requires an integer value.",
                     "Invalid registry properties configuration key " + key + ", value " + str);
             }
         }

--- a/dubbo-rpc/dubbo-rpc-dubbo/src/main/java/org/apache/dubbo/rpc/protocol/dubbo/CallbackServiceCodec.java
+++ b/dubbo-rpc/dubbo-rpc-dubbo/src/main/java/org/apache/dubbo/rpc/protocol/dubbo/CallbackServiceCodec.java
@@ -54,7 +54,7 @@ import static org.apache.dubbo.common.constants.CommonConstants.METHODS_KEY;
 import static org.apache.dubbo.common.constants.CommonConstants.VERSION_KEY;
 import static org.apache.dubbo.common.constants.LoggerCodeConstants.PROTOCOL_FAILED_DESTROY_INVOKER;
 import static org.apache.dubbo.common.constants.LoggerCodeConstants.PROTOCOL_FAILED_LOAD_MODEL;
-import static org.apache.dubbo.common.constants.LoggerCodeConstants.PROTOCOL_INCORRECT_PARAMETER_VALUES;
+import static org.apache.dubbo.common.constants.LoggerCodeConstants.COMMON_PROPERTY_TYPE_MISMATCH;
 import static org.apache.dubbo.rpc.Constants.IS_SERVER_KEY;
 import static org.apache.dubbo.rpc.protocol.dubbo.Constants.CALLBACK_SERVICE_KEY;
 import static org.apache.dubbo.rpc.protocol.dubbo.Constants.CALLBACK_SERVICE_PROXY_KEY;
@@ -286,7 +286,7 @@ public class CallbackServiceCodec {
             }
             channel.setAttribute(countkey, count);
         } catch (Exception e) {
-            logger.error(PROTOCOL_INCORRECT_PARAMETER_VALUES, "", "", e.getMessage(), e);
+            logger.error(COMMON_PROPERTY_TYPE_MISMATCH, "", "", e.getMessage(), e);
         }
     }
 
@@ -300,7 +300,7 @@ public class CallbackServiceCodec {
             }
             channel.setAttribute(countkey, count);
         } catch (Exception e) {
-            logger.error(PROTOCOL_INCORRECT_PARAMETER_VALUES, "", "", e.getMessage(), e);
+            logger.error(COMMON_PROPERTY_TYPE_MISMATCH, "", "", e.getMessage(), e);
         }
     }
 


### PR DESCRIPTION
## What is the purpose of the change
Add missing error code.


## Brief changelog
1. Add error code of 'port is overridden' hint.
2. Since 4-19 is same as 0-2, this PR merged original code 4-19 to code 0-2.
