### PR TITLE
support catch actual exception

### DIFF
--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/stream/TripleClientStream.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/stream/TripleClientStream.java
@@ -120,7 +120,6 @@ public class TripleClientStream extends AbstractStream implements ClientStream {
                     Channel channel = ctx.channel();
                     channel.pipeline().addLast(new TripleCommandOutBoundHandler());
                     channel.pipeline().addLast(new TripleHttp2ClientResponseHandler(createTransportListener()));
-                    channel.closeFuture().addListener(f -> transportException(f.cause()));
                 }
             });
         CreateStreamQueueCommand cmd = CreateStreamQueueCommand.create(bootstrap, streamChannelFuture);
@@ -149,7 +148,7 @@ public class TripleClientStream extends AbstractStream implements ClientStream {
     private void transportException(Throwable cause) {
         final TriRpcStatus status = TriRpcStatus.INTERNAL.withDescription("Http2 exception")
             .withCause(cause);
-        listener.onComplete(status, null);
+        listener.onComplete(status, null, null, false);
     }
 
     public ChannelFuture cancelByLocal(TriRpcStatus status) {


### PR DESCRIPTION
## What is the purpose of the change
support catch actual exception


# case
When the provider is offline, the consumer continues to send requests, and it is expected that the `ClosedChannelException` will be caught

# after
<img width="1800" alt="image" src="https://github.com/apache/dubbo/assets/42876375/10d30c8d-fa02-4d71-9308-599bbd9e4521">

# before
<img width="1631" alt="image" src="https://github.com/apache/dubbo/assets/42876375/e922a848-027c-44b1-8e47-2d458254e473">

