### PR TITLE
Fix abstractServiceDiscovery update exception caused by loading order

### DIFF
--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/AbstractServiceDiscovery.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/AbstractServiceDiscovery.java
@@ -64,6 +64,7 @@ import static org.apache.dubbo.registry.client.metadata.ServiceInstanceMetadataU
 public abstract class AbstractServiceDiscovery implements ServiceDiscovery {
     private final ErrorTypeAwareLogger logger = LoggerFactory.getErrorTypeAwareLogger(AbstractServiceDiscovery.class);
     private volatile boolean isDestroy;
+    private volatile boolean isRegistry = true;
 
     protected final String serviceName;
     protected volatile ServiceInstance serviceInstance;
@@ -97,32 +98,32 @@ public abstract class AbstractServiceDiscovery implements ServiceDiscovery {
         this.metadataInfo = new MetadataInfo(serviceName);
         boolean localCacheEnabled = registryURL.getParameter(REGISTRY_LOCAL_FILE_CACHE_ENABLED, true);
         this.metaCacheManager = new MetaCacheManager(localCacheEnabled, getCacheNameSuffix(),
-            applicationModel.getFrameworkModel().getBeanFactory()
-                .getBean(FrameworkExecutorRepository.class).getCacheRefreshingScheduledExecutor());
+                applicationModel.getFrameworkModel().getBeanFactory()
+                        .getBean(FrameworkExecutorRepository.class).getCacheRefreshingScheduledExecutor());
         int metadataInfoCacheExpireTime = registryURL.getParameter(METADATA_INFO_CACHE_EXPIRE_KEY, DEFAULT_METADATA_INFO_CACHE_EXPIRE);
         int metadataInfoCacheSize = registryURL.getParameter(METADATA_INFO_CACHE_SIZE_KEY, DEFAULT_METADATA_INFO_CACHE_SIZE);
         this.refreshCacheFuture = applicationModel.getFrameworkModel().getBeanFactory()
-            .getBean(FrameworkExecutorRepository.class).getSharedScheduledExecutor()
-            .scheduleAtFixedRate(() -> {
-                try {
-                    while (metadataInfos.size() > metadataInfoCacheSize) {
-                        AtomicReference<String> oldestRevision = new AtomicReference<>();
-                        AtomicReference<MetadataInfoStat> oldestStat = new AtomicReference<>();
-                        metadataInfos.forEach((k, v) -> {
-                            if (System.currentTimeMillis() - v.getUpdateTime() > metadataInfoCacheExpireTime &&
-                                (oldestStat.get() == null || oldestStat.get().getUpdateTime() > v.getUpdateTime())) {
-                                oldestRevision.set(k);
-                                oldestStat.set(v);
+                .getBean(FrameworkExecutorRepository.class).getSharedScheduledExecutor()
+                .scheduleAtFixedRate(() -> {
+                    try {
+                        while (metadataInfos.size() > metadataInfoCacheSize) {
+                            AtomicReference<String> oldestRevision = new AtomicReference<>();
+                            AtomicReference<MetadataInfoStat> oldestStat = new AtomicReference<>();
+                            metadataInfos.forEach((k, v) -> {
+                                if (System.currentTimeMillis() - v.getUpdateTime() > metadataInfoCacheExpireTime &&
+                                        (oldestStat.get() == null || oldestStat.get().getUpdateTime() > v.getUpdateTime())) {
+                                    oldestRevision.set(k);
+                                    oldestStat.set(v);
+                                }
+                            });
+                            if (oldestStat.get() != null) {
+                                metadataInfos.remove(oldestRevision.get(), oldestStat.get());
                             }
-                        });
-                        if (oldestStat.get() != null) {
-                            metadataInfos.remove(oldestRevision.get(), oldestStat.get());
                         }
+                    } catch (Throwable t) {
+                        logger.error(INTERNAL_ERROR, "", "", "Error occurred when clean up metadata info cache.", t);
                     }
-                } catch (Throwable t) {
-                    logger.error(INTERNAL_ERROR, "", "", "Error occurred when clean up metadata info cache.", t);
-                }
-            }, metadataInfoCacheExpireTime / 2, metadataInfoCacheExpireTime / 2, TimeUnit.MILLISECONDS);
+                }, metadataInfoCacheExpireTime / 2, metadataInfoCacheExpireTime / 2, TimeUnit.MILLISECONDS);
     }
 
 
@@ -133,6 +134,7 @@ public abstract class AbstractServiceDiscovery implements ServiceDiscovery {
         }
         this.serviceInstance = createServiceInstance(this.metadataInfo);
         if (!isValidInstance(this.serviceInstance)) {
+            isRegistry = false;
             logger.warn(REGISTRY_FAILED_FETCH_INSTANCE, "", "", "No valid instance found, stop registering instance address to registry.");
             return;
         }
@@ -142,6 +144,7 @@ public abstract class AbstractServiceDiscovery implements ServiceDiscovery {
             reportMetadata(this.metadataInfo);
             doRegister(this.serviceInstance);
         }
+        isRegistry = true;
     }
 
     /**
@@ -162,6 +165,11 @@ public abstract class AbstractServiceDiscovery implements ServiceDiscovery {
         }
 
         if (!isValidInstance(this.serviceInstance)) {
+            return;
+        }
+
+        if (!isRegistry) {
+            register();
             return;
         }
 
@@ -301,7 +309,7 @@ public abstract class AbstractServiceDiscovery implements ServiceDiscovery {
      * Can be override if registry support update instance directly.
      * <br/>
      * NOTICE: Remind to update {@link AbstractServiceDiscovery#serviceInstance}'s reference if updated
-     *         and report metadata by {@link AbstractServiceDiscovery#reportMetadata(MetadataInfo)}
+     * and report metadata by {@link AbstractServiceDiscovery#reportMetadata(MetadataInfo)}
      *
      * @param oldServiceInstance origin service instance
      * @param newServiceInstance new service instance

--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/AbstractServiceDiscovery.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/AbstractServiceDiscovery.java
@@ -49,7 +49,6 @@ import static org.apache.dubbo.common.constants.CommonConstants.METADATA_INFO_CA
 import static org.apache.dubbo.common.constants.CommonConstants.REGISTRY_LOCAL_FILE_CACHE_ENABLED;
 import static org.apache.dubbo.common.constants.CommonConstants.REMOTE_METADATA_STORAGE_TYPE;
 import static org.apache.dubbo.common.constants.LoggerCodeConstants.INTERNAL_ERROR;
-import static org.apache.dubbo.common.constants.LoggerCodeConstants.REGISTRY_FAILED_FETCH_INSTANCE;
 import static org.apache.dubbo.common.constants.LoggerCodeConstants.REGISTRY_FAILED_LOAD_METADATA;
 import static org.apache.dubbo.common.constants.RegistryConstants.REGISTRY_CLUSTER_KEY;
 import static org.apache.dubbo.metadata.RevisionResolver.EMPTY_REVISION;


### PR DESCRIPTION
## What is the purpose of the change
when there is a referenceConfig get for a dependent jar package, the loading order will change, causing exceptions in abstractServiceDiscovery update
1、it will fix abstractServiceDiscovery update exception caused by loading order
2、Fix issue Closes #12032
## Brief changelog


## Verifying this change


<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [ ] GitHub Actions works fine on your own branch.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
