### PR TITLE
Make methods synchronized to match parent declaration

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/cache/FileCacheStore.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/cache/FileCacheStore.java
@@ -218,12 +218,12 @@ public class FileCacheStore {
         }
 
         @Override
-        public Map<String, String> loadCache(int entrySize) throws IOException {
+        public synchronized Map<String, String> loadCache(int entrySize) throws IOException {
             return Collections.emptyMap();
         }
 
         @Override
-        public void refreshCache(Map<String, String> properties, String comment, long maxFileSize) {
+        public synchronized void refreshCache(Map<String, String> properties, String comment, long maxFileSize) {
             // No-op.
         }
     }

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/io/StreamUtils.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/io/StreamUtils.java
@@ -94,13 +94,13 @@ public class StreamUtils {
             }
 
             @Override
-            public void mark(int readlimit) {
+            public synchronized void mark(int readlimit) {
                 is.mark(readlimit);
                 mMark = mPosition;
             }
 
             @Override
-            public void reset() throws IOException {
+            public synchronized void reset() throws IOException {
                 is.reset();
                 mPosition = mMark;
             }

--- a/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/buffer/ChannelBufferInputStream.java
+++ b/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/buffer/ChannelBufferInputStream.java
@@ -57,7 +57,7 @@ public class ChannelBufferInputStream extends InputStream {
     }
 
     @Override
-    public void mark(int readLimit) {
+    public synchronized void mark(int readLimit) {
         buffer.markReaderIndex();
     }
 
@@ -87,7 +87,7 @@ public class ChannelBufferInputStream extends InputStream {
     }
 
     @Override
-    public void reset() throws IOException {
+    public synchronized void reset() throws IOException {
         buffer.resetReaderIndex();
     }
 


### PR DESCRIPTION
## What is the purpose of the change

Some methods are declared to not be synchronized, but they override a synchronized method declared in their parent.
This practically breaks the contract stated by the parent class. I'm not aware of any actual problem that this causes but nontheless, it should be fixed.

## Brief changelog

Adding a `synchronized` statement to overriding methods that were missing it. 

## Verifying this change

Not really testable, so there is no way to verify it.

<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [ ] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [x] Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [ ] GitHub Actions works fine on your own branch.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
