### PR TITLE
repair 404 page links

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,10 +167,10 @@ The consumer will print out `hi, dubbo` on the screen.
 
 ### Next steps
 
-* [Your first Dubbo application](https://cn.dubbo.apache.org/en/blog/2018/08/07/dubbo-101/) - A 101 tutorial to reveal more details, with the same code above.
-* [Dubbo user manual](https://cn.dubbo.apache.org/en/overview/what/) - How to use Dubbo and all its features.
-* [Dubbo developer guide](https://cn.dubbo.apache.org/en/docs3-v2/java-sdk/) - How to involve in Dubbo development.
-* [Dubbo admin manual](https://cn.dubbo.apache.org/zh/docsv2.7/admin/ops/) - How to admin and manage Dubbo services.
+* [Your first Dubbo application](https://dubbo.apache.org/en/blog/2018/08/07/dubbo-101/) - A 101 tutorial to reveal more details, with the same code above.
+* [Dubbo user manual](https://dubbo.apache.org/en/overview/what/) - How to use Dubbo and all its features.
+* [Dubbo developer guide](https://dubbo.apache.org/en/docs3-v2/java-sdk/) - How to involve in Dubbo development.
+* [Dubbo admin manual](https://dubbo.apache.org/en/docs/v2.7/admin/ops/) - How to admin and manage Dubbo services.
 
 ## Building
 

--- a/README.md
+++ b/README.md
@@ -167,10 +167,10 @@ The consumer will print out `hi, dubbo` on the screen.
 
 ### Next steps
 
-* [Your first Dubbo application](https://dubbo.apache.org/blog/2018/08/07/dubbo-101/) - A 101 tutorial to reveal more details, with the same code above.
-* [Dubbo user manual](https://dubbo.apache.org/docs/v2.7/user/preface/background/) - How to use Dubbo and all its features.
-* [Dubbo developer guide](https://dubbo.apache.org/docs/v2.7/dev/build/) - How to involve in Dubbo development.
-* [Dubbo admin manual](https://dubbo.apache.org/docs/v2.7/admin/install/provider-demo/) - How to admin and manage Dubbo services.
+* [Your first Dubbo application](https://cn.dubbo.apache.org/en/blog/2018/08/07/dubbo-101/) - A 101 tutorial to reveal more details, with the same code above.
+* [Dubbo user manual](https://cn.dubbo.apache.org/en/overview/what/) - How to use Dubbo and all its features.
+* [Dubbo developer guide](https://cn.dubbo.apache.org/en/docs3-v2/java-sdk/) - How to involve in Dubbo development.
+* [Dubbo admin manual](https://cn.dubbo.apache.org/zh/docsv2.7/admin/ops/) - How to admin and manage Dubbo services.
 
 ## Building
 


### PR DESCRIPTION
## What is the purpose of the change
Replace the 404 link in the readme file with an available link, but because the English document of admin manual on dubbo website is not synchronized, the Chinese document link is used for the time being.

## Brief changelog
fix #11426 

## Verifying this change


<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [ ] GitHub Actions works fine on your own branch.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
