### PR TITLE
fix: load zipkin after springboot3

### DIFF
--- a/dubbo-spring-boot/dubbo-spring-boot-observability-starters/dubbo-spring-boot-observability-autoconfigure/src/main/java/org/apache/dubbo/spring/boot/observability/autoconfigure/exporter/zipkin/ZipkinAutoConfiguration.java
+++ b/dubbo-spring-boot/dubbo-spring-boot-observability-starters/dubbo-spring-boot-observability-autoconfigure/src/main/java/org/apache/dubbo/spring/boot/observability/autoconfigure/exporter/zipkin/ZipkinAutoConfiguration.java
@@ -44,10 +44,12 @@ import static org.apache.dubbo.spring.boot.observability.autoconfigure.Observabi
  * {@link EnableAutoConfiguration Auto-configuration} for Zipkin.
  * <p>
  * It uses imports on {@link ZipkinConfigurations} to guarantee the correct configuration ordering.
+ * Create Zipkin sender and exporter when you are using Boot < 3.0 or you are not using spring-boot-starter-actuator.
+ * When you use SpringBoot 3.*, priority should be given to loading S3 related configurations. Dubbo related zipkin configurations are invalid.
  *
  * @since 3.2.1
  */
-@AutoConfiguration(after = RestTemplateAutoConfiguration.class)
+@AutoConfiguration(after = RestTemplateAutoConfiguration.class, afterName = "org.springframework.boot.actuate.autoconfigure.tracing.zipkin")
 @ConditionalOnClass(Sender.class)
 @Import({SenderConfiguration.class,
         ReporterConfiguration.class, BraveConfiguration.class,


### PR DESCRIPTION
## What is the purpose of the change

`ZipkinAutoConfiguration` create Zipkin sender and exporter when you are using Boot < 3.0 or you are not using spring-boot-starter-actuator.
When you use SpringBoot 3.*, priority should be given to loading S3 related configurations. Dubbo related zipkin configurations are invalid.

springboot3 zipkin config:
```yaml
management:
  zipkin:
    tracing:
      endpoint: http://localhost:9411/api/v2/spans
```

## Brief changelog


## Verifying this change


<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [ ] GitHub Actions works fine on your own branch.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
