### PR TITLE
feat: add Duration as SIMPLE_TYPE and Convert

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/convert/StringToDurationConverter.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/convert/StringToDurationConverter.java
@@ -1,0 +1,243 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.common.convert;
+
+import org.apache.dubbo.common.utils.Assert;
+import org.apache.dubbo.common.utils.StringUtils;
+
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+import java.util.function.Function;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.apache.dubbo.common.utils.StringUtils.isNotEmpty;
+
+public class StringToDurationConverter implements StringConverter<Duration> {
+
+    @Override
+    public Duration convert(String source) {
+        return isNotEmpty(source) ? DurationStyle.detectAndParse(source) : null;
+    }
+
+    @Override
+    public int getPriority() {
+        return NORMAL_PRIORITY + 10;
+    }
+
+    /**
+     * @author Phillip Webb
+     * @author Valentine Wu
+     * @link {org.springframework.boot.convert.DurationStyle}
+     */
+    enum DurationStyle {
+
+        /**
+         * Simple formatting, for example '1s'.
+         */
+        SIMPLE("^([+-]?\\d+)([a-zA-Z]{0,2})$") {
+            @Override
+            public Duration parse(String value, ChronoUnit unit) {
+                try {
+                    Matcher matcher = matcher(value);
+                    Assert.assertTrue(matcher.matches(), "Does not match simple duration pattern");
+                    String suffix = matcher.group(2);
+                    return (StringUtils.isNotBlank(suffix) ? TimeUnit.fromSuffix(suffix) : TimeUnit.fromChronoUnit(unit))
+                            .parse(matcher.group(1));
+                } catch (Exception ex) {
+                    throw new IllegalArgumentException("'" + value + "' is not a valid simple duration", ex);
+                }
+            }
+
+        },
+
+        /**
+         * ISO-8601 formatting.
+         */
+        ISO8601("^[+-]?[pP].*$") {
+            @Override
+            public Duration parse(String value, ChronoUnit unit) {
+                try {
+                    return Duration.parse(value);
+                } catch (Exception ex) {
+                    throw new IllegalArgumentException("'" + value + "' is not a valid ISO-8601 duration", ex);
+                }
+            }
+
+        };
+
+        private final Pattern pattern;
+
+        DurationStyle(String pattern) {
+            this.pattern = Pattern.compile(pattern);
+        }
+
+        protected final boolean matches(String value) {
+            return this.pattern.matcher(value).matches();
+        }
+
+        protected final Matcher matcher(String value) {
+            return this.pattern.matcher(value);
+        }
+
+        /**
+         * Parse the given value to a duration.
+         *
+         * @param value the value to parse
+         * @return a duration
+         */
+        public Duration parse(String value) {
+            return parse(value, null);
+        }
+
+        /**
+         * Parse the given value to a duration.
+         *
+         * @param value the value to parse
+         * @param unit  the duration unit to use if the value doesn't specify one ({@code null}
+         *              will default to ms)
+         * @return a duration
+         */
+        public abstract Duration parse(String value, ChronoUnit unit);
+
+        /**
+         * Detect the style then parse the value to return a duration.
+         *
+         * @param value the value to parse
+         * @return the parsed duration
+         * @throws IllegalArgumentException if the value is not a known style or cannot be
+         *                                  parsed
+         */
+        public static Duration detectAndParse(String value) {
+            return detectAndParse(value, null);
+        }
+
+        /**
+         * Detect the style then parse the value to return a duration.
+         *
+         * @param value the value to parse
+         * @param unit  the duration unit to use if the value doesn't specify one ({@code null}
+         *              will default to ms)
+         * @return the parsed duration
+         * @throws IllegalArgumentException if the value is not a known style or cannot be
+         *                                  parsed
+         */
+        public static Duration detectAndParse(String value, ChronoUnit unit) {
+            return detect(value).parse(value, unit);
+        }
+
+        /**
+         * Detect the style from the given source value.
+         *
+         * @param value the source value
+         * @return the duration style
+         * @throws IllegalArgumentException if the value is not a known style
+         */
+        public static DurationStyle detect(String value) {
+            Assert.notNull(value, "Value must not be null");
+            for (DurationStyle candidate : values()) {
+                if (candidate.matches(value)) {
+                    return candidate;
+                }
+            }
+            throw new IllegalArgumentException("'" + value + "' is not a valid duration");
+        }
+
+        /**
+         * Time Unit that support.
+         */
+        enum TimeUnit {
+
+            /**
+             * Nanoseconds.
+             */
+            NANOS(ChronoUnit.NANOS, "ns", Duration::toNanos),
+
+            /**
+             * Microseconds.
+             */
+            MICROS(ChronoUnit.MICROS, "us", (duration) -> duration.toNanos() / 1000L),
+
+            /**
+             * Milliseconds.
+             */
+            MILLIS(ChronoUnit.MILLIS, "ms", Duration::toMillis),
+
+            /**
+             * Seconds.
+             */
+            SECONDS(ChronoUnit.SECONDS, "s", Duration::getSeconds),
+
+            /**
+             * Minutes.
+             */
+            MINUTES(ChronoUnit.MINUTES, "m", Duration::toMinutes),
+
+            /**
+             * Hours.
+             */
+            HOURS(ChronoUnit.HOURS, "h", Duration::toHours),
+
+            /**
+             * Days.
+             */
+            DAYS(ChronoUnit.DAYS, "d", Duration::toDays);
+
+            private final ChronoUnit chronoUnit;
+
+            private final String suffix;
+
+            private final Function<Duration, Long> longValue;
+
+            TimeUnit(ChronoUnit chronoUnit, String suffix, Function<Duration, Long> toUnit) {
+                this.chronoUnit = chronoUnit;
+                this.suffix = suffix;
+                this.longValue = toUnit;
+            }
+
+            public Duration parse(String value) {
+                return Duration.of(Long.parseLong(value), this.chronoUnit);
+            }
+
+            public long longValue(Duration value) {
+                return this.longValue.apply(value);
+            }
+
+            public static TimeUnit fromChronoUnit(ChronoUnit chronoUnit) {
+                if (chronoUnit == null) {
+                    return TimeUnit.MILLIS;
+                }
+                for (TimeUnit candidate : values()) {
+                    if (candidate.chronoUnit == chronoUnit) {
+                        return candidate;
+                    }
+                }
+                throw new IllegalArgumentException("Unknown unit " + chronoUnit);
+            }
+
+            public static TimeUnit fromSuffix(String suffix) {
+                for (TimeUnit candidate : values()) {
+                    if (candidate.suffix.equalsIgnoreCase(suffix)) {
+                        return candidate;
+                    }
+                }
+                throw new IllegalArgumentException("Unknown unit '" + suffix + "'");
+            }
+
+        }
+    }
+}

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/utils/ClassUtils.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/utils/ClassUtils.java
@@ -24,6 +24,7 @@ import java.lang.reflect.Array;
 import java.lang.reflect.Method;
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
@@ -87,7 +88,8 @@ public class ClassUtils {
         BigDecimal.class,
         BigInteger.class,
         Date.class,
-        Object.class
+        Object.class,
+        Duration.class
     );
     /**
      * Prefix for internal array class names: "[L"

--- a/dubbo-common/src/main/java/org/apache/dubbo/config/context/ConfigManager.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/config/context/ConfigManager.java
@@ -254,6 +254,7 @@ public class ConfigManager extends AbstractConfigManager implements ApplicationE
         // load dubbo.metrics.xxx
         loadConfigsOfTypeFromProps(MetricsConfig.class);
 
+        //load dubbo.tracing.xxx
         loadConfigsOfTypeFromProps(TracingConfig.class);
 
         // load multiple config types:

--- a/dubbo-common/src/main/resources/META-INF/dubbo/internal/org.apache.dubbo.common.convert.Converter
+++ b/dubbo-common/src/main/resources/META-INF/dubbo/internal/org.apache.dubbo.common.convert.Converter
@@ -10,3 +10,4 @@ string-to-optional=org.apache.dubbo.common.convert.StringToOptionalConverter
 string-to-short=org.apache.dubbo.common.convert.StringToShortConverter
 string-to-string=org.apache.dubbo.common.convert.StringToStringConverter
 string-to-byte=org.apache.dubbo.common.convert.StringToByteConverter
+string-to-duration=org.apache.dubbo.common.convert.StringToDurationConverter

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/convert/StringToDurationConverterTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/convert/StringToDurationConverterTest.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.common.convert;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+
+import static org.apache.dubbo.common.extension.ExtensionLoader.getExtensionLoader;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * {@link StringToDurationConverter} Test
+ *
+ * @since 3.2.3
+ */
+class StringToDurationConverterTest {
+
+    private StringToDurationConverter converter;
+
+    @BeforeEach
+    public void init() {
+        converter = (StringToDurationConverter) getExtensionLoader(Converter.class).getExtension("string-to-duration");
+    }
+
+    @Test
+    void testAccept() {
+        assertTrue(converter.accept(String.class, Duration.class));
+    }
+
+    @Test
+    void testConvert() {
+        assertEquals(Duration.ofMillis(1000), converter.convert("1000ms"));
+        assertEquals(Duration.ofSeconds(1), converter.convert("1s"));
+        assertEquals(Duration.ofMinutes(1), converter.convert("1m"));
+        assertEquals(Duration.ofHours(1), converter.convert("1h"));
+        assertEquals(Duration.ofDays(1), converter.convert("1d"));
+
+        assertNull(converter.convert(null));
+        assertThrows(IllegalArgumentException.class, () -> {
+            converter.convert("ttt");
+        });
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

I found Dubbo can not convert String to Duration.class in config from #12453 

So I resloved it.

![image](https://github.com/apache/dubbo/assets/56248584/9a473472-cca4-430f-8163-ee87b4aa8f8f)


## Brief changelog


## Verifying this change


<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [ ] GitHub Actions works fine on your own branch.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
