### PR TITLE
fix(sec): upgrade org.yaml:snakeyaml to 2.0

### DIFF
--- a/dubbo-dependencies-bom/pom.xml
+++ b/dubbo-dependencies-bom/pom.xml
@@ -129,7 +129,7 @@
         <fst_version>2.57</fst_version>
         <avro_version>1.11.1</avro_version>
         <apollo_client_version>2.1.0</apollo_client_version>
-        <snakeyaml_version>1.33</snakeyaml_version>
+        <snakeyaml_version>2.0</snakeyaml_version>
         <commons_lang3_version>3.12.0</commons_lang3_version>
         <protostuff_version>1.8.0</protostuff_version>
         <envoy_api_version>0.1.35</envoy_api_version>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.yaml:snakeyaml 1.33
- [CVE-2022-1471](https://www.oscs1024.com/hd/CVE-2022-1471)


### What did I do？
Upgrade org.yaml:snakeyaml from 1.33 to 2.0 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS