### PR TITLE
Fix thread pool configuration is invalid

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/threadpool/manager/DefaultExecutorRepository.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/threadpool/manager/DefaultExecutorRepository.java
@@ -43,6 +43,7 @@ import java.util.concurrent.ThreadPoolExecutor;
 
 import static org.apache.dubbo.common.constants.CommonConstants.CONSUMER_SHARED_EXECUTOR_SERVICE_COMPONENT_KEY;
 import static org.apache.dubbo.common.constants.CommonConstants.CONSUMER_SIDE;
+import static org.apache.dubbo.common.constants.CommonConstants.PROVIDER_SIDE;
 import static org.apache.dubbo.common.constants.CommonConstants.DEFAULT_EXPORT_THREAD_NUM;
 import static org.apache.dubbo.common.constants.CommonConstants.DEFAULT_PROTOCOL;
 import static org.apache.dubbo.common.constants.CommonConstants.DEFAULT_REFER_THREAD_NUM;

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/threadpool/manager/DefaultExecutorRepository.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/threadpool/manager/DefaultExecutorRepository.java
@@ -140,9 +140,21 @@ public class DefaultExecutorRepository implements ExecutorRepository, ExtensionA
         return (ExecutorService) extensionAccessor.getExtensionLoader(ThreadPool.class).getAdaptiveExtension().getExecutor(url);
     }
 
+    private Map<Integer, ExecutorService> getExecutors(URL url) {
+        Map<Integer, ExecutorService> executors;
+        // if it's on the provider side and has user-defined services, use biz service executor first, avoid using internal executor
+        if (PROVIDER_SIDE.equalsIgnoreCase(url.getParameter(SIDE_KEY))
+            && data.containsKey(EXECUTOR_SERVICE_COMPONENT_KEY)) {
+            executors = data.get(EXECUTOR_SERVICE_COMPONENT_KEY);
+        } else {
+            executors = data.get(getExecutorKey(url));
+        }
+        return executors;
+    }
+
     @Override
     public ExecutorService getExecutor(URL url) {
-        Map<Integer, ExecutorService> executors = data.get(getExecutorKey(url));
+        Map<Integer, ExecutorService> executors = getExecutors(url);
 
         /*
          * It's guaranteed that this method is called after {@link #createExecutorIfAbsent(URL)}, so data should already


### PR DESCRIPTION
## What is the purpose of the change

Fix #11524 

issue:
Initiating RPC in the life cycle initialization phase of Spring Bean, that is, before ServiceBean#afterPropertiesSet, because configManager does not have any serviceConfig, and without publishing any provider, the DefaultApplicationDeployer#exportMetadataService() method is first triggered, resulting in org.apache.dubbo.metadata The .MetadataService metadata interface is exported first, and finally the url is passed and fixed in the ChannelHandler. After the service starts to receive the request, when obtaining the ExecutorService, the thread pool of the MetadataService is obtained through the url, not the thread pool configured by parameters such as dubbo.protocol.threads.

solve:
When the getExecutor(URL url) method obtains the thread pool, if it is the provider side and has a user-defined interface, the service thread pool will be used first to avoid using its own thread when the registered URL is org.apache.dubbo.metadata.MetadataService pool.

## Brief changelog


## Verifying this change


<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [ ] GitHub Actions works fine on your own branch.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
