### PR TITLE
Metrics collection is enabled by default

### DIFF
--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/deploy/DefaultApplicationDeployer.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/deploy/DefaultApplicationDeployer.java
@@ -363,12 +363,14 @@ public class DefaultApplicationDeployer extends AbstractDeployer<ApplicationMode
     private void initMetricsReporter() {
         DefaultMetricsCollector collector =
             applicationModel.getBeanFactory().getBean(DefaultMetricsCollector.class);
-        MetricsConfig metricsConfig = configManager.getMetrics().orElse(null);
+        MetricsConfig metricsConfig = configManager.getMetrics().orElse(new MetricsConfig());
+        if (StringUtils.isBlank(metricsConfig.getProtocol())) {
+            metricsConfig.setProtocol(PROTOCOL_PROMETHEUS);
+        }
         // TODO compatible with old usage of metrics, remove protocol check after new metrics is ready for use.
-        if (metricsConfig != null && PROTOCOL_PROMETHEUS.equals(metricsConfig.getProtocol())) {
+        if (PROTOCOL_PROMETHEUS.equals(metricsConfig.getProtocol())) {
             collector.setCollectEnabled(true);
             collector.collectApplication(applicationModel);
-            String protocol = metricsConfig.getProtocol();
             MetricsReporterFactory metricsReporterFactory = getExtensionLoader(MetricsReporterFactory.class).getAdaptiveExtension();
             MetricsReporter metricsReporter = metricsReporterFactory.createMetricsReporter(metricsConfig.toUrl());
             metricsReporter.init();

--- a/dubbo-metrics/dubbo-metrics-default/src/main/java/org/apache/dubbo/metrics/collector/AggregateMetricsCollector.java
+++ b/dubbo-metrics/dubbo-metrics-default/src/main/java/org/apache/dubbo/metrics/collector/AggregateMetricsCollector.java
@@ -66,7 +66,7 @@ public class AggregateMetricsCollector implements MetricsCollector, MetricsListe
         this.applicationModel = applicationModel;
         ConfigManager configManager = applicationModel.getApplicationConfigManager();
         MetricsConfig config = configManager.getMetrics().orElse(null);
-        if (config != null && config.getAggregation() != null && Boolean.TRUE.equals(config.getAggregation().getEnabled())) {
+        if (config != null && config.getAggregation() != null && (config.getAggregation().getEnabled() == null || Boolean.TRUE.equals(config.getAggregation().getEnabled()))) {
             // only registered when aggregation is enabled.
             registerListener();
 
@@ -94,7 +94,7 @@ public class AggregateMetricsCollector implements MetricsCollector, MetricsListe
 
 
     private void onRequestEvent(MethodEvent event) {
-        MethodMetric metric =  event.getMethodMetric();
+        MethodMetric metric = event.getMethodMetric();
 
         String type = event.getType();
 

--- a/dubbo-metrics/dubbo-metrics-default/src/main/java/org/apache/dubbo/metrics/report/AbstractMetricsReporter.java
+++ b/dubbo-metrics/dubbo-metrics-default/src/main/java/org/apache/dubbo/metrics/report/AbstractMetricsReporter.java
@@ -108,7 +108,7 @@ public abstract class AbstractMetricsReporter implements MetricsReporter {
     }
 
     private void addJvmMetrics() {
-        boolean enableJvmMetrics = url.getParameter(ENABLE_JVM_METRICS_KEY, false);
+        boolean enableJvmMetrics = url.getParameter(ENABLE_JVM_METRICS_KEY, true);
         if (enableJvmMetrics) {
             Tags extraTags = Tags.of(MetricsConstants.TAG_APPLICATION_NAME,
                 Optional.ofNullable(applicationModel.getApplicationName()).orElse(""));


### PR DESCRIPTION
## What is the purpose of the change

According to the following configuration, data will not be collected currently, and it is expected to collect

```yaml
dubbo:
  application:
    name: sp-provider
  registry:
    address: zookeeper://127.0.0.1:2181
  protocol:
    port: 20881
#  provider:
#    serialization: hessian2
#  metrics:
#    protocol: prometheus
#    enable-jvm-metrics: true
#    enable-registry-metrics: true
#    enable-metadata-metrics: true
#    aggregation:
#      enabled: true
#    prometheus:
#      exporter:
#        enabled: true
```




