### PR TITLE
When PropertyValue "parameters" is [null] or [EMPTY], return to HashMap that can be modified

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/config/AbstractMethodConfig.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/config/AbstractMethodConfig.java
@@ -23,7 +23,9 @@ import org.apache.dubbo.rpc.model.ModuleModel;
 import org.apache.dubbo.rpc.model.ScopeModel;
 
 import java.beans.Transient;
+import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * AbstractMethodConfig
@@ -240,7 +242,8 @@ public abstract class AbstractMethodConfig extends AbstractConfig {
     }
 
     public Map<String, String> getParameters() {
-        return parameters;
+        this.parameters = Optional.ofNullable(parameters).orElseGet(HashMap::new);
+        return this.parameters;
     }
 
     public void setParameters(Map<String, String> parameters) {

--- a/dubbo-common/src/main/java/org/apache/dubbo/config/AbstractMethodConfig.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/config/AbstractMethodConfig.java
@@ -242,7 +242,7 @@ public abstract class AbstractMethodConfig extends AbstractConfig {
     }
 
     public Map<String, String> getParameters() {
-        this.parameters = Optional.ofNullable(parameters).orElseGet(HashMap::new);
+        this.parameters = Optional.ofNullable(this.parameters).orElseGet(HashMap::new);
         return this.parameters;
     }
 

--- a/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/util/DubboAnnotationUtils.java
+++ b/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/util/DubboAnnotationUtils.java
@@ -27,7 +27,7 @@ import org.springframework.util.Assert;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -154,7 +154,7 @@ public class DubboAnnotationUtils {
      */
     public static Map<String, String> convertParameters(String[] parameters) {
         if (ArrayUtils.isEmpty(parameters)) {
-            return Collections.emptyMap();
+            return new HashMap<>();
         }
 
         List<String> compatibleParameterArray = Arrays.stream(parameters)


### PR DESCRIPTION
1. `org.apache.dubbo.config.spring.util.DubboAnnotationUtils.convertParameters`
When the `put` target is an empty String array, the empty `HashMap` instead of `java.util.Collections.EmptyMap` supports subsequent scalable `put` operations  #12350 
## What is the purpose of the change

So that `@DubbboService#parameter`, even if empty, does not affect the extra put operation causing the program to throw an exception

```java
  if (ArrayUtils.isEmpty(parameters)) {
       return Collections.emptyMap();
   }
```

---->

```java
  if (ArrayUtils.isEmpty(parameters)) {
       return new HashMap<>();
  }
```

`Collections.emptyMap()`is a special implementation of EmptyMap inside Collections that doesn't support change, so I don't think it makes any sense to set a Map of that type here

```java
    public V put(K key, V value) {
        throw new UnsupportedOperationException();
    }

```

2. `org.apache.dubbo.config.AbstractMethodConfig#getParameters`

Prevents this function from returning null
```java
    public Map<String, String> getParameters() {
        return parameters;
    }

```
---->
```java
    public Map<String, String> getParameters() {
        this.parameters = Optional.ofNullable(this.parameters).orElseGet(HashMap::new);
        return this.parameters;
    }
```

## Verifying this change

......