### PR TITLE
fix issue #12407

### DIFF
--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/router/state/AbstractStateRouter.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/router/state/AbstractStateRouter.java
@@ -116,9 +116,6 @@ public abstract class AbstractStateRouter<T> implements StateRouter<T> {
         BitList<Invoker<T>> routeResult;
 
         routeResult = doRoute(invokers, url, invocation, needToPrintMessage, nodeHolder, messageHolder);
-        if (routeResult != invokers) {
-            routeResult = invokers.and(routeResult);
-        }
         // check if router support call continue route by itself
         if (!supportContinueRoute()) {
             // use current node's result as next node's parameter


### PR DESCRIPTION
AbstractStateRouter类第120行invokers.and(routeResult)导致正确的Invoker被过滤

## What is the purpose of the change
修复 AbstractStateRouter类第120行invokers.and(routeResult)导致正确的Invoker被过滤问题


## Brief changelog
删除了 AbstractStateRouter 执行route之后的 and操作
此处的and操作无法选出自定义规则下正常的Invoker

## Verifying this change


<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [x] Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [x] GitHub Actions works fine on your own branch.
- [x] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
