### PR TITLE
Collect No Provider Request count 

### DIFF
--- a/dubbo-metrics/dubbo-metrics-api/src/main/java/org/apache/dubbo/metrics/event/MetricsEvent.java
+++ b/dubbo-metrics/dubbo-metrics-api/src/main/java/org/apache/dubbo/metrics/event/MetricsEvent.java
@@ -103,6 +103,7 @@ public abstract class MetricsEvent {
         NETWORK_EXCEPTION("NETWORK_EXCEPTION_%s"),
         SERVICE_UNAVAILABLE("SERVICE_UNAVAILABLE_%s"),
         CODEC_EXCEPTION("CODEC_EXCEPTION_%s"),
+        NO_INVOKER_AVAILABLE("NO_INVOKER_AVAILABLE_%s"),
         ;
 
         private final String name;

--- a/dubbo-metrics/dubbo-metrics-api/src/main/java/org/apache/dubbo/metrics/model/key/MetricsKey.java
+++ b/dubbo-metrics/dubbo-metrics-api/src/main/java/org/apache/dubbo/metrics/model/key/MetricsKey.java
@@ -118,6 +118,7 @@ public enum MetricsKey {
     METADATA_GIT_COMMITID_METRIC("git.commit.id", "Git Commit Id Metrics"),
 
     // consumer metrics key
+    INVOKER_NO_AVAILABLE_COUNT("dubbo.consumer.invoker.no.available.count", "Request Throw No Invoker Available Exception Count"),
     ;
 
     private String name;

--- a/dubbo-metrics/dubbo-metrics-default/src/main/java/org/apache/dubbo/metrics/collector/AggregateMetricsCollector.java
+++ b/dubbo-metrics/dubbo-metrics-default/src/main/java/org/apache/dubbo/metrics/collector/AggregateMetricsCollector.java
@@ -139,6 +139,7 @@ public class AggregateMetricsCollector implements MetricsCollector, MetricsListe
         collectMethod(list, MetricsEvent.Type.NETWORK_EXCEPTION.getNameByType(side), MetricsKey.METRIC_REQUESTS_TOTAL_NETWORK_FAILED_AGG);
         collectMethod(list, MetricsEvent.Type.CODEC_EXCEPTION.getNameByType(side), MetricsKey.METRIC_REQUESTS_TOTAL_CODEC_FAILED_AGG);
         collectMethod(list, MetricsEvent.Type.SERVICE_UNAVAILABLE.getNameByType(side), MetricsKey.METRIC_REQUESTS_TOTAL_SERVICE_UNAVAILABLE_FAILED_AGG);
+        collectMethod(list, MetricsEvent.Type.NO_INVOKER_AVAILABLE.getNameByType(side), MetricsKey.INVOKER_NO_AVAILABLE_COUNT);
     }
 
     private void collectMethod(List<MetricSample> list, String eventType, MetricsKey metricsKey) {
@@ -179,6 +180,7 @@ public class AggregateMetricsCollector implements MetricsCollector, MetricsListe
         methodTypeCounter.put(MetricsEvent.Type.SERVICE_UNAVAILABLE.getNameByType(side), new ConcurrentHashMap<>());
         methodTypeCounter.put(MetricsEvent.Type.NETWORK_EXCEPTION.getNameByType(side), new ConcurrentHashMap<>());
         methodTypeCounter.put(MetricsEvent.Type.CODEC_EXCEPTION.getNameByType(side), new ConcurrentHashMap<>());
+        methodTypeCounter.put(MetricsEvent.Type.NO_INVOKER_AVAILABLE.getNameByType(side), new ConcurrentHashMap<>());
     }
 
     private void registerListener() {

--- a/dubbo-metrics/dubbo-metrics-default/src/main/java/org/apache/dubbo/metrics/filter/MethodMetricsInterceptor.java
+++ b/dubbo-metrics/dubbo-metrics-default/src/main/java/org/apache/dubbo/metrics/filter/MethodMetricsInterceptor.java
@@ -17,6 +17,7 @@
 
 package org.apache.dubbo.metrics.filter;
 
+import org.apache.dubbo.common.constants.CommonConstants;
 import org.apache.dubbo.metrics.collector.sample.MethodMetricsSampler;
 import org.apache.dubbo.metrics.event.MetricsEvent;
 import org.apache.dubbo.rpc.Invocation;
@@ -84,7 +85,7 @@ public class MethodMetricsInterceptor {
             if (e.isNetwork()) {
                 eventType = MetricsEvent.Type.NETWORK_EXCEPTION;
             }
-            if (e.isNoInvokerAvailableAfterFilter()) {
+            if (e.isNoInvokerAvailableAfterFilter() && CommonConstants.CONSUMER_SIDE.equals(side)) {
                 eventType = MetricsEvent.Type.NO_INVOKER_AVAILABLE;
             }
         }

--- a/dubbo-metrics/dubbo-metrics-default/src/main/java/org/apache/dubbo/metrics/filter/MethodMetricsInterceptor.java
+++ b/dubbo-metrics/dubbo-metrics-default/src/main/java/org/apache/dubbo/metrics/filter/MethodMetricsInterceptor.java
@@ -84,6 +84,9 @@ public class MethodMetricsInterceptor {
             if (e.isNetwork()) {
                 eventType = MetricsEvent.Type.NETWORK_EXCEPTION;
             }
+            if (e.isNoInvokerAvailableAfterFilter()) {
+                eventType = MetricsEvent.Type.NO_INVOKER_AVAILABLE;
+            }
         }
         sampler.incOnEvent(invocation, eventType.getNameByType(side));
         onCompleted(invocation);

--- a/dubbo-metrics/dubbo-metrics-default/src/test/java/org/apache/dubbo/metrics/collector/AggregateMetricsCollectorTest.java
+++ b/dubbo-metrics/dubbo-metrics-default/src/test/java/org/apache/dubbo/metrics/collector/AggregateMetricsCollectorTest.java
@@ -156,6 +156,7 @@ class AggregateMetricsCollectorTest {
         methodMetricsCountSampler.incOnEvent(invocation, MetricsEvent.Type.NETWORK_EXCEPTION.getNameByType(side));
         methodMetricsCountSampler.incOnEvent(invocation, MetricsEvent.Type.SERVICE_UNAVAILABLE.getNameByType(side));
         methodMetricsCountSampler.incOnEvent(invocation, MetricsEvent.Type.CODEC_EXCEPTION.getNameByType(side));
+        methodMetricsCountSampler.incOnEvent(invocation, MetricsEvent.Type.NO_INVOKER_AVAILABLE.getNameByType(side));
 
 
         List<MetricSample> samples = collector.collect();
@@ -181,6 +182,7 @@ class AggregateMetricsCollectorTest {
         Assertions.assertEquals(sampleMap.get(MetricsKey.METRIC_REQUESTS_TOTAL_NETWORK_FAILED_AGG.getNameByType(side)), 1L);
         Assertions.assertEquals(sampleMap.get(MetricsKey.METRIC_REQUESTS_TOTAL_CODEC_FAILED_AGG.getNameByType(side)), 1L);
         Assertions.assertEquals(sampleMap.get(MetricsKey.METRIC_REQUESTS_TOTAL_SERVICE_UNAVAILABLE_FAILED_AGG.getNameByType(side)), 1L);
+        Assertions.assertEquals(sampleMap.get(MetricsKey.INVOKER_NO_AVAILABLE_COUNT.getNameByType(side)), 1L);
 
         Assertions.assertTrue(sampleMap.containsKey(MetricsKey.METRIC_QPS.getNameByType(side)));
     }


### PR DESCRIPTION
…ble.count Metrics

## What is the purpose of the change

fix #12129 

## Brief changelog

Collect No Provider Request count as dubbo.consumer.invoker.no.available.count Metrics

## Verifying this change


<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [ ] GitHub Actions works fine on your own branch.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
