### PR TITLE
support passing detect context to help build netty handlers

### DIFF
--- a/dubbo-plugin/dubbo-qos/src/main/java/org/apache/dubbo/qos/pu/QosDetector.java
+++ b/dubbo-plugin/dubbo-qos/src/main/java/org/apache/dubbo/qos/pu/QosDetector.java
@@ -37,20 +37,20 @@ public class QosDetector implements ProtocolDetector {
     @Override
     public Result detect(ChannelBuffer in) {
         if(!QosEnableFlag) {
-            return Result.UNRECOGNIZED;
+            return Result.unrecognized();
         }
         Result h1Res = qosHTTP1Detector.detect(in);
-        if(h1Res.equals(Result.RECOGNIZED)) {
+        if(h1Res.equals(Result.recognized())) {
             return h1Res;
         }
         Result telRes = telnetDetector.detect(in);
-        if(telRes.equals(Result.RECOGNIZED)) {
+        if(telRes.equals(Result.recognized())) {
             return telRes;
         }
-        if(h1Res.equals(Result.NEED_MORE_DATA) || telRes.equals(Result.NEED_MORE_DATA)) {
-            return Result.NEED_MORE_DATA;
+        if(h1Res.equals(Result.needMoreData()) || telRes.equals(Result.needMoreData())) {
+            return Result.needMoreData();
         }
-        return Result.UNRECOGNIZED;
+        return Result.unrecognized();
     }
 
 }

--- a/dubbo-plugin/dubbo-qos/src/main/java/org/apache/dubbo/qos/pu/QosHTTP1Detector.java
+++ b/dubbo-plugin/dubbo-qos/src/main/java/org/apache/dubbo/qos/pu/QosHTTP1Detector.java
@@ -27,13 +27,13 @@ public class QosHTTP1Detector implements ProtocolDetector {
     @Override
     public Result detect(ChannelBuffer in) {
         if (in.readableBytes() < 2) {
-            return Result.NEED_MORE_DATA;
+            return Result.needMoreData();
         }
         final int magic = in.getByte(in.readerIndex());
         // h2 starts with "PR"
         if (isHttp(magic) && in.getByte(in.readerIndex()+1) != 'R' ){
-            return Result.RECOGNIZED;
+            return Result.recognized();
         }
-        return Result.UNRECOGNIZED;
+        return Result.unrecognized();
     }
 }

--- a/dubbo-plugin/dubbo-qos/src/main/java/org/apache/dubbo/qos/pu/TelnetDetector.java
+++ b/dubbo-plugin/dubbo-qos/src/main/java/org/apache/dubbo/qos/pu/TelnetDetector.java
@@ -43,20 +43,20 @@ public class TelnetDetector implements ProtocolDetector {
     @Override
     public Result detect(ChannelBuffer in) {
         if (in.readableBytes() >= MaxSize) {
-            return Result.UNRECOGNIZED;
+            return Result.unrecognized();
         }
         Result resCommand = commandDetect(in);
-        if (resCommand.equals(Result.RECOGNIZED)) {
+        if (resCommand.equals(Result.recognized())) {
             return resCommand;
         }
         Result resAyt = telnetAytDetect(in);
-        if (resAyt.equals(Result.RECOGNIZED)) {
+        if (resAyt.equals(Result.recognized())) {
             return resAyt;
         }
-        if (resAyt.equals(Result.UNRECOGNIZED) && resCommand.equals(Result.UNRECOGNIZED)) {
-            return Result.UNRECOGNIZED;
+        if (resAyt.equals(Result.unrecognized()) && resCommand.equals(Result.unrecognized())) {
+            return Result.unrecognized();
         }
-        return Result.NEED_MORE_DATA;
+        return Result.needMoreData();
     }
 
     private Result commandDetect(ChannelBuffer in) {
@@ -75,9 +75,9 @@ public class TelnetDetector implements ProtocolDetector {
         s = s.trim();
         CommandContext commandContext = TelnetCommandDecoder.decode(s);
         if (frameworkModel.getExtensionLoader(BaseCommand.class).hasExtension(commandContext.getCommandName())) {
-            return Result.RECOGNIZED;
+            return Result.recognized();
         }
-        return Result.UNRECOGNIZED;
+        return Result.unrecognized();
     }
 
     private Result telnetAytDetect(ChannelBuffer in) {
@@ -85,16 +85,16 @@ public class TelnetDetector implements ProtocolDetector {
         int prefaceLen = AytPreface.readableBytes();
         int bytesRead = min(in.readableBytes(), prefaceLen);
         if (bytesRead == 0 || !ChannelBuffers.prefixEquals(in, AytPreface, bytesRead)) {
-            return Result.UNRECOGNIZED;
+            return Result.unrecognized();
         }
         if (bytesRead == prefaceLen) {
             // we need to consume preface because it's not a qos command
             // consume and remember to mark, pu server handler reset reader index
             in.readBytes(AytPreface.readableBytes());
             in.markReaderIndex();
-            return Result.RECOGNIZED;
+            return Result.recognized();
         }
-        return Result.NEED_MORE_DATA;
+        return Result.needMoreData();
     }
 
 }

--- a/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/api/ProtocolDetector.java
+++ b/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/api/ProtocolDetector.java
@@ -19,16 +19,59 @@ package org.apache.dubbo.remoting.api;
 
 import org.apache.dubbo.remoting.buffer.ChannelBuffer;
 
+import java.util.HashMap;
+import java.util.Map;
+
 
 /**
  * Determine incoming bytes belong to the specific protocol.
- *
  */
 public interface ProtocolDetector {
 
     Result detect(ChannelBuffer in);
 
-    enum Result {
+    class Result {
+
+        private final Flag flag;
+
+        private final Map<String, String> detectContext = new HashMap<>(4);
+
+        private Result(Flag flag) {
+            this.flag = flag;
+        }
+
+        public void setAttribute(String key, String value) {
+            this.detectContext.put(key, value);
+        }
+
+        public String getAttribute(String key) {
+            return this.detectContext.get(key);
+        }
+
+        public void removeAttribute(String key) {
+            this.detectContext.remove(key);
+        }
+
+        public Flag flag() {
+            return flag;
+        }
+
+        public static Result recognized(){
+            return new Result(Flag.RECOGNIZED);
+        }
+
+
+        public static Result unrecognized(){
+            return new Result(Flag.UNRECOGNIZED);
+        }
+
+
+        public static Result needMoreData(){
+            return new Result(Flag.NEED_MORE_DATA);
+        }
+    }
+
+    enum Flag {
         RECOGNIZED, UNRECOGNIZED, NEED_MORE_DATA
     }
 }

--- a/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/api/pu/ChannelOperator.java
+++ b/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/api/pu/ChannelOperator.java
@@ -17,9 +17,12 @@
 package org.apache.dubbo.remoting.api.pu;
 
 import org.apache.dubbo.remoting.ChannelHandler;
+import org.apache.dubbo.remoting.api.ProtocolDetector;
 
 import java.util.List;
 
 public interface ChannelOperator {
     void configChannelHandler(List<ChannelHandler> handlerList);
+
+    ProtocolDetector.Result detectResult();
 }

--- a/dubbo-remoting/dubbo-remoting-netty4/src/main/java/org/apache/dubbo/remoting/transport/netty4/NettyConfigOperator.java
+++ b/dubbo-remoting/dubbo-remoting-netty4/src/main/java/org/apache/dubbo/remoting/transport/netty4/NettyConfigOperator.java
@@ -24,6 +24,7 @@ import org.apache.dubbo.remoting.ChannelHandler;
 import org.apache.dubbo.remoting.Codec;
 import org.apache.dubbo.remoting.Codec2;
 import org.apache.dubbo.remoting.Constants;
+import org.apache.dubbo.remoting.api.ProtocolDetector;
 import org.apache.dubbo.remoting.api.pu.ChannelHandlerPretender;
 import org.apache.dubbo.remoting.api.pu.ChannelOperator;
 import org.apache.dubbo.remoting.api.pu.DefaultCodec;
@@ -35,6 +36,8 @@ public class NettyConfigOperator implements ChannelOperator {
 
     private final Channel channel;
     private ChannelHandler handler;
+
+    private ProtocolDetector.Result detectResult;
 
     public NettyConfigOperator(NettyChannel channel, ChannelHandler handler) {
         this.channel = channel;
@@ -89,6 +92,15 @@ public class NettyConfigOperator implements ChannelOperator {
                 sh
             );
         }
+    }
+
+    public void setDetectResult(ProtocolDetector.Result detectResult) {
+        this.detectResult = detectResult;
+    }
+
+    @Override
+    public ProtocolDetector.Result detectResult() {
+        return detectResult;
     }
 
     private boolean isClientSide(Channel channel) {

--- a/dubbo-remoting/dubbo-remoting-netty4/src/main/java/org/apache/dubbo/remoting/transport/netty4/NettyPortUnificationServerHandler.java
+++ b/dubbo-remoting/dubbo-remoting-netty4/src/main/java/org/apache/dubbo/remoting/transport/netty4/NettyPortUnificationServerHandler.java
@@ -107,7 +107,7 @@ public class NettyPortUnificationServerHandler extends ByteToMessageDecoder {
                 ChannelBuffer buf = new NettyBackedChannelBuffer(in);
                 final ProtocolDetector.Result result = protocol.detector().detect(buf);
                 in.resetReaderIndex();
-                switch (result) {
+                switch (result.flag()) {
                     case UNRECOGNIZED:
                         continue;
                     case RECOGNIZED:
@@ -117,6 +117,7 @@ public class NettyPortUnificationServerHandler extends ByteToMessageDecoder {
                         URL localURL = this.urlMapper.getOrDefault(protocolName, url);
                         channel.setUrl(localURL);
                         NettyConfigOperator operator = new NettyConfigOperator(channel, localHandler);
+                        operator.setDetectResult(result);
                         protocol.configServerProtocolHandler(url, operator);
                         ctx.pipeline().remove(this);
                     case NEED_MORE_DATA:

--- a/dubbo-rpc/dubbo-rpc-dubbo/src/main/java/org/apache/dubbo/rpc/protocol/dubbo/pu/DubboDetector.java
+++ b/dubbo-rpc/dubbo-rpc-dubbo/src/main/java/org/apache/dubbo/rpc/protocol/dubbo/pu/DubboDetector.java
@@ -36,12 +36,12 @@ public class DubboDetector implements ProtocolDetector {
         int bytesRead = min(in.readableBytes(), prefaceLen);
 
         if (bytesRead ==0 || !ChannelBuffers.prefixEquals(in,  Preface,  bytesRead)) {
-            return Result.UNRECOGNIZED;
+            return Result.unrecognized();
         }
         if (bytesRead == prefaceLen) {
-            return Result.RECOGNIZED;
+            return Result.recognized();
         }
 
-        return Result.NEED_MORE_DATA;
+        return Result.needMoreData();
     }
 }

--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/Http2ProtocolDetector.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/Http2ProtocolDetector.java
@@ -36,11 +36,11 @@ public class Http2ProtocolDetector implements ProtocolDetector {
 
         // If the input so far doesn't match the preface, break the connection.
         if (bytesRead == 0 || !ChannelBuffers.prefixEquals(in, clientPrefaceString, bytesRead)) {
-            return Result.UNRECOGNIZED;
+            return Result.unrecognized();
         }
         if (bytesRead == prefaceLen) {
-            return Result.RECOGNIZED;
+            return Result.recognized();
         }
-        return Result.NEED_MORE_DATA;
+        return Result.needMoreData();
     }
 }

--- a/dubbo-rpc/dubbo-rpc-triple/src/test/java/org/apache/dubbo/rpc/protocol/tri/Http2ProtocolDetectorTest.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/test/java/org/apache/dubbo/rpc/protocol/tri/Http2ProtocolDetectorTest.java
@@ -42,16 +42,16 @@ class Http2ProtocolDetectorTest {
         ByteBuf byteBuf = ByteBufAllocator.DEFAULT.buffer();
         ChannelBuffer in = new ByteBufferBackedChannelBuffer(byteBuf.nioBuffer());
         ProtocolDetector.Result result = detector.detect(in);
-        Assertions.assertEquals(result, ProtocolDetector.Result.UNRECOGNIZED);
+        Assertions.assertEquals(result.flag(), ProtocolDetector.Result.unrecognized().flag());
 
         byteBuf.writeBytes(connectionPrefaceBuf);
         result = detector.detect(new ByteBufferBackedChannelBuffer(byteBuf.nioBuffer()));
-        Assertions.assertEquals(result, ProtocolDetector.Result.RECOGNIZED);
+        Assertions.assertEquals(result.flag(), ProtocolDetector.Result.recognized().flag());
 
         byteBuf.clear();
         byteBuf.writeBytes(connectionPrefaceBuf, 0, 1);
         result = detector.detect(new ByteBufferBackedChannelBuffer(byteBuf.nioBuffer()));
-        Assertions.assertEquals(result, ProtocolDetector.Result.NEED_MORE_DATA);
+        Assertions.assertEquals(result.flag(), ProtocolDetector.Result.needMoreData().flag());
 
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

Support passing detect context to help build netty handlers.

Supports multiple versions of the same protocol, for example: HTTP -> HTTP1, HTTP2, HTTP3

## Brief changelog




