### PR TITLE
Reactor some newInstance method

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/extension/ExtensionLoader.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/extension/ExtensionLoader.java
@@ -1385,7 +1385,7 @@ public class ExtensionLoader<T> {
     @SuppressWarnings("unchecked")
     private T createAdaptiveExtension() {
         try {
-            T instance = (T) getAdaptiveExtensionClass().getDeclaredConstructor().newInstance();
+            T instance = (T) getAdaptiveExtensionClass().newInstance();
             instance = postProcessBeforeInitialization(instance, null);
             injectExtension(instance);
             instance = postProcessAfterInitialization(instance, null);

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/extension/ExtensionLoader.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/extension/ExtensionLoader.java
@@ -741,7 +741,7 @@ public class ExtensionLoader<T> {
                     try {
                         instance = createAdaptiveExtension();
                         cachedAdaptiveInstance.set(instance);
-                    } catch (Throwable t) {
+                    } catch (Exception t) {
                         createAdaptiveInstanceError = t;
                         throw new IllegalStateException(
                             "Failed to create adaptive instance: " + t.toString(), t);
@@ -821,10 +821,10 @@ public class ExtensionLoader<T> {
             // Warning: After an instance of Lifecycle is wrapped by cachedWrapperClasses, it may not still be Lifecycle instance, this application may not invoke the lifecycle.initialize hook.
             initExtension(instance);
             return instance;
-        } catch (Throwable t) {
+        } catch (Exception e) {
             throw new IllegalStateException(
-                "Extension instance (name: " + name + ", class: " + type + ") couldn't be instantiated: " + t.getMessage(),
-                t);
+                "Extension instance (name: " + name + ", class: " + type + ") couldn't be instantiated: " + e.getMessage(),
+                e);
         }
     }
 
@@ -1134,17 +1134,17 @@ public class ExtensionLoader<T> {
                         loadClass(classLoader, extensionClasses, resourceURL,
                             Class.forName(clazz, true, classLoader), name, overridden);
                     }
-                } catch (Throwable t) {
+                } catch (Exception e1) {
                     IllegalStateException e = new IllegalStateException(
-                        "Failed to load extension class (interface: " + type + ", class line: " + line + ") in " + resourceURL + ", cause: " + t.getMessage(),
-                        t);
+                        "Failed to load extension class (interface: " + type + ", class line: " + line + ") in " + resourceURL + ", cause: " + e1.getMessage(),
+                        e1);
                     exceptions.put(line, e);
                 }
             }
-        } catch (Throwable t) {
+        } catch (Exception e) {
             logger.error(COMMON_ERROR_LOAD_EXTENSION, "", "",
                 "Exception occurred when loading extension class (interface: " + type + ", class file: " + resourceURL + ") in " + resourceURL,
-                t);
+                e);
         }
     }
 

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/extension/ExtensionLoader.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/extension/ExtensionLoader.java
@@ -1385,7 +1385,7 @@ public class ExtensionLoader<T> {
     @SuppressWarnings("unchecked")
     private T createAdaptiveExtension() {
         try {
-            T instance = (T) getAdaptiveExtensionClass().newInstance();
+            T instance = (T) getAdaptiveExtensionClass().getDeclaredConstructor().newInstance();
             instance = postProcessBeforeInitialization(instance, null);
             injectExtension(instance);
             instance = postProcessAfterInitialization(instance, null);

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/extension/ExtensionLoader.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/extension/ExtensionLoader.java
@@ -741,7 +741,7 @@ public class ExtensionLoader<T> {
                     try {
                         instance = createAdaptiveExtension();
                         cachedAdaptiveInstance.set(instance);
-                    } catch (Exception t) {
+                    } catch (Throwable t) {
                         createAdaptiveInstanceError = t;
                         throw new IllegalStateException(
                             "Failed to create adaptive instance: " + t.toString(), t);
@@ -821,10 +821,10 @@ public class ExtensionLoader<T> {
             // Warning: After an instance of Lifecycle is wrapped by cachedWrapperClasses, it may not still be Lifecycle instance, this application may not invoke the lifecycle.initialize hook.
             initExtension(instance);
             return instance;
-        } catch (Exception e) {
+        } catch (Throwable t) {
             throw new IllegalStateException(
-                "Extension instance (name: " + name + ", class: " + type + ") couldn't be instantiated: " + e.getMessage(),
-                e);
+                "Extension instance (name: " + name + ", class: " + type + ") couldn't be instantiated: " + t.getMessage(),
+                t);
         }
     }
 
@@ -1134,17 +1134,17 @@ public class ExtensionLoader<T> {
                         loadClass(classLoader, extensionClasses, resourceURL,
                             Class.forName(clazz, true, classLoader), name, overridden);
                     }
-                } catch (Exception e1) {
+                } catch (Throwable t) {
                     IllegalStateException e = new IllegalStateException(
-                        "Failed to load extension class (interface: " + type + ", class line: " + line + ") in " + resourceURL + ", cause: " + e1.getMessage(),
-                        e1);
+                        "Failed to load extension class (interface: " + type + ", class line: " + line + ") in " + resourceURL + ", cause: " + t.getMessage(),
+                        t);
                     exceptions.put(line, e);
                 }
             }
