### PR TITLE
fix: remove redundancy exceptions

### DIFF
--- a/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/ConfiguratorTest.java
+++ b/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/ConfiguratorTest.java
@@ -34,7 +34,7 @@ import java.util.Optional;
 class ConfiguratorTest {
 
     @Test
-    void test() throws Exception {
+    void test() {
 
         Optional<List<Configurator>> emptyOptional = Configurator.toConfigurators(Collections.emptyList());
         Assertions.assertEquals(Optional.empty(), emptyOptional);

--- a/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/filter/DefaultFilterChainBuilderTest.java
+++ b/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/filter/DefaultFilterChainBuilderTest.java
@@ -78,7 +78,7 @@ class DefaultFilterChainBuilderTest {
         urlWithoutFilter = urlWithoutFilter.setScopeModel(ApplicationModel.defaultModel());
         AbstractInvoker<DemoService> invokerWithoutFilter = new AbstractInvoker<DemoService>(DemoService.class, urlWithoutFilter) {
             @Override
-            protected Result doInvoke(Invocation invocation) throws Throwable {
+            protected Result doInvoke(Invocation invocation) {
                 return null;
             }
         };

--- a/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/support/AbstractClusterInvokerTest.java
+++ b/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/support/AbstractClusterInvokerTest.java
@@ -35,6 +35,7 @@ import org.apache.dubbo.rpc.cluster.loadbalance.LeastActiveLoadBalance;
 import org.apache.dubbo.rpc.cluster.loadbalance.RandomLoadBalance;
 import org.apache.dubbo.rpc.cluster.loadbalance.RoundRobinLoadBalance;
 import org.apache.dubbo.rpc.model.ApplicationModel;
+
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
@@ -259,7 +260,7 @@ class AbstractClusterInvokerTest {
     }
 
     @Test
-    void testSelect_multiInvokers() throws Exception {
+    void testSelect_multiInvokers() {
         testSelect_multiInvokers(RoundRobinLoadBalance.NAME);
         testSelect_multiInvokers(LeastActiveLoadBalance.NAME);
         testSelect_multiInvokers(RandomLoadBalance.NAME);

--- a/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/ConsumerConfigTest.java
+++ b/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/ConsumerConfigTest.java
@@ -17,18 +17,19 @@
 
 package org.apache.dubbo.config;
 
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Map;
-
 import org.apache.dubbo.common.utils.JsonUtils;
 import org.apache.dubbo.config.api.DemoService;
 import org.apache.dubbo.config.bootstrap.DubboBootstrap;
 import org.apache.dubbo.rpc.model.ApplicationModel;
+
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
@@ -47,7 +48,7 @@ class ConsumerConfigTest {
     }
 
     @Test
-    void testTimeout() throws Exception {
+    void testTimeout() {
         System.clearProperty("sun.rmi.transport.tcp.responseTimeout");
         ConsumerConfig consumer = new ConsumerConfig();
         consumer.setTimeout(10);
@@ -63,35 +64,35 @@ class ConsumerConfigTest {
     }
 
     @Test
-    void testClient() throws Exception {
+    void testClient() {
         ConsumerConfig consumer = new ConsumerConfig();
         consumer.setClient("client");
         assertThat(consumer.getClient(), equalTo("client"));
     }
 
     @Test
-    void testThreadpool() throws Exception {
+    void testThreadpool() {
         ConsumerConfig consumer = new ConsumerConfig();
         consumer.setThreadpool("fixed");
         assertThat(consumer.getThreadpool(), equalTo("fixed"));
     }
 
     @Test
-    void testCorethreads() throws Exception {
+    void testCorethreads() {
         ConsumerConfig consumer = new ConsumerConfig();
         consumer.setCorethreads(10);
         assertThat(consumer.getCorethreads(), equalTo(10));
     }
 
     @Test
-    void testThreads() throws Exception {
+    void testThreads() {
         ConsumerConfig consumer = new ConsumerConfig();
         consumer.setThreads(20);
         assertThat(consumer.getThreads(), equalTo(20));
     }
 
     @Test
-    void testQueues() throws Exception {
+    void testQueues() {
         ConsumerConfig consumer = new ConsumerConfig();
         consumer.setQueues(5);
         assertThat(consumer.getQueues(), equalTo(5));

--- a/dubbo-filter/dubbo-filter-validation/src/test/java/org/apache/dubbo/validation/filter/ValidationFilterTest.java
+++ b/dubbo-filter/dubbo-filter-validation/src/test/java/org/apache/dubbo/validation/filter/ValidationFilterTest.java
@@ -43,12 +43,12 @@ class ValidationFilterTest {
     private ValidationFilter validationFilter;
 
     @BeforeEach
-    public void setUp() throws Exception {
+    public void setUp() {
         this.validationFilter = new ValidationFilter();
     }
 
     @Test
-    void testItWithNotExistClass() throws Exception {
+    void testItWithNotExistClass() {
         URL url = URL.valueOf("test://test:11/test?validation=true");
 
         given(validation.getValidator(url)).willThrow(new IllegalStateException("Not found class test, cause: test"));
@@ -66,7 +66,7 @@ class ValidationFilterTest {
     }
 
     @Test
-    void testItWithExistClass() throws Exception {
+    void testItWithExistClass() {
         URL url = URL.valueOf("test://test:11/test?validation=true");
 
         given(validation.getValidator(url)).willReturn(validator);
@@ -83,7 +83,7 @@ class ValidationFilterTest {
     }
 
     @Test
-    void testItWithoutUrlParameters() throws Exception {
+    void testItWithoutUrlParameters() {
         URL url = URL.valueOf("test://test:11/test");
 
         given(validation.getValidator(url)).willReturn(validator);
@@ -100,7 +100,7 @@ class ValidationFilterTest {
     }
 
     @Test
-    void testItWhileMethodNameStartWithDollar() throws Exception {
+    void testItWhileMethodNameStartWithDollar() {
         URL url = URL.valueOf("test://test:11/test");
 
         given(validation.getValidator(url)).willReturn(validator);
@@ -119,7 +119,7 @@ class ValidationFilterTest {
 
 
     @Test
-    void testItWhileThrowoutRpcException() throws Exception {
+    void testItWhileThrowoutRpcException() {
         Assertions.assertThrows(RpcException.class, () -> {
             URL url = URL.valueOf("test://test:11/test?validation=true");
 

--- a/dubbo-filter/dubbo-filter-validation/src/test/java/org/apache/dubbo/validation/support/jvalidation/JValidatorTest.java
+++ b/dubbo-filter/dubbo-filter-validation/src/test/java/org/apache/dubbo/validation/support/jvalidation/JValidatorTest.java
@@ -30,7 +30,7 @@ import java.util.Map;
 
 class JValidatorTest {
     @Test
-    void testItWithNonExistMethod() throws Exception {
+    void testItWithNonExistMethod() {
         Assertions.assertThrows(NoSuchMethodException.class, () -> {
             URL url = URL.valueOf("test://test:11/org.apache.dubbo.validation.support.jvalidation.mock.JValidatorTestTarget");
             JValidator jValidator = new JValidator(url);
@@ -46,7 +46,7 @@ class JValidatorTest {
     }
 
     @Test
-    void testItWhenItViolatedConstraint() throws Exception {
+    void testItWhenItViolatedConstraint() {
         Assertions.assertThrows(ValidationException.class, () -> {
             URL url = URL.valueOf("test://test:11/org.apache.dubbo.validation.support.jvalidation.mock.JValidatorTestTarget");
             JValidator jValidator = new JValidator(url);

--- a/dubbo-plugin/dubbo-qos/src/test/java/org/apache/dubbo/qos/command/CommandContextTest.java
+++ b/dubbo-plugin/dubbo-qos/src/test/java/org/apache/dubbo/qos/command/CommandContextTest.java
@@ -30,7 +30,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class CommandContextTest {
     @Test
-    void test() throws Exception {
+    void test() {
         CommandContext context = new CommandContext("test", new String[]{"hello"}, true);
         Object request = new Object();
         context.setOriginRequest(request);

--- a/dubbo-plugin/dubbo-qos/src/test/java/org/apache/dubbo/qos/command/util/CommandHelperTest.java
+++ b/dubbo-plugin/dubbo-qos/src/test/java/org/apache/dubbo/qos/command/util/CommandHelperTest.java
@@ -72,13 +72,13 @@ class CommandHelperTest {
     private CommandHelper commandHelper = new CommandHelper(FrameworkModel.defaultModel());
 
     @Test
-    void testHasCommand() throws Exception {
+    void testHasCommand() {
         assertTrue(commandHelper.hasCommand("greeting"));
         assertFalse(commandHelper.hasCommand("not-exiting"));
     }
 
     @Test
-    void testGetAllCommandClass() throws Exception {
+    void testGetAllCommandClass() {
         List<Class<?>> classes = commandHelper.getAllCommandClass();
 
         // update this list when introduce a new command
@@ -125,7 +125,7 @@ class CommandHelperTest {
     }
 
     @Test
-    void testGetCommandClass() throws Exception {
+    void testGetCommandClass() {
         assertThat(commandHelper.getCommandClass("greeting"), equalTo(GreetingCommand.class));
         assertNull(commandHelper.getCommandClass("not-exiting"));
     }

--- a/dubbo-plugin/dubbo-qos/src/test/java/org/apache/dubbo/qos/legacy/service/generic/GenericServiceTest.java
+++ b/dubbo-plugin/dubbo-qos/src/test/java/org/apache/dubbo/qos/legacy/service/generic/GenericServiceTest.java
@@ -216,7 +216,7 @@ class GenericServiceTest {
     }
 
     @Test
-    void testGenericInvokeWithBeanSerialization() throws Exception {
+    void testGenericInvokeWithBeanSerialization() {
         ServiceConfig<DemoService> service = new ServiceConfig<DemoService>();
         service.setInterface(DemoService.class);
         DemoServiceImpl impl = new DemoServiceImpl();
@@ -256,7 +256,7 @@ class GenericServiceTest {
     }
 
     @Test
-    void testGenericImplementationWithBeanSerialization() throws Exception {
+    void testGenericImplementationWithBeanSerialization() {
         final AtomicReference reference = new AtomicReference();
 
         ServiceConfig<GenericService> service = new ServiceConfig<GenericService>();

--- a/dubbo-registry/dubbo-registry-api/src/test/java/org/apache/dubbo/registry/ZKTools.java
+++ b/dubbo-registry/dubbo-registry-api/src/test/java/org/apache/dubbo/registry/ZKTools.java
@@ -260,7 +260,7 @@ public class ZKTools {
         treeCache.start();
         treeCache.getListenable().addListener(new TreeCacheListener() {
             @Override
-            public void childEvent(CuratorFramework client, TreeCacheEvent event) throws Exception {
+            public void childEvent(CuratorFramework client, TreeCacheEvent event) {
 
                 TreeCacheEvent.Type type = event.getType();
                 ChildData data = event.getData();

--- a/dubbo-registry/dubbo-registry-nacos/src/test/java/org/apache/dubbo/registry/nacos/MockNamingService.java
+++ b/dubbo-registry/dubbo-registry-nacos/src/test/java/org/apache/dubbo/registry/nacos/MockNamingService.java
@@ -16,8 +16,6 @@
  */
 package org.apache.dubbo.registry.nacos;
 
-import java.util.List;
-
 import com.alibaba.nacos.api.exception.NacosException;
 import com.alibaba.nacos.api.naming.NamingService;
 import com.alibaba.nacos.api.naming.listener.EventListener;
@@ -26,29 +24,31 @@ import com.alibaba.nacos.api.naming.pojo.ListView;
 import com.alibaba.nacos.api.naming.pojo.ServiceInfo;
 import com.alibaba.nacos.api.selector.AbstractSelector;
 
+import java.util.List;
+
 public class MockNamingService implements NamingService {
     @Override
-    public void registerInstance(String serviceName, String ip, int port) throws NacosException {
+    public void registerInstance(String serviceName, String ip, int port) {
 
     }
 
     @Override
-    public void registerInstance(String serviceName, String groupName, String ip, int port) throws NacosException {
+    public void registerInstance(String serviceName, String groupName, String ip, int port) {
 
     }
 
     @Override
-    public void registerInstance(String serviceName, String ip, int port, String clusterName) throws NacosException {
+    public void registerInstance(String serviceName, String ip, int port, String clusterName) {
 
     }
 
     @Override
-    public void registerInstance(String serviceName, String groupName, String ip, int port, String clusterName) throws NacosException {
+    public void registerInstance(String serviceName, String groupName, String ip, int port, String clusterName) {
 
     }
 
     @Override
-    public void registerInstance(String serviceName, Instance instance) throws NacosException {
+    public void registerInstance(String serviceName, Instance instance) {
 
     }
 
@@ -58,42 +58,42 @@ public class MockNamingService implements NamingService {
     }
 
     @Override
-    public void batchRegisterInstance(String serviceName, String groupName, List<Instance> instances) throws NacosException {
+    public void batchRegisterInstance(String serviceName, String groupName, List<Instance> instances) {
 
     }
 
     @Override
-    public void deregisterInstance(String serviceName, String ip, int port) throws NacosException {
+    public void deregisterInstance(String serviceName, String ip, int port) {
 
     }
 
     @Override
-    public void deregisterInstance(String serviceName, String groupName, String ip, int port) throws NacosException {
+    public void deregisterInstance(String serviceName, String groupName, String ip, int port) {
 
     }
 
     @Override
-    public void deregisterInstance(String serviceName, String ip, int port, String clusterName) throws NacosException {
+    public void deregisterInstance(String serviceName, String ip, int port, String clusterName) {
 
     }
 
     @Override
-    public void deregisterInstance(String serviceName, String groupName, String ip, int port, String clusterName) throws NacosException {
+    public void deregisterInstance(String serviceName, String groupName, String ip, int port, String clusterName) {
 
     }
 
     @Override
-    public void deregisterInstance(String serviceName, Instance instance) throws NacosException {
+    public void deregisterInstance(String serviceName, Instance instance) {
 
     }
 
     @Override
-    public void deregisterInstance(String serviceName, String groupName, Instance instance) throws NacosException {
+    public void deregisterInstance(String serviceName, String groupName, Instance instance) {
 
     }
 
     @Override
-    public List<Instance> getAllInstances(String serviceName) throws NacosException {
+    public List<Instance> getAllInstances(String serviceName) {
         return null;
     }
 
@@ -108,107 +108,107 @@ public class MockNamingService implements NamingService {
     }
 
     @Override
-    public List<Instance> getAllInstances(String serviceName, String groupName, boolean subscribe) throws NacosException {
+    public List<Instance> getAllInstances(String serviceName, String groupName, boolean subscribe) {
         return null;
     }
 
     @Override
-    public List<Instance> getAllInstances(String serviceName, List<String> clusters) throws NacosException {
+    public List<Instance> getAllInstances(String serviceName, List<String> clusters) {
         return null;
     }
 
     @Override
-    public List<Instance> getAllInstances(String serviceName, String groupName, List<String> clusters) throws NacosException {
+    public List<Instance> getAllInstances(String serviceName, String groupName, List<String> clusters) {
         return null;
     }
 
     @Override
-    public List<Instance> getAllInstances(String serviceName, List<String> clusters, boolean subscribe) throws NacosException {
+    public List<Instance> getAllInstances(String serviceName, List<String> clusters, boolean subscribe) {
         return null;
     }
 
     @Override
-    public List<Instance> getAllInstances(String serviceName, String groupName, List<String> clusters, boolean subscribe) throws NacosException {
+    public List<Instance> getAllInstances(String serviceName, String groupName, List<String> clusters, boolean subscribe) {
         return null;
     }
 
     @Override
-    public List<Instance> selectInstances(String serviceName, boolean healthy) throws NacosException {
+    public List<Instance> selectInstances(String serviceName, boolean healthy) {
         return null;
     }
 
     @Override
-    public List<Instance> selectInstances(String serviceName, String groupName, boolean healthy) throws NacosException {
+    public List<Instance> selectInstances(String serviceName, String groupName, boolean healthy) {
         return null;
     }
 
     @Override
-    public List<Instance> selectInstances(String serviceName, boolean healthy, boolean subscribe) throws NacosException {
+    public List<Instance> selectInstances(String serviceName, boolean healthy, boolean subscribe) {
         return null;
     }
 
     @Override
-    public List<Instance> selectInstances(String serviceName, String groupName, boolean healthy, boolean subscribe) throws NacosException {
+    public List<Instance> selectInstances(String serviceName, String groupName, boolean healthy, boolean subscribe) {
         return null;
     }
 
     @Override
-    public List<Instance> selectInstances(String serviceName, List<String> clusters, boolean healthy) throws NacosException {
+    public List<Instance> selectInstances(String serviceName, List<String> clusters, boolean healthy) {
         return null;
     }
 
     @Override
-    public List<Instance> selectInstances(String serviceName, String groupName, List<String> clusters, boolean healthy) throws NacosException {
+    public List<Instance> selectInstances(String serviceName, String groupName, List<String> clusters, boolean healthy) {
         return null;
     }
 
     @Override
-    public List<Instance> selectInstances(String serviceName, List<String> clusters, boolean healthy, boolean subscribe) throws NacosException {
+    public List<Instance> selectInstances(String serviceName, List<String> clusters, boolean healthy, boolean subscribe) {
         return null;
     }
 
     @Override
-    public List<Instance> selectInstances(String serviceName, String groupName, List<String> clusters, boolean healthy, boolean subscribe) throws NacosException {
+    public List<Instance> selectInstances(String serviceName, String groupName, List<String> clusters, boolean healthy, boolean subscribe) {
         return null;
     }
 
     @Override
-    public Instance selectOneHealthyInstance(String serviceName) throws NacosException {
+    public Instance selectOneHealthyInstance(String serviceName) {
         return null;
     }
 
     @Override
-    public Instance selectOneHealthyInstance(String serviceName, String groupName) throws NacosException {
+    public Instance selectOneHealthyInstance(String serviceName, String groupName) {
         return null;
     }
 
     @Override
-    public Instance selectOneHealthyInstance(String serviceName, boolean subscribe) throws NacosException {
+    public Instance selectOneHealthyInstance(String serviceName, boolean subscribe) {
         return null;
     }
 
     @Override
-    public Instance selectOneHealthyInstance(String serviceName, String groupName, boolean subscribe) throws NacosException {
+    public Instance selectOneHealthyInstance(String serviceName, String groupName, boolean subscribe) {
         return null;
     }
 
     @Override
-    public Instance selectOneHealthyInstance(String serviceName, List<String> clusters) throws NacosException {
+    public Instance selectOneHealthyInstance(String serviceName, List<String> clusters) {
         return null;
     }
 
     @Override
-    public Instance selectOneHealthyInstance(String serviceName, String groupName, List<String> clusters) throws NacosException {
+    public Instance selectOneHealthyInstance(String serviceName, String groupName, List<String> clusters) {
         return null;
     }
 
     @Override
-    public Instance selectOneHealthyInstance(String serviceName, List<String> clusters, boolean subscribe) throws NacosException {
+    public Instance selectOneHealthyInstance(String serviceName, List<String> clusters, boolean subscribe) {
         return null;
     }
 
     @Override
-    public Instance selectOneHealthyInstance(String serviceName, String groupName, List<String> clusters, boolean subscribe) throws NacosException {
+    public Instance selectOneHealthyInstance(String serviceName, String groupName, List<String> clusters, boolean subscribe) {
         return null;
     }
 
@@ -233,47 +233,47 @@ public class MockNamingService implements NamingService {
     }
 
     @Override
-    public void unsubscribe(String serviceName, EventListener listener) throws NacosException {
+    public void unsubscribe(String serviceName, EventListener listener) {
 
     }
 
     @Override
-    public void unsubscribe(String serviceName, String groupName, EventListener listener) throws NacosException {
+    public void unsubscribe(String serviceName, String groupName, EventListener listener) {
 
     }
 
     @Override
-    public void unsubscribe(String serviceName, List<String> clusters, EventListener listener) throws NacosException {
+    public void unsubscribe(String serviceName, List<String> clusters, EventListener listener) {
 
     }
 
     @Override
-    public void unsubscribe(String serviceName, String groupName, List<String> clusters, EventListener listener) throws NacosException {
+    public void unsubscribe(String serviceName, String groupName, List<String> clusters, EventListener listener) {
 
     }
 
     @Override
-    public ListView<String> getServicesOfServer(int pageNo, int pageSize) throws NacosException {
+    public ListView<String> getServicesOfServer(int pageNo, int pageSize) {
         return null;
     }
 
     @Override
-    public ListView<String> getServicesOfServer(int pageNo, int pageSize, String groupName) throws NacosException {
+    public ListView<String> getServicesOfServer(int pageNo, int pageSize, String groupName) {
         return null;
     }
 
     @Override
-    public ListView<String> getServicesOfServer(int pageNo, int pageSize, AbstractSelector selector) throws NacosException {
+    public ListView<String> getServicesOfServer(int pageNo, int pageSize, AbstractSelector selector) {
         return null;
     }
 
     @Override
-    public ListView<String> getServicesOfServer(int pageNo, int pageSize, String groupName, AbstractSelector selector) throws NacosException {
+    public ListView<String> getServicesOfServer(int pageNo, int pageSize, String groupName, AbstractSelector selector) {
         return null;
     }
 
     @Override
-    public List<ServiceInfo> getSubscribeServices() throws NacosException {
+    public List<ServiceInfo> getSubscribeServices() {
         return null;
     }
 
@@ -283,7 +283,7 @@ public class MockNamingService implements NamingService {
     }
 
     @Override
-    public void shutDown() throws NacosException {
+    public void shutDown() {
 
     }
 }

--- a/dubbo-registry/dubbo-registry-nacos/src/test/java/org/apache/dubbo/registry/nacos/NacosConnectionsManagerTest.java
+++ b/dubbo-registry/dubbo-registry-nacos/src/test/java/org/apache/dubbo/registry/nacos/NacosConnectionsManagerTest.java
@@ -16,23 +16,23 @@
  */
 package org.apache.dubbo.registry.nacos;
 
+import org.apache.dubbo.common.URL;
+
+import com.alibaba.nacos.api.NacosFactory;
+import com.alibaba.nacos.api.exception.NacosException;
+import com.alibaba.nacos.api.naming.NamingService;
+import com.alibaba.nacos.api.naming.pojo.Instance;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Properties;
 import java.util.concurrent.atomic.AtomicInteger;
-
-import org.apache.dubbo.common.URL;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
-import org.mockito.MockedStatic;
-import org.mockito.Mockito;
-
-import com.alibaba.nacos.api.NacosFactory;
-import com.alibaba.nacos.api.exception.NacosException;
-import com.alibaba.nacos.api.naming.NamingService;
-import com.alibaba.nacos.api.naming.pojo.Instance;
 
 import static com.alibaba.nacos.client.constant.Constants.HealthCheck.DOWN;
 import static com.alibaba.nacos.client.constant.Constants.HealthCheck.UP;
@@ -93,7 +93,7 @@ public class NacosConnectionsManagerTest {
     }
 
     @Test
-    void testRetryCreate() throws NacosException {
+    void testRetryCreate() {
         try (MockedStatic<NacosFactory> nacosFactoryMockedStatic = Mockito.mockStatic(NacosFactory.class)) {
             AtomicInteger atomicInteger = new AtomicInteger(0);
             NamingService mock = new MockNamingService() {
@@ -115,7 +115,7 @@ public class NacosConnectionsManagerTest {
         }
     }
     @Test
-    void testNoCheck() throws NacosException {
+    void testNoCheck() {
         try (MockedStatic<NacosFactory> nacosFactoryMockedStatic = Mockito.mockStatic(NacosFactory.class)) {
             NamingService mock = new MockNamingService() {
                 @Override

--- a/dubbo-registry/dubbo-registry-nacos/src/test/java/org/apache/dubbo/registry/nacos/NacosNamingServiceWrapperTest.java
+++ b/dubbo-registry/dubbo-registry-nacos/src/test/java/org/apache/dubbo/registry/nacos/NacosNamingServiceWrapperTest.java
@@ -16,6 +16,16 @@
  */
 package org.apache.dubbo.registry.nacos;
 
+import org.apache.dubbo.common.URL;
+
+import com.alibaba.nacos.api.exception.NacosException;
+import com.alibaba.nacos.api.naming.NamingService;
+import com.alibaba.nacos.api.naming.listener.EventListener;
+import com.alibaba.nacos.api.naming.pojo.Instance;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -23,16 +33,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicInteger;
-
-import org.apache.dubbo.common.URL;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
-
-import com.alibaba.nacos.api.exception.NacosException;
-import com.alibaba.nacos.api.naming.NamingService;
-import com.alibaba.nacos.api.naming.listener.EventListener;
-import com.alibaba.nacos.api.naming.pojo.Instance;
 
 class NacosNamingServiceWrapperTest {
     @Test
@@ -501,12 +501,12 @@ class NacosNamingServiceWrapperTest {
     void testSuccess() {
         NamingService namingService = new MockNamingService() {
             @Override
-            public void registerInstance(String serviceName, String groupName, Instance instance) throws NacosException {
+            public void registerInstance(String serviceName, String groupName, Instance instance) {
 
             }
 
             @Override
-            public List<Instance> getAllInstances(String serviceName, String groupName) throws NacosException {
+            public List<Instance> getAllInstances(String serviceName, String groupName) {
                 return null;
             }
         };

--- a/dubbo-remoting/dubbo-remoting-zookeeper-curator5/src/test/java/org/apache/dubbo/remoting/zookeeper/curator5/Curator5ZookeeperClientTest.java
+++ b/dubbo-remoting/dubbo-remoting-zookeeper-curator5/src/test/java/org/apache/dubbo/remoting/zookeeper/curator5/Curator5ZookeeperClientTest.java
@@ -88,7 +88,7 @@ class Curator5ZookeeperClientTest {
         curatorClient.addTargetChildListener(path, new Curator5ZookeeperClient.CuratorWatcherImpl() {
 
             @Override
-            public void process(WatchedEvent watchedEvent) throws Exception {
+            public void process(WatchedEvent watchedEvent) {
                 countDownLatch.countDown();
             }
         });
@@ -201,7 +201,7 @@ class Curator5ZookeeperClientTest {
         final AtomicInteger atomicInteger = new AtomicInteger(0);
         curatorClient.addTargetDataListener(path + "/d.json", new Curator5ZookeeperClient.NodeCacheListenerImpl() {
             @Override
-            public void nodeChanged() throws Exception {
+            public void nodeChanged() {
                 atomicInteger.incrementAndGet();
             }
         });
@@ -280,7 +280,7 @@ class Curator5ZookeeperClientTest {
     }
 
     @Test
-    void testPersistentCas2() throws Exception {
+    void testPersistentCas2() {
         // test update failed when others create success
         String path = "/dubbo/mapping/org.apache.dubbo.demo.DemoService";
         Curator5ZookeeperClient curatorClient = new Curator5ZookeeperClient(URL.valueOf(zookeeperConnectionAddress1 + "/org.apache.dubbo.registry.RegistryService"));
@@ -405,7 +405,7 @@ class Curator5ZookeeperClientTest {
     }
 
     @Test
-    void testEphemeralCas2() throws Exception {
+    void testEphemeralCas2() {
         // test update failed when others create success
         String path = "/dubbo/mapping/org.apache.dubbo.demo.DemoService";
         Curator5ZookeeperClient curatorClient = new Curator5ZookeeperClient(URL.valueOf(zookeeperConnectionAddress1 + "/org.apache.dubbo.registry.RegistryService"));

--- a/dubbo-remoting/dubbo-remoting-zookeeper-curator5/src/test/java/org/apache/dubbo/remoting/zookeeper/curator5/Curator5ZookeeperTransporterTest.java
+++ b/dubbo-remoting/dubbo-remoting-zookeeper-curator5/src/test/java/org/apache/dubbo/remoting/zookeeper/curator5/Curator5ZookeeperTransporterTest.java
@@ -38,7 +38,7 @@ class Curator5ZookeeperTransporterTest {
     }
 
     @BeforeEach
-    public void setUp() throws Exception {
+    public void setUp() {
         zookeeperClient = new Curator5ZookeeperTransporter().connect(URL.valueOf(zookeeperConnectionAddress1 + "/service"));
         curatorZookeeperTransporter = new Curator5ZookeeperTransporter();
     }

--- a/dubbo-rpc/dubbo-rpc-api/src/test/java/org/apache/dubbo/rpc/filter/TimeoutFilterTest.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/test/java/org/apache/dubbo/rpc/filter/TimeoutFilterTest.java
@@ -36,7 +36,7 @@ class TimeoutFilterTest {
     private TimeoutFilter timeoutFilter = new TimeoutFilter();
 
     @Test
-    void testInvokeWithoutTimeout() throws Exception {
+    void testInvokeWithoutTimeout() {
         int timeout = 3000;
 
         Invoker invoker = Mockito.mock(Invoker.class);
@@ -51,7 +51,7 @@ class TimeoutFilterTest {
     }
 
     @Test
-    void testInvokeWithTimeout() throws Exception {
+    void testInvokeWithTimeout() {
         int timeout = 100;
 
         URL url = URL.valueOf("test://test:11/test?accesslog=true&group=dubbo&version=1.1&timeout=" + timeout);


### PR DESCRIPTION
## What is the purpose of the change
Remove redundant exceptions that are not actually thrown.
Types such as:
Exception 'java.io.IOException' is never thrown in the method

This is the first PR, expect 3 more.

## Brief changelog


## Verifying this change


<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [ ] GitHub Actions works fine on your own branch.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
