### PR TITLE
clean the RpcContext in ThreadLocal after QoS invoke, synchronously get the result while async started

### DIFF
--- a/dubbo-plugin/dubbo-qos/src/main/java/org/apache/dubbo/qos/command/impl/InvokeTelnet.java
+++ b/dubbo-plugin/dubbo-qos/src/main/java/org/apache/dubbo/qos/command/impl/InvokeTelnet.java
@@ -168,7 +168,9 @@ public class InvokeTelnet implements BaseCommand {
                 }
             } catch (Throwable t) {
                 result.setException(t);
-                Thread.currentThread().interrupt();
+                if (t instanceof InterruptedException) {
+                    Thread.currentThread().interrupt();
+                }
             } finally {
                 RpcContext.removeContext();
             }

--- a/dubbo-plugin/dubbo-qos/src/main/java/org/apache/dubbo/qos/command/impl/InvokeTelnet.java
+++ b/dubbo-plugin/dubbo-qos/src/main/java/org/apache/dubbo/qos/command/impl/InvokeTelnet.java
@@ -168,6 +168,7 @@ public class InvokeTelnet implements BaseCommand {
                 }
             } catch (Throwable t) {
                 result.setException(t);
+                Thread.currentThread().interrupt();
             } finally {
                 RpcContext.removeContext();
             }

--- a/dubbo-plugin/dubbo-qos/src/main/java/org/apache/dubbo/qos/command/impl/InvokeTelnet.java
+++ b/dubbo-plugin/dubbo-qos/src/main/java/org/apache/dubbo/qos/command/impl/InvokeTelnet.java
@@ -25,6 +25,9 @@ import org.apache.dubbo.qos.api.BaseCommand;
 import org.apache.dubbo.qos.api.CommandContext;
 import org.apache.dubbo.qos.api.Cmd;
 import org.apache.dubbo.rpc.AppResponse;
+import org.apache.dubbo.rpc.AsyncContext;
+import org.apache.dubbo.rpc.AsyncContextImpl;
+import org.apache.dubbo.rpc.RpcContext;
 import org.apache.dubbo.rpc.model.FrameworkModel;
 import org.apache.dubbo.rpc.model.MethodDescriptor;
 import org.apache.dubbo.rpc.model.ProviderModel;
@@ -38,6 +41,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 
 import static org.apache.dubbo.common.utils.PojoUtils.realize;
 
@@ -150,9 +154,22 @@ public class InvokeTelnet implements BaseCommand {
             AppResponse result = new AppResponse();
             try {
                 Object o = invokeMethod.invoke(selectedProvider.getServiceInstance(), array);
-                result.setValue(o);
+                boolean setValueDone = false;
+                if (RpcContext.getServerAttachment().isAsyncStarted()) {
+                    AsyncContext asyncContext = RpcContext.getServerAttachment().getAsyncContext();
+                    if (asyncContext instanceof AsyncContextImpl) {
+                        CompletableFuture<Object> internalFuture = ((AsyncContextImpl) asyncContext).getInternalFuture();
+                        result.setValue(internalFuture.get());
+                        setValueDone = true;
+                    }
+                }
+                if (!setValueDone) {
+                    result.setValue(o);
+                }
             } catch (Throwable t) {
                 result.setException(t);
+            } finally {
+                RpcContext.removeContext();
             }
             long end = System.currentTimeMillis();
             buf.append("\r\nresult: ");


### PR DESCRIPTION
## What is the purpose of the change

to fix #12290 

## Brief changelog

1. clean the RpcContext in ThreadLocal after QoS invoke in the ```InvokeTelnet```
2. synchronously get the result while async started, so the invoke command could get the correct result instead of null



<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [ ] GitHub Actions works fine on your own branch.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
