### PR TITLE
fix : delete never thrown exception

### DIFF
--- a/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/filter/DefaultFilterChainBuilderTest.java
+++ b/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/filter/DefaultFilterChainBuilderTest.java
@@ -43,7 +43,7 @@ class DefaultFilterChainBuilderTest {
         urlWithoutFilter = urlWithoutFilter.setScopeModel(ApplicationModel.defaultModel());
         AbstractInvoker<DemoService> invokerWithoutFilter = new AbstractInvoker<DemoService>(DemoService.class, urlWithoutFilter) {
             @Override
-            protected Result doInvoke(Invocation invocation) throws Throwable {
+            protected Result doInvoke(Invocation invocation) {
                 return null;
             }
         };
@@ -58,7 +58,7 @@ class DefaultFilterChainBuilderTest {
         urlWithFilter = urlWithFilter.setScopeModel(ApplicationModel.defaultModel());
         AbstractInvoker<DemoService> invokerWithFilter = new AbstractInvoker<DemoService>(DemoService.class, urlWithFilter) {
             @Override
-            protected Result doInvoke(Invocation invocation) throws Throwable {
+            protected Result doInvoke(Invocation invocation) {
                 return null;
             }
         };
@@ -93,7 +93,7 @@ class DefaultFilterChainBuilderTest {
         urlWithFilter = urlWithFilter.setScopeModel(ApplicationModel.defaultModel());
         AbstractInvoker<DemoService> invokerWithFilter = new AbstractInvoker<DemoService>(DemoService.class, urlWithFilter) {
             @Override
-            protected Result doInvoke(Invocation invocation) throws Throwable {
+            protected Result doInvoke(Invocation invocation) {
                 return null;
             }
         };

--- a/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/support/AbstractClusterInvokerTest.java
+++ b/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/support/AbstractClusterInvokerTest.java
@@ -194,7 +194,7 @@ class AbstractClusterInvokerTest {
     }
 
     @Test
-    void testSelect_Invokersize0() throws Exception {
+    void testSelect_Invokersize0() {
         LoadBalance l = cluster.initLoadBalance(invokers, invocation);
         Assertions.assertNotNull(l,"cluster.initLoadBalance returns null!");
         {
@@ -228,7 +228,7 @@ class AbstractClusterInvokerTest {
     }
 
     @Test
-    void testSelect_Invokersize1() throws Exception {
+    void testSelect_Invokersize1() {
         invokers.clear();
         invokers.add(invoker1);
         LoadBalance l = cluster.initLoadBalance(invokers, invocation);
@@ -238,7 +238,7 @@ class AbstractClusterInvokerTest {
     }
 
     @Test
-    void testSelect_Invokersize2AndselectNotNull() throws Exception {
+    void testSelect_Invokersize2AndselectNotNull() {
         invokers.clear();
         invokers.add(invoker2);
         invokers.add(invoker4);
@@ -412,7 +412,7 @@ class AbstractClusterInvokerTest {
     }
 
 
-    public void testSelect_multiInvokers(String lbname) throws Exception {
+    public void testSelect_multiInvokers(String lbname) {
 
         int min = 100, max = 500;
         Double d = (Math.random() * (max - min + 1) + min);

--- a/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/support/ClusterUtilsTest.java
+++ b/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/support/ClusterUtilsTest.java
@@ -55,7 +55,7 @@ class ClusterUtilsTest {
     }
 
     @Test
-    void testMergeUrl() throws Exception {
+    void testMergeUrl() {
         URL providerURL = URL.valueOf("dubbo://localhost:55555");
         providerURL = providerURL.setPath("path")
             .setUsername("username")

--- a/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/support/merger/DefaultProviderURLMergeProcessorTest.java
+++ b/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/support/merger/DefaultProviderURLMergeProcessorTest.java
@@ -57,7 +57,7 @@ class DefaultProviderURLMergeProcessorTest {
     }
 
     @Test
-    void testMergeUrl() throws Exception {
+    void testMergeUrl() {
         URL providerURL = URL.valueOf("dubbo://localhost:55555");
         providerURL = providerURL.setPath("path")
             .setUsername("username")

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/bytecode/MixinTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/bytecode/MixinTest.java
@@ -23,7 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class MixinTest {
 
     @Test
-    void testMain() throws Exception {
+    void testMain() {
         Mixin mixin = Mixin.mixin(new Class[]{I1.class, I2.class, I3.class}, new Class[]{C1.class, C2.class});
         Object o = mixin.newInstance(new Object[]{new C1(), new C2()});
         assertTrue(o instanceof I1);

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/compiler/support/JavassistCompilerTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/compiler/support/JavassistCompilerTest.java
@@ -55,7 +55,7 @@ class JavassistCompilerTest extends JavaCodeTest {
     }
 
     @Test
-    void testCompileJavaClass1() throws Exception {
+    void testCompileJavaClass1() {
         Assertions.assertThrows(IllegalStateException.class, () -> {
             JavassistCompiler compiler = new JavassistCompiler();
             Class<?> clazz = compiler.compile(JavaCodeTest.class, getSimpleCodeWithSyntax0(), JavassistCompiler.class.getClassLoader());

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/compiler/support/JdkCompilerTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/compiler/support/JdkCompilerTest.java
@@ -33,7 +33,7 @@ class JdkCompilerTest extends JavaCodeTest {
     }
 
     @Test
-    void test_compileJavaClass0() throws Exception {
+    void test_compileJavaClass0() {
         Assertions.assertThrows(IllegalStateException.class, () -> {
             JdkCompiler compiler = new JdkCompiler();
             Class<?> clazz = compiler.compile(JavaCodeTest.class, getSimpleCodeWithoutPackage(), JdkCompiler.class.getClassLoader());
@@ -44,7 +44,7 @@ class JdkCompilerTest extends JavaCodeTest {
     }
 
     @Test
-    void test_compileJavaClass1() throws Exception {
+    void test_compileJavaClass1() {
         Assertions.assertThrows(IllegalStateException.class, () -> {
             JdkCompiler compiler = new JdkCompiler();
             Class<?> clazz = compiler.compile(JavaCodeTest.class, getSimpleCodeWithSyntax(), JdkCompiler.class.getClassLoader());
@@ -64,7 +64,7 @@ class JdkCompilerTest extends JavaCodeTest {
     }
 
     @Test
-    void test_compileJavaClass0_java8() throws Exception {
+    void test_compileJavaClass0_java8() {
         Assertions.assertThrows(IllegalStateException.class, () -> {
             JdkCompiler compiler = new JdkCompiler("1.8");
             Class<?> clazz = compiler.compile(JavaCodeTest.class, getSimpleCodeWithoutPackage(), JdkCompiler.class.getClassLoader());
@@ -75,7 +75,7 @@ class JdkCompilerTest extends JavaCodeTest {
     }
 
     @Test
-    void test_compileJavaClass1_java8() throws Exception {
+    void test_compileJavaClass1_java8() {
         Assertions.assertThrows(IllegalStateException.class, () -> {
             JdkCompiler compiler = new JdkCompiler("1.8");
             Class<?> clazz = compiler.compile(JavaCodeTest.class, getSimpleCodeWithSyntax(), JdkCompiler.class.getClassLoader());

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/config/configcenter/AbstractDynamicConfigurationTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/config/configcenter/AbstractDynamicConfigurationTest.java
@@ -52,17 +52,17 @@ class AbstractDynamicConfigurationTest {
     public void init() {
         configuration = new AbstractDynamicConfiguration(null) {
             @Override
-            protected String doGetConfig(String key, String group) throws Exception {
+            protected String doGetConfig(String key, String group) {
                 return null;
             }
 
             @Override
-            protected void doClose() throws Exception {
+            protected void doClose() {
 
             }
 
             @Override
-            protected boolean doRemoveConfig(String key, String group) throws Exception {
+            protected boolean doRemoveConfig(String key, String group) {
                 return false;
             }
         };
@@ -93,17 +93,17 @@ class AbstractDynamicConfigurationTest {
         AbstractDynamicConfiguration configuration = new AbstractDynamicConfiguration(url) {
 
             @Override
-            protected String doGetConfig(String key, String group) throws Exception {
+            protected String doGetConfig(String key, String group) {
                 return null;
             }
 
             @Override
-            protected void doClose() throws Exception {
+            protected void doClose() {
 
             }
 
             @Override
-            protected boolean doRemoveConfig(String key, String group) throws Exception {
+            protected boolean doRemoveConfig(String key, String group) {
                 return false;
             }
         };

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/io/BytesTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/io/BytesTest.java
@@ -32,7 +32,7 @@ class BytesTest {
     private byte[] bytes2 = {3, 12, 14, 41, 12, 2, 3, 12, 4, 67};
 
     @Test
-    void testMain() throws Exception {
+    void testMain() {
         short s = (short) 0xabcd;
         assertThat(s, is(Bytes.bytes2short(Bytes.short2bytes(s))));
 
@@ -86,7 +86,7 @@ class BytesTest {
     }
 
     @Test
-    void testBase64S2b2sFailCaseLog() throws Exception {
+    void testBase64S2b2sFailCaseLog() {
         String s1 = Bytes.bytes2base64(bytes1);
         byte[] out1 = Bytes.base642bytes(s1);
         assertThat(bytes1, is(out1));

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/resource/GlobalResourcesRepositoryTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/resource/GlobalResourcesRepositoryTest.java
@@ -27,7 +27,7 @@ import java.util.concurrent.ExecutorService;
 class GlobalResourcesRepositoryTest {
 
     @Test
-    void test() throws NoSuchFieldException {
+    void test() {
         GlobalResourcesRepository repository = GlobalResourcesRepository.getInstance();
 
         ExecutorService globalExecutorService = GlobalResourcesRepository.getGlobalExecutorService();

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/status/support/LoadStatusCheckerTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/status/support/LoadStatusCheckerTest.java
@@ -30,7 +30,7 @@ class LoadStatusCheckerTest {
     private static Logger logger = LoggerFactory.getLogger(LoadStatusCheckerTest.class);
 
     @Test
-    void test() throws Exception {
+    void test() {
         LoadStatusChecker statusChecker = new LoadStatusChecker();
         Status status = statusChecker.check();
         assertThat(status, notNullValue());

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/status/support/MemoryStatusCheckerTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/status/support/MemoryStatusCheckerTest.java
@@ -33,7 +33,7 @@ class MemoryStatusCheckerTest {
     private static final Logger logger = LoggerFactory.getLogger(MemoryStatusCheckerTest.class);
 
     @Test
-    void test() throws Exception {
+    void test() {
         MemoryStatusChecker statusChecker = new MemoryStatusChecker();
         Status status = statusChecker.check();
         assertThat(status.getLevel(), anyOf(is(OK), is(WARN)));

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/threadlocal/InternalThreadLocalTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/threadlocal/InternalThreadLocalTest.java
@@ -49,7 +49,7 @@ class InternalThreadLocalTest {
     }
 
     @Test
-    void testInternalThreadLocal() throws InterruptedException {
+    void testInternalThreadLocal() {
         final AtomicInteger index = new AtomicInteger(0);
 
         final InternalThreadLocal<Integer> internalThreadLocal = new InternalThreadLocal<Integer>() {
@@ -71,7 +71,7 @@ class InternalThreadLocalTest {
     }
 
     @Test
-    void testRemoveAll() throws InterruptedException {
+    void testRemoveAll() {
         final InternalThreadLocal<Integer> internalThreadLocal = new InternalThreadLocal<Integer>();
         internalThreadLocal.set(1);
         Assertions.assertEquals(1, (int)internalThreadLocal.get(), "set failed");
@@ -86,7 +86,7 @@ class InternalThreadLocalTest {
     }
 
     @Test
-    void testSize() throws InterruptedException {
+    void testSize() {
         final InternalThreadLocal<Integer> internalThreadLocal = new InternalThreadLocal<Integer>();
         internalThreadLocal.set(1);
         Assertions.assertEquals(1, InternalThreadLocal.size(), "size method is wrong!");
@@ -120,7 +120,7 @@ class InternalThreadLocalTest {
         final Integer[] valueToRemove = {null};
         final InternalThreadLocal<Integer> internalThreadLocal = new InternalThreadLocal<Integer>() {
             @Override
-            protected void onRemoval(Integer value) throws Exception {
+            protected void onRemoval(Integer value) {
                 //value calculate
                 valueToRemove[0] = value + 1;
             }

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/threadpool/MemoryLimitedLinkedBlockingQueueTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/threadpool/MemoryLimitedLinkedBlockingQueueTest.java
@@ -27,7 +27,7 @@ import static org.hamcrest.Matchers.is;
 
 class MemoryLimitedLinkedBlockingQueueTest {
     @Test
-    void test() throws Exception {
+    void test() {
         ByteBuddyAgent.install();
         final Instrumentation instrumentation = ByteBuddyAgent.getInstrumentation();
         MemoryLimitedLinkedBlockingQueue<Runnable> queue = new MemoryLimitedLinkedBlockingQueue<>(1, instrumentation);

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/threadpool/MemorySafeLinkedBlockingQueueTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/threadpool/MemorySafeLinkedBlockingQueueTest.java
@@ -31,7 +31,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class MemorySafeLinkedBlockingQueueTest {
     @Test
-    void test() throws Exception {
+    void test() {
         ByteBuddyAgent.install();
         final Instrumentation instrumentation = ByteBuddyAgent.getInstrumentation();
         final long objectSize = instrumentation.getObjectSize((Runnable) () -> {
@@ -49,7 +49,7 @@ class MemorySafeLinkedBlockingQueueTest {
     }
 
     @Test
-    void testCustomReject() throws Exception {
+    void testCustomReject() {
         MemorySafeLinkedBlockingQueue<Runnable> queue = new MemorySafeLinkedBlockingQueue<>(Integer.MAX_VALUE);
         queue.setRejector(new AbortPolicy<>());
         assertThrows(RejectException.class, () -> queue.offer(() -> {

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/threadpool/support/AbortPolicyWithReportTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/threadpool/support/AbortPolicyWithReportTest.java
@@ -38,13 +38,13 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class AbortPolicyWithReportTest {
     @Test
-    void jStackDumpTest() throws InterruptedException {
+    void jStackDumpTest() {
         URL url = URL.valueOf("dubbo://admin:hello1234@10.20.130.230:20880/context/path?dump.directory=/tmp&version=1.0.0&application=morgan&noValue=");
         AtomicReference<FileOutputStream> fileOutputStream = new AtomicReference<>();
 
         AbortPolicyWithReport abortPolicyWithReport = new AbortPolicyWithReport("Test", url) {
             @Override
-            protected void jstack(FileOutputStream jStackStream) throws Exception {
+            protected void jstack(FileOutputStream jStackStream) {
                 fileOutputStream.set(jStackStream);
             }
         };
@@ -59,7 +59,7 @@ class AbortPolicyWithReportTest {
     }
 
     @Test
-    void jStackDumpTest_dumpDirectoryNotExists_cannotBeCreatedTakeUserHome() throws InterruptedException {
+    void jStackDumpTest_dumpDirectoryNotExists_cannotBeCreatedTakeUserHome() {
         final String dumpDirectory = dumpDirectoryCannotBeCreated();
 
         URL url = URL.valueOf("dubbo://admin:hello1234@10.20.130.230:20880/context/path?dump.directory="
@@ -81,7 +81,7 @@ class AbortPolicyWithReportTest {
     }
 
     @Test
-    void jStackDumpTest_dumpDirectoryNotExists_canBeCreated() throws InterruptedException {
+    void jStackDumpTest_dumpDirectoryNotExists_canBeCreated() {
         final String dumpDirectory = UUID.randomUUID().toString();
 
         URL url = URL.valueOf("dubbo://admin:hello1234@10.20.130.230:20880/context/path?dump.directory="

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/threadpool/support/cached/CachedThreadPoolTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/threadpool/support/cached/CachedThreadPoolTest.java
@@ -72,7 +72,7 @@ class CachedThreadPoolTest {
     }
 
     @Test
-    void getExecutor2() throws Exception {
+    void getExecutor2() {
         URL url = URL.valueOf("dubbo://10.20.130.230:20880/context/path?" + QUEUES_KEY + "=1");
         ThreadPool threadPool = new CachedThreadPool();
         ThreadPoolExecutor executor = (ThreadPoolExecutor) threadPool.getExecutor(url);

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/threadpool/support/eager/EagerThreadPoolExecutorTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/threadpool/support/eager/EagerThreadPoolExecutorTest.java
@@ -101,7 +101,7 @@ class EagerThreadPoolExecutorTest {
     }
 
     @Test
-    void testEagerThreadPoolFast() throws Exception {
+    void testEagerThreadPoolFast() {
         String name = "eager-tf";
         int queues = 5;
         int cores = 5;
@@ -171,7 +171,7 @@ class EagerThreadPoolExecutorTest {
     }
 
     @Test
-    void testEagerThreadPool_rejectExecution1() throws Exception {
+    void testEagerThreadPool_rejectExecution1() {
         String name = "eager-tf";
         int cores = 1;
         int threads = 3;
@@ -213,7 +213,7 @@ class EagerThreadPoolExecutorTest {
 
 
     @Test
-    void testEagerThreadPool_rejectExecution2() throws Exception {
+    void testEagerThreadPool_rejectExecution2() {
         String name = "eager-tf";
         int cores = 1;
         int threads = 3;

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/threadpool/support/eager/EagerThreadPoolTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/threadpool/support/eager/EagerThreadPoolTest.java
@@ -74,7 +74,7 @@ class EagerThreadPoolTest {
     }
 
     @Test
-    void getExecutor2() throws Exception {
+    void getExecutor2() {
         URL url = URL.valueOf("dubbo://10.20.130.230:20880/context/path?" + QUEUES_KEY + "=2");
         ThreadPool threadPool = new EagerThreadPool();
         ThreadPoolExecutor executor = (ThreadPoolExecutor) threadPool.getExecutor(url);

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/threadpool/support/limited/LimitedThreadPoolTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/threadpool/support/limited/LimitedThreadPoolTest.java
@@ -73,7 +73,7 @@ class LimitedThreadPoolTest {
     }
 
     @Test
-    void getExecutor2() throws Exception {
+    void getExecutor2() {
         URL url = URL.valueOf("dubbo://10.20.130.230:20880/context/path?" + QUEUES_KEY + "=1");
         ThreadPool threadPool = new LimitedThreadPool();
         ThreadPoolExecutor executor = (ThreadPoolExecutor) threadPool.getExecutor(url);

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/utils/AnnotationUtilsTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/utils/AnnotationUtilsTest.java
@@ -69,7 +69,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class AnnotationUtilsTest {
 
     @Test
-    void testIsType() throws NoSuchMethodException {
+    void testIsType() {
         // null checking
         assertFalse(isType(null));
         // Method checking

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/utils/ArrayUtilsTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/utils/ArrayUtilsTest.java
@@ -25,14 +25,14 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class ArrayUtilsTest {
 
     @Test
-    void isEmpty() throws Exception {
+    void isEmpty() {
         assertTrue(ArrayUtils.isEmpty(null));
         assertTrue(ArrayUtils.isEmpty(new Object[0]));
         assertFalse(ArrayUtils.isEmpty(new Object[]{"abc"}));
     }
 
     @Test
-    void isNotEmpty() throws Exception {
+    void isNotEmpty() {
         assertFalse(ArrayUtils.isNotEmpty(null));
         assertFalse(ArrayUtils.isNotEmpty(new Object[0]));
         assertTrue(ArrayUtils.isNotEmpty(new Object[]{"abc"}));

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/utils/AtomicPositiveIntegerTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/utils/AtomicPositiveIntegerTest.java
@@ -35,14 +35,14 @@ class AtomicPositiveIntegerTest {
     private AtomicPositiveInteger i3 = new AtomicPositiveInteger(Integer.MAX_VALUE);
 
     @Test
-    void testGet() throws Exception {
+    void testGet() {
         assertEquals(0, i1.get());
         assertEquals(127, i2.get());
         assertEquals(Integer.MAX_VALUE, i3.get());
     }
 
     @Test
-    void testSet() throws Exception {
+    void testSet() {
         i1.set(100);
         assertEquals(100, i1.get());
 
@@ -56,7 +56,7 @@ class AtomicPositiveIntegerTest {
     }
 
     @Test
-    void testGetAndIncrement() throws Exception {
+    void testGetAndIncrement() {
         int get = i1.getAndIncrement();
         assertEquals(0, get);
         assertEquals(1, i1.get());
@@ -71,7 +71,7 @@ class AtomicPositiveIntegerTest {
     }
 
     @Test
-    void testGetAndDecrement() throws Exception {
+    void testGetAndDecrement() {
         int get = i1.getAndDecrement();
         assertEquals(0, get);
         assertEquals(Integer.MAX_VALUE, i1.get());
@@ -86,7 +86,7 @@ class AtomicPositiveIntegerTest {
     }
 
     @Test
-    void testIncrementAndGet() throws Exception {
+    void testIncrementAndGet() {
         int get = i1.incrementAndGet();
         assertEquals(1, get);
         assertEquals(1, i1.get());
@@ -101,7 +101,7 @@ class AtomicPositiveIntegerTest {
     }
 
     @Test
-    void testDecrementAndGet() throws Exception {
+    void testDecrementAndGet() {
         int get = i1.decrementAndGet();
         assertEquals(Integer.MAX_VALUE, get);
         assertEquals(Integer.MAX_VALUE, i1.get());
@@ -116,7 +116,7 @@ class AtomicPositiveIntegerTest {
     }
 
     @Test
-    void testGetAndSet() throws Exception {
+    void testGetAndSet() {
         int get = i1.getAndSet(100);
         assertEquals(0, get);
         assertEquals(100, i1.get());
@@ -130,7 +130,7 @@ class AtomicPositiveIntegerTest {
     }
 
     @Test
-    void testGetAndAnd() throws Exception {
+    void testGetAndAnd() {
         int get = i1.getAndAdd(3);
         assertEquals(0, get);
         assertEquals(3, i1.get());
@@ -146,7 +146,7 @@ class AtomicPositiveIntegerTest {
 
 
     @Test
-    void testAddAndGet() throws Exception {
+    void testAddAndGet() {
         int get = i1.addAndGet(3);
         assertEquals(3, get);
         assertEquals(3, i1.get());
@@ -187,7 +187,7 @@ class AtomicPositiveIntegerTest {
     }
 
     @Test
-    void testValues() throws Exception {
+    void testValues() {
         Integer i = i1.get();
         assertThat(i1.byteValue(), equalTo(i.byteValue()));
         assertThat(i1.shortValue(), equalTo(i.shortValue()));

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/utils/ClassUtilsTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/utils/ClassUtilsTest.java
@@ -48,12 +48,12 @@ class ClassUtilsTest {
     }
 
     @Test
-    void testGetCallerClassLoader() throws Exception {
+    void testGetCallerClassLoader() {
         assertThat(ClassUtils.getCallerClassLoader(ClassUtilsTest.class), sameInstance(ClassUtilsTest.class.getClassLoader()));
     }
 
     @Test
-    void testGetClassLoader1() throws Exception {
+    void testGetClassLoader1() {
         ClassLoader oldClassLoader = Thread.currentThread().getContextClassLoader();
         try {
             assertThat(ClassUtils.getClassLoader(ClassUtilsTest.class), sameInstance(oldClassLoader));
@@ -65,7 +65,7 @@ class ClassUtilsTest {
     }
 
     @Test
-    void testGetClassLoader2() throws Exception {
+    void testGetClassLoader2() {
         assertThat(ClassUtils.getClassLoader(), sameInstance(ClassUtils.class.getClassLoader()));
     }
 
@@ -89,7 +89,7 @@ class ClassUtilsTest {
     }
 
     @Test
-    void testResolvePrimitiveClassName() throws Exception {
+    void testResolvePrimitiveClassName() {
         assertThat(ClassUtils.resolvePrimitiveClassName("boolean") == boolean.class, is(true));
         assertThat(ClassUtils.resolvePrimitiveClassName("byte") == byte.class, is(true));
         assertThat(ClassUtils.resolvePrimitiveClassName("char") == char.class, is(true));
@@ -109,13 +109,13 @@ class ClassUtilsTest {
     }
 
     @Test
-    void testToShortString() throws Exception {
+    void testToShortString() {
         assertThat(ClassUtils.toShortString(null), equalTo("null"));
         assertThat(ClassUtils.toShortString(new ClassUtilsTest()), startsWith("ClassUtilsTest@"));
     }
 
     @Test
-    void testConvertPrimitive() throws Exception {
+    void testConvertPrimitive() {
 
         assertThat(ClassUtils.convertPrimitive(char.class, ""), equalTo(null));
         assertThat(ClassUtils.convertPrimitive(char.class, null), equalTo(null));

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/utils/CollectionUtilsTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/utils/CollectionUtilsTest.java
@@ -50,7 +50,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class CollectionUtilsTest {
     @Test
-    void testSort() throws Exception {
+    void testSort() {
         List<Integer> list = new ArrayList<Integer>();
         list.add(100);
         list.add(10);
@@ -65,14 +65,14 @@ class CollectionUtilsTest {
     }
 
     @Test
-    void testSortNull() throws Exception {
+    void testSortNull() {
         assertNull(CollectionUtils.sort(null));
 
         assertTrue(CollectionUtils.sort(new ArrayList<Integer>()).isEmpty());
     }
 
     @Test
-    void testSortSimpleName() throws Exception {
+    void testSortSimpleName() {
         List<String> list = new ArrayList<String>();
         list.add("aaa.z");
         list.add("b");
@@ -87,7 +87,7 @@ class CollectionUtilsTest {
     }
 
     @Test
-    void testSortSimpleNameNull() throws Exception {
+    void testSortSimpleNameNull() {
         assertNull(CollectionUtils.sortSimpleName(null));
 
         assertTrue(CollectionUtils.sortSimpleName(new ArrayList<String>()).isEmpty());
@@ -110,7 +110,7 @@ class CollectionUtilsTest {
     }
 
     @Test
-    void testSplitAll() throws Exception {
+    void testSplitAll() {
         assertNull(CollectionUtils.splitAll(null, null));
         assertNull(CollectionUtils.splitAll(null, "-"));
 
@@ -132,7 +132,7 @@ class CollectionUtilsTest {
     }
 
     @Test
-    void testJoinAll() throws Exception {
+    void testJoinAll() {
         assertNull(CollectionUtils.joinAll(null, null));
         assertNull(CollectionUtils.joinAll(null, "-"));
 
@@ -159,7 +159,7 @@ class CollectionUtilsTest {
     }
 
     @Test
-    void testJoinList() throws Exception {
+    void testJoinList() {
         List<String> list = emptyList();
         assertEquals("", CollectionUtils.join(list, "/"));
 
@@ -171,7 +171,7 @@ class CollectionUtilsTest {
     }
 
     @Test
-    void testMapEquals() throws Exception {
+    void testMapEquals() {
         assertTrue(CollectionUtils.mapEquals(null, null));
         assertFalse(CollectionUtils.mapEquals(null, new HashMap<String, String>()));
         assertFalse(CollectionUtils.mapEquals(new HashMap<String, String>(), null));
@@ -181,17 +181,17 @@ class CollectionUtilsTest {
     }
 
     @Test
-    void testStringMap1() throws Exception {
+    void testStringMap1() {
         assertThat(toStringMap("key", "value"), equalTo(Collections.singletonMap("key", "value")));
     }
 
     @Test
-    void testStringMap2() throws Exception {
+    void testStringMap2() {
         Assertions.assertThrows(IllegalArgumentException.class, () -> toStringMap("key", "value", "odd"));
     }
 
     @Test
-    void testToMap1() throws Exception {
+    void testToMap1() {
         assertTrue(CollectionUtils.toMap().isEmpty());
 
         Map<String, Integer> expected = new HashMap<String, Integer>();
@@ -211,19 +211,19 @@ class CollectionUtilsTest {
     }
 
     @Test
-    void testToMap2() throws Exception {
+    void testToMap2() {
         Assertions.assertThrows(IllegalArgumentException.class, () -> toMap("a", "b", "c"));
     }
 
     @Test
-    void testIsEmpty() throws Exception {
+    void testIsEmpty() {
         assertThat(isEmpty(null), is(true));
         assertThat(isEmpty(new HashSet()), is(true));
         assertThat(isEmpty(emptyList()), is(true));
     }
 
     @Test
-    void testIsNotEmpty() throws Exception {
+    void testIsNotEmpty() {
         assertThat(isNotEmpty(singleton("a")), is(true));
     }
 

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/utils/LFUCacheTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/utils/LFUCacheTest.java
@@ -27,7 +27,7 @@ import static org.hamcrest.Matchers.equalTo;
 class LFUCacheTest {
 
     @Test
-    void testCacheEviction() throws Exception {
+    void testCacheEviction() {
         LFUCache<String, Integer> cache = new LFUCache<>(8, 0.8f);
         cache.put("one", 1);
         cache.put("two", 2);
@@ -48,7 +48,7 @@ class LFUCacheTest {
     }
 
     @Test
-    void testCacheRemove() throws Exception {
+    void testCacheRemove() {
         LFUCache<String, Integer> cache = new LFUCache<>(8, 0.8f);
         cache.put("one", 1);
         cache.put("two", 2);
@@ -68,13 +68,13 @@ class LFUCacheTest {
     }
 
     @Test
-    void testDefaultCapacity() throws Exception {
+    void testDefaultCapacity() {
         LFUCache<String, Integer> cache = new LFUCache<>();
         assertThat(cache.getCapacity(), equalTo(1000));
     }
 
     @Test
-    void testErrorConstructArguments() throws IOException {
+    void testErrorConstructArguments() {
         Assertions.assertThrows(IllegalArgumentException.class, () -> new LFUCache<>(0, 0.8f));
         Assertions.assertThrows(IllegalArgumentException.class, () -> new LFUCache<>(-1, 0.8f));
         Assertions.assertThrows(IllegalArgumentException.class, () -> new LFUCache<>(100, 0.0f));

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/utils/LRU2CacheTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/utils/LRU2CacheTest.java
@@ -26,7 +26,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class LRU2CacheTest {
     @Test
-    void testCache() throws Exception {
+    void testCache() {
         LRU2Cache<String, Integer> cache = new LRU2Cache<String, Integer>(3);
         cache.put("one", 1);
         cache.put("two", 2);
@@ -62,7 +62,7 @@ class LRU2CacheTest {
     }
 
     @Test
-    void testCapacity() throws Exception {
+    void testCapacity() {
         LRU2Cache<String, Integer> cache = new LRU2Cache<String, Integer>();
         assertThat(cache.getMaxCapacity(), equalTo(1000));
         cache.setMaxCapacity(10);

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/utils/LogHelperTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/utils/LogHelperTest.java
@@ -28,7 +28,7 @@ import static org.mockito.Mockito.when;
 class LogHelperTest {
 
     @Test
-    void testTrace() throws Exception {
+    void testTrace() {
         Logger logger = Mockito.mock(Logger.class);
         when(logger.isTraceEnabled()).thenReturn(true);
         LogHelper.trace(logger, "trace");
@@ -41,7 +41,7 @@ class LogHelperTest {
     }
 
     @Test
-    void testDebug() throws Exception {
+    void testDebug() {
         Logger logger = Mockito.mock(Logger.class);
         when(logger.isDebugEnabled()).thenReturn(true);
         LogHelper.debug(logger, "debug");
@@ -54,7 +54,7 @@ class LogHelperTest {
     }
 
     @Test
-    void testInfo() throws Exception {
+    void testInfo() {
         Logger logger = Mockito.mock(Logger.class);
         when(logger.isInfoEnabled()).thenReturn(true);
         LogHelper.info(logger, "info");
@@ -67,7 +67,7 @@ class LogHelperTest {
     }
 
     @Test
-    void testWarn() throws Exception {
+    void testWarn() {
         Logger logger = Mockito.mock(Logger.class);
         when(logger.isWarnEnabled()).thenReturn(true);
         LogHelper.warn(logger, "warn");
@@ -80,7 +80,7 @@ class LogHelperTest {
     }
 
     @Test
-    void testError() throws Exception {
+    void testError() {
         Logger logger = Mockito.mock(Logger.class);
         when(logger.isErrorEnabled()).thenReturn(true);
         LogHelper.error(logger, "error");

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/utils/LogTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/utils/LogTest.java
@@ -27,7 +27,7 @@ import static org.hamcrest.Matchers.is;
 
 class LogTest {
     @Test
-    void testLogName() throws Exception {
+    void testLogName() {
         Log log1 = new Log();
         Log log2 = new Log();
         Log log3 = new Log();
@@ -41,7 +41,7 @@ class LogTest {
     }
 
     @Test
-    void testLogLevel() throws Exception {
+    void testLogLevel() {
         Log log1 = new Log();
         Log log2 = new Log();
         Log log3 = new Log();
@@ -55,7 +55,7 @@ class LogTest {
     }
 
     @Test
-    void testLogMessage() throws Exception {
+    void testLogMessage() {
         Log log1 = new Log();
         Log log2 = new Log();
         Log log3 = new Log();
@@ -69,7 +69,7 @@ class LogTest {
     }
 
     @Test
-    void testLogThread() throws Exception {
+    void testLogThread() {
         Log log1 = new Log();
         Log log2 = new Log();
         Log log3 = new Log();

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/utils/LogUtilTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/utils/LogUtilTest.java
@@ -34,7 +34,7 @@ class LogUtilTest {
     }
 
     @Test
-    void testStartStop() throws Exception {
+    void testStartStop() {
         LogUtil.start();
         assertThat(DubboAppender.available, is(true));
         LogUtil.stop();
@@ -42,7 +42,7 @@ class LogUtilTest {
     }
 
     @Test
-    void testCheckNoError() throws Exception {
+    void testCheckNoError() {
         Log log = mock(Log.class);
         DubboAppender.logList.add(log);
         when(log.getLogLevel()).thenReturn(Level.ERROR);
@@ -52,7 +52,7 @@ class LogUtilTest {
     }
 
     @Test
-    void testFindName() throws Exception {
+    void testFindName() {
         Log log = mock(Log.class);
         DubboAppender.logList.add(log);
         when(log.getLogName()).thenReturn("a");
@@ -60,7 +60,7 @@ class LogUtilTest {
     }
 
     @Test
-    void testFindLevel() throws Exception {
+    void testFindLevel() {
         Log log = mock(Log.class);
         DubboAppender.logList.add(log);
         when(log.getLogLevel()).thenReturn(Level.ERROR);
@@ -69,7 +69,7 @@ class LogUtilTest {
     }
 
     @Test
-    void testFindLevelWithThreadName() throws Exception {
+    void testFindLevelWithThreadName() {
         Log log = mock(Log.class);
         DubboAppender.logList.add(log);
         when(log.getLogLevel()).thenReturn(Level.ERROR);
@@ -82,7 +82,7 @@ class LogUtilTest {
     }
 
     @Test
-    void testFindThread() throws Exception {
+    void testFindThread() {
         Log log = mock(Log.class);
         DubboAppender.logList.add(log);
         when(log.getLogThread()).thenReturn("thread-1");
@@ -90,7 +90,7 @@ class LogUtilTest {
     }
 
     @Test
-    void testFindMessage1() throws Exception {
+    void testFindMessage1() {
         Log log = mock(Log.class);
         DubboAppender.logList.add(log);
         when(log.getLogMessage()).thenReturn("message");
@@ -98,7 +98,7 @@ class LogUtilTest {
     }
 
     @Test
-    void testFindMessage2() throws Exception {
+    void testFindMessage2() {
         Log log = mock(Log.class);
         DubboAppender.logList.add(log);
         when(log.getLogMessage()).thenReturn("message");

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/utils/MemberUtilsTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/utils/MemberUtilsTest.java
@@ -40,7 +40,7 @@ class MemberUtilsTest {
         assertTrue(isPublic(getClass().getMethod("publicMethod")));
     }
 
-    public void noStatic() throws NoSuchMethodException {
+    public void noStatic() {
 
     }
 

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/utils/NetUtilsTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/utils/NetUtilsTest.java
@@ -45,48 +45,48 @@ import static org.mockito.Mockito.when;
 class NetUtilsTest {
 
     @Test
-    void testGetRandomPort() throws Exception {
+    void testGetRandomPort() {
         assertThat(NetUtils.getRandomPort(), greaterThanOrEqualTo(30000));
         assertThat(NetUtils.getRandomPort(), greaterThanOrEqualTo(30000));
         assertThat(NetUtils.getRandomPort(), greaterThanOrEqualTo(30000));
     }
 
     @Test
-    void testGetAvailablePort() throws Exception {
+    void testGetAvailablePort() {
         assertThat(NetUtils.getAvailablePort(), greaterThan(0));
         assertThat(NetUtils.getAvailablePort(12345), greaterThanOrEqualTo(12345));
         assertThat(NetUtils.getAvailablePort(-1), greaterThanOrEqualTo(0));
     }
 
     @Test
-    void testValidAddress() throws Exception {
+    void testValidAddress() {
         assertTrue(NetUtils.isValidAddress("10.20.130.230:20880"));
         assertFalse(NetUtils.isValidAddress("10.20.130.230"));
         assertFalse(NetUtils.isValidAddress("10.20.130.230:666666"));
     }
 
     @Test
-    void testIsInvalidPort() throws Exception {
+    void testIsInvalidPort() {
         assertTrue(NetUtils.isInvalidPort(0));
         assertTrue(NetUtils.isInvalidPort(65536));
         assertFalse(NetUtils.isInvalidPort(1024));
     }
 
     @Test
-    void testIsLocalHost() throws Exception {
+    void testIsLocalHost() {
         assertTrue(NetUtils.isLocalHost("localhost"));
         assertTrue(NetUtils.isLocalHost("127.1.2.3"));
         assertFalse(NetUtils.isLocalHost("128.1.2.3"));
     }
 
     @Test
-    void testIsAnyHost() throws Exception {
+    void testIsAnyHost() {
         assertTrue(NetUtils.isAnyHost("0.0.0.0"));
         assertFalse(NetUtils.isAnyHost("1.1.1.1"));
     }
 
     @Test
-    void testIsInvalidLocalHost() throws Exception {
+    void testIsInvalidLocalHost() {
         assertTrue(NetUtils.isInvalidLocalHost(null));
         assertTrue(NetUtils.isInvalidLocalHost(""));
         assertTrue(NetUtils.isInvalidLocalHost("localhost"));
@@ -97,13 +97,13 @@ class NetUtilsTest {
     }
 
     @Test
-    void testIsValidLocalHost() throws Exception {
+    void testIsValidLocalHost() {
         assertTrue(NetUtils.isValidLocalHost("1.2.3.4"));
         assertTrue(NetUtils.isValidLocalHost("128.0.0.1"));
     }
 
     @Test
-    void testGetLocalSocketAddress() throws Exception {
+    void testGetLocalSocketAddress() {
         InetSocketAddress address = NetUtils.getLocalSocketAddress("localhost", 12345);
         assertTrue(address.getAddress().isAnyLocalAddress());
         assertEquals(address.getPort(), 12345);
@@ -113,7 +113,7 @@ class NetUtilsTest {
     }
 
     @Test
-    void testIsValidAddress() throws Exception {
+    void testIsValidAddress() {
         assertFalse(NetUtils.isValidV4Address((InetAddress) null));
         InetAddress address = mock(InetAddress.class);
         when(address.isLoopbackAddress()).thenReturn(true);
@@ -133,19 +133,19 @@ class NetUtilsTest {
     }
 
     @Test
-    void testGetLocalHost() throws Exception {
+    void testGetLocalHost() {
         assertNotNull(NetUtils.getLocalHost());
     }
 
     @Test
-    void testGetLocalAddress() throws Exception {
+    void testGetLocalAddress() {
         InetAddress address = NetUtils.getLocalAddress();
         assertNotNull(address);
         assertTrue(NetUtils.isValidLocalHost(address.getHostAddress()));
     }
 
     @Test
-    void testFilterLocalHost() throws Exception {
+    void testFilterLocalHost() {
         assertNull(NetUtils.filterLocalHost(null));
         assertEquals(NetUtils.filterLocalHost(""), "");
         String host = NetUtils.filterLocalHost("dubbo://127.0.0.1:8080/foo");
@@ -159,18 +159,18 @@ class NetUtilsTest {
     }
 
     @Test
-    void testGetHostName() throws Exception {
+    void testGetHostName() {
         assertNotNull(NetUtils.getHostName("127.0.0.1"));
     }
 
     @Test
-    void testGetIpByHost() throws Exception {
+    void testGetIpByHost() {
         assertThat(NetUtils.getIpByHost("localhost"), equalTo("127.0.0.1"));
         assertThat(NetUtils.getIpByHost("dubbo.local"), equalTo("dubbo.local"));
     }
 
     @Test
-    void testToAddressString() throws Exception {
+    void testToAddressString() {
         InetAddress address = mock(InetAddress.class);
         when(address.getHostAddress()).thenReturn("dubbo");
         InetSocketAddress socketAddress = new InetSocketAddress(address, 1234);
@@ -178,7 +178,7 @@ class NetUtilsTest {
     }
 
     @Test
-    void testToAddress() throws Exception {
+    void testToAddress() {
         InetSocketAddress address = NetUtils.toAddress("localhost:1234");
         assertThat(address.getHostName(), equalTo("localhost"));
         assertThat(address.getPort(), equalTo(1234));
@@ -188,7 +188,7 @@ class NetUtilsTest {
     }
 
     @Test
-    void testToURL() throws Exception {
+    void testToURL() {
         String url = NetUtils.toURL("dubbo", "host", 1234, "foo");
         assertThat(url, equalTo("dubbo://host:1234/foo"));
     }
@@ -248,7 +248,7 @@ class NetUtilsTest {
     }
 
     @Test
-    void testMatchIpRangeMatchWhenIpv6Exception() throws UnknownHostException {
+    void testMatchIpRangeMatchWhenIpv6Exception() {
         IllegalArgumentException thrown =
             assertThrows(IllegalArgumentException.class, () ->
                 NetUtils.matchIpRange("234e:0:4567::3d:*", "234e:0:4567::3d:ff", 90));
@@ -265,7 +265,7 @@ class NetUtilsTest {
     }
 
     @Test
-    void testMatchIpRangeMatchWhenIpWrongException() throws UnknownHostException {
+    void testMatchIpRangeMatchWhenIpWrongException() {
         UnknownHostException thrown =
             assertThrows(UnknownHostException.class, () ->
                 NetUtils.matchIpRange("192.168.1.63", "192.168.1.ff", 90));

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/utils/ParametersTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/utils/ParametersTest.java
@@ -26,7 +26,7 @@ class ParametersTest {
     final String ServiceVersion = "1.0.15";
     final String LoadBalance = "lcr";
 
-    public void testMap2Parameters() throws Exception {
+    public void testMap2Parameters() {
         Map<String, String> map = new HashMap<String, String>();
         map.put("name", "org.apache.dubbo.rpc.service.GenericService");
         map.put("version", "1.0.15");

--- a/dubbo-compatible/src/test/java/org/apache/dubbo/config/ApplicationConfigTest.java
+++ b/dubbo-compatible/src/test/java/org/apache/dubbo/config/ApplicationConfigTest.java
@@ -41,7 +41,7 @@ import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
 
 class ApplicationConfigTest {
     @Test
-    void testName() throws Exception {
+    void testName() {
         ApplicationConfig application = new ApplicationConfig();
         application.setName("app");
         assertThat(application.getName(), equalTo("app"));
@@ -53,7 +53,7 @@ class ApplicationConfigTest {
     }
 
     @Test
-    void testVersion() throws Exception {
+    void testVersion() {
         ApplicationConfig application = new ApplicationConfig("app");
         application.setVersion("1.0.0");
         assertThat(application.getVersion(), equalTo("1.0.0"));
@@ -63,28 +63,28 @@ class ApplicationConfigTest {
     }
 
     @Test
-    void testOwner() throws Exception {
+    void testOwner() {
         ApplicationConfig application = new ApplicationConfig("app");
         application.setOwner("owner");
         assertThat(application.getOwner(), equalTo("owner"));
     }
 
     @Test
-    void testOrganization() throws Exception {
+    void testOrganization() {
         ApplicationConfig application = new ApplicationConfig("app");
         application.setOrganization("org");
         assertThat(application.getOrganization(), equalTo("org"));
     }
 
     @Test
-    void testArchitecture() throws Exception {
+    void testArchitecture() {
         ApplicationConfig application = new ApplicationConfig("app");
         application.setArchitecture("arch");
         assertThat(application.getArchitecture(), equalTo("arch"));
     }
 
     @Test
-    void testEnvironment1() throws Exception {
+    void testEnvironment1() {
         ApplicationConfig application = new ApplicationConfig("app");
         application.setEnvironment("develop");
         assertThat(application.getEnvironment(), equalTo("develop"));
@@ -95,7 +95,7 @@ class ApplicationConfigTest {
     }
 
     @Test
-    void testEnvironment2() throws Exception {
+    void testEnvironment2() {
         Assertions.assertThrows(IllegalStateException.class, () -> {
             ApplicationConfig application = new ApplicationConfig("app");
             application.setEnvironment("illegal-env");
@@ -103,7 +103,7 @@ class ApplicationConfigTest {
     }
 
     @Test
-    void testRegistry() throws Exception {
+    void testRegistry() {
         ApplicationConfig application = new ApplicationConfig("app");
         RegistryConfig registry = new RegistryConfig();
         application.setRegistry(registry);
@@ -114,7 +114,7 @@ class ApplicationConfigTest {
     }
 
     @Test
-    void testMonitor() throws Exception {
+    void testMonitor() {
         ApplicationConfig application = new ApplicationConfig("app");
         application.setMonitor(new MonitorConfig("monitor-addr"));
         assertThat(application.getMonitor().getAddress(), equalTo("monitor-addr"));
@@ -123,21 +123,21 @@ class ApplicationConfigTest {
     }
 
     @Test
-    void testLogger() throws Exception {
+    void testLogger() {
         ApplicationConfig application = new ApplicationConfig("app");
         application.setLogger("log4j");
         assertThat(application.getLogger(), equalTo("log4j"));
     }
 
     @Test
-    void testDefault() throws Exception {
+    void testDefault() {
         ApplicationConfig application = new ApplicationConfig("app");
         application.setDefault(true);
         assertThat(application.isDefault(), is(true));
     }
 
     @Test
-    void testDumpDirectory() throws Exception {
+    void testDumpDirectory() {
         ApplicationConfig application = new ApplicationConfig("app");
         application.setDumpDirectory("/dump");
         assertThat(application.getDumpDirectory(), equalTo("/dump"));
@@ -147,7 +147,7 @@ class ApplicationConfigTest {
     }
 
     @Test
-    void testQosEnable() throws Exception {
+    void testQosEnable() {
         ApplicationConfig application = new ApplicationConfig("app");
         application.setQosEnable(true);
         assertThat(application.getQosEnable(), is(true));
@@ -157,14 +157,14 @@ class ApplicationConfigTest {
     }
 
     @Test
-    void testQosPort() throws Exception {
+    void testQosPort() {
         ApplicationConfig application = new ApplicationConfig("app");
         application.setQosPort(8080);
         assertThat(application.getQosPort(), equalTo(8080));
     }
 
     @Test
-    void testQosAcceptForeignIp() throws Exception {
+    void testQosAcceptForeignIp() {
         ApplicationConfig application = new ApplicationConfig("app");
         application.setQosAcceptForeignIp(true);
         assertThat(application.getQosAcceptForeignIp(), is(true));
@@ -174,7 +174,7 @@ class ApplicationConfigTest {
     }
 
     @Test
-    void testParameters() throws Exception {
+    void testParameters() {
         ApplicationConfig application = new ApplicationConfig("app");
         application.setQosAcceptForeignIp(true);
         Map<String, String> parameters = new HashMap<String, String>();

--- a/dubbo-compatible/src/test/java/org/apache/dubbo/config/ArgumentConfigTest.java
+++ b/dubbo-compatible/src/test/java/org/apache/dubbo/config/ArgumentConfigTest.java
@@ -30,28 +30,28 @@ import static org.hamcrest.Matchers.is;
 
 class ArgumentConfigTest {
     @Test
-    void testIndex() throws Exception {
+    void testIndex() {
         ArgumentConfig argument = new ArgumentConfig();
         argument.setIndex(1);
         assertThat(argument.getIndex(), is(1));
     }
 
     @Test
-    void testType() throws Exception {
+    void testType() {
         ArgumentConfig argument = new ArgumentConfig();
         argument.setType("int");
         assertThat(argument.getType(), equalTo("int"));
     }
 
     @Test
-    void testCallback() throws Exception {
+    void testCallback() {
         ArgumentConfig argument = new ArgumentConfig();
         argument.setCallback(true);
         assertThat(argument.isCallback(), is(true));
     }
 
     @Test
-    void testArguments() throws Exception {
+    void testArguments() {
         ArgumentConfig argument = new ArgumentConfig();
         argument.setIndex(1);
         argument.setType("int");

--- a/dubbo-compatible/src/test/java/org/apache/dubbo/config/MethodConfigTest.java
+++ b/dubbo-compatible/src/test/java/org/apache/dubbo/config/MethodConfigTest.java
@@ -46,7 +46,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class MethodConfigTest {
     @Test
-    void testName() throws Exception {
+    void testName() {
         MethodConfig method = new MethodConfig();
         method.setName("hello");
         assertThat(method.getName(), equalTo("hello"));
@@ -56,42 +56,42 @@ class MethodConfigTest {
     }
 
     @Test
-    void testStat() throws Exception {
+    void testStat() {
         MethodConfig method = new MethodConfig();
         method.setStat(10);
         assertThat(method.getStat(), equalTo(10));
     }
 
     @Test
-    void testRetry() throws Exception {
+    void testRetry() {
         MethodConfig method = new MethodConfig();
         method.setRetry(true);
         assertThat(method.isRetry(), is(true));
     }
 
     @Test
-    void testReliable() throws Exception {
+    void testReliable() {
         MethodConfig method = new MethodConfig();
         method.setReliable(true);
         assertThat(method.isReliable(), is(true));
     }
 
     @Test
-    void testExecutes() throws Exception {
+    void testExecutes() {
         MethodConfig method = new MethodConfig();
         method.setExecutes(10);
         assertThat(method.getExecutes(), equalTo(10));
     }
 
     @Test
-    void testDeprecated() throws Exception {
+    void testDeprecated() {
         MethodConfig method = new MethodConfig();
         method.setDeprecated(true);
         assertThat(method.getDeprecated(), is(true));
     }
 
     @Test
-    void testArguments() throws Exception {
+    void testArguments() {
         MethodConfig method = new MethodConfig();
         ArgumentConfig argument = new ArgumentConfig();
         method.setArguments(Collections.singletonList(argument));
@@ -100,7 +100,7 @@ class MethodConfigTest {
     }
 
     @Test
-    void testSticky() throws Exception {
+    void testSticky() {
         MethodConfig method = new MethodConfig();
         method.setSticky(true);
         assertThat(method.getSticky(), is(true));
@@ -118,7 +118,7 @@ class MethodConfigTest {
     }
 
     //@Test
-    public void testOnreturn() throws Exception {
+    public void testOnreturn() {
         MethodConfig method = new MethodConfig();
         method.setOnreturn("on-return-object");
         assertThat(method.getOnreturn(), equalTo((Object) "on-return-object"));
@@ -131,7 +131,7 @@ class MethodConfigTest {
     }
 
     @Test
-    void testOnreturnMethod() throws Exception {
+    void testOnreturnMethod() {
         MethodConfig method = new MethodConfig();
         method.setOnreturnMethod("on-return-method");
         assertThat(method.getOnreturnMethod(), equalTo("on-return-method"));
@@ -144,7 +144,7 @@ class MethodConfigTest {
     }
 
     //@Test
-    public void testOnthrow() throws Exception {
+    public void testOnthrow() {
         MethodConfig method = new MethodConfig();
         method.setOnthrow("on-throw-object");
         assertThat(method.getOnthrow(), equalTo((Object) "on-throw-object"));
@@ -157,7 +157,7 @@ class MethodConfigTest {
     }
 
     @Test
-    void testOnthrowMethod() throws Exception {
+    void testOnthrowMethod() {
         MethodConfig method = new MethodConfig();
         method.setOnthrowMethod("on-throw-method");
         assertThat(method.getOnthrowMethod(), equalTo("on-throw-method"));
@@ -170,7 +170,7 @@ class MethodConfigTest {
     }
 
     //@Test
-    public void testOninvoke() throws Exception {
+    public void testOninvoke() {
         MethodConfig method = new MethodConfig();
         method.setOninvoke("on-invoke-object");
         assertThat(method.getOninvoke(), equalTo((Object) "on-invoke-object"));
@@ -183,7 +183,7 @@ class MethodConfigTest {
     }
 
     @Test
-    void testOninvokeMethod() throws Exception {
+    void testOninvokeMethod() {
         MethodConfig method = new MethodConfig();
         method.setOninvokeMethod("on-invoke-method");
         assertThat(method.getOninvokeMethod(), equalTo("on-invoke-method"));
@@ -196,7 +196,7 @@ class MethodConfigTest {
     }
 
     @Test
-    void testReturn() throws Exception {
+    void testReturn() {
         MethodConfig method = new MethodConfig();
         method.setReturn(true);
         assertThat(method.isReturn(), is(true));

--- a/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/AbstractConfigTest.java
+++ b/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/AbstractConfigTest.java
@@ -135,7 +135,7 @@ class AbstractConfigTest {
     }
 
     @Test
-    void testAppendParameters1() throws Exception {
+    void testAppendParameters1() {
         Map<String, String> parameters = new HashMap<String, String>();
         parameters.put("num", "ONE");
         AbstractConfig.appendParameters(parameters, new ParameterConfig(1, "hello/world", 30, "password"), "prefix");
@@ -148,7 +148,7 @@ class AbstractConfigTest {
     }
 
     @Test
-    void testAppendParameters2() throws Exception {
+    void testAppendParameters2() {
         Assertions.assertThrows(IllegalStateException.class, () -> {
             Map<String, String> parameters = new HashMap<String, String>();
             AbstractConfig.appendParameters(parameters, new ParameterConfig());
@@ -156,14 +156,14 @@ class AbstractConfigTest {
     }
 
     @Test
-    void testAppendParameters3() throws Exception {
+    void testAppendParameters3() {
         Map<String, String> parameters = new HashMap<String, String>();
         AbstractConfig.appendParameters(parameters, null);
         assertTrue(parameters.isEmpty());
     }
 
     @Test
-    void testAppendParameters4() throws Exception {
+    void testAppendParameters4() {
         Map<String, String> parameters = new HashMap<String, String>();
         AbstractConfig.appendParameters(parameters, new ParameterConfig(1, "hello/world", 30, "password"));
         Assertions.assertEquals("one", parameters.get("key.1"));
@@ -174,7 +174,7 @@ class AbstractConfigTest {
     }
 
     @Test
-    void testAppendAttributes1() throws Exception {
+    void testAppendAttributes1() {
         ParameterConfig config = new ParameterConfig(1, "hello/world", 30, "password","BEIJING");
         Map<String, String> parameters = new HashMap<>();
         AbstractConfig.appendParameters(parameters, config);
@@ -195,24 +195,24 @@ class AbstractConfigTest {
     }
 
     @Test
-    void checkExtension() throws Exception {
+    void checkExtension() {
         Assertions.assertThrows(IllegalStateException.class, () -> ConfigValidationUtils.checkExtension(ApplicationModel.defaultModel(), Greeting.class, "hello", "world"));
     }
 
     @Test
-    void checkMultiExtension1() throws Exception {
+    void checkMultiExtension1() {
         Assertions.assertThrows(IllegalStateException.class,
                 () -> ConfigValidationUtils.checkMultiExtension(ApplicationModel.defaultModel(), Greeting.class, "hello", "default,world"));
     }
 
     @Test
-    void checkMultiExtension2() throws Exception {
+    void checkMultiExtension2() {
         Assertions.assertThrows(IllegalStateException.class,
                 () -> ConfigValidationUtils.checkMultiExtension(ApplicationModel.defaultModel(), Greeting.class, "hello", "default,-world"));
     }
 
     @Test
-    void checkLength() throws Exception {
+    void checkLength() {
         Assertions.assertDoesNotThrow(() -> {
             StringBuilder builder = new StringBuilder();
             for (int i = 0; i <= 200; i++) {
@@ -223,7 +223,7 @@ class AbstractConfigTest {
     }
 
     @Test
-    void checkPathLength() throws Exception {
+    void checkPathLength() {
         Assertions.assertDoesNotThrow(() -> {
             StringBuilder builder = new StringBuilder();
             for (int i = 0; i <= 200; i++) {
@@ -234,12 +234,12 @@ class AbstractConfigTest {
     }
 
     @Test
-    void checkName() throws Exception {
+    void checkName() {
         Assertions.assertDoesNotThrow(() -> ConfigValidationUtils.checkName("hello", "world%"));
     }
 
     @Test
-    void checkNameHasSymbol() throws Exception {
+    void checkNameHasSymbol() {
         try {
             ConfigValidationUtils.checkNameHasSymbol("hello", ":*,/ -0123\tabcdABCD");
             ConfigValidationUtils.checkNameHasSymbol("mock", "force:return world");
@@ -249,7 +249,7 @@ class AbstractConfigTest {
     }
 
     @Test
-    void checkKey() throws Exception {
+    void checkKey() {
         try {
             ConfigValidationUtils.checkKey("hello", "*,-0123abcdABCD");
         } catch (Exception e) {
@@ -258,7 +258,7 @@ class AbstractConfigTest {
     }
 
     @Test
-    void checkMultiName() throws Exception {
+    void checkMultiName() {
         try {
             ConfigValidationUtils.checkMultiName("hello", ",-._0123abcdABCD");
         } catch (Exception e) {
@@ -267,7 +267,7 @@ class AbstractConfigTest {
     }
 
     @Test
-    void checkPathName() throws Exception {
+    void checkPathName() {
         try {
             ConfigValidationUtils.checkPathName("hello", "/-$._0123abcdABCD");
         } catch (Exception e) {
@@ -276,7 +276,7 @@ class AbstractConfigTest {
     }
 
     @Test
-    void checkMethodName() throws Exception {
+    void checkMethodName() {
         try {
             ConfigValidationUtils.checkMethodName("hello", "abcdABCD0123abcd");
         } catch (Exception e) {
@@ -292,7 +292,7 @@ class AbstractConfigTest {
     }
 
     @Test
-    void checkParameterName() throws Exception {
+    void checkParameterName() {
         Map<String, String> parameters = Collections.singletonMap("hello", ":*,/-._0123abcdABCD");
         try {
             ConfigValidationUtils.checkParameterName(parameters);

--- a/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/AbstractMethodConfigTest.java
+++ b/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/AbstractMethodConfigTest.java
@@ -38,56 +38,56 @@ class AbstractMethodConfigTest {
     }
 
     @Test
-    void testTimeout() throws Exception {
+    void testTimeout() {
         MethodConfig methodConfig = new MethodConfig();
         methodConfig.setTimeout(10);
         assertThat(methodConfig.getTimeout(), equalTo(10));
     }
 
     @Test
-    void testForks() throws Exception {
+    void testForks() {
         MethodConfig methodConfig = new MethodConfig();
         methodConfig.setForks(10);
         assertThat(methodConfig.getForks(), equalTo(10));
     }
 
     @Test
-    void testRetries() throws Exception {
+    void testRetries() {
         MethodConfig methodConfig = new MethodConfig();
         methodConfig.setRetries(3);
         assertThat(methodConfig.getRetries(), equalTo(3));
     }
 
     @Test
-    void testLoadbalance() throws Exception {
+    void testLoadbalance() {
         MethodConfig methodConfig = new MethodConfig();
         methodConfig.setLoadbalance("mockloadbalance");
         assertThat(methodConfig.getLoadbalance(), equalTo("mockloadbalance"));
     }
 
     @Test
-    void testAsync() throws Exception {
+    void testAsync() {
         MethodConfig methodConfig = new MethodConfig();
         methodConfig.setAsync(true);
         assertThat(methodConfig.isAsync(), is(true));
     }
 
     @Test
-    void testActives() throws Exception {
+    void testActives() {
         MethodConfig methodConfig = new MethodConfig();
         methodConfig.setActives(10);
         assertThat(methodConfig.getActives(), equalTo(10));
     }
 
     @Test
-    void testSent() throws Exception {
+    void testSent() {
         MethodConfig methodConfig = new MethodConfig();
         methodConfig.setSent(true);
         assertThat(methodConfig.getSent(), is(true));
     }
 
     @Test
-    void testMock() throws Exception {
+    void testMock() {
         MethodConfig methodConfig = new MethodConfig();
         methodConfig.setMock((Boolean) null);
         assertThat(methodConfig.getMock(), isEmptyOrNullString());
@@ -100,21 +100,21 @@ class AbstractMethodConfigTest {
     }
 
     @Test
-    void testMerger() throws Exception {
+    void testMerger() {
         MethodConfig methodConfig = new MethodConfig();
         methodConfig.setMerger("merger");
         assertThat(methodConfig.getMerger(), equalTo("merger"));
     }
 
     @Test
-    void testCache() throws Exception {
+    void testCache() {
         MethodConfig methodConfig = new MethodConfig();
         methodConfig.setCache("cache");
         assertThat(methodConfig.getCache(), equalTo("cache"));
     }
 
     @Test
-    void testValidation() throws Exception {
+    void testValidation() {
         MethodConfig methodConfig = new MethodConfig();
         methodConfig.setValidation("validation");
         assertThat(methodConfig.getValidation(), equalTo("validation"));

--- a/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/AbstractReferenceConfigTest.java
+++ b/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/AbstractReferenceConfigTest.java
@@ -56,21 +56,21 @@ class AbstractReferenceConfigTest {
     }
 
     @Test
-    void testCheck() throws Exception {
+    void testCheck() {
         ReferenceConfig referenceConfig = new ReferenceConfig();
         referenceConfig.setCheck(true);
         assertThat(referenceConfig.isCheck(), is(true));
     }
 
     @Test
-    void testInit() throws Exception {
+    void testInit() {
         ReferenceConfig referenceConfig = new ReferenceConfig();
         referenceConfig.setInit(true);
         assertThat(referenceConfig.isInit(), is(true));
     }
 
     @Test
-    void testGeneric() throws Exception {
+    void testGeneric() {
         ReferenceConfig referenceConfig = new ReferenceConfig();
         referenceConfig.setGeneric(true);
         assertThat(referenceConfig.isGeneric(), is(true));
@@ -81,14 +81,14 @@ class AbstractReferenceConfigTest {
     }
 
     @Test
-    void testInjvm() throws Exception {
+    void testInjvm() {
         ReferenceConfig referenceConfig = new ReferenceConfig();
         referenceConfig.setInjvm(true);
         assertThat(referenceConfig.isInjvm(), is(true));
     }
 
     @Test
-    void testFilter() throws Exception {
+    void testFilter() {
         ReferenceConfig referenceConfig = new ReferenceConfig();
         referenceConfig.setFilter("mockfilter");
         assertThat(referenceConfig.getFilter(), equalTo("mockfilter"));
@@ -99,7 +99,7 @@ class AbstractReferenceConfigTest {
     }
 
     @Test
-    void testRouter() throws Exception {
+    void testRouter() {
         ReferenceConfig referenceConfig = new ReferenceConfig();
         referenceConfig.setRouter("condition");
         assertThat(referenceConfig.getRouter(), equalTo("condition"));
@@ -119,7 +119,7 @@ class AbstractReferenceConfigTest {
     }
 
     @Test
-    void testListener() throws Exception {
+    void testListener() {
         ReferenceConfig referenceConfig = new ReferenceConfig();
         referenceConfig.setListener("mockinvokerlistener");
         assertThat(referenceConfig.getListener(), equalTo("mockinvokerlistener"));
@@ -130,14 +130,14 @@ class AbstractReferenceConfigTest {
     }
 
     @Test
-    void testLazy() throws Exception {
+    void testLazy() {
         ReferenceConfig referenceConfig = new ReferenceConfig();
         referenceConfig.setLazy(true);
         assertThat(referenceConfig.getLazy(), is(true));
     }
 
     @Test
-    void testOnconnect() throws Exception {
+    void testOnconnect() {
         ReferenceConfig referenceConfig = new ReferenceConfig();
         referenceConfig.setOnconnect("onConnect");
         assertThat(referenceConfig.getOnconnect(), equalTo("onConnect"));
@@ -145,7 +145,7 @@ class AbstractReferenceConfigTest {
     }
 
     @Test
-    void testOndisconnect() throws Exception {
+    void testOndisconnect() {
         ReferenceConfig referenceConfig = new ReferenceConfig();
         referenceConfig.setOndisconnect("onDisconnect");
         assertThat(referenceConfig.getOndisconnect(), equalTo("onDisconnect"));
@@ -153,7 +153,7 @@ class AbstractReferenceConfigTest {
     }
 
     @Test
-    void testStubevent() throws Exception {
+    void testStubevent() {
         ReferenceConfig referenceConfig = new ReferenceConfig();
         referenceConfig.setOnconnect("onConnect");
         Map<String, String> parameters = new HashMap<String, String>();
@@ -162,7 +162,7 @@ class AbstractReferenceConfigTest {
     }
 
     @Test
-    void testReconnect() throws Exception {
+    void testReconnect() {
         ReferenceConfig referenceConfig = new ReferenceConfig();
         referenceConfig.setReconnect("reconnect");
         Map<String, String> parameters = new HashMap<String, String>();
@@ -172,7 +172,7 @@ class AbstractReferenceConfigTest {
     }
 
     @Test
-    void testSticky() throws Exception {
+    void testSticky() {
         ReferenceConfig referenceConfig = new ReferenceConfig();
         referenceConfig.setSticky(true);
         Map<String, String> parameters = new HashMap<String, String>();
@@ -182,14 +182,14 @@ class AbstractReferenceConfigTest {
     }
 
     @Test
-    void testVersion() throws Exception {
+    void testVersion() {
         ReferenceConfig referenceConfig = new ReferenceConfig();
         referenceConfig.setVersion("version");
         assertThat(referenceConfig.getVersion(), equalTo("version"));
     }
 
     @Test
-    void testGroup() throws Exception {
+    void testGroup() {
         ReferenceConfig referenceConfig = new ReferenceConfig();
         referenceConfig.setGroup("group");
         assertThat(referenceConfig.getGroup(), equalTo("group"));

--- a/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/AbstractServiceConfigTest.java
+++ b/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/AbstractServiceConfigTest.java
@@ -38,42 +38,42 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 
 class AbstractServiceConfigTest {
     @Test
-    void testVersion() throws Exception {
+    void testVersion() {
         ServiceConfig serviceConfig = new ServiceConfig();
         serviceConfig.setVersion("version");
         assertThat(serviceConfig.getVersion(), equalTo("version"));
     }
 
     @Test
-    void testGroup() throws Exception {
+    void testGroup() {
         ServiceConfig serviceConfig = new ServiceConfig();
         serviceConfig.setGroup("group");
         assertThat(serviceConfig.getGroup(), equalTo("group"));
     }
 
     @Test
-    void testDelay() throws Exception {
+    void testDelay() {
         ServiceConfig serviceConfig = new ServiceConfig();
         serviceConfig.setDelay(1000);
         assertThat(serviceConfig.getDelay(), equalTo(1000));
     }
 
     @Test
-    void testExport() throws Exception {
+    void testExport() {
         ServiceConfig serviceConfig = new ServiceConfig();
         serviceConfig.setExport(true);
         assertThat(serviceConfig.getExport(), is(true));
     }
 
     @Test
-    void testWeight() throws Exception {
+    void testWeight() {
         ServiceConfig serviceConfig = new ServiceConfig();
         serviceConfig.setWeight(500);
         assertThat(serviceConfig.getWeight(), equalTo(500));
     }
 
     @Test
-    void testDocument() throws Exception {
+    void testDocument() {
         ServiceConfig serviceConfig = new ServiceConfig();
         serviceConfig.setDocument("http://dubbo.apache.org");
         assertThat(serviceConfig.getDocument(), equalTo("http://dubbo.apache.org"));
@@ -83,7 +83,7 @@ class AbstractServiceConfigTest {
     }
 
     @Test
-    void testToken() throws Exception {
+    void testToken() {
         ServiceConfig serviceConfig = new ServiceConfig();
         serviceConfig.setToken("token");
         assertThat(serviceConfig.getToken(), equalTo("token"));
@@ -94,21 +94,21 @@ class AbstractServiceConfigTest {
     }
 
     @Test
-    void testDeprecated() throws Exception {
+    void testDeprecated() {
         ServiceConfig serviceConfig = new ServiceConfig();
         serviceConfig.setDeprecated(true);
         assertThat(serviceConfig.isDeprecated(), is(true));
     }
 
     @Test
-    void testDynamic() throws Exception {
+    void testDynamic() {
         ServiceConfig serviceConfig = new ServiceConfig();
         serviceConfig.setDynamic(true);
         assertThat(serviceConfig.isDynamic(), is(true));
     }
 
     @Test
-    void testProtocol() throws Exception {
+    void testProtocol() {
         ServiceConfig serviceConfig = new ServiceConfig();
         assertThat(serviceConfig.getProtocol(), nullValue());
         serviceConfig.setProtocol(new ProtocolConfig());
@@ -118,7 +118,7 @@ class AbstractServiceConfigTest {
     }
 
     @Test
-    void testAccesslog() throws Exception {
+    void testAccesslog() {
         ServiceConfig serviceConfig = new ServiceConfig();
         serviceConfig.setAccesslog("access.log");
         assertThat(serviceConfig.getAccesslog(), equalTo("access.log"));
@@ -129,14 +129,14 @@ class AbstractServiceConfigTest {
     }
 
     @Test
-    void testExecutes() throws Exception {
+    void testExecutes() {
         ServiceConfig serviceConfig = new ServiceConfig();
         serviceConfig.setExecutes(10);
         assertThat(serviceConfig.getExecutes(), equalTo(10));
     }
 
     @Test
-    void testFilter() throws Exception {
+    void testFilter() {
         ServiceConfig serviceConfig = new ServiceConfig();
         serviceConfig.setFilter("mockfilter");
         assertThat(serviceConfig.getFilter(), equalTo("mockfilter"));
@@ -147,7 +147,7 @@ class AbstractServiceConfigTest {
     }
 
     @Test
-    void testListener() throws Exception {
+    void testListener() {
         ServiceConfig serviceConfig = new ServiceConfig();
         serviceConfig.setListener("mockexporterlistener");
         assertThat(serviceConfig.getListener(), equalTo("mockexporterlistener"));
@@ -158,35 +158,35 @@ class AbstractServiceConfigTest {
     }
 
     @Test
-    void testRegister() throws Exception {
+    void testRegister() {
         ServiceConfig serviceConfig = new ServiceConfig();
         serviceConfig.setRegister(true);
         assertThat(serviceConfig.isRegister(), is(true));
     }
 
     @Test
-    void testWarmup() throws Exception {
+    void testWarmup() {
         ServiceConfig serviceConfig = new ServiceConfig();
         serviceConfig.setWarmup(100);
         assertThat(serviceConfig.getWarmup(), equalTo(100));
     }
 
     @Test
-    void testSerialization() throws Exception {
+    void testSerialization() {
         ServiceConfig serviceConfig = new ServiceConfig();
         serviceConfig.setSerialization("serialization");
         assertThat(serviceConfig.getSerialization(), equalTo("serialization"));
     }
 
     @Test
-    void testPreferSerialization() throws Exception {
+    void testPreferSerialization() {
         ServiceConfig serviceConfig = new ServiceConfig();
         serviceConfig.setPreferSerialization("preferSerialization");
         assertThat(serviceConfig.getPreferSerialization(), equalTo("preferSerialization"));
     }
 
     @Test
-    void testPreferSerializationDefault1() throws Exception {
+    void testPreferSerializationDefault1() {
         ServiceConfig serviceConfig = new ServiceConfig();
         assertNull(serviceConfig.getPreferSerialization());
 
@@ -202,7 +202,7 @@ class AbstractServiceConfigTest {
     }
 
     @Test
-    void testPreferSerializationDefault2() throws Exception {
+    void testPreferSerializationDefault2() {
         ServiceConfig serviceConfig = new ServiceConfig();
         assertNull(serviceConfig.getPreferSerialization());
 

--- a/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/ApplicationConfigTest.java
+++ b/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/ApplicationConfigTest.java
@@ -55,7 +55,7 @@ class ApplicationConfigTest {
     }
 
     @Test
-    void testName() throws Exception {
+    void testName() {
         ApplicationConfig application = new ApplicationConfig();
         application.setName("app");
         assertThat(application.getName(), equalTo("app"));
@@ -71,7 +71,7 @@ class ApplicationConfigTest {
     }
 
     @Test
-    void testVersion() throws Exception {
+    void testVersion() {
         ApplicationConfig application = new ApplicationConfig("app");
         application.setVersion("1.0.0");
         assertThat(application.getVersion(), equalTo("1.0.0"));
@@ -81,28 +81,28 @@ class ApplicationConfigTest {
     }
 
     @Test
-    void testOwner() throws Exception {
+    void testOwner() {
         ApplicationConfig application = new ApplicationConfig("app");
         application.setOwner("owner");
         assertThat(application.getOwner(), equalTo("owner"));
     }
 
     @Test
-    void testOrganization() throws Exception {
+    void testOrganization() {
         ApplicationConfig application = new ApplicationConfig("app");
         application.setOrganization("org");
         assertThat(application.getOrganization(), equalTo("org"));
     }
 
     @Test
-    void testArchitecture() throws Exception {
+    void testArchitecture() {
         ApplicationConfig application = new ApplicationConfig("app");
         application.setArchitecture("arch");
         assertThat(application.getArchitecture(), equalTo("arch"));
     }
 
     @Test
-    void testEnvironment1() throws Exception {
+    void testEnvironment1() {
         ApplicationConfig application = new ApplicationConfig("app");
         application.setEnvironment("develop");
         assertThat(application.getEnvironment(), equalTo("develop"));
@@ -113,7 +113,7 @@ class ApplicationConfigTest {
     }
 
     @Test
-    void testEnvironment2() throws Exception {
+    void testEnvironment2() {
         Assertions.assertThrows(IllegalStateException.class, () -> {
             ApplicationConfig application = new ApplicationConfig("app");
             application.setEnvironment("illegal-env");
@@ -121,7 +121,7 @@ class ApplicationConfigTest {
     }
 
     @Test
-    void testRegistry() throws Exception {
+    void testRegistry() {
         ApplicationConfig application = new ApplicationConfig("app");
         RegistryConfig registry = new RegistryConfig();
         application.setRegistry(registry);
@@ -132,7 +132,7 @@ class ApplicationConfigTest {
     }
 
     @Test
-    void testMonitor() throws Exception {
+    void testMonitor() {
         ApplicationConfig application = new ApplicationConfig("app");
         application.setMonitor(new MonitorConfig("monitor-addr"));
         assertThat(application.getMonitor().getAddress(), equalTo("monitor-addr"));
@@ -141,21 +141,21 @@ class ApplicationConfigTest {
     }
 
     @Test
-    void testLogger() throws Exception {
+    void testLogger() {
         ApplicationConfig application = new ApplicationConfig("app");
         application.setLogger("log4j");
         assertThat(application.getLogger(), equalTo("log4j"));
     }
 
     @Test
-    void testDefault() throws Exception {
+    void testDefault() {
         ApplicationConfig application = new ApplicationConfig("app");
         application.setDefault(true);
         assertThat(application.isDefault(), is(true));
     }
 
     @Test
-    void testDumpDirectory() throws Exception {
+    void testDumpDirectory() {
         ApplicationConfig application = new ApplicationConfig("app");
         application.setDumpDirectory("/dump");
         assertThat(application.getDumpDirectory(), equalTo("/dump"));
@@ -165,7 +165,7 @@ class ApplicationConfigTest {
     }
 
     @Test
-    void testQosEnable() throws Exception {
+    void testQosEnable() {
         ApplicationConfig application = new ApplicationConfig("app");
         application.setQosEnable(true);
         assertThat(application.getQosEnable(), is(true));
@@ -175,14 +175,14 @@ class ApplicationConfigTest {
     }
 
     @Test
-    void testQosPort() throws Exception {
+    void testQosPort() {
         ApplicationConfig application = new ApplicationConfig("app");
         application.setQosPort(8080);
         assertThat(application.getQosPort(), equalTo(8080));
     }
 
     @Test
-    void testQosAcceptForeignIp() throws Exception {
+    void testQosAcceptForeignIp() {
         ApplicationConfig application = new ApplicationConfig("app");
         application.setQosAcceptForeignIp(true);
         assertThat(application.getQosAcceptForeignIp(), is(true));

--- a/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/ArgumentConfigTest.java
+++ b/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/ArgumentConfigTest.java
@@ -29,28 +29,28 @@ import static org.hamcrest.Matchers.is;
 
 class ArgumentConfigTest {
     @Test
-    void testIndex() throws Exception {
+    void testIndex() {
         ArgumentConfig argument = new ArgumentConfig();
         argument.setIndex(1);
         assertThat(argument.getIndex(), is(1));
     }
 
     @Test
-    void testType() throws Exception {
+    void testType() {
         ArgumentConfig argument = new ArgumentConfig();
         argument.setType("int");
         assertThat(argument.getType(), equalTo("int"));
     }
 
     @Test
-    void testCallback() throws Exception {
+    void testCallback() {
         ArgumentConfig argument = new ArgumentConfig();
         argument.setCallback(true);
         assertThat(argument.isCallback(), is(true));
     }
 
     @Test
-    void testArguments() throws Exception {
+    void testArguments() {
         ArgumentConfig argument = new ArgumentConfig();
         argument.setIndex(1);
         argument.setType("int");

--- a/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/cache/CacheTest.java
+++ b/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/cache/CacheTest.java
@@ -128,7 +128,7 @@ class CacheTest {
     }
 
     @Test
-    void testCacheProvider() throws Exception {
+    void testCacheProvider() {
         CacheFactory cacheFactory = ExtensionLoader.getExtensionLoader(CacheFactory.class).getAdaptiveExtension();
 
         Map<String, String> parameters = new HashMap<String, String>();

--- a/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/invoker/DelegateProviderMetaDataInvokerTest.java
+++ b/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/invoker/DelegateProviderMetaDataInvokerTest.java
@@ -40,7 +40,7 @@ class DelegateProviderMetaDataInvokerTest {
     }
 
     @Test
-    void testDelegate() throws Exception {
+    void testDelegate() {
         DelegateProviderMetaDataInvoker<Greeting> delegate =
                 new DelegateProviderMetaDataInvoker<Greeting>(invoker, service);
         delegate.getInterface();

--- a/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/issues/issue6000/Issue6000Test.java
+++ b/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/issues/issue6000/Issue6000Test.java
@@ -50,7 +50,7 @@ class Issue6000Test {
     }
 
     @Test
-    void test() throws Exception {
+    void test() {
         AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(Issue6000Test.class);
         try {
 

--- a/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/issues/issue6252/Issue6252Test.java
+++ b/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/issues/issue6252/Issue6252Test.java
@@ -52,7 +52,7 @@ class Issue6252Test {
     private DemoService demoService;
 
     @Test
-    void test() throws Exception {
+    void test() {
         AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(Issue6252Test.class);
         try {
             DemoService demoService = context.getBean(DemoService.class);

--- a/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/issues/issue7003/Issue7003Test.java
+++ b/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/issues/issue7003/Issue7003Test.java
@@ -59,7 +59,7 @@ class Issue7003Test {
     }
 
     @Test
-    void test() throws Exception {
+    void test() {
         AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(Issue7003Test.class);
         try {
 

--- a/dubbo-filter/dubbo-filter-cache/src/test/java/org/apache/dubbo/cache/support/jcache/JCacheFactoryTest.java
+++ b/dubbo-filter/dubbo-filter-cache/src/test/java/org/apache/dubbo/cache/support/jcache/JCacheFactoryTest.java
@@ -32,7 +32,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 class JCacheFactoryTest extends AbstractCacheFactoryTest {
 
     @Test
-    void testJCacheFactory() throws Exception {
+    void testJCacheFactory() {
         Cache cache = super.constructCache();
         assertThat(cache instanceof JCache, is(true));
     }

--- a/dubbo-kubernetes/src/test/java/org/apache/dubbo/registry/kubernetes/KubernetesServiceDiscoveryTest.java
+++ b/dubbo-kubernetes/src/test/java/org/apache/dubbo/registry/kubernetes/KubernetesServiceDiscoveryTest.java
@@ -121,7 +121,7 @@ class KubernetesServiceDiscoveryTest {
     }
 
     @Test
-    void testEndpointsUpdate() throws Exception {
+    void testEndpointsUpdate() {
         serviceDiscovery.setCurrentHostname(POD_NAME);
         serviceDiscovery.setKubernetesClient(mockClient);
 
@@ -191,7 +191,7 @@ class KubernetesServiceDiscoveryTest {
     }
 
     @Test
-    void testServiceUpdate() throws Exception {
+    void testServiceUpdate() {
         serviceDiscovery.setCurrentHostname(POD_NAME);
         serviceDiscovery.setKubernetesClient(mockClient);
 

--- a/dubbo-metadata/dubbo-metadata-api/src/test/java/org/apache/dubbo/metadata/AbstractServiceNameMappingTest.java
+++ b/dubbo-metadata/dubbo-metadata-api/src/test/java/org/apache/dubbo/metadata/AbstractServiceNameMappingTest.java
@@ -47,7 +47,7 @@ class AbstractServiceNameMappingTest {
     }
 
     @AfterEach
-    public void clearup() throws Exception {
+    public void clearup() {
         mapping.removeCachedMapping(ServiceNameMapping.buildMappingKey(url));
     }
 

--- a/dubbo-metadata/dubbo-metadata-api/src/test/java/org/apache/dubbo/metadata/report/support/AbstractMetadataReportTest.java
+++ b/dubbo-metadata/dubbo-metadata-api/src/test/java/org/apache/dubbo/metadata/report/support/AbstractMetadataReportTest.java
@@ -82,7 +82,7 @@ class AbstractMetadataReportTest {
     }
 
     @Test
-    void testStoreProviderUsual() throws ClassNotFoundException, InterruptedException {
+    void testStoreProviderUsual() throws ClassNotFoundException {
         String interfaceName = "org.apache.dubbo.metadata.store.InterfaceNameTestService";
         String version = "1.0.0";
         String group = null;
@@ -96,7 +96,7 @@ class AbstractMetadataReportTest {
     }
 
     @Test
-    void testStoreProviderSync() throws ClassNotFoundException, InterruptedException {
+    void testStoreProviderSync() throws ClassNotFoundException {
         String interfaceName = "org.apache.dubbo.metadata.store.InterfaceNameTestService";
         String version = "1.0.0";
         String group = null;
@@ -107,7 +107,7 @@ class AbstractMetadataReportTest {
     }
 
     @Test
-    void testFileExistAfterPut() throws InterruptedException, ClassNotFoundException {
+    void testFileExistAfterPut() throws ClassNotFoundException {
         //just for one method
         URL singleUrl = URL.valueOf("redis://" + NetUtils.getLocalAddress().getHostName() + ":4444/org.apache.dubbo.metadata.store.InterfaceNameTestService?version=1.0.0&application=singleTest");
         NewMetadataReport singleMetadataReport = new NewMetadataReport(singleUrl);
@@ -129,7 +129,7 @@ class AbstractMetadataReportTest {
     }
 
     @Test
-    void testRetry() throws InterruptedException, ClassNotFoundException {
+    void testRetry() throws ClassNotFoundException {
         String interfaceName = "org.apache.dubbo.metadata.store.RetryTestService";
         String version = "1.0.0.retry";
         String group = null;
@@ -164,7 +164,7 @@ class AbstractMetadataReportTest {
     }
 
     @Test
-    void testRetryCancel() throws InterruptedException, ClassNotFoundException {
+    void testRetryCancel() throws ClassNotFoundException {
         String interfaceName = "org.apache.dubbo.metadata.store.RetryTestService";
         String version = "1.0.0.retrycancel";
         String group = null;
@@ -201,7 +201,7 @@ class AbstractMetadataReportTest {
         return providerMetadataIdentifier;
     }
 
-    private MetadataIdentifier storeConsumer(AbstractMetadataReport abstractMetadataReport, String interfaceName, String version, String group, String application, Map<String, String> tmp) throws ClassNotFoundException {
+    private MetadataIdentifier storeConsumer(AbstractMetadataReport abstractMetadataReport, String interfaceName, String version, String group, String application, Map<String, String> tmp) {
         URL url = URL.valueOf("xxx://" + NetUtils.getLocalAddress().getHostName() + ":4444/" + interfaceName + "?version=" + version + "&application="
             + application + (group == null ? "" : "&group=" + group) + "&testPKey=9090");
 
@@ -214,7 +214,7 @@ class AbstractMetadataReportTest {
     }
 
     @Test
-    void testPublishAll() throws ClassNotFoundException, InterruptedException {
+    void testPublishAll() throws ClassNotFoundException {
         ThreadPoolExecutor reportCacheExecutor = (ThreadPoolExecutor) abstractMetadataReport.getReportCacheExecutor();
 
         assertTrue(abstractMetadataReport.store.isEmpty());

--- a/dubbo-metadata/dubbo-metadata-processor/src/test/java/org/apache/dubbo/metadata/annotation/processing/AbstractAnnotationProcessingTest.java
+++ b/dubbo-metadata/dubbo-metadata-processor/src/test/java/org/apache/dubbo/metadata/annotation/processing/AbstractAnnotationProcessingTest.java
@@ -47,7 +47,7 @@ public abstract class AbstractAnnotationProcessingTest {
     protected Types types;
 
     @BeforeEach
-    public final void init() throws IOException {
+    public final void init() {
         testInstanceHolder.set(this);
     }
 

--- a/dubbo-metadata/dubbo-metadata-report-nacos/src/test/java/org/apache/dubbo/metadata/store/nacos/MockConfigService.java
+++ b/dubbo-metadata/dubbo-metadata-report-nacos/src/test/java/org/apache/dubbo/metadata/store/nacos/MockConfigService.java
@@ -27,37 +27,37 @@ public class MockConfigService implements ConfigService {
     }
 
     @Override
-    public String getConfigAndSignListener(String dataId, String group, long timeoutMs, Listener listener) throws NacosException {
+    public String getConfigAndSignListener(String dataId, String group, long timeoutMs, Listener listener) {
         return null;
     }
 
     @Override
-    public void addListener(String dataId, String group, Listener listener) throws NacosException {
+    public void addListener(String dataId, String group, Listener listener) {
 
     }
 
     @Override
-    public boolean publishConfig(String dataId, String group, String content) throws NacosException {
+    public boolean publishConfig(String dataId, String group, String content) {
         return false;
     }
 
     @Override
-    public boolean publishConfig(String dataId, String group, String content, String type) throws NacosException {
+    public boolean publishConfig(String dataId, String group, String content, String type) {
         return false;
     }
 
     @Override
-    public boolean publishConfigCas(String dataId, String group, String content, String casMd5) throws NacosException {
+    public boolean publishConfigCas(String dataId, String group, String content, String casMd5) {
         return false;
     }
 
     @Override
-    public boolean publishConfigCas(String dataId, String group, String content, String casMd5, String type) throws NacosException {
+    public boolean publishConfigCas(String dataId, String group, String content, String casMd5, String type) {
         return false;
     }
 
     @Override
-    public boolean removeConfig(String dataId, String group) throws NacosException {
+    public boolean removeConfig(String dataId, String group) {
         return false;
     }
 
@@ -72,7 +72,7 @@ public class MockConfigService implements ConfigService {
     }
 
     @Override
-    public void shutDown() throws NacosException {
+    public void shutDown() {
 
     }
 }

--- a/dubbo-metadata/dubbo-metadata-report-redis/src/test/java/org/apache/dubbo/metadata/store/redis/RedisMetadataReportTest.java
+++ b/dubbo-metadata/dubbo-metadata-report-redis/src/test/java/org/apache/dubbo/metadata/store/redis/RedisMetadataReportTest.java
@@ -59,7 +59,7 @@ class RedisMetadataReportTest {
     URL registryUrl;
 
     @BeforeEach
-    public void constructor(final TestInfo testInfo) throws IOException {
+    public void constructor(final TestInfo testInfo) {
         final boolean usesAuthentication = usesAuthentication(testInfo);
         int redisPort = 0;
         IOException exception = null;

--- a/dubbo-metrics/dubbo-metrics-default/src/test/java/org/apache/dubbo/metrics/observation/ObservationReceiverFilterTest.java
+++ b/dubbo-metrics/dubbo-metrics-default/src/test/java/org/apache/dubbo/metrics/observation/ObservationReceiverFilterTest.java
@@ -36,7 +36,7 @@ import org.assertj.core.api.BDDAssertions;
 class ObservationReceiverFilterTest extends AbstractObservationFilterTest {
 
     @Override
-    public SampleTestRunnerConsumer yourCode() throws Exception {
+    public SampleTestRunnerConsumer yourCode() {
         return (buildingBlocks, meterRegistry) -> {
             setupConfig();
             setupAttachments(buildingBlocks.getTracer());

--- a/dubbo-metrics/dubbo-metrics-default/src/test/java/org/apache/dubbo/metrics/observation/ObservationSenderFilterTest.java
+++ b/dubbo-metrics/dubbo-metrics-default/src/test/java/org/apache/dubbo/metrics/observation/ObservationSenderFilterTest.java
@@ -29,7 +29,7 @@ import org.assertj.core.api.BDDAssertions;
 class ObservationSenderFilterTest extends AbstractObservationFilterTest {
 
     @Override
-    public SampleTestRunnerConsumer yourCode() throws Exception {
+    public SampleTestRunnerConsumer yourCode() {
         return (buildingBlocks, meterRegistry) -> {
             setupConfig();
             setupAttachments();

--- a/dubbo-monitor/dubbo-monitor-default/src/test/java/org/apache/dubbo/monitor/dubbo/DubboMonitorTest.java
+++ b/dubbo-monitor/dubbo-monitor-default/src/test/java/org/apache/dubbo/monitor/dubbo/DubboMonitorTest.java
@@ -107,7 +107,7 @@ class DubboMonitorTest {
     };
 
     @Test
-    void testCount() throws Exception {
+    void testCount() {
         DubboMonitor monitor = new DubboMonitor(monitorInvoker, monitorService);
         URL statistics = new URLBuilder(DUBBO_PROTOCOL, "10.20.153.10", 0)
             .addParameter(APPLICATION_KEY, "morgan")
@@ -141,7 +141,7 @@ class DubboMonitorTest {
     }
 
     @Test
-    void testMonitorFactory() throws Exception {
+    void testMonitorFactory() {
         MockMonitorService monitorService = new MockMonitorService();
         URL statistics = new URLBuilder(DUBBO_PROTOCOL, "10.20.153.10", 0)
             .addParameter(APPLICATION_KEY, "morgan")

--- a/dubbo-monitor/dubbo-monitor-default/src/test/java/org/apache/dubbo/monitor/dubbo/MetricsFilterTest.java
+++ b/dubbo-monitor/dubbo-monitor-default/src/test/java/org/apache/dubbo/monitor/dubbo/MetricsFilterTest.java
@@ -136,7 +136,7 @@ class MetricsFilterTest {
         }
     }
 
-    private void testConsumerSuccess() throws Exception {
+    private void testConsumerSuccess() {
         IMetricManager metricManager = MetricManager.getIMetricManager();
         metricManager.clear();
         MetricsFilter metricsFilter = new MetricsFilter();
@@ -197,7 +197,7 @@ class MetricsFilterTest {
 
     }
 
-    private void testProviderSuccess() throws Exception {
+    private void testProviderSuccess() {
         IMetricManager metricManager = MetricManager.getIMetricManager();
         metricManager.clear();
         MetricsFilter metricsFilter = new MetricsFilter();

--- a/dubbo-plugin/dubbo-qos/src/test/java/org/apache/dubbo/qos/command/CommandContextFactoryTest.java
+++ b/dubbo-plugin/dubbo-qos/src/test/java/org/apache/dubbo/qos/command/CommandContextFactoryTest.java
@@ -26,7 +26,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class CommandContextFactoryTest {
     @Test
-    void testNewInstance() throws Exception {
+    void testNewInstance() {
         CommandContext context = CommandContextFactory.newInstance("test");
         assertThat(context.getCommandName(), equalTo("test"));
         context = CommandContextFactory.newInstance("command", new String[]{"hello"}, true);

--- a/dubbo-plugin/dubbo-qos/src/test/java/org/apache/dubbo/qos/command/DefaultCommandExecutorTest.java
+++ b/dubbo-plugin/dubbo-qos/src/test/java/org/apache/dubbo/qos/command/DefaultCommandExecutorTest.java
@@ -29,7 +29,7 @@ import static org.hamcrest.Matchers.equalTo;
 
 class DefaultCommandExecutorTest {
     @Test
-    void testExecute1() throws Exception {
+    void testExecute1() {
         Assertions.assertThrows(NoSuchCommandException.class, () -> {
             DefaultCommandExecutor executor = new DefaultCommandExecutor(FrameworkModel.defaultModel());
             executor.execute(CommandContextFactory.newInstance("not-exit"));
@@ -48,7 +48,7 @@ class DefaultCommandExecutorTest {
     }
 
     @Test
-    void shouldNotThrowPermissionDenyException_GivenPermissionConfigAndMatchDefaultPUBLICCmdPermissionLevel() throws Exception {
+    void shouldNotThrowPermissionDenyException_GivenPermissionConfigAndMatchDefaultPUBLICCmdPermissionLevel() {
         DefaultCommandExecutor executor = new DefaultCommandExecutor(FrameworkModel.defaultModel());
         final CommandContext commandContext = CommandContextFactory.newInstance("live", new String[]{"dubbo"}, false);
         commandContext.setQosConfiguration(QosConfiguration.builder().build());
@@ -56,7 +56,7 @@ class DefaultCommandExecutorTest {
     }
 
     @Test
-    void shouldNotThrowPermissionDenyException_GivenPermissionConfigAndNotMatchCmdPermissionLevel() throws Exception {
+    void shouldNotThrowPermissionDenyException_GivenPermissionConfigAndNotMatchCmdPermissionLevel() {
         DefaultCommandExecutor executor = new DefaultCommandExecutor(FrameworkModel.defaultModel());
         final CommandContext commandContext = CommandContextFactory.newInstance("live", new String[]{"dubbo"}, false);
         // 1 PROTECTED

--- a/dubbo-plugin/dubbo-qos/src/test/java/org/apache/dubbo/qos/command/decoder/HttpCommandDecoderTest.java
+++ b/dubbo-plugin/dubbo-qos/src/test/java/org/apache/dubbo/qos/command/decoder/HttpCommandDecoderTest.java
@@ -37,7 +37,7 @@ import static org.mockito.Mockito.when;
 
 class HttpCommandDecoderTest {
     @Test
-    void decodeGet() throws Exception {
+    void decodeGet() {
         HttpRequest request = mock(HttpRequest.class);
         when(request.uri()).thenReturn("localhost:80/test");
         when(request.method()).thenReturn(HttpMethod.GET);
@@ -50,7 +50,7 @@ class HttpCommandDecoderTest {
     }
 
     @Test
-    void decodePost() throws Exception {
+    void decodePost() {
         FullHttpRequest request = mock(FullHttpRequest.class);
         when(request.uri()).thenReturn("localhost:80/test");
         when(request.method()).thenReturn(HttpMethod.POST);

--- a/dubbo-plugin/dubbo-qos/src/test/java/org/apache/dubbo/qos/command/impl/HelpTest.java
+++ b/dubbo-plugin/dubbo-qos/src/test/java/org/apache/dubbo/qos/command/impl/HelpTest.java
@@ -27,7 +27,7 @@ import static org.hamcrest.Matchers.containsString;
 
 class HelpTest {
     @Test
-    void testMainHelp() throws Exception {
+    void testMainHelp() {
         Help help = new Help(FrameworkModel.defaultModel());
         String output = help.execute(Mockito.mock(CommandContext.class), null);
         assertThat(output, containsString("greeting"));
@@ -39,7 +39,7 @@ class HelpTest {
     }
 
     @Test
-    void testGreeting() throws Exception {
+    void testGreeting() {
         Help help = new Help(FrameworkModel.defaultModel());
         String output = help.execute(Mockito.mock(CommandContext.class), new String[]{"greeting"});
         assertThat(output, containsString("COMMAND NAME"));

--- a/dubbo-registry/dubbo-registry-api/src/test/java/org/apache/dubbo/registry/client/metadata/MetadataServiceNameMappingTest.java
+++ b/dubbo-registry/dubbo-registry-api/src/test/java/org/apache/dubbo/registry/client/metadata/MetadataServiceNameMappingTest.java
@@ -103,7 +103,7 @@ class MetadataServiceNameMappingTest {
             private int counter = 0;
 
             @Override
-            public Boolean answer(InvocationOnMock invocationOnMock) throws Throwable {
+            public Boolean answer(InvocationOnMock invocationOnMock) {
                 if (++counter == 10) {
                     return true;
                 }

--- a/dubbo-registry/dubbo-registry-api/src/test/java/org/apache/dubbo/registry/client/migration/MigrationRuleListenerTest.java
+++ b/dubbo-registry/dubbo-registry-api/src/test/java/org/apache/dubbo/registry/client/migration/MigrationRuleListenerTest.java
@@ -86,7 +86,7 @@ class MigrationRuleListenerTest {
      * Check local rule take effect
      */
     @Test
-    void test() throws InterruptedException {
+    void test() {
         DynamicConfiguration dynamicConfiguration = Mockito.mock(DynamicConfiguration.class);
 
         ApplicationModel.reset();
@@ -166,7 +166,7 @@ class MigrationRuleListenerTest {
      * 2. remote rule change and all invokers gets notified
      */
     @Test
-    void testWithConfigurationListenerAndLocalRule() throws InterruptedException {
+    void testWithConfigurationListenerAndLocalRule() {
         DynamicConfiguration dynamicConfiguration = Mockito.mock(DynamicConfiguration.class);
         Mockito.doReturn(remoteRule).when(dynamicConfiguration).getConfig(Mockito.anyString(), Mockito.anyString());
 

--- a/dubbo-registry/dubbo-registry-api/src/test/java/org/apache/dubbo/registry/support/AbstractRegistryFactoryTest.java
+++ b/dubbo-registry/dubbo-registry-api/src/test/java/org/apache/dubbo/registry/support/AbstractRegistryFactoryTest.java
@@ -91,7 +91,7 @@ class AbstractRegistryFactoryTest {
     }
 
     @Test
-    void testRegistryFactoryCache() throws Exception {
+    void testRegistryFactoryCache() {
         URL url = URL.valueOf("dubbo://" + NetUtils.getLocalAddress().getHostAddress() + ":2233");
         Registry registry1 = registryFactory.getRegistry(url);
         Registry registry2 = registryFactory.getRegistry(url);
@@ -102,14 +102,14 @@ class AbstractRegistryFactoryTest {
      * Registration center address `dubbo` does not resolve
      */
     // @Test
-    public void testRegistryFactoryIpCache() throws Exception {
+    public void testRegistryFactoryIpCache() {
         Registry registry1 = registryFactory.getRegistry(URL.valueOf("dubbo://" + NetUtils.getLocalAddress().getHostName() + ":2233"));
         Registry registry2 = registryFactory.getRegistry(URL.valueOf("dubbo://" + NetUtils.getLocalAddress().getHostAddress() + ":2233"));
         Assertions.assertEquals(registry1, registry2);
     }
 
     @Test
-    void testRegistryFactoryGroupCache() throws Exception {
+    void testRegistryFactoryGroupCache() {
         Registry registry1 = registryFactory.getRegistry(URL.valueOf("dubbo://" + NetUtils.getLocalHost() + ":2233?group=aaa"));
         Registry registry2 = registryFactory.getRegistry(URL.valueOf("dubbo://" + NetUtils.getLocalHost() + ":2233?group=bbb"));
         Assertions.assertNotSame(registry1, registry2);

--- a/dubbo-registry/dubbo-registry-api/src/test/java/org/apache/dubbo/registry/support/AbstractRegistryTest.java
+++ b/dubbo-registry/dubbo-registry-api/src/test/java/org/apache/dubbo/registry/support/AbstractRegistryTest.java
@@ -90,10 +90,9 @@ class AbstractRegistryTest {
      * Test method for
      * {@link org.apache.dubbo.registry.support.AbstractRegistry#register(URL)}.
      *
-     * @throws Exception
      */
     @Test
-    void testRegister() throws Exception {
+    void testRegister() {
         //test one url
         abstractRegistry.register(mockUrl);
         assert abstractRegistry.getRegistered().contains(mockUrl);

--- a/dubbo-remoting/dubbo-remoting-api/src/test/java/org/apache/dubbo/remoting/exchange/support/DefaultFutureTest.java
+++ b/dubbo-remoting/dubbo-remoting-api/src/test/java/org/apache/dubbo/remoting/exchange/support/DefaultFutureTest.java
@@ -159,7 +159,7 @@ class DefaultFutureTest {
     }
 
     @Test
-    void testClose() throws Exception {
+    void testClose() {
         Channel channel = new MockedChannel();
         Request request = new Request(123);
         ExecutorService executor = ExtensionLoader.getExtensionLoader(ExecutorRepository.class)

--- a/dubbo-remoting/dubbo-remoting-api/src/test/java/org/apache/dubbo/remoting/transport/AbstractCodecTest.java
+++ b/dubbo-remoting/dubbo-remoting-api/src/test/java/org/apache/dubbo/remoting/transport/AbstractCodecTest.java
@@ -85,12 +85,12 @@ class AbstractCodecTest {
     private AbstractCodec getAbstractCodec() {
         AbstractCodec codec = new AbstractCodec() {
             @Override
-            public void encode(Channel channel, ChannelBuffer buffer, Object message) throws IOException {
+            public void encode(Channel channel, ChannelBuffer buffer, Object message) {
 
             }
 
             @Override
-            public Object decode(Channel channel, ChannelBuffer buffer) throws IOException {
+            public Object decode(Channel channel, ChannelBuffer buffer) {
                 return null;
             }
         };

--- a/dubbo-remoting/dubbo-remoting-netty/src/test/java/org/apache/dubbo/remoting/transport/netty/ClientToServerTest.java
+++ b/dubbo-remoting/dubbo-remoting-netty/src/test/java/org/apache/dubbo/remoting/transport/netty/ClientToServerTest.java
@@ -53,7 +53,7 @@ public abstract class ClientToServerTest  {
     }
 
     @BeforeEach
-    protected void tearDown() throws Exception {
+    protected void tearDown() {
         try {
             if (server != null)
                 server.close();

--- a/dubbo-remoting/dubbo-remoting-netty/src/test/java/org/apache/dubbo/remoting/transport/netty/NettyStringTest.java
+++ b/dubbo-remoting/dubbo-remoting-netty/src/test/java/org/apache/dubbo/remoting/transport/netty/NettyStringTest.java
@@ -45,7 +45,7 @@ class NettyStringTest {
     }
 
     @AfterAll
-    public static void tearDown() throws Exception {
+    public static void tearDown() {
         try {
             if (server != null)
                 server.close();
@@ -56,7 +56,7 @@ class NettyStringTest {
     }
 
     @Test
-    void testHandler() throws Exception {
+    void testHandler() {
         //Thread.sleep(20000);
         /*client.request("world\r\n");
         Future future = client.request("world", 10000);

--- a/dubbo-remoting/dubbo-remoting-zookeeper-curator5/src/test/java/org/apache/dubbo/remoting/zookeeper/curator5/support/AbstractZookeeperTransporterTest.java
+++ b/dubbo-remoting/dubbo-remoting-zookeeper-curator5/src/test/java/org/apache/dubbo/remoting/zookeeper/curator5/support/AbstractZookeeperTransporterTest.java
@@ -80,7 +80,7 @@ class AbstractZookeeperTransporterTest {
     }
 
     @Test
-    void testFetchAndUpdateZookeeperClientCache() throws Exception {
+    void testFetchAndUpdateZookeeperClientCache() {
         URL url = URL.valueOf(zookeeperConnectionAddress1 + "/org.apache.dubbo.registry.RegistryService?backup=127.0.0.1:" + zookeeperServerPort1 + ",127.0.0.1:" + zookeeperServerPort2 + "&application=metadatareport-local-xml-provider2&dubbo=2.0.2&interface=org.apache.dubbo.registry.RegistryService&pid=47418&specVersion=2.7.0-SNAPSHOT&timestamp=1547102428828");
         ZookeeperClient newZookeeperClient = abstractZookeeperTransporter.connect(url);
         //just for connected
@@ -120,7 +120,7 @@ class AbstractZookeeperTransporterTest {
     }
 
     @Test
-    void testNotRepeatConnect() throws Exception {
+    void testNotRepeatConnect() {
         URL url = URL.valueOf(zookeeperConnectionAddress1 + "/org.apache.dubbo.registry.RegistryService?application=metadatareport-local-xml-provider2&dubbo=2.0.2&interface=org.apache.dubbo.registry.RegistryService&pid=47418&specVersion=2.7.0-SNAPSHOT&timestamp=1547102428828");
         URL url2 = URL.valueOf(zookeeperConnectionAddress2 + "/org.apache.dubbo.metadata.store.MetadataReport?address=zookeeper://127.0.0.1:2181&application=metadatareport-local-xml-provider2&cycle-report=false&interface=org.apache.dubbo.metadata.store.MetadataReport&retry-period=4590&retry-times=23&sync-report=true");
         ZookeeperClient newZookeeperClient = abstractZookeeperTransporter.connect(url);
@@ -139,7 +139,7 @@ class AbstractZookeeperTransporterTest {
     }
 
     @Test
-    void testRepeatConnectForBackUpAdd() throws Exception {
+    void testRepeatConnectForBackUpAdd() {
 
         URL url = URL.valueOf(zookeeperConnectionAddress1 + "/org.apache.dubbo.registry.RegistryService?backup=127.0.0.1:" + zookeeperServerPort1 + "&application=metadatareport-local-xml-provider2&dubbo=2.0.2&interface=org.apache.dubbo.registry.RegistryService&pid=47418&specVersion=2.7.0-SNAPSHOT&timestamp=1547102428828");
         URL url2 = URL.valueOf(zookeeperConnectionAddress1 + "/org.apache.dubbo.metadata.store.MetadataReport?backup=127.0.0.1:" + zookeeperServerPort2 + "&address=zookeeper://127.0.0.1:2181&application=metadatareport-local-xml-provider2&cycle-report=false&interface=org.apache.dubbo.metadata.store.MetadataReport&retry-period=4590&retry-times=23&sync-report=true");
@@ -159,7 +159,7 @@ class AbstractZookeeperTransporterTest {
     }
 
     @Test
-    void testRepeatConnectForNoMatchBackUpAdd() throws Exception {
+    void testRepeatConnectForNoMatchBackUpAdd() {
 
         URL url = URL.valueOf(zookeeperConnectionAddress1 + "/org.apache.dubbo.registry.RegistryService?backup=127.0.0.1:" + zookeeperServerPort1 + "&application=metadatareport-local-xml-provider2&dubbo=2.0.2&interface=org.apache.dubbo.registry.RegistryService&pid=47418&specVersion=2.7.0-SNAPSHOT&timestamp=1547102428828");
         URL url2 = URL.valueOf(zookeeperConnectionAddress2 + "/org.apache.dubbo.metadata.store.MetadataReport?address=zookeeper://127.0.0.1:2181&application=metadatareport-local-xml-provider2&cycle-report=false&interface=org.apache.dubbo.metadata.store.MetadataReport&retry-period=4590&retry-times=23&sync-report=true");
@@ -179,7 +179,7 @@ class AbstractZookeeperTransporterTest {
     }
 
     @Test
-    void testSameHostWithDifferentUser() throws Exception {
+    void testSameHostWithDifferentUser() {
         URL url1 = URL.valueOf("zookeeper://us1:pw1@127.0.0.1:" + zookeeperServerPort1 + "/path1");
         URL url2 = URL.valueOf("zookeeper://us2:pw2@127.0.0.1:" + zookeeperServerPort1 + "/path2");
         ZookeeperClient client1 = abstractZookeeperTransporter.connect(url1);

--- a/dubbo-remoting/dubbo-remoting-zookeeper/src/test/java/org/apache/dubbo/remoting/zookeeper/curator/CuratorZookeeperClientTest.java
+++ b/dubbo-remoting/dubbo-remoting-zookeeper/src/test/java/org/apache/dubbo/remoting/zookeeper/curator/CuratorZookeeperClientTest.java
@@ -97,7 +97,7 @@ class CuratorZookeeperClientTest {
         curatorClient.addTargetChildListener(path, new CuratorZookeeperClient.CuratorWatcherImpl() {
 
             @Override
-            public void process(WatchedEvent watchedEvent) throws Exception {
+            public void process(WatchedEvent watchedEvent) {
                 countDownLatch.countDown();
             }
         });
@@ -116,7 +116,7 @@ class CuratorZookeeperClientTest {
 
     @Test
     @Disabled("Global registry center cannot stop")
-    public void testWithStoppedServer() throws IOException {
+    public void testWithStoppedServer() {
         Assertions.assertThrows(IllegalStateException.class, () -> {
             curatorClient.create("/testPath", true, true);
             curatorClient.delete("/testPath");
@@ -225,7 +225,7 @@ class CuratorZookeeperClientTest {
         curatorClient.addTargetDataListener(path + "/d.json", new CuratorZookeeperClient.NodeCacheListenerImpl() {
 
             @Override
-            public void nodeChanged() throws Exception {
+            public void nodeChanged() {
                 atomicInteger.incrementAndGet();
             }
         });
@@ -305,7 +305,7 @@ class CuratorZookeeperClientTest {
     }
 
     @Test
-    void testPersistentCas2() throws Exception {
+    void testPersistentCas2() {
         // test update failed when others create success
         String path = "/dubbo/mapping/org.apache.dubbo.demo.DemoService";
         CuratorZookeeperClient curatorClient = new CuratorZookeeperClient(URL.valueOf(zookeeperConnectionAddress1 + "/org.apache.dubbo.registry.RegistryService"));
@@ -430,7 +430,7 @@ class CuratorZookeeperClientTest {
     }
 
     @Test
-    void testEphemeralCas2() throws Exception {
+    void testEphemeralCas2() {
         // test update failed when others create success
         String path = "/dubbo/mapping/org.apache.dubbo.demo.DemoService";
         CuratorZookeeperClient curatorClient = new CuratorZookeeperClient(URL.valueOf(zookeeperConnectionAddress1 + "/org.apache.dubbo.registry.RegistryService"));

--- a/dubbo-remoting/dubbo-remoting-zookeeper/src/test/java/org/apache/dubbo/remoting/zookeeper/curator/support/AbstractZookeeperTransporterTest.java
+++ b/dubbo-remoting/dubbo-remoting-zookeeper/src/test/java/org/apache/dubbo/remoting/zookeeper/curator/support/AbstractZookeeperTransporterTest.java
@@ -84,7 +84,7 @@ class AbstractZookeeperTransporterTest {
     }
 
     @Test
-    void testFetchAndUpdateZookeeperClientCache() throws Exception {
+    void testFetchAndUpdateZookeeperClientCache() {
         URL url = URL.valueOf(zookeeperConnectionAddress1 + "/org.apache.dubbo.registry.RegistryService?backup=127.0.0.1:" + zookeeperServerPort1 + ",127.0.0.1:" + zookeeperServerPort2 + "&application=metadatareport-local-xml-provider2&dubbo=2.0.2&interface=org.apache.dubbo.registry.RegistryService&pid=47418&specVersion=2.7.0-SNAPSHOT&timestamp=1547102428828");
         ZookeeperClient newZookeeperClient = abstractZookeeperTransporter.connect(url);
         //just for connected
@@ -124,7 +124,7 @@ class AbstractZookeeperTransporterTest {
     }
 
     @Test
-    void testNotRepeatConnect() throws Exception {
+    void testNotRepeatConnect() {
         URL url = URL.valueOf(zookeeperConnectionAddress1 + "/org.apache.dubbo.registry.RegistryService?application=metadatareport-local-xml-provider2&dubbo=2.0.2&interface=org.apache.dubbo.registry.RegistryService&pid=47418&specVersion=2.7.0-SNAPSHOT&timestamp=1547102428828");
         URL url2 = URL.valueOf(zookeeperConnectionAddress2 + "/org.apache.dubbo.metadata.store.MetadataReport?address=zookeeper://127.0.0.1:2181&application=metadatareport-local-xml-provider2&cycle-report=false&interface=org.apache.dubbo.metadata.store.MetadataReport&retry-period=4590&retry-times=23&sync-report=true");
         ZookeeperClient newZookeeperClient = abstractZookeeperTransporter.connect(url);
@@ -143,7 +143,7 @@ class AbstractZookeeperTransporterTest {
     }
 
     @Test
-    void testRepeatConnectForBackUpAdd() throws Exception {
+    void testRepeatConnectForBackUpAdd() {
 
         URL url = URL.valueOf(zookeeperConnectionAddress1 + "/org.apache.dubbo.registry.RegistryService?backup=127.0.0.1:" + zookeeperServerPort1 + "&application=metadatareport-local-xml-provider2&dubbo=2.0.2&interface=org.apache.dubbo.registry.RegistryService&pid=47418&specVersion=2.7.0-SNAPSHOT&timestamp=1547102428828");
         URL url2 = URL.valueOf(zookeeperConnectionAddress1 + "/org.apache.dubbo.metadata.store.MetadataReport?backup=127.0.0.1:" + zookeeperServerPort2 + "&address=zookeeper://127.0.0.1:2181&application=metadatareport-local-xml-provider2&cycle-report=false&interface=org.apache.dubbo.metadata.store.MetadataReport&retry-period=4590&retry-times=23&sync-report=true");
@@ -163,7 +163,7 @@ class AbstractZookeeperTransporterTest {
     }
 
     @Test
-    void testRepeatConnectForNoMatchBackUpAdd() throws Exception {
+    void testRepeatConnectForNoMatchBackUpAdd() {
 
         URL url = URL.valueOf(zookeeperConnectionAddress1 + "/org.apache.dubbo.registry.RegistryService?backup=127.0.0.1:" + zookeeperServerPort1 + "&application=metadatareport-local-xml-provider2&dubbo=2.0.2&interface=org.apache.dubbo.registry.RegistryService&pid=47418&specVersion=2.7.0-SNAPSHOT&timestamp=1547102428828");
         URL url2 = URL.valueOf(zookeeperConnectionAddress2 + "/org.apache.dubbo.metadata.store.MetadataReport?address=zookeeper://127.0.0.1:2181&application=metadatareport-local-xml-provider2&cycle-report=false&interface=org.apache.dubbo.metadata.store.MetadataReport&retry-period=4590&retry-times=23&sync-report=true");
@@ -183,7 +183,7 @@ class AbstractZookeeperTransporterTest {
     }
 
     @Test
-    void testSameHostWithDifferentUser() throws Exception {
+    void testSameHostWithDifferentUser() {
         URL url1 = URL.valueOf("zookeeper://us1:pw1@127.0.0.1:" + zookeeperServerPort1 + "/path1");
         URL url2 = URL.valueOf("zookeeper://us2:pw2@127.0.0.1:" + zookeeperServerPort1 + "/path2");
         ZookeeperClient client1 = abstractZookeeperTransporter.connect(url1);

--- a/dubbo-rpc/dubbo-rpc-api/src/test/java/org/apache/dubbo/rpc/filter/ActiveLimitFilterTest.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/test/java/org/apache/dubbo/rpc/filter/ActiveLimitFilterTest.java
@@ -98,7 +98,7 @@ class ActiveLimitFilterTest {
     }
 
     @Test
-    void testInvokeTimeOut() throws Exception {
+    void testInvokeTimeOut() {
         int totalThread = 100;
         int maxActives = 10;
         long timeout = 1;
@@ -147,7 +147,7 @@ class ActiveLimitFilterTest {
     }
 
     @Test
-    void testInvokeNotTimeOut() throws Exception {
+    void testInvokeNotTimeOut() {
         int totalThread = 100;
         int maxActives = 10;
         long timeout = 1000;

--- a/dubbo-rpc/dubbo-rpc-api/src/test/java/org/apache/dubbo/rpc/filter/tps/DefaultTPSLimiterTest.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/test/java/org/apache/dubbo/rpc/filter/tps/DefaultTPSLimiterTest.java
@@ -37,7 +37,7 @@ class DefaultTPSLimiterTest {
     private final DefaultTPSLimiter defaultTPSLimiter = new DefaultTPSLimiter();
 
     @Test
-    void testIsAllowable() throws Exception {
+    void testIsAllowable() {
         Invocation invocation = new MockInvocation();
         URL url = URL.valueOf("test://test");
         url = url.addParameter(INTERFACE_KEY, "org.apache.dubbo.rpc.file.TpsService");
@@ -49,7 +49,7 @@ class DefaultTPSLimiterTest {
     }
 
     @Test
-    void testIsNotAllowable() throws Exception {
+    void testIsNotAllowable() {
         Invocation invocation = new MockInvocation();
         URL url = URL.valueOf("test://test");
         url = url.addParameter(INTERFACE_KEY, "org.apache.dubbo.rpc.file.TpsService");
@@ -65,7 +65,7 @@ class DefaultTPSLimiterTest {
     }
 
     @Test
-    void testTPSLimiterForMethodLevelConfig() throws Exception {
+    void testTPSLimiterForMethodLevelConfig() {
         Invocation invocation = new MockInvocation();
         URL url = URL.valueOf("test://test");
         url = url.addParameter(INTERFACE_KEY, "org.apache.dubbo.rpc.file.TpsService");
@@ -83,7 +83,7 @@ class DefaultTPSLimiterTest {
     }
 
     @Test
-    void testConfigChange() throws Exception {
+    void testConfigChange() {
         Invocation invocation = new MockInvocation();
         URL url = URL.valueOf("test://test");
         url = url.addParameter(INTERFACE_KEY, "org.apache.dubbo.rpc.file.TpsService");

--- a/dubbo-rpc/dubbo-rpc-api/src/test/java/org/apache/dubbo/rpc/proxy/AbstractProxyTest.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/test/java/org/apache/dubbo/rpc/proxy/AbstractProxyTest.java
@@ -38,7 +38,7 @@ public abstract class AbstractProxyTest {
     public static ProxyFactory factory;
 
     @Test
-    void testGetProxy() throws Exception {
+    void testGetProxy() {
         URL url = URL.valueOf("test://test:11/test?group=dubbo&version=1.1");
 
         MyInvoker<DemoService> invoker = new MyInvoker<>(url);
@@ -61,7 +61,7 @@ public abstract class AbstractProxyTest {
     }
 
     @Test
-    void testGetInvoker() throws Exception {
+    void testGetInvoker() {
         URL url = URL.valueOf("test://test:11/test?group=dubbo&version=1.1");
 
         DemoService origin = new DemoServiceImpl();

--- a/dubbo-rpc/dubbo-rpc-dubbo/src/test/java/org/apache/dubbo/rpc/protocol/dubbo/ArgumentCallbackTest.java
+++ b/dubbo-rpc/dubbo-rpc-dubbo/src/test/java/org/apache/dubbo/rpc/protocol/dubbo/ArgumentCallbackTest.java
@@ -78,7 +78,7 @@ class ArgumentCallbackTest {
     public void setUp() {
     }
 
-    public void initOrResetUrl(int callbacks, int timeout) throws Exception {
+    public void initOrResetUrl(int callbacks, int timeout) {
         int port = NetUtils.getAvailablePort();
         consumerUrl = serviceURL = URL.valueOf("dubbo://127.0.0.1:" + port + "/" + IDemoService.class.getName() + "?group=test"
                 + "&xxx.0.callback=true"
@@ -206,7 +206,7 @@ class ArgumentCallbackTest {
     }
 
     @Test
-    void TestCallbackConsumerLimit() throws Exception {
+    void TestCallbackConsumerLimit() {
         Assertions.assertThrows(RpcException.class, () -> {
             initOrResetUrl(1, 1000);
             // URL cannot be transferred automatically from the server side to the client side by using API, instead,
@@ -233,7 +233,7 @@ class ArgumentCallbackTest {
     }
 
     @Test
-    void TestCallbackProviderLimit() throws Exception {
+    void TestCallbackProviderLimit() {
         Assertions.assertThrows(RpcException.class, () -> {
             initOrResetUrl(1, 1000);
             // URL cannot be transferred automatically from the server side to the client side by using API, instead,

--- a/dubbo-rpc/dubbo-rpc-dubbo/src/test/java/org/apache/dubbo/rpc/protocol/dubbo/DubboInvokerAvailableTest.java
+++ b/dubbo-rpc/dubbo-rpc-dubbo/src/test/java/org/apache/dubbo/rpc/protocol/dubbo/DubboInvokerAvailableTest.java
@@ -47,7 +47,7 @@ class DubboInvokerAvailableTest {
     private static ProxyFactory proxy = ExtensionLoader.getExtensionLoader(ProxyFactory.class).getAdaptiveExtension();
 
     @BeforeAll
-    public static void setUpBeforeClass() throws Exception {
+    public static void setUpBeforeClass() {
     }
 
     @BeforeEach
@@ -91,7 +91,7 @@ class DubboInvokerAvailableTest {
 
     @Disabled
     @Test
-    void test_normal_channel_close_wait_gracefully() throws Exception {
+    void test_normal_channel_close_wait_gracefully() {
         int testPort = NetUtils.getAvailablePort();
         URL url = URL.valueOf("dubbo://127.0.0.1:" + testPort + "/org.apache.dubbo.rpc.protocol.dubbo.IDemoService?scope=true&lazy=false");
         Exporter<IDemoService> exporter = ProtocolUtils.export(new DemoServiceImpl(), IDemoService.class, url);

--- a/dubbo-rpc/dubbo-rpc-dubbo/src/test/java/org/apache/dubbo/rpc/protocol/dubbo/DubboProtocolTest.java
+++ b/dubbo-rpc/dubbo-rpc-dubbo/src/test/java/org/apache/dubbo/rpc/protocol/dubbo/DubboProtocolTest.java
@@ -74,7 +74,7 @@ class DubboProtocolTest {
     }
 
     @Test
-    void testDemoProtocol() throws Exception {
+    void testDemoProtocol() {
         DemoService service = new DemoServiceImpl();
         int port = NetUtils.getAvailablePort();
         protocol.export(proxy.getInvoker(service, DemoService.class, URL.valueOf("dubbo://127.0.0.1:" + port + "/" + DemoService.class.getName() + "?codec=exchange")));
@@ -187,7 +187,7 @@ class DubboProtocolTest {
     }
 
     @Test
-    void testPerm() throws Exception {
+    void testPerm() {
         DemoService service = new DemoServiceImpl();
         int port = NetUtils.getAvailablePort();
         protocol.export(proxy.getInvoker(service, DemoService.class, URL.valueOf("dubbo://127.0.0.1:" + port + "/" + DemoService.class.getName() + "?codec=exchange")));
@@ -201,7 +201,7 @@ class DubboProtocolTest {
 
     @Test
     @Disabled
-    public void testNonSerializedParameter() throws Exception {
+    public void testNonSerializedParameter() {
         DemoService service = new DemoServiceImpl();
         int port = NetUtils.getAvailablePort();
         protocol.export(proxy.getInvoker(service, DemoService.class, URL.valueOf("dubbo://127.0.0.1:" + port + "/" + DemoService.class.getName() + "?codec=exchange")));
@@ -217,7 +217,7 @@ class DubboProtocolTest {
 
     @Test
     @Disabled
-    public void testReturnNonSerialized() throws Exception {
+    public void testReturnNonSerialized() {
         DemoService service = new DemoServiceImpl();
         int port = NetUtils.getAvailablePort();
         protocol.export(proxy.getInvoker(service, DemoService.class, URL.valueOf("dubbo://127.0.0.1:" + port + "/" + DemoService.class.getName() + "?codec=exchange")));
@@ -256,7 +256,7 @@ class DubboProtocolTest {
     }
 
     @Test
-    void testPayloadOverException() throws Exception {
+    void testPayloadOverException() {
         DemoService service = new DemoServiceImpl();
         int port = NetUtils.getAvailablePort();
         protocol.export(proxy.getInvoker(service, DemoService.class,

--- a/dubbo-rpc/dubbo-rpc-injvm/src/test/java/org/apache/dubbo/rpc/protocol/injvm/InjvmProtocolTest.java
+++ b/dubbo-rpc/dubbo-rpc-injvm/src/test/java/org/apache/dubbo/rpc/protocol/injvm/InjvmProtocolTest.java
@@ -82,7 +82,7 @@ class InjvmProtocolTest {
     }
 
     @Test
-    void testLocalProtocolWithToken() throws Exception {
+    void testLocalProtocolWithToken() {
         DemoService service = new DemoServiceImpl();
         Invoker<?> invoker = proxy.getInvoker(service, DemoService.class, URL.valueOf("injvm://127.0.0.1/TestService?token=abc").addParameter(INTERFACE_KEY, DemoService.class.getName()));
         assertTrue(invoker.isAvailable());
@@ -93,7 +93,7 @@ class InjvmProtocolTest {
     }
 
     @Test
-    void testIsInjvmRefer() throws Exception {
+    void testIsInjvmRefer() {
         DemoService service = new DemoServiceImpl();
         URL url = URL.valueOf("injvm://127.0.0.1/TestService")
             .addParameter(INTERFACE_KEY, DemoService.class.getName());
@@ -124,7 +124,7 @@ class InjvmProtocolTest {
     }
 
     @Test
-    void testLocalProtocolAsync() throws Exception {
+    void testLocalProtocolAsync() {
         DemoService service = new DemoServiceImpl();
         URL url = URL.valueOf("injvm://127.0.0.1/TestService")
             .addParameter(ASYNC_KEY, true)

--- a/dubbo-xds/src/test/java/org/apache/dubbo/registry/xds/util/bootstrap/BootstrapperTest.java
+++ b/dubbo-xds/src/test/java/org/apache/dubbo/registry/xds/util/bootstrap/BootstrapperTest.java
@@ -142,7 +142,7 @@ class BootstrapperTest {
     private static BootstrapperImpl.FileReader createFileReader(final String rawData) {
         return new BootstrapperImpl.FileReader() {
             @Override
-            public String readFile(String path) throws IOException {
+            public String readFile(String path) {
                 return rawData;
             }
         };


### PR DESCRIPTION
## What is the purpose of the change

Delete unnecessary exceptions thrown in the test.
Types such as:
Exception 'java.io.IOException' is never thrown in the method

This is the first PR, expect 3 more.

## Brief changelog


## Verifying this change


<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [ ] GitHub Actions works fine on your own branch.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
