### PR TITLE
Fix #11767,  restore the original parameter pair instead of giving default value when doing URL.parse.

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/URLStrParser.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/URLStrParser.java
@@ -278,7 +278,7 @@ public final class URLStrParser {
             String name = decodeComponent(str, nameStart, valueStart - 3, false, tempBuf);
             String value;
             if (valueStart >= valueEnd) {
-                value = name;
+                value = "";
             } else {
                 value = decodeComponent(str, valueStart, valueEnd, false, tempBuf);
             }
@@ -291,7 +291,7 @@ public final class URLStrParser {
             String name = str.substring(nameStart, valueStart - 1);
             String value;
             if (valueStart >= valueEnd) {
-                value = name;
+                value = "";
             } else {
                 value = str.substring(valueStart, valueEnd);
             }

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/URLStrParserTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/URLStrParserTest.java
@@ -44,6 +44,7 @@ class URLStrParserTest {
         testCases.add("file:/path/to/file.txt");
         testCases.add("dubbo://fe80:0:0:0:894:aeec:f37d:23e1%en0/path?abc=abc");
         testCases.add("dubbo://[fe80:0:0:0:894:aeec:f37d:23e1]:20880/path?abc=abc");
+        testCases.add("nacos://192.168.1.1:8848?username=&password=");
 
         errorDecodedCases.add("dubbo:192.168.1.1");
         errorDecodedCases.add("://192.168.1.1");

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/URLTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/URLTest.java
@@ -308,7 +308,7 @@ class URLTest {
         assertEquals(3, url.getParameters().size());
         assertEquals("1.0.0", url.getVersion());
         assertEquals("morgan", url.getParameter("application"));
-        assertEquals("noValue", url.getParameter("noValue"));
+        assertEquals("", url.getParameter("noValue"));
     }
 
     // TODO Do not want to use spaces? See: DUBBO-502, URL class handles special conventions for special characters.
@@ -325,10 +325,10 @@ class URLTest {
         URL url = URL.valueOf("http://1.2.3.4:8080/path?k0=&k1=v1");
 
         assertURLStrDecoder(url);
-        assertTrue(url.hasParameter("k0"));
+        assertFalse(url.hasParameter("k0"));
 
-        // If a Key has no corresponding Value, then the Key also used as the Value.
-        assertEquals("k0", url.getParameter("k0"));
+        // If a Key has no corresponding Value, then empty string used as the Value.
+        assertEquals("", url.getParameter("k0"));
     }
 
     @Test
@@ -1047,7 +1047,7 @@ class URLTest {
     @Test
     void test_valueOfHasNameWithoutValue() throws Exception {
         URL url = URL.valueOf("dubbo://admin:hello1234@10.20.130.230:20880/context/path?version=1.0.0&application=morgan&noValue");
-        Assertions.assertEquals("noValue", url.getParameter("noValue"));
+        Assertions.assertEquals("", url.getParameter("noValue"));
     }
 
     @Test


### PR DESCRIPTION
## What is the purpose of the change

When value has no value, make sure value is an empty string, rather than assigning the value of name to value

For key-value pair `key_name=`, the generated URL parameter should be 'key_name=' rather than `key_name=key_ name`

## Brief changelog

## Verifying this change

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues/11767) 

