### PR TITLE
Fix ServiceConfig Ref unable to toString

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/utils/ToStringUtils.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/utils/ToStringUtils.java
@@ -16,7 +16,11 @@
  */
 package org.apache.dubbo.common.utils;
 
+import org.apache.dubbo.config.AbstractConfig;
+
 import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
 
 public class ToStringUtils {
 
@@ -35,5 +39,64 @@ public class ToStringUtils {
             }
             return obj.toString();
         }
+    }
+
+    public static String toString(Object obj) {
+        if (obj == null) {
+            return "null";
+        }
+        if (ClassUtils.isSimpleType(obj.getClass())) {
+            return obj.toString();
+        }
+        if (obj.getClass().isPrimitive()) {
+            return obj.toString();
+        }
+        if (obj instanceof Object[]) {
+            StringBuilder stringBuilder = new StringBuilder();
+            stringBuilder.append("[");
+            Object[] objects = (Object[]) obj;
+            for (int i = 0; i < objects.length; i++) {
+                stringBuilder.append(toString(objects[i]));
+                if (i != objects.length - 1) {
+                    stringBuilder.append(", ");
+                }
+            }
+            stringBuilder.append("]");
+            return stringBuilder.toString();
+        }
+        if (obj instanceof List) {
+            StringBuilder stringBuilder = new StringBuilder();
+            stringBuilder.append("[");
+            List list = (List) obj;
+            for (int i = 0; i < list.size(); i++) {
+                stringBuilder.append(toString(list.get(i)));
+                if (i != list.size() - 1) {
+                    stringBuilder.append(", ");
+                }
+            }
+            stringBuilder.append("]");
+            return stringBuilder.toString();
+        }
+        if (obj instanceof Map) {
+            StringBuilder stringBuilder = new StringBuilder();
+            stringBuilder.append("{");
+            Map map = (Map) obj;
+            int i = 0;
+            for (Object key : map.keySet()) {
+                stringBuilder.append(toString(key));
+                stringBuilder.append("=");
+                stringBuilder.append(toString(map.get(key)));
+                if (i != map.size() - 1) {
+                    stringBuilder.append(", ");
+                }
+                i++;
+            }
+            stringBuilder.append("}");
+            return stringBuilder.toString();
+        }
+        if (obj instanceof AbstractConfig) {
+            return obj.toString();
+        }
+        return obj.getClass() + "@" + Integer.toHexString(System.identityHashCode(obj));
     }
 }

--- a/dubbo-common/src/main/java/org/apache/dubbo/config/AbstractConfig.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/config/AbstractConfig.java
@@ -31,6 +31,7 @@ import org.apache.dubbo.common.utils.FieldUtils;
 import org.apache.dubbo.common.utils.MethodUtils;
 import org.apache.dubbo.common.utils.ReflectUtils;
 import org.apache.dubbo.common.utils.StringUtils;
+import org.apache.dubbo.common.utils.ToStringUtils;
 import org.apache.dubbo.config.context.ConfigManager;
 import org.apache.dubbo.config.context.ConfigMode;
 import org.apache.dubbo.config.support.Nested;
@@ -967,7 +968,7 @@ public abstract class AbstractConfig implements Serializable {
                         buf.append(' ');
                         buf.append(key);
                         buf.append("=\"");
-                        buf.append(key.equals("password") ? "******" : value);
+                        buf.append(key.equals("password") ? "******" : ToStringUtils.toString(value));
                         buf.append('\"');
                     }
                 } catch (Exception e) {

--- a/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/ServiceConfigTest.java
+++ b/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/ServiceConfigTest.java
@@ -683,4 +683,20 @@ class ServiceConfigTest {
 
         scheduledExecutorService.shutdown();
     }
+
+    @Test
+    void testToString() {
+        ServiceConfig<DemoService> serviceConfig = new ServiceConfig<>();
+        service.setRef(new DemoServiceImpl() {
+            @Override
+            public String toString() {
+                throw new IllegalStateException();
+            }
+        });
+        try {
+            serviceConfig.toString();
+        } catch (Throwable t) {
+            Assertions.fail(t);
+        }
+    }
 }


### PR DESCRIPTION
## What is the purpose of the change



## Brief changelog
```java
    @Test
    void testToString() {
        ServiceConfig<DemoService> serviceConfig = new ServiceConfig<>();
        service.setRef(new DemoServiceImpl() {
            @Override
            public String toString() {
                throw new IllegalStateException();
            }
        });
        try {
            serviceConfig.toString();
        } catch (Throwable t) {
            Assertions.fail(t);
        }
    }
```

## Verifying this change


<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [ ] GitHub Actions works fine on your own branch.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
