### PR TITLE
bugfix of registry directory metrics only show num_valid_total

### DIFF
--- a/dubbo-metrics/dubbo-metrics-registry/src/main/java/org/apache/dubbo/metrics/registry/event/RegistrySubDispatcher.java
+++ b/dubbo-metrics/dubbo-metrics-registry/src/main/java/org/apache/dubbo/metrics/registry/event/RegistrySubDispatcher.java
@@ -101,7 +101,7 @@ public final class RegistrySubDispatcher extends SimpleMetricsEventMulticaster {
                 Map<MetricsKey, Map<String, Integer>> summaryMap = event.getAttachmentValue(ATTACHMENT_DIRECTORY_MAP);
                 summaryMap.forEach((metricsKey, map) ->
                     map.forEach(
-                        (k, v) -> collector.setNum(new MetricsKeyWrapper(key, OP_TYPE_DIRECTORY), k, v)));
+                        (k, v) -> collector.setNum(new MetricsKeyWrapper(metricsKey, OP_TYPE_DIRECTORY), k, v)));
             }
         ));
 


### PR DESCRIPTION
## What is the purpose of the change
 registry directory metrics only show num_valid_total ，The key should be dynamically obtained when collecting

