### PR TITLE
observationreceiver instance error

### DIFF
--- a/dubbo-metrics/dubbo-metrics-api/src/main/java/org/apache/dubbo/metrics/filter/observation/ObservationReceiverFilter.java
+++ b/dubbo-metrics/dubbo-metrics-api/src/main/java/org/apache/dubbo/metrics/filter/observation/ObservationReceiverFilter.java
@@ -33,7 +33,7 @@ import static org.apache.dubbo.common.constants.CommonConstants.PROVIDER;
 /**
  * A {@link Filter} that creates an {@link Observation} around the incoming message.
  */
-@Activate(group = PROVIDER, order = -1)
+@Activate(group = PROVIDER, order = -1,onClass = "io.micrometer.observation.NoopObservationRegistry")
 public class ObservationReceiverFilter implements Filter, BaseFilter.Listener, ScopeModelAware {
 
     private ObservationRegistry observationRegistry = ObservationRegistry.NOOP;

--- a/dubbo-metrics/dubbo-metrics-api/src/main/java/org/apache/dubbo/metrics/filter/observation/ObservationSenderFilter.java
+++ b/dubbo-metrics/dubbo-metrics-api/src/main/java/org/apache/dubbo/metrics/filter/observation/ObservationSenderFilter.java
@@ -34,7 +34,7 @@ import static org.apache.dubbo.common.constants.CommonConstants.CONSUMER;
 /**
  * A {@link Filter} that creates an {@link Observation} around the outgoing message.
  */
-@Activate(group = CONSUMER, order = -1)
+@Activate(group = CONSUMER, order = -1,onClass = "io.micrometer.observation.NoopObservationRegistry")
 public class ObservationSenderFilter implements ClusterFilter, BaseFilter.Listener, ScopeModelAware {
 
     private ObservationRegistry observationRegistry = ObservationRegistry.NOOP;


### PR DESCRIPTION
dubbo-metrics-api 在dobbo-all pom 文件在配置依赖时，maven 配置的依赖为可选配置，当ExtensionLoader 在读取Filter里面的配置进行实例化出现异常