### PR TITLE
fix: DefaultModuleDeployer start fail, but export MetadataService(#12…

### DIFF
--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/deploy/DefaultModuleDeployer.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/deploy/DefaultModuleDeployer.java
@@ -316,7 +316,7 @@ public class DefaultModuleDeployer extends AbstractDeployer<ModuleModel> impleme
         try {
             setFailed(ex);
             logger.error(CONFIG_FAILED_START_MODEL, "", "", "Model start failed: " + msg, ex);
-            applicationDeployer.notifyModuleChanged(moduleModel, DeployState.STARTED);
+            applicationDeployer.notifyModuleChanged(moduleModel, DeployState.FAILED);
         } finally {
             completeStartFuture(false);
         }


### PR DESCRIPTION
…315)

## What is the purpose of the change

fix https://github.com/apache/dubbo/issues/12315.

## Brief changelog

DefaultModuleDeployer#onModuleFailed pass right DeployState to ApplicationDeployer.

## Verifying this change


<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [ ] GitHub Actions works fine on your own branch.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
