### PR TITLE
optimized sync on channel write

### DIFF
--- a/dubbo-remoting/dubbo-remoting-netty4/src/main/java/org/apache/dubbo/remoting/transport/netty4/NettyConnectionClient.java
+++ b/dubbo-remoting/dubbo-remoting-netty4/src/main/java/org/apache/dubbo/remoting/transport/netty4/NettyConnectionClient.java
@@ -33,8 +33,6 @@ import io.netty.bootstrap.Bootstrap;
 import io.netty.buffer.PooledByteBufAllocator;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
-import io.netty.channel.ChannelHandlerContext;
-import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.ChannelPipeline;
@@ -73,8 +71,6 @@ public class NettyConnectionClient extends AbstractConnectionClient {
 
     public static final AttributeKey<AbstractConnectionClient> CONNECTION = AttributeKey.valueOf("connection");
 
-    public static final AttributeKey<Boolean> ACTIVE = AttributeKey.valueOf("active");
-
 
     public NettyConnectionClient(URL url, ChannelHandler handler) throws RemotingException {
         super(url, handler);
@@ -110,7 +106,6 @@ public class NettyConnectionClient extends AbstractConnectionClient {
                 .channel(socketChannelClass());
 
         final NettyConnectionHandler connectionHandler = new NettyConnectionHandler(this);
-        final ChannelStateListener channelStateListener = new ChannelStateListener();
         nettyBootstrap.option(ChannelOption.CONNECT_TIMEOUT_MILLIS, getConnectTimeout());
         nettyBootstrap.handler(new ChannelInitializer<SocketChannel>() {
             @Override
@@ -127,7 +122,6 @@ public class NettyConnectionClient extends AbstractConnectionClient {
                 // TODO support IDLE
 //                int heartbeatInterval = UrlUtils.getHeartbeat(getUrl());
                 pipeline.addLast("connectionHandler", connectionHandler);
-                pipeline.addLast("channelStateListener", channelStateListener);
                 NettyConfigOperator operator = new NettyConfigOperator(nettyChannel, getChannelHandler());
                 protocol.configClientPipeline(getUrl(), operator, nettySslContextOperator);
                 // TODO support Socks5
@@ -265,13 +259,6 @@ public class NettyConnectionClient extends AbstractConnectionClient {
             return false;
         }
         io.netty.channel.Channel nettyChannel = getNettyChannel();
-        if (nettyChannel != null) {
-            Boolean active = nettyChannel.attr(ACTIVE).get();
-            if (active != null
-                && active) {
-                return true;
-            }
-        }
         if (nettyChannel != null && nettyChannel.isActive()) {
             return true;
         }
@@ -333,24 +320,6 @@ public class NettyConnectionClient extends AbstractConnectionClient {
         return super.toString() + " (Ref=" + this.getCounter() + ",local=" +
                 (getChannel() == null ? null : getChannel().getLocalAddress()) + ",remote=" + getRemoteAddress();
     }
-
-    @io.netty.channel.ChannelHandler.Sharable
-    static class ChannelStateListener extends ChannelInboundHandlerAdapter {
-
-        @Override
-        public void channelActive(ChannelHandlerContext ctx) throws Exception {
-            ctx.channel().attr(ACTIVE).set(true);
-            super.channelActive(ctx);
-        }
-
-        @Override
-        public void channelInactive(ChannelHandlerContext ctx) throws Exception {
-            ctx.channel().attr(ACTIVE).set(false);
-            super.channelInactive(ctx);
-        }
-
-    }
-
     class ConnectionListener implements ChannelFutureListener {
 
         @Override

--- a/dubbo-remoting/dubbo-remoting-netty4/src/main/java/org/apache/dubbo/remoting/transport/netty4/NettyConnectionClient.java
+++ b/dubbo-remoting/dubbo-remoting-netty4/src/main/java/org/apache/dubbo/remoting/transport/netty4/NettyConnectionClient.java
@@ -122,6 +122,7 @@ public class NettyConnectionClient extends AbstractConnectionClient {
                 // TODO support IDLE
 //                int heartbeatInterval = UrlUtils.getHeartbeat(getUrl());
                 pipeline.addLast("connectionHandler", connectionHandler);
+
                 NettyConfigOperator operator = new NettyConfigOperator(nettyChannel, getChannelHandler());
                 protocol.configClientPipeline(getUrl(), operator, nettySslContextOperator);
                 // TODO support Socks5
@@ -320,6 +321,7 @@ public class NettyConnectionClient extends AbstractConnectionClient {
         return super.toString() + " (Ref=" + this.getCounter() + ",local=" +
                 (getChannel() == null ? null : getChannel().getLocalAddress()) + ",remote=" + getRemoteAddress();
     }
+
     class ConnectionListener implements ChannelFutureListener {
 
         @Override

--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/TripleInvoker.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/TripleInvoker.java
@@ -265,7 +265,7 @@ public class TripleInvoker<T> extends AbstractInvoker<T> {
         if (!super.isAvailable()) {
             return false;
         }
-        return connectionClient.isAvailable();
+        return connectionClient.isConnected();
     }
 
     @Override

--- a/dubbo-rpc/dubbo-rpc-triple/src/test/java/org/apache/dubbo/rpc/protocol/tri/TripleInvokerTest.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/test/java/org/apache/dubbo/rpc/protocol/tri/TripleInvokerTest.java
@@ -53,7 +53,7 @@ class TripleInvokerTest {
                 .thenReturn(connectionClient);
         when(connectionClient.getChannel(true))
                 .thenReturn(channel);
-        when(connectionClient.isAvailable()).thenReturn(true);
+        when(connectionClient.isConnected()).thenReturn(true);
 
         ExecutorService executorService = ExecutorRepository.getInstance(url.getOrDefaultApplicationModel())
                 .createExecutorIfAbsent(url);


### PR DESCRIPTION
修改了`NettyConnectionClient`中的`isAvailable`逻辑以便消除锁竞争。
该方法会被`TripleInvoker.isAvailable`调用，而调用`TripleInvoker.isAvailable`时处于用户线程而非EventLoop线程，则此时会与EventLoop线程上的`channel.write`出现锁竞争问题。

#### 修复后的结果
<img width="1494" alt="Pasted Graphic 2" src="https://user-images.githubusercontent.com/42876375/216111973-e5a568ff-a6b3-4810-b43b-9292d09e191f.png">

可以看到，图中已经没有了`ensureWriteOpen`方法的损耗

ref: #11439 