### PR TITLE
[Triple] Fix boxed type methods

### DIFF
--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/ReflectionPackableMethod.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/ReflectionPackableMethod.java
@@ -73,7 +73,7 @@ public class ReflectionPackableMethod implements PackableMethod {
                 break;
             case UNARY:
                 actualRequestTypes = method.getParameterClasses();
-                actualResponseType = method.getReturnClass();
+                actualResponseType = (Class<?>) method.getReturnTypes()[0];
                 break;
             default:
                 throw new IllegalStateException("Can not reach here");

--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/ReflectionPackableMethod.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/ReflectionPackableMethod.java
@@ -22,7 +22,6 @@ import org.apache.dubbo.common.constants.CommonConstants;
 import org.apache.dubbo.common.serialize.MultipleSerialization;
 import org.apache.dubbo.common.serialize.support.DefaultSerializationSelector;
 import org.apache.dubbo.common.stream.StreamObserver;
-import org.apache.dubbo.common.utils.ClassUtils;
 import org.apache.dubbo.config.Constants;
 import org.apache.dubbo.rpc.model.MethodDescriptor;
 import org.apache.dubbo.rpc.model.PackableMethod;
@@ -34,8 +33,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.lang.reflect.ParameterizedType;
 import java.util.Iterator;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Stream;
 
 import static org.apache.dubbo.common.constants.CommonConstants.$ECHO;
 import static org.apache.dubbo.common.constants.CommonConstants.PROTOBUF_MESSAGE_CLASS_NAME;
@@ -75,7 +73,7 @@ public class ReflectionPackableMethod implements PackableMethod {
                 break;
             case UNARY:
                 actualRequestTypes = method.getParameterClasses();
-                actualResponseType = (Class<?>) method.getReturnTypes()[0];
+                actualResponseType = method.getReturnClass();
                 break;
             default:
                 throw new IllegalStateException("Can not reach here");
@@ -93,7 +91,8 @@ public class ReflectionPackableMethod implements PackableMethod {
                 .getExtension(url.getParameter(Constants.MULTI_SERIALIZATION_KEY,
                     CommonConstants.DEFAULT_KEY));
 
-            this.requestPack = new WrapRequestPack(serialization, url, serializeName, singleArgument);
+            this.requestPack = new WrapRequestPack(serialization, url, serializeName, actualRequestTypes,
+                singleArgument);
             this.responsePack = new WrapResponsePack(serialization, url, actualResponseType);
             this.requestUnpack = new WrapRequestUnpack(serialization, url, actualRequestTypes);
             this.responseUnpack = new WrapResponseUnpack(serialization, url, actualResponseType);
@@ -323,16 +322,10 @@ public class ReflectionPackableMethod implements PackableMethod {
         @Override
         public byte[] pack(Object obj) throws IOException {
             ByteArrayOutputStream bos = new ByteArrayOutputStream();
-            Class<?> clz;
-            if (obj != null) {
-                clz = obj.getClass();
-            } else {
-                clz = actualResponseType;
-            }
-            multipleSerialization.serialize(url, serialize, clz, obj, bos);
+            multipleSerialization.serialize(url, serialize, actualResponseType, obj, bos);
             return TripleCustomerProtocolWapper.TripleResponseWrapper.Builder.newBuilder()
                 .setSerializeType(serialize)
-                .setType(clz.getName())
+                .setType(actualResponseType.getName())
                 .setData(bos.toByteArray())
                 .build()
                 .toByteArray();
@@ -341,17 +334,15 @@ public class ReflectionPackableMethod implements PackableMethod {
 
     private static class WrapResponseUnpack implements UnPack {
 
-        private final Map<String, Class<?>> classCache = new ConcurrentHashMap<>();
-
         private final MultipleSerialization serialization;
         private final URL url;
+        private final Class<?> returnClass;
 
-        private final Class<?> actualResponseType;
 
-        private WrapResponseUnpack(MultipleSerialization serialization, URL url, Class<?> actualResponseType) {
+        private WrapResponseUnpack(MultipleSerialization serialization, URL url, Class<?> returnClass) {
             this.serialization = serialization;
             this.url = url;
-            this.actualResponseType = actualResponseType;
+            this.returnClass = returnClass;
         }
 
         @Override
@@ -360,8 +351,7 @@ public class ReflectionPackableMethod implements PackableMethod {
                 .parseFrom(data);
             final String serializeType = convertHessianFromWrapper(wrapper.getSerializeType());
             ByteArrayInputStream bais = new ByteArrayInputStream(wrapper.getData());
-            Class<?> clz = getClassFromCache(wrapper.getType(), classCache, actualResponseType);
-            return serialization.deserialize(url, serializeType, clz, bais);
+            return serialization.deserialize(url, serializeType, returnClass, bais);
         }
     }
 
@@ -369,16 +359,19 @@ public class ReflectionPackableMethod implements PackableMethod {
 
         private final String serialize;
         private final MultipleSerialization multipleSerialization;
+        private final String[] argumentsType;
         private final URL url;
         private final boolean singleArgument;
 
         private WrapRequestPack(MultipleSerialization multipleSerialization,
                                 URL url,
                                 String serialize,
+                                Class<?>[] actualRequestTypes,
                                 boolean singleArgument) {
             this.url = url;
             this.serialize = convertHessianToWrapper(serialize);
             this.multipleSerialization = multipleSerialization;
+            this.argumentsType = Stream.of(actualRequestTypes).map(Class::getName).toArray(String[]::new);
             this.singleArgument = singleArgument;
         }
 
@@ -392,8 +385,10 @@ public class ReflectionPackableMethod implements PackableMethod {
             }
             final TripleCustomerProtocolWapper.TripleRequestWrapper.Builder builder = TripleCustomerProtocolWapper.TripleRequestWrapper.Builder.newBuilder();
             builder.setSerializeType(serialize);
+            for (String type : argumentsType) {
+                builder.addArgTypes(type);
+            }
             for (Object argument : arguments) {
-                builder.addArgTypes(argument.getClass().getName());
                 ByteArrayOutputStream bos = new ByteArrayOutputStream();
                 multipleSerialization.serialize(url, serialize, argument.getClass(), argument, bos);
                 builder.addArgs(bos.toByteArray());
@@ -436,8 +431,6 @@ public class ReflectionPackableMethod implements PackableMethod {
 
     private class WrapRequestUnpack implements UnPack {
 
-        private final Map<String, Class<?>> classCache = new ConcurrentHashMap<>();
-
         private final MultipleSerialization serialization;
         private final URL url;
 
@@ -458,32 +451,11 @@ public class ReflectionPackableMethod implements PackableMethod {
             for (int i = 0; i < wrapper.getArgs().size(); i++) {
                 ByteArrayInputStream bais = new ByteArrayInputStream(
                     wrapper.getArgs().get(i));
-                String className = wrapper.getArgTypes().get(i);
-                Class<?> clz = getClassFromCache(className, classCache, actualRequestTypes[i]);
-                ret[i] = serialization.deserialize(url, wrapper.getSerializeType(), clz, bais);
+                ret[i] = serialization.deserialize(url, wrapper.getSerializeType(),
+                    actualRequestTypes[i],
+                    bais);
             }
             return ret;
         }
-
-
-    }
-
-
-    private static Class<?> getClassFromCache(String className, Map<String, Class<?>> classCache, Class<?> expectedClass) {
-        if (expectedClass.getName().equals(className)) {
-            return expectedClass;
-        }
-
-        Class<?> clz = classCache.get(className);
-        if (clz == null) {
-            try {
-                clz = ClassUtils.forName(className);
-            } catch (Exception e) {
-                // To catch IllegalStateException, LinkageError, ClassNotFoundException
-                clz = expectedClass;
-            }
-            classCache.put(className, clz);
-        }
-        return clz;
     }
 }

--- a/dubbo-serialization/dubbo-serialization-api/src/main/java/org/apache/dubbo/common/serialize/MultipleSerialization.java
+++ b/dubbo-serialization/dubbo-serialization-api/src/main/java/org/apache/dubbo/common/serialize/MultipleSerialization.java
@@ -29,21 +29,7 @@ import java.io.OutputStream;
 @SPI(scope = ExtensionScope.FRAMEWORK)
 public interface MultipleSerialization {
 
-
-    default void serialize(URL url, String serializeType, String clzStr, Object obj, OutputStream os) throws IOException, ClassNotFoundException {
-        Class<?> clz = ClassUtils.forName(clzStr);
-        serialize(url, serializeType, clz, obj, os);
-    }
-
-
     void serialize(URL url, String serializeType, Class<?> clz, Object obj, OutputStream os) throws IOException;
-
-
-    default Object deserialize(URL url, String serializeType, String clzStr, InputStream os) throws IOException, ClassNotFoundException {
-        Class<?> clz = ClassUtils.forName(clzStr);
-        return deserialize(url, serializeType, clz, os);
-    }
-
 
     Object deserialize(URL url, String serializeType, Class<?> clz, InputStream os) throws IOException, ClassNotFoundException;
 

--- a/dubbo-serialization/dubbo-serialization-api/src/main/java/org/apache/dubbo/common/serialize/MultipleSerialization.java
+++ b/dubbo-serialization/dubbo-serialization-api/src/main/java/org/apache/dubbo/common/serialize/MultipleSerialization.java
@@ -20,7 +20,6 @@ package org.apache.dubbo.common.serialize;
 import org.apache.dubbo.common.URL;
 import org.apache.dubbo.common.extension.ExtensionScope;
 import org.apache.dubbo.common.extension.SPI;
-import org.apache.dubbo.common.utils.ClassUtils;
 
 import java.io.IOException;
 import java.io.InputStream;


### PR DESCRIPTION
## What is the purpose of the change

Fix triple protocol's  wrapper mode  can not recognize primitive method.
```java
interface A{
  // call0
  void call(int a);

 // call1
  void call(Integer b);
}
```
When client wants to invoke `call0` with argument `1`,
Server will call `call1` with `(Integer)1`

## Brief changelog
1. Pass interface's argument types instead of actual types.
2. Delete unused methods in `MultipleSerialization` interface.

## Verifying this change


<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [ ] GitHub Actions works fine on your own branch.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
