### PR TITLE
Metrics default val set 0

### DIFF
--- a/dubbo-metrics/dubbo-metrics-api/src/main/java/org/apache/dubbo/metrics/data/MethodStatComposite.java
+++ b/dubbo-metrics/dubbo-metrics-api/src/main/java/org/apache/dubbo/metrics/data/MethodStatComposite.java
@@ -20,6 +20,7 @@ package org.apache.dubbo.metrics.data;
 import org.apache.dubbo.common.utils.CollectionUtils;
 import org.apache.dubbo.metrics.model.MethodMetric;
 import org.apache.dubbo.metrics.model.MetricsCategory;
+import org.apache.dubbo.metrics.model.MetricsSupport;
 import org.apache.dubbo.metrics.model.key.MetricsKeyWrapper;
 import org.apache.dubbo.metrics.model.sample.CounterMetricSample;
 import org.apache.dubbo.metrics.model.sample.GaugeMetricSample;
@@ -58,6 +59,7 @@ public class MethodStatComposite extends AbstractMetricsExport {
             return;
         }
         methodNumStats.get(wrapper).computeIfAbsent(new MethodMetric(getApplicationModel(), invocation), k -> new AtomicLong(0L)).getAndAdd(size);
+        MetricsSupport.fillZero(methodNumStats);
     }
 
     public List<MetricSample> export(MetricsCategory category) {

--- a/dubbo-metrics/dubbo-metrics-api/src/main/java/org/apache/dubbo/metrics/data/MethodStatComposite.java
+++ b/dubbo-metrics/dubbo-metrics-api/src/main/java/org/apache/dubbo/metrics/data/MethodStatComposite.java
@@ -17,6 +17,8 @@
 
 package org.apache.dubbo.metrics.data;
 
+import org.apache.dubbo.common.logger.Logger;
+import org.apache.dubbo.common.logger.LoggerFactory;
 import org.apache.dubbo.common.utils.CollectionUtils;
 import org.apache.dubbo.metrics.model.MethodMetric;
 import org.apache.dubbo.metrics.model.MetricsCategory;
@@ -42,9 +44,12 @@ import java.util.concurrent.atomic.AtomicLong;
  */
 public class MethodStatComposite extends AbstractMetricsExport {
 
+    private static final Logger logger = LoggerFactory.getLogger(MethodStatComposite.class);
+
     public MethodStatComposite(ApplicationModel applicationModel) {
         super(applicationModel);
     }
+
     private final Map<MetricsKeyWrapper, Map<MethodMetric, AtomicLong>> methodNumStats = new ConcurrentHashMap<>();
 
     public void initWrapper(List<MetricsKeyWrapper> metricsKeyWrappers) {
@@ -67,11 +72,13 @@ public class MethodStatComposite extends AbstractMetricsExport {
         for (MetricsKeyWrapper wrapper : methodNumStats.keySet()) {
             Map<MethodMetric, AtomicLong> stringAtomicLongMap = methodNumStats.get(wrapper);
             for (MethodMetric methodMetric : stringAtomicLongMap.keySet()) {
-                if (methodMetric.getSampleType() == MetricSample.Type.GAUGE) {
+                if (wrapper.getSampleType() == MetricSample.Type.COUNTER) {
                     list.add(new CounterMetricSample<>(wrapper,
-                            methodMetric.getTags(), category, stringAtomicLongMap.get(methodMetric)));
-                } else {
+                        methodMetric.getTags(), category, stringAtomicLongMap.get(methodMetric)));
+                } else if (wrapper.getSampleType() == MetricSample.Type.GAUGE) {
                     list.add(new GaugeMetricSample<>(wrapper, methodMetric.getTags(), category, stringAtomicLongMap, value -> value.get(methodMetric).get()));
+                } else {
+                    logger.error("Unsupported metricSample type: "+wrapper.getSampleType());
                 }
 
             }

--- a/dubbo-metrics/dubbo-metrics-api/src/main/java/org/apache/dubbo/metrics/data/MethodStatComposite.java
+++ b/dubbo-metrics/dubbo-metrics-api/src/main/java/org/apache/dubbo/metrics/data/MethodStatComposite.java
@@ -20,6 +20,7 @@ package org.apache.dubbo.metrics.data;
 import org.apache.dubbo.common.logger.Logger;
 import org.apache.dubbo.common.logger.LoggerFactory;
 import org.apache.dubbo.common.utils.CollectionUtils;
+import org.apache.dubbo.metrics.exception.MetricsNeverHappenException;
 import org.apache.dubbo.metrics.model.MethodMetric;
 import org.apache.dubbo.metrics.model.MetricsCategory;
 import org.apache.dubbo.metrics.model.MetricsSupport;
@@ -78,7 +79,7 @@ public class MethodStatComposite extends AbstractMetricsExport {
                 } else if (wrapper.getSampleType() == MetricSample.Type.GAUGE) {
                     list.add(new GaugeMetricSample<>(wrapper, methodMetric.getTags(), category, stringAtomicLongMap, value -> value.get(methodMetric).get()));
                 } else {
-                    logger.error("Unsupported metricSample type: "+wrapper.getSampleType());
+                    throw new MetricsNeverHappenException("Unsupported metricSample type: " + wrapper.getSampleType());
                 }
 
             }

--- a/dubbo-metrics/dubbo-metrics-api/src/main/java/org/apache/dubbo/metrics/data/ServiceStatComposite.java
+++ b/dubbo-metrics/dubbo-metrics-api/src/main/java/org/apache/dubbo/metrics/data/ServiceStatComposite.java
@@ -19,6 +19,7 @@ package org.apache.dubbo.metrics.data;
 
 import org.apache.dubbo.common.utils.CollectionUtils;
 import org.apache.dubbo.metrics.model.MetricsCategory;
+import org.apache.dubbo.metrics.model.MetricsSupport;
 import org.apache.dubbo.metrics.model.ServiceKeyMetric;
 import org.apache.dubbo.metrics.model.key.MetricsKeyWrapper;
 import org.apache.dubbo.metrics.model.sample.GaugeMetricSample;
@@ -57,6 +58,7 @@ public class ServiceStatComposite extends AbstractMetricsExport {
             return;
         }
         serviceWrapperNumStats.get(wrapper).computeIfAbsent(new ServiceKeyMetric(getApplicationModel(), serviceKey), k -> new AtomicLong(0L)).getAndAdd(size);
+        MetricsSupport.fillZero(serviceWrapperNumStats);
     }
 
     public void setServiceKey(MetricsKeyWrapper wrapper, String serviceKey, int num) {
@@ -64,6 +66,7 @@ public class ServiceStatComposite extends AbstractMetricsExport {
             return;
         }
         serviceWrapperNumStats.get(wrapper).computeIfAbsent(new ServiceKeyMetric(getApplicationModel(), serviceKey), k -> new AtomicLong(0L)).set(num);
+        MetricsSupport.fillZero(serviceWrapperNumStats);
     }
 
     public List<MetricSample> export(MetricsCategory category) {

--- a/dubbo-metrics/dubbo-metrics-api/src/main/java/org/apache/dubbo/metrics/model/MetricsSupport.java
+++ b/dubbo-metrics/dubbo-metrics-api/src/main/java/org/apache/dubbo/metrics/model/MetricsSupport.java
@@ -229,6 +229,9 @@ public class MetricsSupport {
         collector.addRt(event.getAttachmentValue(INVOCATION), placeType.getType(), event.getTimePair().calc());
     }
 
+    /**
+     *  Generate a complete indicator item for an interface/method
+     */
     public static <T> void fillZero(Map<MetricsKeyWrapper, Map<T, AtomicLong>> data) {
         if (CollectionUtils.isEmptyMap(data)) {
             return;

--- a/dubbo-metrics/dubbo-metrics-api/src/main/java/org/apache/dubbo/metrics/model/MetricsSupport.java
+++ b/dubbo-metrics/dubbo-metrics-api/src/main/java/org/apache/dubbo/metrics/model/MetricsSupport.java
@@ -18,6 +18,7 @@
 package org.apache.dubbo.metrics.model;
 
 import org.apache.dubbo.common.Version;
+import org.apache.dubbo.common.utils.CollectionUtils;
 import org.apache.dubbo.metrics.collector.MethodMetricsCollector;
 import org.apache.dubbo.metrics.collector.ServiceMetricsCollector;
 import org.apache.dubbo.metrics.event.MetricsEvent;
@@ -35,6 +36,9 @@ import org.apache.dubbo.rpc.model.ApplicationModel;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Collectors;
 
 import static org.apache.dubbo.common.constants.CommonConstants.GROUP_CHAR_SEPARATOR;
 import static org.apache.dubbo.common.constants.CommonConstants.PATH_SEPARATOR;
@@ -158,9 +162,9 @@ public class MetricsSupport {
     public static String getMethodName(Invocation invocation) {
         String methodName = invocation.getMethodName();
         if (invocation instanceof RpcInvocation
-                && isGenericCall(((RpcInvocation) invocation).getParameterTypesDesc(), methodName)
-                && invocation.getArguments() != null
-                && invocation.getArguments().length == 3) {
+            && isGenericCall(((RpcInvocation) invocation).getParameterTypesDesc(), methodName)
+            && invocation.getArguments() != null
+            && invocation.getArguments().length == 3) {
             methodName = ((String) invocation.getArguments()[0]).trim();
         }
         return methodName;
@@ -223,5 +227,19 @@ public class MetricsSupport {
     public static void incrAndAddRt(MetricsKey metricsKey, MetricsPlaceValue placeType, MethodMetricsCollector<TimeCounterEvent> collector, TimeCounterEvent event) {
         collector.increment(event.getAttachmentValue(INVOCATION), new MetricsKeyWrapper(metricsKey, placeType), SELF_INCREMENT_SIZE);
         collector.addRt(event.getAttachmentValue(INVOCATION), placeType.getType(), event.getTimePair().calc());
+    }
+
+    public static <T> void fillZero(Map<MetricsKeyWrapper, Map<T, AtomicLong>> data) {
+        if (CollectionUtils.isEmptyMap(data)) {
+            return;
+        }
+        Set<T> allKeyMetrics = data.values().stream().flatMap(map -> map.keySet().stream()).collect(Collectors.toSet());
+        data.forEach((keyWrapper, mapVal) ->
+        {
+            for (T key : allKeyMetrics) {
+                mapVal.computeIfAbsent(key, k -> new AtomicLong(0));
+            }
+        });
+
     }
 }

--- a/dubbo-metrics/dubbo-metrics-api/src/main/java/org/apache/dubbo/metrics/model/key/CategoryOverall.java
+++ b/dubbo-metrics/dubbo-metrics-api/src/main/java/org/apache/dubbo/metrics/model/key/CategoryOverall.java
@@ -17,7 +17,8 @@
 
 package org.apache.dubbo.metrics.model.key;
 
-import io.micrometer.common.lang.Nullable;
+
+import org.apache.dubbo.common.lang.Nullable;
 
 /**
  *  The overall event set, including the event processing functions in three stages

--- a/dubbo-metrics/dubbo-metrics-api/src/main/java/org/apache/dubbo/metrics/model/key/MetricsCat.java
+++ b/dubbo-metrics/dubbo-metrics-api/src/main/java/org/apache/dubbo/metrics/model/key/MetricsCat.java
@@ -23,18 +23,27 @@ import org.apache.dubbo.metrics.listener.AbstractMetricsKeyListener;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 
+/**
+ * The behavior wrapper class of MetricsKey,
+ * which saves the complete content of the key {@link MetricsPlaceValue},
+ * the corresponding collector {@link CombMetricsCollector},
+ * and the event listener (generate function) at the key level {@link AbstractMetricsKeyListener}
+ */
 public class MetricsCat {
 
     private MetricsPlaceValue placeType;
     private final Function<CombMetricsCollector, AbstractMetricsKeyListener> eventFunc;
 
+    /**
+     * @param metricsKey The key corresponding to the listening event, not necessarily the export key(export key may be dynamic)
+     * @param biFunc Binary function, corresponding to MetricsKey with less content, corresponding to post event
+     */
     public MetricsCat(MetricsKey metricsKey, BiFunction<MetricsKey, CombMetricsCollector, AbstractMetricsKeyListener> biFunc) {
         this.eventFunc = collector -> biFunc.apply(metricsKey, collector);
     }
 
     /**
-     * @param metricsKey The key that the current category listens to，not necessarily the export key(export key may be dynamic)
-     * @param tpFunc     Build the func that outputs the MetricsListener by listen metricsKey
+     * @param tpFunc   Ternary function, corresponding to finish and error events, because an additional record rt is required, and the type type of metricsKey is required
      */
     public MetricsCat(MetricsKey metricsKey, TpFunction<MetricsKey, MetricsPlaceValue, CombMetricsCollector, AbstractMetricsKeyListener> tpFunc) {
         this.eventFunc = collector -> tpFunc.apply(metricsKey, placeType, collector);

--- a/dubbo-metrics/dubbo-metrics-api/src/main/java/org/apache/dubbo/metrics/model/key/MetricsKey.java
+++ b/dubbo-metrics/dubbo-metrics-api/src/main/java/org/apache/dubbo/metrics/model/key/MetricsKey.java
@@ -134,12 +134,6 @@ public enum MetricsKey {
         return String.format(name, type);
     }
 
-
-    public final MetricsKey formatName(String type) {
-        this.name = String.format(name, type);
-        return this;
-    }
-
     public final String getDescription() {
         return this.description;
     }

--- a/dubbo-metrics/dubbo-metrics-api/src/main/java/org/apache/dubbo/metrics/model/key/MetricsKeyWrapper.java
+++ b/dubbo-metrics/dubbo-metrics-api/src/main/java/org/apache/dubbo/metrics/model/key/MetricsKeyWrapper.java
@@ -19,6 +19,7 @@ package org.apache.dubbo.metrics.model.key;
 
 import io.micrometer.common.lang.Nullable;
 import org.apache.dubbo.metrics.model.MetricsSupport;
+import org.apache.dubbo.metrics.model.sample.MetricSample;
 import org.apache.dubbo.rpc.model.ApplicationModel;
 
 import java.util.Map;
@@ -40,12 +41,26 @@ public class MetricsKeyWrapper {
     private final MetricsPlaceValue placeType;
 
     /**
+     * Exported sample type
+     */
+    private MetricSample.Type sampleType = MetricSample.Type.COUNTER;
+
+    /**
      * When the MetricsPlaceType is null, it is equivalent to a single MetricsKey.
      * Use the decorator mode to share a container with MetricsKey
      */
     public MetricsKeyWrapper(MetricsKey metricsKey, @Nullable MetricsPlaceValue placeType) {
         this.metricsKey = metricsKey;
         this.placeType = placeType;
+    }
+
+    public MetricsKeyWrapper setSampleType(MetricSample.Type sampleType) {
+        this.sampleType = sampleType;
+        return this;
+    }
+
+    public MetricSample.Type getSampleType() {
+        return sampleType;
     }
 
     public MetricsPlaceValue getPlaceType() {

--- a/dubbo-metrics/dubbo-metrics-api/src/test/java/org/apache/dubbo/metrics/MetricsSupportTest.java
+++ b/dubbo-metrics/dubbo-metrics-api/src/test/java/org/apache/dubbo/metrics/MetricsSupportTest.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.dubbo.metrics;
 
 import org.apache.dubbo.common.constants.CommonConstants;

--- a/dubbo-metrics/dubbo-metrics-api/src/test/java/org/apache/dubbo/metrics/MetricsSupportTest.java
+++ b/dubbo-metrics/dubbo-metrics-api/src/test/java/org/apache/dubbo/metrics/MetricsSupportTest.java
@@ -1,0 +1,42 @@
+package org.apache.dubbo.metrics;
+
+import org.apache.dubbo.common.constants.CommonConstants;
+import org.apache.dubbo.config.ApplicationConfig;
+import org.apache.dubbo.metrics.model.MetricsSupport;
+import org.apache.dubbo.metrics.model.ServiceKeyMetric;
+import org.apache.dubbo.metrics.model.key.MetricsKeyWrapper;
+import org.apache.dubbo.metrics.model.key.MetricsLevel;
+import org.apache.dubbo.metrics.model.key.MetricsPlaceValue;
+import org.apache.dubbo.rpc.model.ApplicationModel;
+import org.apache.dubbo.rpc.model.FrameworkModel;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.apache.dubbo.metrics.model.key.MetricsKey.METRIC_REQUESTS;
+
+public class MetricsSupportTest {
+
+    @Test
+    void testFillZero() {
+        ApplicationModel applicationModel = FrameworkModel.defaultModel().newApplication();
+        ApplicationConfig config = new ApplicationConfig();
+        config.setName("MockMetrics");
+        applicationModel.getApplicationConfigManager().setApplication(config);
+
+        Map<MetricsKeyWrapper, Map<ServiceKeyMetric, AtomicLong>> data = new HashMap<>();
+        MetricsKeyWrapper key1 = new MetricsKeyWrapper(METRIC_REQUESTS, MetricsPlaceValue.of(CommonConstants.PROVIDER, MetricsLevel.METHOD));
+        MetricsKeyWrapper key2 = new MetricsKeyWrapper(METRIC_REQUESTS, MetricsPlaceValue.of(CommonConstants.CONSUMER, MetricsLevel.METHOD));
+        ServiceKeyMetric sm1 = new ServiceKeyMetric(applicationModel, "a.b.c");
+        ServiceKeyMetric sm2 = new ServiceKeyMetric(applicationModel, "a.b.d");
+        data.computeIfAbsent(key1, k -> new HashMap<>()).put(sm1, new AtomicLong(1));
+        data.computeIfAbsent(key1, k -> new HashMap<>()).put(sm2, new AtomicLong(1));
+        data.put(key2, new HashMap<>());
+        Assertions.assertEquals(2, data.values().stream().mapToLong(map -> map.values().size()).sum());
+        MetricsSupport.fillZero(data);
+        Assertions.assertEquals(4, data.values().stream().mapToLong(map -> map.values().size()).sum());
+    }
+}

--- a/dubbo-metrics/dubbo-metrics-default/src/main/java/org/apache/dubbo/metrics/DefaultConstants.java
+++ b/dubbo-metrics/dubbo-metrics-default/src/main/java/org/apache/dubbo/metrics/DefaultConstants.java
@@ -21,6 +21,7 @@ import org.apache.dubbo.common.constants.CommonConstants;
 import org.apache.dubbo.metrics.model.key.MetricsKeyWrapper;
 import org.apache.dubbo.metrics.model.key.MetricsLevel;
 import org.apache.dubbo.metrics.model.key.MetricsPlaceValue;
+import org.apache.dubbo.metrics.model.sample.MetricSample;
 
 import java.util.Arrays;
 import java.util.List;
@@ -46,8 +47,9 @@ public interface DefaultConstants {
     List<MetricsKeyWrapper> METHOD_LEVEL_KEYS = Arrays.asList(
         new MetricsKeyWrapper(METRIC_REQUESTS, MetricsPlaceValue.of(CommonConstants.PROVIDER, MetricsLevel.METHOD)),
         new MetricsKeyWrapper(METRIC_REQUESTS, MetricsPlaceValue.of(CommonConstants.CONSUMER, MetricsLevel.METHOD)),
-        new MetricsKeyWrapper(METRIC_REQUESTS_PROCESSING, MetricsPlaceValue.of(CommonConstants.PROVIDER, MetricsLevel.METHOD)),
-        new MetricsKeyWrapper(METRIC_REQUESTS_PROCESSING, MetricsPlaceValue.of(CommonConstants.CONSUMER, MetricsLevel.METHOD)),
+        // METRIC_REQUESTS_PROCESSING use GAUGE
+        new MetricsKeyWrapper(METRIC_REQUESTS_PROCESSING, MetricsPlaceValue.of(CommonConstants.PROVIDER, MetricsLevel.METHOD)).setSampleType(MetricSample.Type.GAUGE),
+        new MetricsKeyWrapper(METRIC_REQUESTS_PROCESSING, MetricsPlaceValue.of(CommonConstants.CONSUMER, MetricsLevel.METHOD)).setSampleType(MetricSample.Type.GAUGE),
         new MetricsKeyWrapper(METRIC_REQUESTS_SUCCEED, MetricsPlaceValue.of(CommonConstants.PROVIDER, MetricsLevel.METHOD)),
         new MetricsKeyWrapper(METRIC_REQUESTS_SUCCEED, MetricsPlaceValue.of(CommonConstants.CONSUMER, MetricsLevel.METHOD)),
         new MetricsKeyWrapper(METRIC_REQUEST_BUSINESS_FAILED, MetricsPlaceValue.of(CommonConstants.PROVIDER, MetricsLevel.METHOD)),

--- a/dubbo-metrics/dubbo-metrics-default/src/main/java/org/apache/dubbo/metrics/event/DefaultSubDispatcher.java
+++ b/dubbo-metrics/dubbo-metrics-default/src/main/java/org/apache/dubbo/metrics/event/DefaultSubDispatcher.java
@@ -29,12 +29,8 @@ import org.apache.dubbo.metrics.model.key.MetricsCat;
 import org.apache.dubbo.metrics.model.key.MetricsKey;
 import org.apache.dubbo.metrics.model.key.MetricsLevel;
 import org.apache.dubbo.metrics.model.key.MetricsPlaceValue;
-import org.apache.dubbo.metrics.model.sample.MetricSample;
-import org.apache.dubbo.rpc.Invocation;
 
 import static org.apache.dubbo.metrics.DefaultConstants.METRIC_THROWABLE;
-import static org.apache.dubbo.metrics.MetricsConstants.INVOCATION;
-import static org.apache.dubbo.metrics.MetricsConstants.INVOCATION_METRICS_COUNTER;
 import static org.apache.dubbo.metrics.model.key.MetricsKey.METRIC_REQUESTS_SERVICE_UNAVAILABLE_FAILED;
 
 @SuppressWarnings({"unchecked", "rawtypes"})
@@ -71,17 +67,13 @@ public final class DefaultSubDispatcher extends SimpleMetricsEventMulticaster {
                         {
                             MetricsPlaceValue dynamicPlaceType = MetricsPlaceValue.of(event.getAttachmentValue(MetricsConstants.INVOCATION_SIDE), MetricsLevel.METHOD);
                             MetricsSupport.increment(key, dynamicPlaceType, (MethodMetricsCollector) collector, event);
-
-                            // METRIC_REQUESTS_PROCESSING use GAUGE
-                            Invocation invocation = event.getAttachmentValue(INVOCATION);
-                            invocation.put(INVOCATION_METRICS_COUNTER, MetricSample.Type.GAUGE);
                             MetricsSupport.increment(MetricsKey.METRIC_REQUESTS_PROCESSING, dynamicPlaceType, (MethodMetricsCollector) collector, event);
                         })),
                 new MetricsCat(MetricsKey.METRIC_REQUESTS_SUCCEED, (key, placeType, collector) -> AbstractMetricsKeyListener.onFinish(key,
                         event ->
                         {
                             MetricsPlaceValue dynamicPlaceType = MetricsPlaceValue.of(event.getAttachmentValue(MetricsConstants.INVOCATION_SIDE), MetricsLevel.METHOD);
-                            MetricsSupport.dec(MetricsKey.METRIC_REQUESTS_PROCESSING, dynamicPlaceType, (MethodMetricsCollector) collector, event);
+                            MetricsSupport.dec(MetricsKey.METRIC_REQUESTS_PROCESSING, dynamicPlaceType, collector, event);
 
                             Object throwableObj = event.getAttachmentValue(METRIC_THROWABLE);
                             MetricsKey targetKey;
@@ -99,7 +91,7 @@ public final class DefaultSubDispatcher extends SimpleMetricsEventMulticaster {
                             // Dynamic metricsKey && dynamicPlaceType
                             MetricsPlaceValue dynamicPlaceType = MetricsPlaceValue.of(event.getAttachmentValue(MetricsConstants.INVOCATION_SIDE), MetricsLevel.METHOD);
                             MetricsSupport.increment(MetricsKey.METRIC_REQUESTS_TOTAL_FAILED, dynamicPlaceType, (MethodMetricsCollector) collector, event);
-                            MetricsSupport.dec(MetricsKey.METRIC_REQUESTS_PROCESSING, dynamicPlaceType, (MethodMetricsCollector) collector, event);
+                            MetricsSupport.dec(MetricsKey.METRIC_REQUESTS_PROCESSING, dynamicPlaceType, collector, event);
                             MetricsSupport.incrAndAddRt(targetKey, dynamicPlaceType, (MethodMetricsCollector) collector, event);
                         }
                 )));

--- a/dubbo-metrics/dubbo-metrics-default/src/test/java/org/apache/dubbo/metrics/collector/DefaultCollectorTest.java
+++ b/dubbo-metrics/dubbo-metrics-default/src/test/java/org/apache/dubbo/metrics/collector/DefaultCollectorTest.java
@@ -20,6 +20,7 @@ package org.apache.dubbo.metrics.collector;
 import org.apache.dubbo.common.URL;
 import org.apache.dubbo.common.constants.CommonConstants;
 import org.apache.dubbo.config.ApplicationConfig;
+import org.apache.dubbo.metrics.DefaultConstants;
 import org.apache.dubbo.metrics.TestMetricsInvoker;
 import org.apache.dubbo.metrics.event.MetricsDispatcher;
 import org.apache.dubbo.metrics.event.RequestBeforeEvent;
@@ -148,8 +149,8 @@ class DefaultCollectorTest {
 
         // push finish rt +1
         List<MetricSample> metricSamples = collector.collect();
-        //num(total+success+processing) + rt(5) = 8
-        Assertions.assertEquals(8, metricSamples.size());
+        //all METHOD_LEVEL_KEYS + rt(5) = 27
+        Assertions.assertEquals(DefaultConstants.METHOD_LEVEL_KEYS.size() + 5, metricSamples.size());
         List<String> metricsNames = metricSamples.stream().map(MetricSample::getName).collect(Collectors.toList());
         // No error will contain total+success+processing
         String REQUESTS = new MetricsKeyWrapper(METRIC_REQUESTS, MetricsPlaceValue.of(side, MetricsLevel.SERVICE)).targetKey();
@@ -191,7 +192,7 @@ class DefaultCollectorTest {
         metricSamples = collector.collect();
 
         // num(total+success+error+total_error+processing) + rt(5) = 5
-        Assertions.assertEquals(10, metricSamples.size());
+        Assertions.assertEquals(DefaultConstants.METHOD_LEVEL_KEYS.size() + 5, metricSamples.size());
 
         String TIMEOUT = new MetricsKeyWrapper(METRIC_REQUESTS_TIMEOUT, MetricsPlaceValue.of(side, MetricsLevel.SERVICE)).targetKey();
         String TOTAL_FAILED = new MetricsKeyWrapper(METRIC_REQUESTS_TOTAL_FAILED, MetricsPlaceValue.of(side, MetricsLevel.SERVICE)).targetKey();

--- a/dubbo-metrics/dubbo-metrics-default/src/test/java/org/apache/dubbo/metrics/filter/MetricsFilterTest.java
+++ b/dubbo-metrics/dubbo-metrics-default/src/test/java/org/apache/dubbo/metrics/filter/MetricsFilterTest.java
@@ -25,6 +25,9 @@ import org.apache.dubbo.metrics.collector.DefaultMetricsCollector;
 import org.apache.dubbo.metrics.event.MetricsEventBus;
 import org.apache.dubbo.metrics.event.RequestEvent;
 import org.apache.dubbo.metrics.model.key.MetricsKey;
+import org.apache.dubbo.metrics.model.key.MetricsKeyWrapper;
+import org.apache.dubbo.metrics.model.key.MetricsLevel;
+import org.apache.dubbo.metrics.model.key.MetricsPlaceValue;
 import org.apache.dubbo.metrics.model.sample.CounterMetricSample;
 import org.apache.dubbo.metrics.model.sample.MetricSample;
 import org.apache.dubbo.rpc.AppResponse;
@@ -152,7 +155,7 @@ class MetricsFilterTest {
 
         Map<String, MetricSample> metricsMap = getMetricsMap();
         Assertions.assertTrue(metricsMap.containsKey(MetricsKey.METRIC_REQUEST_BUSINESS_FAILED.getNameByType(side)));
-        Assertions.assertFalse(metricsMap.containsKey(MetricsKey.METRIC_REQUESTS_SUCCEED.getNameByType(side)));
+        Assertions.assertTrue(metricsMap.containsKey(MetricsKey.METRIC_REQUESTS_SUCCEED.getNameByType(side)));
 
         MetricSample sample = metricsMap.get(MetricsKey.METRIC_REQUEST_BUSINESS_FAILED.getNameByType(side));
 
@@ -266,12 +269,13 @@ class MetricsFilterTest {
 
     @Test
     public void testErrors() {
-        testFilterError(RpcException.SERIALIZATION_EXCEPTION, MetricsKey.METRIC_REQUESTS_CODEC_FAILED.formatName(side));
-        testFilterError(RpcException.NETWORK_EXCEPTION, MetricsKey.METRIC_REQUESTS_NETWORK_FAILED.formatName(side));
+        testFilterError(RpcException.SERIALIZATION_EXCEPTION, MetricsKey.METRIC_REQUESTS_CODEC_FAILED);
+        testFilterError(RpcException.NETWORK_EXCEPTION, MetricsKey.METRIC_REQUESTS_NETWORK_FAILED);
     }
 
 
     private void testFilterError(int errorCode, MetricsKey metricsKey) {
+        String targetKey = new MetricsKeyWrapper(metricsKey, MetricsPlaceValue.of(side, MetricsLevel.METHOD)).targetKey();
         setup();
         collector.setCollectEnabled(true);
         given(invoker.invoke(invocation)).willThrow(new RpcException(errorCode));
@@ -288,14 +292,14 @@ class MetricsFilterTest {
             }
         }
         Map<String, MetricSample> metricsMap = getMetricsMap();
-        Assertions.assertTrue(metricsMap.containsKey(metricsKey.getName()));
+        Assertions.assertTrue(metricsMap.containsKey(targetKey));
 
-        MetricSample sample = metricsMap.get(metricsKey.getName());
+        MetricSample sample = metricsMap.get(targetKey);
 
-        Assertions.assertSame(((CounterMetricSample) sample).getValue().longValue(), count);
+        Assertions.assertSame(((CounterMetricSample<?>) sample).getValue().longValue(), count);
 
 
-        Assertions.assertTrue(metricsMap.containsKey(metricsKey.getName()));
+        Assertions.assertTrue(metricsMap.containsKey(targetKey));
         Map<String, String> tags = sample.getTags();
 
         Assertions.assertEquals(tags.get(TAG_INTERFACE_KEY), INTERFACE_NAME);

--- a/dubbo-metrics/dubbo-metrics-default/src/test/java/org/apache/dubbo/metrics/filter/MetricsFilterTest.java
+++ b/dubbo-metrics/dubbo-metrics-default/src/test/java/org/apache/dubbo/metrics/filter/MetricsFilterTest.java
@@ -125,7 +125,7 @@ class MetricsFilterTest {
 
         Map<String, MetricSample> metricsMap = getMetricsMap();
         Assertions.assertTrue(metricsMap.containsKey(MetricsKey.METRIC_REQUESTS_FAILED.getNameByType(side)));
-        Assertions.assertFalse(metricsMap.containsKey(MetricsKey.METRIC_REQUESTS_SUCCEED.getNameByType(side)));
+        Assertions.assertTrue(metricsMap.containsKey(MetricsKey.METRIC_REQUESTS_SUCCEED.getNameByType(side)));
 
         MetricSample sample = metricsMap.get(MetricsKey.METRIC_REQUESTS_FAILED.getNameByType(side));
         Map<String, String> tags = sample.getTags();
@@ -229,7 +229,7 @@ class MetricsFilterTest {
         filter.onResponse(result, invoker, invocation);
 
         Map<String, MetricSample> metricsMap = getMetricsMap();
-        Assertions.assertFalse(metricsMap.containsKey(MetricsKey.METRIC_REQUEST_BUSINESS_FAILED.getNameByType(side)));
+        Assertions.assertTrue(metricsMap.containsKey(MetricsKey.METRIC_REQUEST_BUSINESS_FAILED.getNameByType(side)));
         Assertions.assertTrue(metricsMap.containsKey(MetricsKey.METRIC_REQUESTS_SUCCEED.getNameByType(side)));
 
         MetricSample sample = metricsMap.get(MetricsKey.METRIC_REQUESTS_SUCCEED.getNameByType(side));

--- a/dubbo-metrics/dubbo-metrics-metadata/src/main/java/org/apache/dubbo/metrics/metadata/event/MetadataSubDispatcher.java
+++ b/dubbo-metrics/dubbo-metrics-metadata/src/main/java/org/apache/dubbo/metrics/metadata/event/MetadataSubDispatcher.java
@@ -50,6 +50,9 @@ public final class MetadataSubDispatcher extends SimpleMetricsEventMulticaster {
 
     }
 
+    /**
+     * A closer aggregation of MetricsCat, a summary collection of certain types of events
+     */
     interface CategorySet {
         CategoryOverall APPLICATION_PUSH = new CategoryOverall(OP_TYPE_PUSH, MCat.APPLICATION_PUSH_POST, MCat.APPLICATION_PUSH_FINISH, MCat.APPLICATION_PUSH_ERROR);
         CategoryOverall APPLICATION_SUBSCRIBE = new CategoryOverall(OP_TYPE_SUBSCRIBE, MCat.APPLICATION_SUBSCRIBE_POST, MCat.APPLICATION_SUBSCRIBE_FINISH, MCat.APPLICATION_SUBSCRIBE_ERROR);
@@ -58,6 +61,10 @@ public final class MetadataSubDispatcher extends SimpleMetricsEventMulticaster {
         List<CategoryOverall> ALL = Arrays.asList(APPLICATION_PUSH, APPLICATION_SUBSCRIBE, SERVICE_SUBSCRIBE);
     }
 
+    /**
+     *  {@link MetricsCat} MetricsCat collection, for better classification processing
+     *  Except for a few custom functions, most of them can build standard event listening functions through the static methods of MetricsApplicationListener
+     */
     interface MCat {
         // MetricsPushListener
         MetricsCat APPLICATION_PUSH_POST = new MetricsCat(MetricsKey.METADATA_PUSH_METRIC_NUM, MetricsApplicationListener::onPostEventBuild);

--- a/dubbo-metrics/dubbo-metrics-metadata/src/test/java/org/apache/dubbo/metrics/metadata/MetadataMetricsCollectorTest.java
+++ b/dubbo-metrics/dubbo-metrics-metadata/src/test/java/org/apache/dubbo/metrics/metadata/MetadataMetricsCollectorTest.java
@@ -211,7 +211,7 @@ class MetadataMetricsCollectorTest {
                 List<MetricSample> metricSamples = collector.collect();
 
                 // App(6) + service success(1)
-                Assertions.assertEquals(MetadataMetricsConstants.APP_LEVEL_KEYS.size() + 1, metricSamples.size());
+                Assertions.assertEquals(MetadataMetricsConstants.APP_LEVEL_KEYS.size() + MetadataMetricsConstants.SERVICE_LEVEL_KEYS.size(), metricSamples.size());
                 Assertions.assertTrue(metricSamples.stream().allMatch(metricSample -> metricSample instanceof GaugeMetricSample));
                 Assertions.assertTrue(metricSamples.stream().anyMatch(metricSample -> ((GaugeMetricSample) metricSample).applyAsDouble() == 1));
                 return null;
@@ -221,7 +221,7 @@ class MetadataMetricsCollectorTest {
         // push finish rt +1
         List<MetricSample> metricSamples = collector.collect();
         // App(6) + service total/success(2) + rt(5) = 7
-        Assertions.assertEquals(MetadataMetricsConstants.APP_LEVEL_KEYS.size() + 2 + 5, metricSamples.size());
+        Assertions.assertEquals(MetadataMetricsConstants.APP_LEVEL_KEYS.size() + MetadataMetricsConstants.SERVICE_LEVEL_KEYS.size() + 5, metricSamples.size());
 
         long c1 = metadataEvent.getTimePair().calc();
         metadataEvent = MetadataEvent.toServiceSubscribeEvent(applicationModel, serviceKey);

--- a/dubbo-metrics/dubbo-metrics-registry/src/main/java/org/apache/dubbo/metrics/registry/event/RegistrySubDispatcher.java
+++ b/dubbo-metrics/dubbo-metrics-registry/src/main/java/org/apache/dubbo/metrics/registry/event/RegistrySubDispatcher.java
@@ -58,6 +58,9 @@ public final class RegistrySubDispatcher extends SimpleMetricsEventMulticaster {
         });
     }
 
+    /**
+     * A closer aggregation of MetricsCat, a summary collection of certain types of events
+     */
     interface CategorySet {
         CategoryOverall APPLICATION_REGISTER = new CategoryOverall(OP_TYPE_REGISTER, MCat.APPLICATION_REGISTER_POST, MCat.APPLICATION_REGISTER_FINISH, MCat.APPLICATION_REGISTER_ERROR);
         CategoryOverall APPLICATION_SUBSCRIBE = new CategoryOverall(OP_TYPE_SUBSCRIBE, MCat.APPLICATION_SUBSCRIBE_POST, MCat.APPLICATION_SUBSCRIBE_FINISH, MCat.APPLICATION_SUBSCRIBE_ERROR);
@@ -70,6 +73,10 @@ public final class RegistrySubDispatcher extends SimpleMetricsEventMulticaster {
     }
 
 
+    /**
+     *  {@link MetricsCat} MetricsCat collection, for better classification processing
+     *  Except for a few custom functions, most of them can build standard event listening functions through the static methods of MetricsApplicationListener
+     */
     interface MCat {
         // MetricsRegisterListener
         MetricsCat APPLICATION_REGISTER_POST = new MetricsCat(MetricsKey.REGISTER_METRIC_REQUESTS, MetricsApplicationListener::onPostEventBuild);

--- a/dubbo-metrics/dubbo-metrics-registry/src/test/java/org/apache/dubbo/metrics/registry/metrics/collector/RegistryMetricsCollectorTest.java
+++ b/dubbo-metrics/dubbo-metrics-registry/src/test/java/org/apache/dubbo/metrics/registry/metrics/collector/RegistryMetricsCollectorTest.java
@@ -201,10 +201,10 @@ class RegistryMetricsCollectorTest {
                 List<MetricSample> metricSamples = collector.collect();
                 Assertions.assertTrue(metricSamples.stream().allMatch(metricSample -> metricSample instanceof GaugeMetricSample));
                 Assertions.assertTrue(metricSamples.stream().anyMatch(metricSample -> ((GaugeMetricSample) metricSample).applyAsDouble() == 1));
-                // App(7) + (service success +1)
-                Assertions.assertEquals(RegistryMetricsConstants.APP_LEVEL_KEYS.size() + 1, metricSamples.size());
+                // App(default=7) + (service success +1)
+                Assertions.assertEquals(RegistryMetricsConstants.APP_LEVEL_KEYS.size() + RegistryMetricsConstants.SERVICE_LEVEL_KEYS.size(), metricSamples.size());
                 // Service num only 1 and contains tag of interface
-                Assertions.assertEquals(1, metricSamples.stream().filter(metricSample -> serviceName.equals(metricSample.getTags().get("interface"))).count());
+                Assertions.assertEquals(RegistryMetricsConstants.SERVICE_LEVEL_KEYS.size(), metricSamples.stream().filter(metricSample -> serviceName.equals(metricSample.getTags().get("interface"))).count());
                 return null;
             }
         );
@@ -212,7 +212,7 @@ class RegistryMetricsCollectorTest {
         // push finish rt +1
         List<MetricSample> metricSamples = collector.collect();
         // App(7) + rt(5) + service(total/success) = 14
-        Assertions.assertEquals(RegistryMetricsConstants.APP_LEVEL_KEYS.size() + 5 + 2, metricSamples.size());
+        Assertions.assertEquals(RegistryMetricsConstants.APP_LEVEL_KEYS.size() + 5 + RegistryMetricsConstants.SERVICE_LEVEL_KEYS.size(), metricSamples.size());
 
         long c1 = subscribeEvent.getTimePair().calc();
         subscribeEvent = RegistryEvent.toSsEvent(applicationModel, serviceName);
@@ -233,7 +233,7 @@ class RegistryMetricsCollectorTest {
         metricSamples = collector.collect();
 
         // App(7) + rt(5) + service(total/success/failed) = 15
-        Assertions.assertEquals(RegistryMetricsConstants.APP_LEVEL_KEYS.size() + 5 + 3, metricSamples.size());
+        Assertions.assertEquals(RegistryMetricsConstants.APP_LEVEL_KEYS.size() + 5 + RegistryMetricsConstants.SERVICE_LEVEL_KEYS.size(), metricSamples.size());
 
         // calc rt
         for (MetricSample sample : metricSamples) {

--- a/dubbo-metrics/dubbo-metrics-registry/src/test/java/org/apache/dubbo/metrics/registry/metrics/collector/RegistryMetricsCollectorTest.java
+++ b/dubbo-metrics/dubbo-metrics-registry/src/test/java/org/apache/dubbo/metrics/registry/metrics/collector/RegistryMetricsCollectorTest.java
@@ -140,9 +140,9 @@ class RegistryMetricsCollectorTest {
                 List<MetricSample> metricSamples = collector.collect();
 
                 // push success +1
-                Assertions.assertEquals(RegistryMetricsConstants.APP_LEVEL_KEYS.size() + 1, metricSamples.size());
+                Assertions.assertEquals(RegistryMetricsConstants.APP_LEVEL_KEYS.size() + RegistryMetricsConstants.SERVICE_LEVEL_KEYS.size(), metricSamples.size());
                 // Service num only 1 and contains tag of interface
-                Assertions.assertEquals(1, metricSamples.stream().filter(metricSample -> serviceName.equals(metricSample.getTags().get("interface"))).count());
+                Assertions.assertEquals(RegistryMetricsConstants.SERVICE_LEVEL_KEYS.size(), metricSamples.stream().filter(metricSample -> serviceName.equals(metricSample.getTags().get("interface"))).count());
                 return null;
             }
         );
@@ -150,7 +150,7 @@ class RegistryMetricsCollectorTest {
         // push finish rt +1
         List<MetricSample> metricSamples = collector.collect();
         // App(7) + rt(5) + service(total/success) = 14
-        Assertions.assertEquals(RegistryMetricsConstants.APP_LEVEL_KEYS.size() + 5 + 2, metricSamples.size());
+        Assertions.assertEquals(RegistryMetricsConstants.APP_LEVEL_KEYS.size() + 5 + RegistryMetricsConstants.SERVICE_LEVEL_KEYS.size(), metricSamples.size());
 
         long c1 = registryEvent.getTimePair().calc();
         registryEvent = RegistryEvent.toRsEvent(applicationModel, serviceName, 2);
@@ -171,7 +171,7 @@ class RegistryMetricsCollectorTest {
         metricSamples = collector.collect();
 
         // App(7) + rt(5) + service(total/success/failed) = 15
-        Assertions.assertEquals(RegistryMetricsConstants.APP_LEVEL_KEYS.size() + 5 + 3, metricSamples.size());
+        Assertions.assertEquals(RegistryMetricsConstants.APP_LEVEL_KEYS.size() + 5 + RegistryMetricsConstants.SERVICE_LEVEL_KEYS.size(), metricSamples.size());
 
         // calc rt
         for (MetricSample sample : metricSamples) {
@@ -254,6 +254,7 @@ class RegistryMetricsCollectorTest {
 
     @Test
     public void testNotify() {
+        Map<String, Integer> lastNumMap = new HashMap<>();
         MetricsEventBus.post(RegistryEvent.toNotifyEvent(applicationModel),
             () -> {
                 try {
@@ -261,7 +262,6 @@ class RegistryMetricsCollectorTest {
                 } catch (InterruptedException e) {
                     e.printStackTrace();
                 }
-                Map<String, Integer> lastNumMap = new HashMap<>();
                 // 1 different services
                 lastNumMap.put("demo.service1", 3);
                 lastNumMap.put("demo.service2", 4);
@@ -271,7 +271,7 @@ class RegistryMetricsCollectorTest {
         );
         List<MetricSample> metricSamples = collector.collect();
         // App(7) + num(service*3) + rt(5) = 9
-        Assertions.assertEquals(RegistryMetricsConstants.APP_LEVEL_KEYS.size() + 3 + 5, metricSamples.size());
+        Assertions.assertEquals((RegistryMetricsConstants.APP_LEVEL_KEYS.size() + 3 + 5)*3, metricSamples.size());
 
     }
 }


### PR DESCRIPTION
## What is the purpose of the change
1、For metrics data sets at the servce and method levels, if a key exists in a certain category of data, it should set the default 0 for other categories to make the data aligned
2、some code opt/ add metrics code comment。delete MetricsKey.formatName,It will change the attribute value of the enum causing ci to fail. 
3、MetricSample.Type changed from invocation to built-in property of MetricsKeyWrapper to avoid fillZero injecting a fixed key

## Verifying this change
add testcase.

# TYPE dubbo_registry_subscribe_service_num_total gauge
dubbo_registry_subscribe_service_num_total{application_module_id="1.1",application_name="dubbo-springboot-demo-provider",application_version="3.2.2-SNAPSHOT",git_commit_id="9df27cb8b256fed00928a4958e1977d6b51d1bcc",hostname="linyaoMac.local",interface="dubbo-springboot-demo-provider/org.apache.dubbo.metrics.service.MetricsService:1.0.0",ip="10.201.94.160",} 0.0
dubbo_registry_subscribe_service_num_total{application_module_id="1.1",application_name="dubbo-springboot-demo-provider",application_version="3.2.2-SNAPSHOT",git_commit_id="9df27cb8b256fed00928a4958e1977d6b51d1bcc",hostname="linyaoMac.local",interface="dubbo-springboot-demo-provider/org.apache.dubbo.metadata.MetadataService:1.0.0",ip="10.201.94.160",} 0.0
dubbo_registry_subscribe_service_num_total{application_module_id="1.1",application_name="dubbo-springboot-demo-provider",application_version="3.2.2-SNAPSHOT",git_commit_id="9df27cb8b256fed00928a4958e1977d6b51d1bcc",hostname="linyaoMac.local",interface="org.apache.dubbo.springboot.demo.DemoService",ip="10.201.94.160",} 0.0