### PR TITLE
don't delete lock file when lock is held by other

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/cache/FileCacheStoreFactory.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/cache/FileCacheStoreFactory.java
@@ -168,7 +168,6 @@ public final class FileCacheStoreFactory {
 
     private static void tryFileLock(FileCacheStore.Builder builder, String fileName) throws PathNotExclusiveException {
         File lockFile = new File(fileName + ".lock");
-        lockFile.deleteOnExit();
 
         FileLock dirLock;
         try {
@@ -188,6 +187,7 @@ public final class FileCacheStoreFactory {
             throw new PathNotExclusiveException(fileName + " is not exclusive. Maybe multiple Dubbo instances are using the same folder.");
         }
 
+        lockFile.deleteOnExit();
         builder.directoryLock(dirLock).lockFile(lockFile);
     }
 


### PR DESCRIPTION
## What is the purpose of the change
when two servers started on the same machine. the first one can acquire the lock, and the second one failed.
but when the second server shutdown, the lock file held by the first server will be deleted.

## Brief changelog
change to only delete lock when successfully acquiring file lock

## Verifying this change


<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [ ] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [ ] GitHub Actions works fine on your own branch.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
