### PR TITLE
Add metrics option for use global registry

### DIFF
--- a/dubbo-metrics/dubbo-metrics-default/src/main/java/org/apache/dubbo/metrics/DubboMetrics.java
+++ b/dubbo-metrics/dubbo-metrics-default/src/main/java/org/apache/dubbo/metrics/DubboMetrics.java
@@ -23,11 +23,8 @@ import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
 
 public class DubboMetrics implements MeterBinder {
 
-    private MeterRegistry globalRegistry = null;
-
     @Override
     public void bindTo(MeterRegistry registry) {
-        globalRegistry = registry;
         CompositeMeterRegistry compositeRegistry = MetricsGlobalRegistry.getCompositeRegistry();
         if (compositeRegistry != null) {
             compositeRegistry.add(registry);

--- a/dubbo-metrics/dubbo-metrics-default/src/main/java/org/apache/dubbo/metrics/MetricsGlobalRegistry.java
+++ b/dubbo-metrics/dubbo-metrics-default/src/main/java/org/apache/dubbo/metrics/MetricsGlobalRegistry.java
@@ -17,6 +17,7 @@
 
 package org.apache.dubbo.metrics;
 
+import io.micrometer.core.instrument.Metrics;
 import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
 
 public class MetricsGlobalRegistry {
@@ -24,6 +25,10 @@ public class MetricsGlobalRegistry {
     private static final CompositeMeterRegistry compositeRegistry = new CompositeMeterRegistry();
 
     public static CompositeMeterRegistry getCompositeRegistry() {
-        return compositeRegistry;
+        if (Boolean.parseBoolean(System.getProperty("dubbo.metrics.useGlobalRegistry", "true"))) {
+            return Metrics.globalRegistry;
+        } else {
+            return compositeRegistry;
+        }
     }
 }


### PR DESCRIPTION
## What is the purpose of the change
micrometer provides a default global CompositeMeterRegistry, generally, dubbo can use it directly. Considering the isolation of multiple applications, provide configuration options and use a separate Registry for dubbo


## Brief changelog
Provide a jvm level switch option


