### PR TITLE
add tri native image support

### DIFF
--- a/dubbo-remoting/dubbo-remoting-netty4/src/main/java/org/apache/dubbo/remoting/transport/netty4/aot/Netty4ReflectionTypeDescriberRegistrar.java
+++ b/dubbo-remoting/dubbo-remoting-netty4/src/main/java/org/apache/dubbo/remoting/transport/netty4/aot/Netty4ReflectionTypeDescriberRegistrar.java
@@ -19,11 +19,15 @@ package org.apache.dubbo.remoting.transport.netty4.aot;
 import org.apache.dubbo.aot.api.MemberCategory;
 import org.apache.dubbo.aot.api.ReflectionTypeDescriberRegistrar;
 import org.apache.dubbo.aot.api.TypeDescriber;
+import org.apache.dubbo.remoting.transport.netty4.NettyChannelHandler;
 import org.apache.dubbo.remoting.transport.netty4.NettyClientHandler;
+import org.apache.dubbo.remoting.transport.netty4.NettyConnectionHandler;
+import org.apache.dubbo.remoting.transport.netty4.NettyPortUnificationServerHandler;
 import org.apache.dubbo.remoting.transport.netty4.NettyServerHandler;
 import org.apache.dubbo.remoting.transport.netty4.ssl.SslClientTlsHandler;
 import org.apache.dubbo.remoting.transport.netty4.ssl.SslServerTlsHandler;
 
+import java.nio.channels.spi.SelectorProvider;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -35,16 +39,20 @@ public class Netty4ReflectionTypeDescriberRegistrar implements ReflectionTypeDes
     @Override
     public List<TypeDescriber> getTypeDescribers() {
         List<TypeDescriber> typeDescribers = new ArrayList<>();
-        typeDescribers.add(buildTypeDescriberWithDeclaredMethods(NettyServerHandler.class));
-        typeDescribers.add(buildTypeDescriberWithDeclaredMethods(SslServerTlsHandler.class));
-        typeDescribers.add(buildTypeDescriberWithDeclaredMethods(NettyClientHandler.class));
-        typeDescribers.add(buildTypeDescriberWithDeclaredMethods(SslClientTlsHandler.class));
+        typeDescribers.add(buildTypeDescriberWithPublicMethod(NettyServerHandler.class));
+        typeDescribers.add(buildTypeDescriberWithPublicMethod(SslServerTlsHandler.class));
+        typeDescribers.add(buildTypeDescriberWithPublicMethod(NettyClientHandler.class));
+        typeDescribers.add(buildTypeDescriberWithPublicMethod(SslClientTlsHandler.class));
+        typeDescribers.add(buildTypeDescriberWithPublicMethod(SelectorProvider.class));
+        typeDescribers.add(buildTypeDescriberWithPublicMethod(NettyPortUnificationServerHandler.class));
+        typeDescribers.add(buildTypeDescriberWithPublicMethod(NettyChannelHandler.class));
+        typeDescribers.add(buildTypeDescriberWithPublicMethod(NettyConnectionHandler.class));
         return typeDescribers;
     }
 
-    private TypeDescriber buildTypeDescriberWithDeclaredMethods(Class<?> c){
+    private TypeDescriber buildTypeDescriberWithPublicMethod(Class<?> cl) {
         Set<MemberCategory> memberCategories = new HashSet<>();
-        memberCategories.add(MemberCategory.INVOKE_DECLARED_METHODS);
-        return new TypeDescriber(c.getName(), null, new HashSet<>(), new HashSet<>(), new HashSet<>(), memberCategories);
+        memberCategories.add(MemberCategory.INVOKE_PUBLIC_METHODS);
+        return new TypeDescriber(cl.getName(), null, new HashSet<>(), new HashSet<>(), new HashSet<>(), memberCategories);
     }
 }

--- a/dubbo-rpc/dubbo-rpc-triple/pom.xml
+++ b/dubbo-rpc/dubbo-rpc-triple/pom.xml
@@ -86,6 +86,11 @@
             <artifactId>reactor-core</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.dubbo</groupId>
+            <artifactId>dubbo-native</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/aot/TripleReflectionTypeDescriberRegistrar.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/aot/TripleReflectionTypeDescriberRegistrar.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.rpc.protocol.tri.aot;
+
+import org.apache.dubbo.aot.api.MemberCategory;
+import org.apache.dubbo.aot.api.ReflectionTypeDescriberRegistrar;
+import org.apache.dubbo.aot.api.TypeDescriber;
+import org.apache.dubbo.rpc.protocol.tri.transport.TripleClientHandler;
+import org.apache.dubbo.rpc.protocol.tri.transport.TripleCommandOutBoundHandler;
+import org.apache.dubbo.rpc.protocol.tri.transport.TripleHttp2ClientResponseHandler;
+import org.apache.dubbo.rpc.protocol.tri.transport.TripleHttp2FrameServerHandler;
+import org.apache.dubbo.rpc.protocol.tri.transport.TripleServerConnectionHandler;
+import org.apache.dubbo.rpc.protocol.tri.transport.TripleTailHandler;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+public class TripleReflectionTypeDescriberRegistrar implements ReflectionTypeDescriberRegistrar {
+    @Override
+    public List<TypeDescriber> getTypeDescribers() {
+        List<TypeDescriber> typeDescribers = new ArrayList<>();
+        typeDescribers.add(buildTypeDescriberWithPublicMethod(TripleHttp2FrameServerHandler.class));
+        typeDescribers.add(buildTypeDescriberWithPublicMethod(TripleCommandOutBoundHandler.class));
+        typeDescribers.add(buildTypeDescriberWithPublicMethod(TripleTailHandler.class));
+        typeDescribers.add(buildTypeDescriberWithPublicMethod(TripleServerConnectionHandler.class));
+        typeDescribers.add(buildTypeDescriberWithPublicMethod(TripleClientHandler.class));
+        typeDescribers.add(buildTypeDescriberWithPublicMethod(TripleHttp2ClientResponseHandler.class));
+        return typeDescribers;
+    }
+
+    private TypeDescriber buildTypeDescriberWithPublicMethod(Class<?> c) {
+        Set<MemberCategory> memberCategories = new HashSet<>();
+        memberCategories.add(MemberCategory.INVOKE_PUBLIC_METHODS);
+        return new TypeDescriber(c.getName(), null, new HashSet<>(), new HashSet<>(), new HashSet<>(), memberCategories);
+    }
+}

--- a/dubbo-rpc/dubbo-rpc-triple/src/main/resources/META-INF/dubbo/internal/org.apache.dubbo.aot.api.ReflectionTypeDescriberRegistrar
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/resources/META-INF/dubbo/internal/org.apache.dubbo.aot.api.ReflectionTypeDescriberRegistrar
@@ -1,0 +1,1 @@
+tri=org.apache.dubbo.rpc.protocol.tri.aot.TripleReflectionTypeDescriberRegistrar


### PR DESCRIPTION
## What is the purpose of the change

fix #12535 
add tri native image support 

every netty channelHandler should have a reflect-config conf in native image build
as netty does https://github.com/netty/netty/pull/12794, https://github.com/netty/netty/pull/12738
otherwise will cause io.netty.channel.ChannelHandlerMask#isSkippable check failed

https://github.com/netty/netty/blob/4.1/transport/src/main/java/io/netty/channel/ChannelHandlerMask.java#L177


## Brief changelog


## Verifying this change


<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [x] Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [ ] GitHub Actions works fine on your own branch.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
