### PR TITLE
log miss

### DIFF
--- a/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/context/DubboConfigBeanInitializer.java
+++ b/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/context/DubboConfigBeanInitializer.java
@@ -16,8 +16,6 @@
  */
 package org.apache.dubbo.config.spring.context;
 
-import org.apache.dubbo.common.logger.Logger;
-import org.apache.dubbo.common.logger.LoggerFactory;
 import org.apache.dubbo.config.AbstractConfig;
 import org.apache.dubbo.config.ApplicationConfig;
 import org.apache.dubbo.config.ConsumerConfig;
@@ -35,6 +33,8 @@ import org.apache.dubbo.config.spring.ConfigCenterBean;
 import org.apache.dubbo.config.spring.reference.ReferenceBeanManager;
 import org.apache.dubbo.rpc.model.ModuleModel;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.FatalBeanException;
 import org.springframework.beans.factory.BeanFactory;
@@ -59,7 +59,7 @@ public class DubboConfigBeanInitializer implements BeanFactoryAware, Initializin
 
     public static String BEAN_NAME = "dubboConfigBeanInitializer";
 
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private final Log logger = LogFactory.getLog(getClass());
 
     private AtomicBoolean initialized = new AtomicBoolean(false);
     private ConfigurableListableBeanFactory beanFactory;

--- a/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/reference/ReferenceCreator.java
+++ b/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/reference/ReferenceCreator.java
@@ -16,8 +16,6 @@
  */
 package org.apache.dubbo.config.spring.reference;
 
-import org.apache.dubbo.common.logger.Logger;
-import org.apache.dubbo.common.logger.LoggerFactory;
 import org.apache.dubbo.config.AbstractConfig;
 import org.apache.dubbo.config.ArgumentConfig;
 import org.apache.dubbo.config.ConsumerConfig;
@@ -34,6 +32,8 @@ import org.apache.dubbo.config.spring.util.DubboBeanUtils;
 import org.apache.dubbo.rpc.model.ModuleModel;
 
 import com.alibaba.spring.util.AnnotationUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.springframework.beans.propertyeditors.StringTrimmerEditor;
 import org.springframework.context.ApplicationContext;
 import org.springframework.core.convert.support.DefaultConversionService;
@@ -66,7 +66,7 @@ public class ReferenceCreator {
 
     private static final String METHOD = "Method";
 
-    protected final Logger logger = LoggerFactory.getLogger(getClass());
+    protected final Log logger = LogFactory.getLog(getClass());
 
     protected final Map<String, Object> attributes;
 

--- a/dubbo-spring-boot/dubbo-spring-boot-compatible/autoconfigure/src/main/java/org/apache/dubbo/spring/boot/context/event/WelcomeLogoApplicationListener.java
+++ b/dubbo-spring-boot/dubbo-spring-boot-compatible/autoconfigure/src/main/java/org/apache/dubbo/spring/boot/context/event/WelcomeLogoApplicationListener.java
@@ -19,8 +19,8 @@ package org.apache.dubbo.spring.boot.context.event;
 import org.apache.dubbo.common.Version;
 
 
-import org.apache.dubbo.common.logger.Logger;
-import org.apache.dubbo.common.logger.LoggerFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.boot.context.event.ApplicationEnvironmentPreparedEvent;
 import org.springframework.boot.logging.LoggingApplicationListener;
 import org.springframework.context.ApplicationListener;


### PR DESCRIPTION
10952做了log4j的适配 https://github.com/apache/dubbo/pull/10952，
代码3.1.5和3.1.0不变，但是WelcomeLogoApplicationListener中的Logger：
3.1.0版本使用：org.slf4j.Logger
3.1.5版本使用：org.apache.dubbo.common.logger.Logger
此pull修改了Logger的包引发的问题https://github.com/apache/dubbo/pull/11000
结论：
3.1.4版本合并了https://github.com/apache/dubbo/pull/11000但是没合并 https://github.com/apache/dubbo/pull/10952的问题，
以后是否在3.1.x版本中合并10952，如果合并的话此pr可以取消