### PR TITLE
Fix 2.6.x LoadBalance SPI not work

### DIFF
--- a/dubbo-compatible/src/main/java/com/alibaba/dubbo/rpc/Invoker.java
+++ b/dubbo-compatible/src/main/java/com/alibaba/dubbo/rpc/Invoker.java
@@ -51,6 +51,11 @@ public interface Invoker<T> extends org.apache.dubbo.rpc.Invoker<T> {
         }
 
         @Override
+        public org.apache.dubbo.rpc.Result invoke(org.apache.dubbo.rpc.Invocation invocation) throws org.apache.dubbo.rpc.RpcException {
+            return new Result.CompatibleResult(invoker.invoke(invocation));
+        }
+        
+        @Override
         public Result invoke(Invocation invocation) throws RpcException {
             return new Result.CompatibleResult(invoker.invoke(invocation.getOriginal()));
         }

--- a/dubbo-compatible/src/main/java/com/alibaba/dubbo/rpc/Result.java
+++ b/dubbo-compatible/src/main/java/com/alibaba/dubbo/rpc/Result.java
@@ -104,6 +104,11 @@ public interface Result extends org.apache.dubbo.rpc.Result {
         }
 
         @Override
+        public org.apache.dubbo.rpc.Result whenCompleteWithContext(BiConsumer<org.apache.dubbo.rpc.Result, Throwable> fn) {
+            return delegate.whenCompleteWithContext(fn);
+        }
+
+        @Override
         public Object getValue() {
             return delegate.getValue();
         }


### PR DESCRIPTION
## What is the purpose of the change

fix bug see https://github.com/apache/dubbo/issues/11644

## Brief changelog

Add compatible method of com.alibaba.dubbo.rpc.Result and com.alibaba.dubbo.rpc.Invoker

## Verifying this change

I test calling 2.6.x's method both sync and async

<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [ ] GitHub Actions works fine on your own branch.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
