### PR TITLE
dubbo-dependencies-zookeeper-curator5在dubbo新版本兼容 

### DIFF
--- a/dubbo-dependencies/dubbo-dependencies-zookeeper-curator5/pom.xml
+++ b/dubbo-dependencies/dubbo-dependencies-zookeeper-curator5/pom.xml
@@ -35,7 +35,7 @@
         <revision>3.2.0-beta.7-SNAPSHOT</revision>
         <maven_flatten_version>1.1.0</maven_flatten_version>
         <curator5_version>5.1.0</curator5_version>
-        <zookeeper_version>3.7.0</zookeeper_version>
+        <zookeeper_version>3.8.1</zookeeper_version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
如果我们使用了高版本JDK,例如JDK17,我们的dubbo应用启动会报错，
java.lang.IllegalArgumentException: 
Unable to canonicalize address 127.0.0.1/<unresolved>:2181 because it's not resolvable

因为引入的dubbo-dependencies-zookeeper-curator5中zookeeper是低版本的，
我们需要重新引入高版本zookeeper或者使用JDK8。
#11966 


