### PR TITLE
Fix issue:12376

### DIFF
--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/RpcServiceContext.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/RpcServiceContext.java
@@ -143,7 +143,7 @@ public class RpcServiceContext extends RpcContext {
      */
     @Override
     public boolean isConsumerSide() {
-        return getUrl().getSide(PROVIDER_SIDE).equals(CONSUMER_SIDE);
+        return consumerUrl != null || getUrl().getSide(PROVIDER_SIDE).equals(CONSUMER_SIDE);
     }
 
     /**


### PR DESCRIPTION
It's better to remove setContext in AbstractClusterInvoker.invokeWithContext, which will set provider's url in consumer's Filter. Or only use consumerUrl to check whether is consumer side.

## What is the purpose of the change

Fix https://github.com/apache/dubbo/issues/12376

## Brief changelog

When checking RpcServiceContext.isConsumerSide, check consumerUrl is not null first.

## Verifying this change

I tested on my local env.

<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [x] Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [x] GitHub Actions works fine on your own branch.
- [x] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
