### PR TITLE
fix channelHandlers has null object (#11357)

### DIFF
--- a/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/transport/ChannelHandlerDispatcher.java
+++ b/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/transport/ChannelHandlerDispatcher.java
@@ -24,7 +24,9 @@ import org.apache.dubbo.remoting.ChannelHandler;
 
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Objects;
 import java.util.concurrent.CopyOnWriteArraySet;
+import java.util.stream.Collectors;
 
 import static org.apache.dubbo.common.constants.LoggerCodeConstants.INTERNAL_ERROR;
 
@@ -41,12 +43,15 @@ public class ChannelHandlerDispatcher implements ChannelHandler {
     }
 
     public ChannelHandlerDispatcher(ChannelHandler... handlers) {
+        // if varargs is used, the type of handlers is ChannelHandler[] and it is not null
+        // so we should filter the null object
         this(handlers == null ? null : Arrays.asList(handlers));
     }
 
     public ChannelHandlerDispatcher(Collection<ChannelHandler> handlers) {
         if (CollectionUtils.isNotEmpty(handlers)) {
-            this.channelHandlers.addAll(handlers);
+            // filter null object
+            this.channelHandlers.addAll(handlers.stream().filter(Objects::nonNull).collect(Collectors.toSet()));
         }
     }
 

--- a/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/transport/ChannelHandlerDispatcher.java
+++ b/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/transport/ChannelHandlerDispatcher.java
@@ -51,7 +51,7 @@ public class ChannelHandlerDispatcher implements ChannelHandler {
     public ChannelHandlerDispatcher(Collection<ChannelHandler> handlers) {
         if (CollectionUtils.isNotEmpty(handlers)) {
             // filter null object
-            handlers.stream().filter(Objects::nonNull).foreach(this.channelHandlers::add);
+            this.channelHandlers.addAll(handlers.stream().filter(Objects::nonNull).collect(Collectors.toSet()));
         }
     }
 

--- a/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/transport/ChannelHandlerDispatcher.java
+++ b/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/transport/ChannelHandlerDispatcher.java
@@ -51,7 +51,7 @@ public class ChannelHandlerDispatcher implements ChannelHandler {
     public ChannelHandlerDispatcher(Collection<ChannelHandler> handlers) {
         if (CollectionUtils.isNotEmpty(handlers)) {
             // filter null object
-            this.channelHandlers.addAll(handlers.stream().filter(Objects::nonNull).collect(Collectors.toSet()));
+            handlers.stream().filter(Objects::nonNull).foreach(this.channelHandlers::add);
         }
     }
 

--- a/dubbo-remoting/dubbo-remoting-api/src/test/java/org/apache/dubbo/remoting/transport/ChannelHandlerDispatcherTest.java
+++ b/dubbo-remoting/dubbo-remoting-api/src/test/java/org/apache/dubbo/remoting/transport/ChannelHandlerDispatcherTest.java
@@ -61,18 +61,18 @@ class ChannelHandlerDispatcherTest {
     @Test
     void constructorNullObjectTest() {
         ChannelHandlerDispatcher channelHandlerDispatcher = new ChannelHandlerDispatcher(null, null);
-        Assertions.assertEquals(channelHandlerDispatcher.getChannelHandlers().size(), 0);
+        Assertions.assertEquals(0, channelHandlerDispatcher.getChannelHandlers().size());
         ChannelHandlerDispatcher channelHandlerDispatcher1 = new ChannelHandlerDispatcher((MockChannelHandler) null);
-        Assertions.assertEquals(channelHandlerDispatcher1.getChannelHandlers().size(), 0);
+        Assertions.assertEquals(0, channelHandlerDispatcher1.getChannelHandlers().size());
         ChannelHandlerDispatcher channelHandlerDispatcher2 = new ChannelHandlerDispatcher(null, new MockChannelHandler());
-        Assertions.assertEquals(channelHandlerDispatcher2.getChannelHandlers().size(), 1);
+        Assertions.assertEquals(1, channelHandlerDispatcher2.getChannelHandlers().size());
         ChannelHandlerDispatcher channelHandlerDispatcher3 = new ChannelHandlerDispatcher(Collections.singleton(new MockChannelHandler()));
-        Assertions.assertEquals(channelHandlerDispatcher3.getChannelHandlers().size(), 1);
+        Assertions.assertEquals(1, channelHandlerDispatcher3.getChannelHandlers().size());
         Collection<ChannelHandler> mockChannelHandlers = new HashSet<>();
         mockChannelHandlers.add(new MockChannelHandler());
         mockChannelHandlers.add(null);
         ChannelHandlerDispatcher channelHandlerDispatcher4 = new ChannelHandlerDispatcher(mockChannelHandlers);
-        Assertions.assertEquals(channelHandlerDispatcher4.getChannelHandlers().size(), 1);
+        Assertions.assertEquals(1, channelHandlerDispatcher4.getChannelHandlers().size());
     }
 
 }

--- a/dubbo-remoting/dubbo-remoting-api/src/test/java/org/apache/dubbo/remoting/transport/ChannelHandlerDispatcherTest.java
+++ b/dubbo-remoting/dubbo-remoting-api/src/test/java/org/apache/dubbo/remoting/transport/ChannelHandlerDispatcherTest.java
@@ -19,12 +19,13 @@ package org.apache.dubbo.remoting.transport;
 import org.apache.dubbo.remoting.Channel;
 import org.apache.dubbo.remoting.ChannelHandler;
 import org.apache.dubbo.remoting.RemotingException;
-
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
 
 class ChannelHandlerDispatcherTest {
 
@@ -55,6 +56,23 @@ class ChannelHandlerDispatcherTest {
         channelHandlerDispatcher = channelHandlerDispatcher.removeChannelHandler(channelHandler1);
         Assertions.assertFalse(channelHandlerDispatcher.getChannelHandlers().contains(channelHandler1));
 
+    }
+
+    @Test
+    void constructorNullObjectTest() {
+        ChannelHandlerDispatcher channelHandlerDispatcher = new ChannelHandlerDispatcher(null, null);
+        Assertions.assertEquals(channelHandlerDispatcher.getChannelHandlers().size(), 0);
+        ChannelHandlerDispatcher channelHandlerDispatcher1 = new ChannelHandlerDispatcher((MockChannelHandler) null);
+        Assertions.assertEquals(channelHandlerDispatcher1.getChannelHandlers().size(), 0);
+        ChannelHandlerDispatcher channelHandlerDispatcher2 = new ChannelHandlerDispatcher(null, new MockChannelHandler());
+        Assertions.assertEquals(channelHandlerDispatcher2.getChannelHandlers().size(), 1);
+        ChannelHandlerDispatcher channelHandlerDispatcher3 = new ChannelHandlerDispatcher(Collections.singleton(new MockChannelHandler()));
+        Assertions.assertEquals(channelHandlerDispatcher3.getChannelHandlers().size(), 1);
+        Collection<ChannelHandler> mockChannelHandlers = new HashSet<>();
+        mockChannelHandlers.add(new MockChannelHandler());
+        mockChannelHandlers.add(null);
+        ChannelHandlerDispatcher channelHandlerDispatcher4 = new ChannelHandlerDispatcher(mockChannelHandlers);
+        Assertions.assertEquals(channelHandlerDispatcher4.getChannelHandlers().size(), 1);
     }
 
 }


### PR DESCRIPTION
## What is the purpose of the change

fix channelHandlers has null object bug

## Brief changelog


## Verifying this change


<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [ ] GitHub Actions works fine on your own branch.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