-        } catch (Exception e) {
+        } catch (Throwable t) {
             logger.error(COMMON_ERROR_LOAD_EXTENSION, "", "",
                 "Exception occurred when loading extension class (interface: " + type + ", class file: " + resourceURL + ") in " + resourceURL,
-                e);
+                t);
         }
     }
 

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/logger/LoggerFactory.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/logger/LoggerFactory.java
@@ -75,7 +75,7 @@ public class LoggerFactory {
                 // try to use the first available adapter
                 for (Class<? extends LoggerAdapter> clazz : candidates) {
                     try {
-                        LoggerAdapter loggerAdapter = clazz.getConstructor().newInstance();
+                        LoggerAdapter loggerAdapter = clazz.getDeclaredConstructor().newInstance();
                         loggerAdapter.getLogger(LoggerFactory.class);
                         if (loggerAdapter.isConfigured()) {
                             setLoggerAdapter(loggerAdapter);
@@ -93,7 +93,7 @@ public class LoggerFactory {
                 System.err.println("Dubbo: Unable to find a proper configured logger to log out.");
                 for (Class<? extends LoggerAdapter> clazz : candidates) {
                     try {
-                        LoggerAdapter loggerAdapter = clazz.getConstructor().newInstance();
+                        LoggerAdapter loggerAdapter = clazz.getDeclaredConstructor().newInstance();
                         loggerAdapter.getLogger(LoggerFactory.class);
                         setLoggerAdapter(loggerAdapter);
                         found = true;
@@ -221,7 +221,7 @@ public class LoggerFactory {
         List<String> result = new LinkedList<>();
         for (Map.Entry<Class<? extends LoggerAdapter>, String> entry : candidates.entrySet()) {
             try {
-                LoggerAdapter loggerAdapter = entry.getKey().getConstructor().newInstance();
+                LoggerAdapter loggerAdapter = entry.getKey().getDeclaredConstructor().newInstance();
                 loggerAdapter.getLogger(LoggerFactory.class);
                 result.add(entry.getValue());
             } catch (Exception ignored) {

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/utils/CompatibleTypeUtils.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/utils/CompatibleTypeUtils.java
@@ -204,7 +204,7 @@ public class CompatibleTypeUtils {
             }
             if (!type.isInterface()) {
                 try {
-                    Collection result = (Collection) type.newInstance();
+                    Collection result = (Collection) type.getDeclaredConstructor().newInstance();
                     result.addAll(collection);
                     return result;
                 } catch (Throwable ignored) {
@@ -222,7 +222,7 @@ public class CompatibleTypeUtils {
             Collection collection;
             if (!type.isInterface()) {
                 try {
-                    collection = (Collection) type.newInstance();
+                    collection = (Collection) type.getDeclaredConstructor().newInstance();
                 } catch (Throwable e) {
                     collection = new ArrayList<Object>(length);
                 }

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/utils/CompatibleTypeUtils.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/utils/CompatibleTypeUtils.java
@@ -223,7 +223,7 @@ public class CompatibleTypeUtils {
             if (!type.isInterface()) {
                 try {
                     collection = (Collection) type.getDeclaredConstructor().newInstance();
-                } catch (Throwable e) {
+                } catch (Exception e) {
                     collection = new ArrayList<Object>(length);
                 }
             } else if (type == Set.class) {

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/utils/PojoUtils.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/utils/PojoUtils.java
@@ -275,7 +275,7 @@ public class PojoUtils {
         }
         if (!type.isInterface() && !Modifier.isAbstract(type.getModifiers())) {
             try {
-                return (Collection<Object>) type.newInstance();
+                return (Collection<Object>) type.getDeclaredConstructor().newInstance();
             } catch (Exception e) {
                 // ignore
             }
@@ -306,7 +306,7 @@ public class PojoUtils {
             result = new ConcurrentSkipListMap();
         } else {
             try {
-                result = cl.newInstance();
+                result = cl.getDeclaredConstructor().newInstance();
             } catch (Exception e) { /* ignore */ }
 
             if (result == null) {
@@ -434,7 +434,7 @@ public class PojoUtils {
             // when return type is not the subclass of return type from the signature and not an interface
             if (!type.isInterface() && !type.isAssignableFrom(pojo.getClass())) {
                 try {
-                    map = (Map<Object, Object>) type.newInstance();
+                    map = (Map<Object, Object>) type.getDeclaredConstructor().newInstance();
                     Map<Object, Object> mapPojo = (Map<Object, Object>) pojo;
                     map.putAll(mapPojo);
                     if (GENERIC_WITH_CLZ) {
@@ -596,7 +596,7 @@ public class PojoUtils {
 
     private static Object newInstance(Class<?> cls) {
         try {
-            return cls.newInstance();
+            return cls.getDeclaredConstructor().newInstance();
         } catch (Throwable t) {
             Constructor<?>[] constructors = cls.getDeclaredConstructors();
             /*

--- a/dubbo-common/src/main/java/org/apache/dubbo/config/context/AbstractConfigManager.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/config/context/AbstractConfigManager.java
@@ -538,7 +538,7 @@ public abstract class AbstractConfigManager extends LifecycleAdapter {
     }
 
     private <T extends AbstractConfig> T createConfig(Class<T> cls, ScopeModel scopeModel) throws ReflectiveOperationException {
-        T config = cls.newInstance();
+        T config = cls.getDeclaredConstructor().newInstance();
         config.setScopeModel(scopeModel);
         return config;
     }

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/bytecode/ClassGeneratorTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/bytecode/ClassGeneratorTest.java
@@ -166,7 +166,7 @@ class ClassGeneratorTest {
         cl.getField("FNAME").set(null, fname);
 
         System.out.println(cl.getName());
-        Builder<String> builder = (Builder<String>) cl.newInstance();
+        Builder<String> builder = (Builder<String>) cl.getDeclaredConstructor().newInstance();
         System.out.println(b.getName());
         builder.setName(b, "ok");
         System.out.println(b.getName());
@@ -192,7 +192,7 @@ class ClassGeneratorTest {
         cl.getField("FNAME").set(null, fname);
 
         System.out.println(cl.getName());
-        Builder<String> builder = (Builder<String>) cl.newInstance();
+        Builder<String> builder = (Builder<String>) cl.getDeclaredConstructor().newInstance();
         System.out.println(b.getName());
         builder.setName(b, "ok");
         System.out.println(b.getName());

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/compiler/support/AdaptiveCompilerTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/compiler/support/AdaptiveCompilerTest.java
@@ -29,7 +29,7 @@ class AdaptiveCompilerTest extends JavaCodeTest {
         AdaptiveCompiler compiler = new AdaptiveCompiler();
         compiler.setFrameworkModel(FrameworkModel.defaultModel());
         Class<?> clazz = compiler.compile(JavaCodeTest.class, getSimpleCode(), AdaptiveCompiler.class.getClassLoader());
-        HelloService helloService = (HelloService) clazz.newInstance();
+        HelloService helloService = (HelloService) clazz.getDeclaredConstructor().newInstance();
         Assertions.assertEquals("Hello world!", helloService.sayHello());
     }
 

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/compiler/support/JavassistCompilerTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/compiler/support/JavassistCompilerTest.java
@@ -30,7 +30,7 @@ class JavassistCompilerTest extends JavaCodeTest {
         Class<?> clazz = compiler.compile(JavaCodeTest.class, getSimpleCode(), JavassistCompiler.class.getClassLoader());
 
         // Because javassist compiles using the caller class loader, we should't use HelloService directly
-        Object instance = clazz.newInstance();
+        Object instance = clazz.getDeclaredConstructor().newInstance();
         Method sayHello = instance.getClass().getMethod("sayHello");
         Assertions.assertEquals("Hello world!", sayHello.invoke(instance));
     }
@@ -48,7 +48,7 @@ class JavassistCompilerTest extends JavaCodeTest {
             Assertions.assertThrows(RuntimeException.class, () -> compiler.compile(null, getSimpleCodeWithoutPackage(), JavassistCompiler.class.getClassLoader()));
         } else {
             Class<?> clazz = compiler.compile(null, getSimpleCodeWithoutPackage(), JavassistCompiler.class.getClassLoader());
-            Object instance = clazz.newInstance();
+            Object instance = clazz.getDeclaredConstructor().newInstance();
             Method sayHello = instance.getClass().getMethod("sayHello");
             Assertions.assertEquals("Hello world!", sayHello.invoke(instance));
         }
@@ -59,7 +59,7 @@ class JavassistCompilerTest extends JavaCodeTest {
         Assertions.assertThrows(IllegalStateException.class, () -> {
             JavassistCompiler compiler = new JavassistCompiler();
             Class<?> clazz = compiler.compile(JavaCodeTest.class, getSimpleCodeWithSyntax0(), JavassistCompiler.class.getClassLoader());
-            Object instance = clazz.newInstance();
+            Object instance = clazz.getDeclaredConstructor().newInstance();
             Method sayHello = instance.getClass().getMethod("sayHello");
             Assertions.assertEquals("Hello world!", sayHello.invoke(instance));
         });
@@ -69,7 +69,7 @@ class JavassistCompilerTest extends JavaCodeTest {
     void testCompileJavaClassWithImport() throws Exception {
         JavassistCompiler compiler = new JavassistCompiler();
         Class<?> clazz = compiler.compile(JavaCodeTest.class, getSimpleCodeWithImports(), JavassistCompiler.class.getClassLoader());
-        Object instance = clazz.newInstance();
+        Object instance = clazz.getDeclaredConstructor().newInstance();
         Method sayHello = instance.getClass().getMethod("sayHello");
         Assertions.assertEquals("Hello world!", sayHello.invoke(instance));
     }
@@ -78,7 +78,7 @@ class JavassistCompilerTest extends JavaCodeTest {
     void testCompileJavaClassWithExtends() throws Exception {
         JavassistCompiler compiler = new JavassistCompiler();
         Class<?> clazz = compiler.compile(JavaCodeTest.class, getSimpleCodeWithWithExtends(), JavassistCompiler.class.getClassLoader());
-        Object instance = clazz.newInstance();
+        Object instance = clazz.getDeclaredConstructor().newInstance();
         Method sayHello = instance.getClass().getMethod("sayHello");
         Assertions.assertEquals("Hello world3!", sayHello.invoke(instance));
     }

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/compiler/support/JdkCompilerTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/compiler/support/JdkCompilerTest.java
@@ -27,7 +27,7 @@ class JdkCompilerTest extends JavaCodeTest {
     void test_compileJavaClass() throws Exception {
         JdkCompiler compiler = new JdkCompiler();
         Class<?> clazz = compiler.compile(JavaCodeTest.class, getSimpleCode(), JdkCompiler.class.getClassLoader());
-        Object instance = clazz.newInstance();
+        Object instance = clazz.getDeclaredConstructor().newInstance();
         Method sayHello = instance.getClass().getMethod("sayHello");
         Assertions.assertEquals("Hello world!", sayHello.invoke(instance));
     }
@@ -37,7 +37,7 @@ class JdkCompilerTest extends JavaCodeTest {
         Assertions.assertThrows(IllegalStateException.class, () -> {
             JdkCompiler compiler = new JdkCompiler();
             Class<?> clazz = compiler.compile(JavaCodeTest.class, getSimpleCodeWithoutPackage(), JdkCompiler.class.getClassLoader());
-            Object instance = clazz.newInstance();
+            Object instance = clazz.getDeclaredConstructor().newInstance();
             Method sayHello = instance.getClass().getMethod("sayHello");
             Assertions.assertEquals("Hello world!", sayHello.invoke(instance));
         });
@@ -48,7 +48,7 @@ class JdkCompilerTest extends JavaCodeTest {
         Assertions.assertThrows(IllegalStateException.class, () -> {
             JdkCompiler compiler = new JdkCompiler();
             Class<?> clazz = compiler.compile(JavaCodeTest.class, getSimpleCodeWithSyntax(), JdkCompiler.class.getClassLoader());
-            Object instance = clazz.newInstance();
+            Object instance = clazz.getDeclaredConstructor().newInstance();
             Method sayHello = instance.getClass().getMethod("sayHello");
             Assertions.assertEquals("Hello world!", sayHello.invoke(instance));
         });
@@ -58,7 +58,7 @@ class JdkCompilerTest extends JavaCodeTest {
     void test_compileJavaClass_java8() throws Exception {
         JdkCompiler compiler = new JdkCompiler("1.8");
         Class<?> clazz = compiler.compile(JavaCodeTest.class, getSimpleCode(), JdkCompiler.class.getClassLoader());
-        Object instance = clazz.newInstance();
+        Object instance = clazz.getDeclaredConstructor().newInstance();
         Method sayHello = instance.getClass().getMethod("sayHello");
         Assertions.assertEquals("Hello world!", sayHello.invoke(instance));
     }
@@ -68,7 +68,7 @@ class JdkCompilerTest extends JavaCodeTest {
         Assertions.assertThrows(IllegalStateException.class, () -> {
             JdkCompiler compiler = new JdkCompiler("1.8");
             Class<?> clazz = compiler.compile(JavaCodeTest.class, getSimpleCodeWithoutPackage(), JdkCompiler.class.getClassLoader());
-            Object instance = clazz.newInstance();
+            Object instance = clazz.getDeclaredConstructor().newInstance();
             Method sayHello = instance.getClass().getMethod("sayHello");
             Assertions.assertEquals("Hello world!", sayHello.invoke(instance));
         });
@@ -79,7 +79,7 @@ class JdkCompilerTest extends JavaCodeTest {
         Assertions.assertThrows(IllegalStateException.class, () -> {
             JdkCompiler compiler = new JdkCompiler("1.8");
             Class<?> clazz = compiler.compile(JavaCodeTest.class, getSimpleCodeWithSyntax(), JdkCompiler.class.getClassLoader());
-            Object instance = clazz.newInstance();
+            Object instance = clazz.getDeclaredConstructor().newInstance();
             Method sayHello = instance.getClass().getMethod("sayHello");
             Assertions.assertEquals("Hello world!", sayHello.invoke(instance));
         });

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/logger/LoggerAdapterTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/logger/LoggerAdapterTest.java
@@ -31,6 +31,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import java.lang.reflect.InvocationTargetException;
 import java.util.stream.Stream;
 
 import static org.hamcrest.CoreMatchers.is;
@@ -49,8 +50,8 @@ class LoggerAdapterTest {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void testGetLogger(Class<? extends LoggerAdapter> loggerAdapterClass, Class<? extends Logger> loggerClass) throws IllegalAccessException, InstantiationException {
-        LoggerAdapter loggerAdapter = loggerAdapterClass.newInstance();
+    public void testGetLogger(Class<? extends LoggerAdapter> loggerAdapterClass, Class<? extends Logger> loggerClass) throws IllegalAccessException, InstantiationException, NoSuchMethodException, InvocationTargetException {
+        LoggerAdapter loggerAdapter = loggerAdapterClass.getDeclaredConstructor().newInstance();
         Logger logger = loggerAdapter.getLogger(this.getClass());
         assertThat(logger.getClass().isAssignableFrom(loggerClass), is(true));
 
@@ -61,8 +62,8 @@ class LoggerAdapterTest {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void testLevel(Class<? extends LoggerAdapter> loggerAdapterClass) throws IllegalAccessException, InstantiationException {
-        LoggerAdapter loggerAdapter = loggerAdapterClass.newInstance();
+    public void testLevel(Class<? extends LoggerAdapter> loggerAdapterClass) throws IllegalAccessException, InstantiationException, NoSuchMethodException, InvocationTargetException {
+        LoggerAdapter loggerAdapter = loggerAdapterClass.getDeclaredConstructor().newInstance();
         for (Level targetLevel : Level.values()) {
             loggerAdapter.setLevel(targetLevel);
             assertThat(loggerAdapter.getLevel(), is(targetLevel));

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/logger/LoggerAdapterTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/logger/LoggerAdapterTest.java
@@ -50,7 +50,7 @@ class LoggerAdapterTest {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void testGetLogger(Class<? extends LoggerAdapter> loggerAdapterClass, Class<? extends Logger> loggerClass) throws IllegalAccessException, InstantiationException, NoSuchMethodException, InvocationTargetException {
+    void testGetLogger(Class<? extends LoggerAdapter> loggerAdapterClass, Class<? extends Logger> loggerClass) throws IllegalAccessException, InstantiationException, NoSuchMethodException, InvocationTargetException {
         LoggerAdapter loggerAdapter = loggerAdapterClass.getDeclaredConstructor().newInstance();
         Logger logger = loggerAdapter.getLogger(this.getClass());
         assertThat(logger.getClass().isAssignableFrom(loggerClass), is(true));
@@ -62,7 +62,7 @@ class LoggerAdapterTest {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void testLevel(Class<? extends LoggerAdapter> loggerAdapterClass) throws IllegalAccessException, InstantiationException, NoSuchMethodException, InvocationTargetException {
+    void testLevel(Class<? extends LoggerAdapter> loggerAdapterClass) throws IllegalAccessException, InstantiationException, NoSuchMethodException, InvocationTargetException {
         LoggerAdapter loggerAdapter = loggerAdapterClass.getDeclaredConstructor().newInstance();
         for (Level targetLevel : Level.values()) {
             loggerAdapter.setLevel(targetLevel);

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/logger/LoggerTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/logger/LoggerTest.java
@@ -48,7 +48,7 @@ class LoggerTest {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void testAllLogMethod(Class<? extends LoggerAdapter> loggerAdapter) throws Exception {
+    void testAllLogMethod(Class<? extends LoggerAdapter> loggerAdapter) throws Exception {
         LoggerAdapter adapter = loggerAdapter.getDeclaredConstructor().newInstance();
         adapter.setLevel(Level.ALL);
         Logger logger = adapter.getLogger(this.getClass());
@@ -73,7 +73,7 @@ class LoggerTest {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void testLevelEnable(Class<? extends LoggerAdapter> loggerAdapter) throws IllegalAccessException, InstantiationException, NoSuchMethodException, InvocationTargetException {
+    void testLevelEnable(Class<? extends LoggerAdapter> loggerAdapter) throws IllegalAccessException, InstantiationException, NoSuchMethodException, InvocationTargetException {
         LoggerAdapter adapter = loggerAdapter.getDeclaredConstructor().newInstance();
         adapter.setLevel(Level.ALL);
         Logger logger = adapter.getLogger(this.getClass());

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/logger/LoggerTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/logger/LoggerTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import java.lang.reflect.InvocationTargetException;
 import java.util.stream.Stream;
 
 import static org.hamcrest.CoreMatchers.not;
@@ -48,7 +49,7 @@ class LoggerTest {
     @ParameterizedTest
     @MethodSource("data")
     public void testAllLogMethod(Class<? extends LoggerAdapter> loggerAdapter) throws Exception {
-        LoggerAdapter adapter = loggerAdapter.newInstance();
+        LoggerAdapter adapter = loggerAdapter.getDeclaredConstructor().newInstance();
         adapter.setLevel(Level.ALL);
         Logger logger = adapter.getLogger(this.getClass());
         logger.error("error");
@@ -72,8 +73,8 @@ class LoggerTest {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void testLevelEnable(Class<? extends LoggerAdapter> loggerAdapter) throws IllegalAccessException, InstantiationException {
-        LoggerAdapter adapter = loggerAdapter.newInstance();
+    public void testLevelEnable(Class<? extends LoggerAdapter> loggerAdapter) throws IllegalAccessException, InstantiationException, NoSuchMethodException, InvocationTargetException {
+        LoggerAdapter adapter = loggerAdapter.getDeclaredConstructor().newInstance();
         adapter.setLevel(Level.ALL);
         Logger logger = adapter.getLogger(this.getClass());
         assertThat(logger.isWarnEnabled(), not(nullValue()));

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/utils/ReflectUtilsTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/utils/ReflectUtilsTest.java
@@ -46,14 +46,14 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 class ReflectUtilsTest {
     @Test
-    void testIsPrimitives() throws Exception {
+    void testIsPrimitives() {
         assertTrue(ReflectUtils.isPrimitives(boolean[].class));
         assertTrue(ReflectUtils.isPrimitives(byte.class));
         assertFalse(ReflectUtils.isPrimitive(Map[].class));
     }
 
     @Test
-    void testIsPrimitive() throws Exception {
+    void testIsPrimitive() {
         assertTrue(ReflectUtils.isPrimitive(boolean.class));
         assertTrue(ReflectUtils.isPrimitive(String.class));
         assertTrue(ReflectUtils.isPrimitive(Boolean.class));
@@ -64,7 +64,7 @@ class ReflectUtilsTest {
     }
 
     @Test
-    void testGetBoxedClass() throws Exception {
+    void testGetBoxedClass() {
         assertThat(ReflectUtils.getBoxedClass(int.class), sameInstance(Integer.class));
         assertThat(ReflectUtils.getBoxedClass(boolean.class), sameInstance(Boolean.class));
         assertThat(ReflectUtils.getBoxedClass(long.class), sameInstance(Long.class));

--- a/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/AbstractConfigTest.java
+++ b/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/AbstractConfigTest.java
@@ -1005,7 +1005,7 @@ class AbstractConfigTest {
                 ModuleConfig.class, SslConfig.class, MetricsConfig.class, MonitorConfig.class, MethodConfig.class);
 
         for (Class<? extends AbstractConfig> configClass : configClasses) {
-            AbstractConfig config = configClass.newInstance();
+            AbstractConfig config = configClass.getDeclaredConstructor().newInstance();
             Map<String, String> metaData = config.getMetaData();
             Assertions.assertEquals(0, metaData.size(), "Expect empty metadata for new instance but found: "+metaData +" of "+configClass.getSimpleName());
             System.out.println(configClass.getSimpleName() + " metadata is checked.");

--- a/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/ReferenceConfigTest.java
+++ b/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/ReferenceConfigTest.java
@@ -1070,7 +1070,7 @@ class ReferenceConfigTest {
         classLoader1.loadedClass.put(resultClazzCustom1.getName(), resultClazzCustom1);
         AtomicReference innerRequestReference = new AtomicReference();
         AtomicReference innerResultReference = new AtomicReference();
-        innerResultReference.set(resultClazzCustom1.newInstance());
+        innerResultReference.set(resultClazzCustom1.getDeclaredConstructor().newInstance());
         Constructor<?> declaredConstructor = clazz1impl.getDeclaredConstructor(AtomicReference.class, AtomicReference.class);
 
         ServiceConfig serviceConfig = new ServiceConfig<>();
@@ -1098,14 +1098,14 @@ class ReferenceConfigTest {
 
         java.lang.reflect.Method callBean1 = object1.getClass().getDeclaredMethod("call", requestClazzOrigin);
         callBean1.setAccessible(true);
-        Object result1 = callBean1.invoke(object1, requestClazzCustom2.newInstance());
+        Object result1 = callBean1.invoke(object1, requestClazzCustom2.getDeclaredConstructor().newInstance());
 
         Assertions.assertEquals(resultClazzCustom3, result1.getClass());
         Assertions.assertNotEquals(classLoader2, result1.getClass().getClassLoader());
         Assertions.assertEquals(classLoader1, innerRequestReference.get().getClass().getClassLoader());
 
         Thread.currentThread().setContextClassLoader(classLoader1);
-        callBean1.invoke(object1, requestClazzCustom2.newInstance());
+        callBean1.invoke(object1, requestClazzCustom2.getDeclaredConstructor().newInstance());
         Assertions.assertEquals(classLoader1, Thread.currentThread().getContextClassLoader());
 
         applicationModel.destroy();

--- a/dubbo-filter/dubbo-filter-validation/src/main/java/org/apache/dubbo/validation/support/jvalidation/JValidator.java
+++ b/dubbo-filter/dubbo-filter-validation/src/main/java/org/apache/dubbo/validation/support/jvalidation/JValidator.java
@@ -111,7 +111,7 @@ public class JValidator implements Validator {
             } catch (ClassNotFoundException e) {
                 parameterClass = generateMethodParameterClass(clazz, method, parameterClassName);
             }
-            Object parameterBean = parameterClass.newInstance();
+            Object parameterBean = parameterClass.getDeclaredConstructor().newInstance();
             for (int i = 0; i < args.length; i++) {
                 Field field = parameterClass.getField(method.getName() + "Argument" + i);
                 field.set(parameterBean, args[i]);

--- a/dubbo-filter/dubbo-filter-validation/src/main/java/org/apache/dubbo/validation/support/jvalidation/JValidatorNew.java
+++ b/dubbo-filter/dubbo-filter-validation/src/main/java/org/apache/dubbo/validation/support/jvalidation/JValidatorNew.java
@@ -111,7 +111,7 @@ public class JValidatorNew implements Validator {
             } catch (ClassNotFoundException e) {
                 parameterClass = generateMethodParameterClass(clazz, method, parameterClassName);
             }
-            Object parameterBean = parameterClass.newInstance();
+            Object parameterBean = parameterClass.getDeclaredConstructor().newInstance();
             for (int i = 0; i < args.length; i++) {
                 Field field = parameterClass.getField(method.getName() + "Argument" + i);
                 field.set(parameterBean, args[i]);

--- a/dubbo-plugin/dubbo-spring-security/src/main/java/org/apache/dubbo/spring/security/jackson/ObjectMapperCodec.java
+++ b/dubbo-plugin/dubbo-spring-security/src/main/java/org/apache/dubbo/spring/security/jackson/ObjectMapperCodec.java
@@ -103,7 +103,7 @@ public class ObjectMapperCodec {
         for (String moduleClassName : jacksonModuleClassNameList) {
             try {
                 SimpleModule objectMapperModule = (SimpleModule) ClassUtils.forName(moduleClassName,
-                    ObjectMapperCodec.class.getClassLoader()).newInstance();
+                    ObjectMapperCodec.class.getClassLoader()).getDeclaredConstructor().newInstance();
                 mapper.registerModule(objectMapperModule);
 
             } catch (Throwable ex) {

--- a/dubbo-remoting/dubbo-remoting-http/src/test/java/org/apache/dubbo/remoting/http/jetty/JettyLoggerAdapterTest.java
+++ b/dubbo-remoting/dubbo-remoting-http/src/test/java/org/apache/dubbo/remoting/http/jetty/JettyLoggerAdapterTest.java
@@ -67,7 +67,7 @@ class JettyLoggerAdapterTest {
     void testSuccessLogger() throws Exception{
         Logger successLogger = mock(Logger.class);
         Class<?> clazz = Class.forName("org.apache.dubbo.remoting.http.jetty.JettyLoggerAdapter");
-        JettyLoggerAdapter jettyLoggerAdapter = (JettyLoggerAdapter) clazz.newInstance();
+        JettyLoggerAdapter jettyLoggerAdapter = (JettyLoggerAdapter) clazz.getDeclaredConstructor().newInstance();
 
         Field loggerField = clazz.getDeclaredField("logger");
         loggerField.setAccessible(true);
@@ -116,7 +116,7 @@ class JettyLoggerAdapterTest {
     @Test
     void testLoggerFormat() throws Exception{
         Class<?> clazz = Class.forName("org.apache.dubbo.remoting.http.jetty.JettyLoggerAdapter");
-        Object newInstance = clazz.newInstance();
+        Object newInstance = clazz.getDeclaredConstructor().newInstance();
 
         Method method = clazz.getDeclaredMethod("format", String.class, Object[].class);
         method.setAccessible(true);

--- a/dubbo-remoting/dubbo-remoting-netty4/src/test/java/org/apache/dubbo/remoting/transport/netty4/RpcMessageHandler.java
+++ b/dubbo-remoting/dubbo-remoting-netty4/src/test/java/org/apache/dubbo/remoting/transport/netty4/RpcMessageHandler.java
@@ -34,7 +34,7 @@ public class RpcMessageHandler implements Replier<RpcMessage> {
             String impl = service + "Impl";
             try {
                 Class<?> cl = Thread.currentThread().getContextClassLoader().loadClass(impl);
-                return cl.newInstance();
+                return cl.getDeclaredConstructor().newInstance();
             } catch (Exception e) {
                 e.printStackTrace();
             }

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/filter/GenericImplFilter.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/filter/GenericImplFilter.java
@@ -155,7 +155,7 @@ public class GenericImplFilter implements Filter, Filter.Listener {
                             // find the real interface from url
                             String realInterface = invoker.getUrl().getParameter(Constants.INTERFACE);
                             invokerInterface = ReflectUtils.forName(realInterface);
-                        } catch (Throwable e) {
+                        } catch (Exception e) {
                             // ignore
                         }
                     }

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/filter/GenericImplFilter.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/filter/GenericImplFilter.java
@@ -186,7 +186,7 @@ public class GenericImplFilter implements Filter, Filter.Listener {
                     Throwable targetException = null;
                     Throwable lastException = null;
                     try {
-                        targetException = (Throwable) clazz.newInstance();
+                        targetException = (Throwable) clazz.getDeclaredConstructor().newInstance();
                     } catch (Throwable e) {
                         lastException = e;
                         for (Constructor<?> constructor : clazz.getConstructors()) {

--- a/dubbo-rpc/dubbo-rpc-injvm/src/test/java/org/apache/dubbo/rpc/protocol/injvm/InjvmClassLoaderTest.java
+++ b/dubbo-rpc/dubbo-rpc-injvm/src/test/java/org/apache/dubbo/rpc/protocol/injvm/InjvmClassLoaderTest.java
@@ -75,7 +75,7 @@ class InjvmClassLoaderTest {
         // AtomicReference to cache request/response of provider
         AtomicReference innerRequestReference = new AtomicReference();
         AtomicReference innerResultReference = new AtomicReference();
-        innerResultReference.set(resultClazzCustom1.newInstance());
+        innerResultReference.set(resultClazzCustom1.getDeclaredConstructor().newInstance());
         Constructor<?> declaredConstructor = clazz1impl.getDeclaredConstructor(AtomicReference.class, AtomicReference.class);
 
 
@@ -116,7 +116,7 @@ class InjvmClassLoaderTest {
 
         java.lang.reflect.Method callBean1 = object1.getClass().getDeclaredMethod("call", requestClazzOrigin);
         callBean1.setAccessible(true);
-        Object result1 = callBean1.invoke(object1, requestClazzCustom2.newInstance());
+        Object result1 = callBean1.invoke(object1, requestClazzCustom2.getDeclaredConstructor().newInstance());
 
         // invoke result should load from classLoader3 ( sub classLoader of classLoader2 --> consumer side classLoader)
         Assertions.assertEquals(resultClazzCustom3, result1.getClass());

--- a/dubbo-rpc/dubbo-rpc-rest/src/main/java/org/apache/dubbo/rpc/protocol/rest/util/MultiValueCreator.java
+++ b/dubbo-rpc/dubbo-rpc-rest/src/main/java/org/apache/dubbo/rpc/protocol/rest/util/MultiValueCreator.java
@@ -35,7 +35,7 @@ public class MultiValueCreator {
 
     public static Object createMultiValueMap() {
         try {
-            return multiValueMapClass.newInstance();
+            return multiValueMapClass.getDeclaredConstructor().newInstance();
         } catch (Exception e) {
 
         }


### PR DESCRIPTION
## What is the purpose of the change

```
    @Deprecated(since="9")
    public T newInstance()
```

The newInstance() method is marked as obsolete, and this pr uses a new method to obtain an instance.

Java 9 introduces a new way to create an instance using the `privateLookupIn(Class<?> declaringClass `,  `MethodHandles.Lookup lookup` method of the `MethodHandles.Lookup class`. This method can return a MethodHandles.Lookup object with private access, and then use the findConstructor method of this object to create an instance.


## Brief changelog


## Verifying this change


<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [ ] GitHub Actions works fine on your own branch.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
