### PR TITLE
dubbo-starter  import metrics dep

### DIFF
--- a/dubbo-spring-boot/dubbo-spring-boot-autoconfigure/pom.xml
+++ b/dubbo-spring-boot/dubbo-spring-boot-autoconfigure/pom.xml
@@ -81,6 +81,11 @@
             <optional>true</optional>
         </dependency>
 
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-prometheus</artifactId>
+        </dependency>
+
         <!-- Test Dependencies -->
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/dubbo-spring-boot/dubbo-spring-boot-autoconfigure/pom.xml
+++ b/dubbo-spring-boot/dubbo-spring-boot-autoconfigure/pom.xml
@@ -81,11 +81,6 @@
             <optional>true</optional>
         </dependency>
 
-        <dependency>
-            <groupId>io.micrometer</groupId>
-            <artifactId>micrometer-registry-prometheus</artifactId>
-        </dependency>
-
         <!-- Test Dependencies -->
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/dubbo-spring-boot/dubbo-spring-boot-observability-starter/pom.xml
+++ b/dubbo-spring-boot/dubbo-spring-boot-observability-starter/pom.xml
@@ -66,6 +66,10 @@
             <artifactId>micrometer-core</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-prometheus</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-autoconfigure</artifactId>
             <optional>true</optional>

--- a/dubbo-spring-boot/dubbo-spring-boot-observability-starter/pom.xml
+++ b/dubbo-spring-boot/dubbo-spring-boot-observability-starter/pom.xml
@@ -80,12 +80,6 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>org.apache.dubbo</groupId>
-            <artifactId>dubbo-common</artifactId>
-            <version>${project.version}</version>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
             <groupId>io.micrometer</groupId>
             <artifactId>micrometer-tracing-bridge-otel</artifactId>
             <optional>true</optional>
@@ -97,7 +91,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.dubbo</groupId>
-            <artifactId>dubbo-metrics-default</artifactId>
+            <artifactId>dubbo-spring-boot-starter</artifactId>
             <version>${project.version}</version>
         </dependency>
     </dependencies>


### PR DESCRIPTION
## What is the purpose of the change
The introduction of starter can use the metrics capability。
When you don't need observability, import the dubbp-starter package. If necessary, import the dubbo-spring-boot-observability-starter package
