### PR TITLE
fix: PortUnification+encodeInIOThread=false cause server response emp…

### DIFF
--- a/dubbo-remoting/dubbo-remoting-netty4/src/main/java/org/apache/dubbo/remoting/transport/netty4/NettyChannel.java
+++ b/dubbo-remoting/dubbo-remoting-netty4/src/main/java/org/apache/dubbo/remoting/transport/netty4/NettyChannel.java
@@ -72,7 +72,7 @@ final class NettyChannel extends AbstractChannel {
 
     private final Netty4BatchWriteQueue writeQueue;
 
-    private final Codec2 codec;
+    private Codec2 codec;
 
     private final boolean encodeInIOThread;
 
@@ -364,5 +364,9 @@ final class NettyChannel extends AbstractChannel {
         }else {
             return frameworkModel.getExtensionLoader(Codec2.class).getExtension("default");
         }
+    }
+
+    public void setCodec(Codec2 codec) {
+        this.codec = codec;
     }
 }

--- a/dubbo-remoting/dubbo-remoting-netty4/src/main/java/org/apache/dubbo/remoting/transport/netty4/NettyConfigOperator.java
+++ b/dubbo-remoting/dubbo-remoting-netty4/src/main/java/org/apache/dubbo/remoting/transport/netty4/NettyConfigOperator.java
@@ -60,6 +60,7 @@ public class NettyConfigOperator implements ChannelOperator {
         }
 
         if (!(codec2 instanceof DefaultCodec)){
+            ((NettyChannel) channel).setCodec(codec2);
             NettyCodecAdapter codec = new NettyCodecAdapter(codec2, channel.getUrl(), handler);
             ((NettyChannel) channel).getNioChannel().pipeline().addLast(
                 codec.getDecoder()


### PR DESCRIPTION
…ty buffer(#12353)

## What is the purpose of the change

fix #12353.

## Brief changelog

When Pu specify WireProtocol, change NettyChannel's Codec.

So business threads can encode normally and write to peer.

## Verifying this change


<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [ ] GitHub Actions works fine on your own branch.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
