### PR TITLE
[Enhance] Nacos naming service status check

### DIFF
--- a/dubbo-registry/dubbo-registry-nacos/src/main/java/org/apache/dubbo/registry/nacos/NacosConnectionManager.java
+++ b/dubbo-registry/dubbo-registry-nacos/src/main/java/org/apache/dubbo/registry/nacos/NacosConnectionManager.java
@@ -125,7 +125,7 @@ public class NacosConnectionManager {
      */
     protected NamingService createNamingService() {
         if (!available) {
-            throw new RuntimeException("Nacos connection manager is closed.");
+            throw new IllegalStateException("Nacos connection manager is closed.");
         }
         Properties nacosProperties = buildNacosProperties(this.connectionURL);
         NamingService namingService = null;

--- a/dubbo-registry/dubbo-registry-nacos/src/main/java/org/apache/dubbo/registry/nacos/NacosConnectionManager.java
+++ b/dubbo-registry/dubbo-registry-nacos/src/main/java/org/apache/dubbo/registry/nacos/NacosConnectionManager.java
@@ -111,7 +111,7 @@ public class NacosConnectionManager {
             try {
                 namingService.shutDown();
             } catch (Exception e) {
-                logger.warn(REGISTRY_NACOS_EXCEPTION, "", "", "Unable to available nacos naming service", e);
+                logger.warn(REGISTRY_NACOS_EXCEPTION, "", "", "Unable to shutdown nacos naming service", e);
             }
         }
         this.namingServiceList.clear();

--- a/dubbo-registry/dubbo-registry-nacos/src/main/java/org/apache/dubbo/registry/nacos/NacosConnectionManager.java
+++ b/dubbo-registry/dubbo-registry-nacos/src/main/java/org/apache/dubbo/registry/nacos/NacosConnectionManager.java
@@ -61,6 +61,8 @@ public class NacosConnectionManager {
 
     private final boolean check;
 
+    private volatile boolean shutdown = false;
+
     public NacosConnectionManager(URL connectionURL, boolean check, int retryTimes, int sleepMsBetweenRetries) {
         this.connectionURL = connectionURL;
         this.check = check;
@@ -81,6 +83,10 @@ public class NacosConnectionManager {
         this.check = false;
         // create default one
         this.namingServiceList.add(namingService);
+    }
+
+    public boolean isShutdown() {
+        return this.shutdown;
     }
 
     public synchronized NamingService getNamingService() {
@@ -109,6 +115,7 @@ public class NacosConnectionManager {
             }
         }
         this.namingServiceList.clear();
+        this.shutdown = true;
     }
 
     /**
@@ -117,6 +124,9 @@ public class NacosConnectionManager {
      * @return {@link NamingService}
      */
     protected NamingService createNamingService() {
+        if (shutdown) {
+            throw new RuntimeException("Nacos connection manager is closed.");
+        }
         Properties nacosProperties = buildNacosProperties(this.connectionURL);
         NamingService namingService = null;
         try {

--- a/dubbo-registry/dubbo-registry-nacos/src/main/java/org/apache/dubbo/registry/nacos/NacosConnectionManager.java
+++ b/dubbo-registry/dubbo-registry-nacos/src/main/java/org/apache/dubbo/registry/nacos/NacosConnectionManager.java
@@ -61,7 +61,7 @@ public class NacosConnectionManager {
 
     private final boolean check;
 
-    private volatile boolean shutdown = false;
+    private volatile boolean available = true;
 
     public NacosConnectionManager(URL connectionURL, boolean check, int retryTimes, int sleepMsBetweenRetries) {
         this.connectionURL = connectionURL;
@@ -85,8 +85,8 @@ public class NacosConnectionManager {
         this.namingServiceList.add(namingService);
     }
 
-    public boolean isShutdown() {
-        return this.shutdown;
+    public boolean isAvailable() {
+        return this.available;
     }
 
     public synchronized NamingService getNamingService() {
@@ -111,11 +111,11 @@ public class NacosConnectionManager {
             try {
                 namingService.shutDown();
             } catch (Exception e) {
-                logger.warn(REGISTRY_NACOS_EXCEPTION, "", "", "Unable to shutdown nacos naming service", e);
+                logger.warn(REGISTRY_NACOS_EXCEPTION, "", "", "Unable to available nacos naming service", e);
             }
         }
         this.namingServiceList.clear();
-        this.shutdown = true;
+        this.available = false;
     }
 
     /**
@@ -124,7 +124,7 @@ public class NacosConnectionManager {
      * @return {@link NamingService}
      */
     protected NamingService createNamingService() {
-        if (shutdown) {
+        if (!available) {
             throw new RuntimeException("Nacos connection manager is closed.");
         }
         Properties nacosProperties = buildNacosProperties(this.connectionURL);

--- a/dubbo-registry/dubbo-registry-nacos/src/main/java/org/apache/dubbo/registry/nacos/NacosNamingServiceWrapper.java
+++ b/dubbo-registry/dubbo-registry-nacos/src/main/java/org/apache/dubbo/registry/nacos/NacosNamingServiceWrapper.java
@@ -490,7 +490,7 @@ public class NacosNamingServiceWrapper {
     private void accept(NacosConsumer command) throws NacosException {
         NacosException le = null;
         int times = 0;
-        for (; !nacosConnectionManager.isShutdown() && times < retryTimes + 1; times++) {
+        for (; nacosConnectionManager.isAvailable() && times < retryTimes + 1; times++) {
             try {
                 command.accept();
                 le = null;

--- a/dubbo-registry/dubbo-registry-nacos/src/main/java/org/apache/dubbo/registry/nacos/NacosNamingServiceWrapper.java
+++ b/dubbo-registry/dubbo-registry-nacos/src/main/java/org/apache/dubbo/registry/nacos/NacosNamingServiceWrapper.java
@@ -490,7 +490,7 @@ public class NacosNamingServiceWrapper {
     private void accept(NacosConsumer command) throws NacosException {
         NacosException le = null;
         int times = 0;
-        for (; times < retryTimes + 1; times++) {
+        for (; !nacosConnectionManager.isShutdown() && times < retryTimes + 1; times++) {
             try {
                 command.accept();
                 le = null;

--- a/dubbo-registry/dubbo-registry-nacos/src/main/java/org/apache/dubbo/registry/nacos/function/HealthChecker.java
+++ b/dubbo-registry/dubbo-registry-nacos/src/main/java/org/apache/dubbo/registry/nacos/function/HealthChecker.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.dubbo.registry.nacos.function;
+
+/**
+ * A health checker.
+ */
+@FunctionalInterface
+public interface HealthChecker {
+
+    /**
+     * Do a health check before operation to avoid unnecessary attempts.
+     *
+     * @return the check result, true or false.
+     */
+    boolean check();
+}

--- a/dubbo-registry/dubbo-registry-nacos/src/test/java/org/apache/dubbo/registry/nacos/NacosNamingServiceWrapperTest.java
+++ b/dubbo-registry/dubbo-registry-nacos/src/test/java/org/apache/dubbo/registry/nacos/NacosNamingServiceWrapperTest.java
@@ -40,6 +40,7 @@ class NacosNamingServiceWrapperTest {
         NacosConnectionManager connectionManager = Mockito.mock(NacosConnectionManager.class);
         NamingService namingService = Mockito.mock(NamingService.class);
         Mockito.when(connectionManager.getNamingService()).thenReturn(namingService);
+        Mockito.when(connectionManager.isAvailable()).thenReturn(true);
 
         NacosNamingServiceWrapper nacosNamingServiceWrapper = new NacosNamingServiceWrapper(connectionManager, 0, 0);
 
@@ -63,6 +64,7 @@ class NacosNamingServiceWrapperTest {
     @Test
     void testSubscribeMultiManager() throws NacosException {
         NacosConnectionManager connectionManager = Mockito.mock(NacosConnectionManager.class);
+        Mockito.when(connectionManager.isAvailable()).thenReturn(true);
         NamingService namingService1 = Mockito.mock(NamingService.class);
         NamingService namingService2 = Mockito.mock(NamingService.class);
 

--- a/dubbo-registry/dubbo-registry-nacos/src/test/java/org/apache/dubbo/registry/nacos/NacosNamingServiceWrapperTest.java
+++ b/dubbo-registry/dubbo-registry-nacos/src/test/java/org/apache/dubbo/registry/nacos/NacosNamingServiceWrapperTest.java
@@ -34,6 +34,8 @@ import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import static com.alibaba.nacos.client.constant.Constants.HealthCheck.UP;
+
 class NacosNamingServiceWrapperTest {
     @Test
     void testSubscribe() throws NacosException {
@@ -41,6 +43,7 @@ class NacosNamingServiceWrapperTest {
         NamingService namingService = Mockito.mock(NamingService.class);
         Mockito.when(connectionManager.getNamingService()).thenReturn(namingService);
         Mockito.when(connectionManager.isAvailable()).thenReturn(true);
+        Mockito.when(namingService.getServerStatus()).thenReturn(UP);
 
         NacosNamingServiceWrapper nacosNamingServiceWrapper = new NacosNamingServiceWrapper(connectionManager, 0, 0);
 
@@ -67,6 +70,8 @@ class NacosNamingServiceWrapperTest {
         Mockito.when(connectionManager.isAvailable()).thenReturn(true);
         NamingService namingService1 = Mockito.mock(NamingService.class);
         NamingService namingService2 = Mockito.mock(NamingService.class);
+        Mockito.when(namingService1.getServerStatus()).thenReturn(UP);
+        Mockito.when(namingService2.getServerStatus()).thenReturn(UP);
 
         NacosNamingServiceWrapper nacosNamingServiceWrapper = new NacosNamingServiceWrapper(connectionManager, 0, 0);
 
@@ -97,6 +102,7 @@ class NacosNamingServiceWrapperTest {
             @Override
             protected NamingService createNamingService() {
                 NamingService namingService = Mockito.mock(NamingService.class);
+                Mockito.when(namingService.getServerStatus()).thenReturn(UP);
                 namingServiceList.add(namingService);
                 return namingService;
             }
@@ -146,6 +152,7 @@ class NacosNamingServiceWrapperTest {
             @Override
             protected NamingService createNamingService() {
                 NamingService namingService = Mockito.mock(NamingService.class);
+                Mockito.when(namingService.getServerStatus()).thenReturn(UP);
                 try {
                     Mockito.doThrow(new NacosException()).when(namingService).batchRegisterInstance(Mockito.anyString(), Mockito.anyString(), Mockito.any(List.class));
                 } catch (NacosException e) {
@@ -210,6 +217,7 @@ class NacosNamingServiceWrapperTest {
             @Override
             protected NamingService createNamingService() {
                 NamingService namingService = Mockito.mock(NamingService.class);
+                Mockito.when(namingService.getServerStatus()).thenReturn(UP);
                 namingServiceList.add(namingService);
                 return namingService;
             }
@@ -313,6 +321,7 @@ class NacosNamingServiceWrapperTest {
             @Override
             protected NamingService createNamingService() {
                 NamingService namingService = Mockito.mock(NamingService.class);
+                Mockito.when(namingService.getServerStatus()).thenReturn(UP);
                 namingServiceList.add(namingService);
                 return namingService;
             }
@@ -415,6 +424,7 @@ class NacosNamingServiceWrapperTest {
         CountDownLatch startLatch = new CountDownLatch(1);
         CountDownLatch stopLatch = new CountDownLatch(1);
         NamingService namingService = Mockito.mock(NamingService.class);
+        Mockito.when(namingService.getServerStatus()).thenReturn(UP);
         Mockito.when(connectionManager.getNamingService()).thenReturn(namingService);
 
         NacosNamingServiceWrapper nacosNamingServiceWrapper = new NacosNamingServiceWrapper(connectionManager, false, 0, 0);
@@ -425,7 +435,7 @@ class NacosNamingServiceWrapperTest {
         NacosNamingServiceWrapper.InstancesInfo instancesInfo = nacosNamingServiceWrapper.getRegisterStatus().get(new NacosNamingServiceWrapper.InstanceId("service_name", "test"));
         Assertions.assertEquals(1, instancesInfo.getInstances().size());
 
-        nacosNamingServiceWrapper.getRegisterStatus().put(new NacosNamingServiceWrapper.InstanceId("service_name", "test"), new NacosNamingServiceWrapper.InstancesInfo(){
+        nacosNamingServiceWrapper.getRegisterStatus().put(new NacosNamingServiceWrapper.InstanceId("service_name", "test"), new NacosNamingServiceWrapper.InstancesInfo() {
             private final NacosNamingServiceWrapper.InstancesInfo delegate = instancesInfo;
 
             @Override
@@ -473,7 +483,7 @@ class NacosNamingServiceWrapperTest {
             }
         });
 
-        new Thread(()->{
+        new Thread(() -> {
             try {
                 startLatch.await();
                 nacosNamingServiceWrapper.registerInstance("service_name", "test", instance);
@@ -483,7 +493,7 @@ class NacosNamingServiceWrapperTest {
             }
         }).start();
 
-        new Thread(()->{
+        new Thread(() -> {
             try {
                 nacosNamingServiceWrapper.deregisterInstance("service_name", "test", instance);
             } catch (NacosException e) {
@@ -538,6 +548,11 @@ class NacosNamingServiceWrapperTest {
             public List<Instance> getAllInstances(String serviceName, String groupName) throws NacosException {
                 throw new NacosException();
             }
+
+            @Override
+            public String getServerStatus() {
+                return UP;
+            }
         };
 
         NacosNamingServiceWrapper nacosNamingServiceWrapper = new NacosNamingServiceWrapper(new NacosConnectionManager(namingService), 0, 0);
@@ -565,6 +580,11 @@ class NacosNamingServiceWrapperTest {
                     throw new NacosException();
                 }
                 return null;
+            }
+
+            @Override
+            public String getServerStatus() {
+                return UP;
             }
         };
 

--- a/dubbo-registry/dubbo-registry-nacos/src/test/java/org/apache/dubbo/registry/nacos/NacosRegistryTest.java
+++ b/dubbo-registry/dubbo-registry-nacos/src/test/java/org/apache/dubbo/registry/nacos/NacosRegistryTest.java
@@ -36,7 +36,9 @@ import com.alibaba.nacos.api.naming.NamingService;
 import com.alibaba.nacos.api.naming.pojo.Instance;
 import com.alibaba.nacos.api.naming.pojo.ListView;
 import com.alibaba.nacos.client.naming.NacosNamingService;
+import org.mockito.Mockito;
 
+import static com.alibaba.nacos.client.constant.Constants.HealthCheck.UP;
 import static org.apache.dubbo.common.constants.CommonConstants.GROUP_KEY;
 import static org.apache.dubbo.common.constants.CommonConstants.PATH_KEY;
 import static org.apache.dubbo.common.constants.CommonConstants.PROTOCOL_KEY;
@@ -160,6 +162,7 @@ class NacosRegistryTest {
     @Test
     void testSubscribe() {
         NamingService namingService = mock(NacosNamingService.class);
+        Mockito.when(namingService.getServerStatus()).thenReturn(UP);
 
         try {
 
@@ -197,6 +200,7 @@ class NacosRegistryTest {
     @Test
     void testUnSubscribe() {
         NamingService namingService = mock(NacosNamingService.class);
+        Mockito.when(namingService.getServerStatus()).thenReturn(UP);
 
         try {
 
@@ -242,6 +246,7 @@ class NacosRegistryTest {
     @Test
     void testIsConformRules() {
         NamingService namingService = mock(NacosNamingService.class);
+        Mockito.when(namingService.getServerStatus()).thenReturn(UP);
         URL serviceUrlWithoutCategory = URL.valueOf("nacos://127.0.0.1:3333/" + serviceInterface + "?interface=" +
             serviceInterface + "&notify=false&methods=test1,test2&version=1.0.0&group=default");
         try {


### PR DESCRIPTION
## What is the purpose of the change
The nacos naming service supports command execution retries, adding status checks can avoid unnecessary retries.

Related issue #11680 
