### PR TITLE
update IPv6 annotation and filter invalid IPv6

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/utils/NetUtils.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/utils/NetUtils.java
@@ -129,7 +129,8 @@ public final class NetUtils {
                 USED_PORT.set(i);
                 port = i;
                 break;
-            } catch (IOException e) {
+            }
+            catch (IOException e) {
                 // continue
             }
         }
@@ -145,7 +146,8 @@ public final class NetUtils {
     public static boolean isPortInUsed(int port) {
         try (ServerSocket ignored = new ServerSocket(port)) {
             return false;
-        } catch (IOException e) {
+        }
+        catch (IOException e) {
             // continue
         }
         return true;
@@ -241,7 +243,8 @@ public final class NetUtils {
         if (i > 0) {
             try {
                 return InetAddress.getByName(addr.substring(0, i) + '%' + address.getScopeId());
-            } catch (UnknownHostException e) {
+            }
+            catch (UnknownHostException e) {
                 // ignore
                 logger.debug("Unknown IPV6 address: ", e);
             }
@@ -281,7 +284,7 @@ public final class NetUtils {
             return HOST_ADDRESS_V6;
         }
         //avoid to search network interface card many times
-        if("".equals(HOST_ADDRESS_V6)){
+        if ("".equals(HOST_ADDRESS_V6)) {
             return null;
         }
 
@@ -308,12 +311,14 @@ public final class NetUtils {
             if (NetUtils.isInvalidLocalHost(u.getHost())) {
                 return u.setHost(NetUtils.getLocalHost()).toFullString();
             }
-        } else if (host.contains(":")) {
+        }
+        else if (host.contains(":")) {
             int i = host.lastIndexOf(':');
             if (NetUtils.isInvalidLocalHost(host.substring(0, i))) {
                 return NetUtils.getLocalHost() + host.substring(i);
             }
-        } else {
+        }
+        else {
             if (NetUtils.isInvalidLocalHost(host)) {
                 return NetUtils.getLocalHost();
             }
@@ -380,12 +385,14 @@ public final class NetUtils {
                         if (addressOp.get().isReachable(100)) {
                             return addressOp.get();
                         }
-                    } catch (IOException e) {
+                    }
+                    catch (IOException e) {
                         // ignore
                     }
                 }
             }
-        } catch (Throwable e) {
+        }
+        catch (Throwable e) {
             logger.warn(e);
         }
 
@@ -395,7 +402,8 @@ public final class NetUtils {
             if (addressOp.isPresent()) {
                 return addressOp.get();
             }
-        } catch (Throwable e) {
+        }
+        catch (Throwable e) {
             logger.warn(e);
         }
 
@@ -412,19 +420,33 @@ public final class NetUtils {
             while (addresses.hasMoreElements()) {
                 InetAddress address = addresses.nextElement();
                 if (address instanceof Inet6Address) {
-                    if (!address.isLoopbackAddress() //filter 127.x.x.x
-                        && !address.isAnyLocalAddress() // filter 0.0.0.0
-                        && !address.isLinkLocalAddress() //filter 169.254.0.0/16
+                    if (!address.isLoopbackAddress() //filter ::1
+                        && !address.isAnyLocalAddress() // filter ::/128
+                        && !address.isLinkLocalAddress() //filter fe80::/10
+                        && !address.isSiteLocalAddress()// filter fec0::/10
+                        && !isUniqueLocalAddress(address) //filter fd00::/8
                         && address.getHostAddress().contains(":")) {//filter IPv6
                         return (Inet6Address) address;
                     }
                 }
             }
-        } catch (Throwable e) {
+        }
+        catch (Throwable e) {
             logger.warn(e);
         }
 
         return null;
+    }
+
+    /**
+     * If the address is Unique Local Address.
+     *
+     * @param address {@link InetAddress}
+     * @return {@code true} if the address is Unique Local Address,otherwise {@code false}
+     */
+    private static boolean isUniqueLocalAddress(InetAddress address) {
+        byte[] ip = address.getAddress();
+        return (ip[0] & 0xff) == 0xfd;
     }
 
     /**
@@ -450,10 +472,13 @@ public final class NetUtils {
                 boolean matched = false;
                 try {
                     matched = networkInterfaceDisplayName.matches(trimIgnoredInterface);
-                } catch (PatternSyntaxException e) {
+                }
+                catch (PatternSyntaxException e) {
                     // if trimIgnoredInterface is an invalid regular expression, a PatternSyntaxException will be thrown out
-                    logger.warn("exception occurred: " + networkInterfaceDisplayName + " matches " + trimIgnoredInterface, e);
-                } finally {
+                    logger
+                        .warn("exception occurred: " + networkInterfaceDisplayName + " matches " + trimIgnoredInterface, e);
+                }
+                finally {
                     if (matched) {
                         return true;
                     }
@@ -510,7 +535,8 @@ public final class NetUtils {
         List<NetworkInterface> validNetworkInterfaces = emptyList();
         try {
             validNetworkInterfaces = getValidNetworkInterfaces();
-        } catch (Throwable e) {
+        }
+        catch (Throwable e) {
             logger.warn(e);
         }
 
@@ -534,7 +560,8 @@ public final class NetUtils {
                             if (addressOp.get().isReachable(100)) {
                                 return networkInterface;
                             }
-                        } catch (IOException e) {
+                        }
+                        catch (IOException e) {
                             // ignore
                         }
                     }
@@ -565,7 +592,8 @@ public final class NetUtils {
                 HOST_NAME_CACHE.put(address, hostname);
                 return hostname;
             }
-        } catch (Throwable e) {
+        }
+        catch (Throwable e) {
             // ignore
         }
         return address;
@@ -574,7 +602,8 @@ public final class NetUtils {
     public static String getLocalHostName() {
         try {
             return InetAddress.getLocalHost().getHostName();
-        } catch (UnknownHostException e) {
+        }
+        catch (UnknownHostException e) {
             return getLocalAddress().getHostName();
         }
     }
@@ -586,7 +615,8 @@ public final class NetUtils {
     public static String getIpByHost(String hostName) {
         try {
             return InetAddress.getByName(hostName).getHostAddress();
-        } catch (UnknownHostException e) {
+        }
+        catch (UnknownHostException e) {
             return hostName;
         }
     }
@@ -602,7 +632,8 @@ public final class NetUtils {
         if (i > -1) {
             host = address.substring(0, i);
             port = Integer.parseInt(address.substring(i + 1));
-        } else {
+        }
+        else {
             host = address;
             port = 0;
         }
@@ -645,17 +676,20 @@ public final class NetUtils {
                             interfaceSet = true;
                             break;
                         }
-                    } catch (IOException e) {
+                    }
+                    catch (IOException e) {
                         // ignore
                     }
-                } else if (!preferIpv6 && address instanceof Inet4Address) {
+                }
+                else if (!preferIpv6 && address instanceof Inet4Address) {
                     try {
                         if (address.isReachable(100)) {
                             multicastSocket.setInterface(address);
                             interfaceSet = true;
                             break;
                         }
-                    } catch (IOException e) {
+                    }
+                    catch (IOException e) {
                         // ignore
                     }
                 }
@@ -726,7 +760,8 @@ public final class NetUtils {
         for (int i = 0; i < mask.length; i++) {
             if ("*".equals(mask[i]) || mask[i].equals(ipAddress[i])) {
                 continue;
-            } else if (mask[i].contains("-")) {
+            }
+            else if (mask[i].contains("-")) {
                 String[] rangeNumStrs = StringUtils.split(mask[i], '-');
                 if (rangeNumStrs.length != 2) {
                     throw new IllegalArgumentException("There is wrong format of ip Address: " + mask[i]);
@@ -737,9 +772,12 @@ public final class NetUtils {
                 if (ip < min || ip > max) {
                     return false;
                 }
-            } else if ("0".equals(ipAddress[i]) && ("0".equals(mask[i]) || "00".equals(mask[i]) || "000".equals(mask[i]) || "0000".equals(mask[i]))) {
+            }
+            else if ("0".equals(ipAddress[i]) && ("0".equals(mask[i]) || "00".equals(mask[i]) || "000"
+                .equals(mask[i]) || "0000".equals(mask[i]))) {
                 continue;
-            } else if (!mask[i].equals(ipAddress[i])) {
+            }
+            else if (!mask[i].equals(ipAddress[i])) {
                 return false;
             }
         }
@@ -776,7 +814,8 @@ public final class NetUtils {
             if (mask.length != 8 && !pattern.contains("::")) {
                 throw new IllegalArgumentException("The host is ipv6, but the pattern is not ipv6 pattern : " + pattern);
             }
-        } else {
+        }
+        else {
             if (mask.length != 4) {
                 throw new IllegalArgumentException("The host is ipv4, but the pattern is not ipv4 pattern : " + pattern);
             }
@@ -790,16 +829,19 @@ public final class NetUtils {
             result[0] = pattern.substring(1, end);
             result[1] = pattern.substring(end + 2);
             return result;
-        } else if (pattern.startsWith("[") && pattern.endsWith("]")) {
+        }
+        else if (pattern.startsWith("[") && pattern.endsWith("]")) {
             result[0] = pattern.substring(1, pattern.length() - 1);
             result[1] = null;
             return result;
-        } else if (isIpv4 && pattern.contains(":")) {
+        }
+        else if (isIpv4 && pattern.contains(":")) {
             int end = pattern.indexOf(":");
             result[0] = pattern.substring(0, end);
             result[1] = pattern.substring(end + 1);
             return result;
-        } else {
+        }
+        else {
             result[0] = pattern;
             return result;
         }
@@ -816,9 +858,11 @@ public final class NetUtils {
     public static boolean isIPV6URLStdFormat(String ip) {
         if ((ip.charAt(0) == '[' && ip.indexOf(']') > 2)) {
             return true;
-        } else if (ip.indexOf(":") != ip.lastIndexOf(":")) {
+        }
+        else if (ip.indexOf(":") != ip.lastIndexOf(":")) {
             return true;
-        } else {
+        }
+        else {
             return false;
         }
     }
@@ -831,7 +875,8 @@ public final class NetUtils {
             ip = nhost.substring(0, ind + 1);
             ip = ip.substring(1, ind);
             return ip;
-        } else {
+        }
+        else {
             return ip;
         }
     }


### PR DESCRIPTION
need discussion：
Invalid IPv6 address only filter  

- Any Local Address
- Link Local Address
- Loopback Address

but there still some invalid address need filter:

- Site Local Address, which was discarded, but some address may be deployed.
- Unique Local Address, use to replace Site Local Address, which same to private address in IPv4