### PR TITLE
Use serviceKey when to metadata ServiceSubscribeEvent

### DIFF
--- a/dubbo-metadata/dubbo-metadata-api/src/main/java/org/apache/dubbo/metadata/report/identifier/MetadataIdentifier.java
+++ b/dubbo-metadata/dubbo-metadata-api/src/main/java/org/apache/dubbo/metadata/report/identifier/MetadataIdentifier.java
@@ -97,4 +97,8 @@ public class MetadataIdentifier extends BaseServiceMetadataIdentifier implements
         this.application = application;
     }
 
+    public String getUniqueServiceName() {
+        return serviceInterface != null ? URL.buildKey(serviceInterface, getGroup(), getVersion()) : null;
+    }
+
 }

--- a/dubbo-metadata/dubbo-metadata-api/src/main/java/org/apache/dubbo/metadata/report/support/AbstractMetadataReport.java
+++ b/dubbo-metadata/dubbo-metadata-api/src/main/java/org/apache/dubbo/metadata/report/support/AbstractMetadataReport.java
@@ -279,7 +279,7 @@ public abstract class AbstractMetadataReport implements MetadataReport {
 
     private void storeProviderMetadataTask(MetadataIdentifier providerMetadataIdentifier, ServiceDefinition serviceDefinition) {
 
-        MetadataEvent metadataEvent = MetadataEvent.toServiceSubscribeEvent(applicationModel, serviceDefinition.getCanonicalName());
+        MetadataEvent metadataEvent = MetadataEvent.toServiceSubscribeEvent(applicationModel, providerMetadataIdentifier.getUniqueServiceName());
         MetricsEventBus.post(metadataEvent, () ->
             {
                 boolean result = true;


### PR DESCRIPTION
## What is the purpose of the change
Issue Number: close https://github.com/apache/dubbo/issues/12532


## Brief changelog
Use serviceKey to replace interfaceName.
If a user service does not define version, it will still look like interfaceName

## Verifying this change
```
# HELP dubbo_registry_subscribe_num_total Total Subscribe Num
# TYPE dubbo_registry_subscribe_num_total gauge
dubbo_registry_subscribe_num_total{application_module_id="1.1",application_name="dubbo-springboot-demo-provider",application_version="",git_commit_id="",hostname="192.168.10.100",ip="192.168.10.100",} 0.0
# HELP dubbo_metadata_push_num_succeed_total Succeed Push Num
# TYPE dubbo_metadata_push_num_succeed_total gauge
dubbo_metadata_push_num_succeed_total{application_module_id="1.1",application_name="dubbo-springboot-demo-provider",application_version="",git_commit_id="",hostname="192.168.10.100",ip="192.168.10.100",} 0.0
# HELP jvm_buffer_total_capacity_bytes An estimate of the total capacity of the buffers in this pool
# TYPE jvm_buffer_total_capacity_bytes gauge
jvm_buffer_total_capacity_bytes{application_name="dubbo-springboot-demo-provider",id="direct",} 10963.0
jvm_buffer_total_capacity_bytes{application_name="dubbo-springboot-demo-provider",id="mapped",} 0.0
# HELP jvm_threads_peak_threads The peak live thread count since the Java virtual machine started or peak was reset
# TYPE jvm_threads_peak_threads gauge
jvm_threads_peak_threads{application_name="dubbo-springboot-demo-provider",} 38.0
# HELP jvm_gc_memory_promoted_bytes_total Count of positive increases in the size of the old generation memory pool before GC to after GC
# TYPE jvm_gc_memory_promoted_bytes_total counter
jvm_gc_memory_promoted_bytes_total{application_name="dubbo-springboot-demo-provider",} 1.9565296E7
# HELP dubbo_registry_register_requests_failed_total Failed Register Requests
# TYPE dubbo_registry_register_requests_failed_total gauge
dubbo_registry_register_requests_failed_total{application_module_id="1.1",application_name="dubbo-springboot-demo-provider",application_version="",git_commit_id="",hostname="192.168.10.100",ip="192.168.10.100",} 0.0
# HELP dubbo_register_service_rt_milliseconds_last Last Response Time
# TYPE dubbo_register_service_rt_milliseconds_last gauge
dubbo_register_service_rt_milliseconds_last{application_module_id="1.1",application_name="dubbo-springboot-demo-provider",application_version="",git_commit_id="",hostname="192.168.10.100",interface="dubbo-springboot-demo-provider/org.apache.dubbo.metadata.MetadataService:1.0.0",ip="192.168.10.100",} 128.0
dubbo_register_service_rt_milliseconds_last{application_module_id="1.1",application_name="dubbo-springboot-demo-provider",application_version="",git_commit_id="",hostname="192.168.10.100",interface="dubbo-springboot-demo-provider/org.apache.dubbo.metrics.service.MetricsService:1.0.0",ip="192.168.10.100",} 169.0
dubbo_register_service_rt_milliseconds_last{application_module_id="1.1",application_name="dubbo-springboot-demo-provider",application_version="",git_commit_id="",hostname="192.168.10.100",interface="org.apache.dubbo.springboot.demo.DemoService:1.0.1",ip="192.168.10.100",} 796.0
# HELP dubbo_registry_subscribe_service_num_total Total Service-Level Subscribe Num
# TYPE dubbo_registry_subscribe_service_num_total gauge
dubbo_registry_subscribe_service_num_total{application_module_id="1.1",application_name="dubbo-springboot-demo-provider",application_version="",git_commit_id="",hostname="192.168.10.100",interface="dubbo-springboot-demo-provider/org.apache.dubbo.metadata.MetadataService:1.0.0",ip="192.168.10.100",} 0.0
dubbo_registry_subscribe_service_num_total{application_module_id="1.1",application_name="dubbo-springboot-demo-provider",application_version="",git_commit_id="",hostname="192.168.10.100",interface="dubbo-springboot-demo-provider/org.apache.dubbo.metrics.service.MetricsService:1.0.0",ip="192.168.10.100",} 0.0
dubbo_registry_subscribe_service_num_total{application_module_id="1.1",application_name="dubbo-springboot-demo-provider",application_version="",git_commit_id="",hostname="192.168.10.100",interface="org.apache.dubbo.springboot.demo.DemoService:1.0.1",ip="192.168.10.100",} 0.0
# HELP dubbo_registry_directory_num_all All Directory Urls
# TYPE dubbo_registry_directory_num_all gauge
dubbo_registry_directory_num_all{application_module_id="1.1",application_name="dubbo-springboot-demo-provider",application_version="",git_commit_id="",hostname="192.168.10.100",interface="dubbo-springboot-demo-provider/org.apache.dubbo.metadata.MetadataService:1.0.0",ip="192.168.10.100",} 0.0
dubbo_registry_directory_num_all{application_module_id="1.1",application_name="dubbo-springboot-demo-provider",application_version="",git_commit_id="",hostname="192.168.10.100",interface="dubbo-springboot-demo-provider/org.apache.dubbo.metrics.service.MetricsService:1.0.0",ip="192.168.10.100",} 0.0
dubbo_registry_directory_num_all{application_module_id="1.1",application_name="dubbo-springboot-demo-provider",application_version="",git_commit_id="",hostname="192.168.10.100",interface="org.apache.dubbo.springboot.demo.DemoService:1.0.1",ip="192.168.10.100",} 0.0
# HELP jvm_classes_loaded_classes The number of classes that are currently loaded in the Java virtual machine
# TYPE jvm_classes_loaded_classes gauge
jvm_classes_loaded_classes{application_name="dubbo-springboot-demo-provider",} 7936.0
# HELP dubbo_registry_register_requests_succeed_total Succeed Register Requests
# TYPE dubbo_registry_register_requests_succeed_total gauge
dubbo_registry_register_requests_succeed_total{application_module_id="1.1",application_name="dubbo-springboot-demo-provider",application_version="",git_commit_id="",hostname="192.168.10.100",ip="192.168.10.100",} 1.0
# HELP dubbo_register_service_rt_milliseconds_sum Sum Response Time
# TYPE dubbo_register_service_rt_milliseconds_sum gauge
dubbo_register_service_rt_milliseconds_sum{application_module_id="1.1",application_name="dubbo-springboot-demo-provider",application_version="",git_commit_id="",hostname="192.168.10.100",interface="dubbo-springboot-demo-provider/org.apache.dubbo.metadata.MetadataService:1.0.0",ip="192.168.10.100",} 128.0
dubbo_register_service_rt_milliseconds_sum{application_module_id="1.1",application_name="dubbo-springboot-demo-provider",application_version="",git_commit_id="",hostname="192.168.10.100",interface="dubbo-springboot-demo-provider/org.apache.dubbo.metrics.service.MetricsService:1.0.0",ip="192.168.10.100",} 169.0
dubbo_register_service_rt_milliseconds_sum{application_module_id="1.1",application_name="dubbo-springboot-demo-provider",application_version="",git_commit_id="",hostname="192.168.10.100",interface="org.apache.dubbo.springboot.demo.DemoService:1.0.1",ip="192.168.10.100",} 796.0
# HELP jvm_threads_daemon_threads The current number of live daemon threads
# TYPE jvm_threads_daemon_threads gauge
jvm_threads_daemon_threads{application_name="dubbo-springboot-demo-provider",} 36.0
# HELP dubbo_metadata_store_provider_total Store Provider Metadata
# TYPE dubbo_metadata_store_provider_total gauge
dubbo_metadata_store_provider_total{application_module_id="1.1",application_name="dubbo-springboot-demo-provider",application_version="",git_commit_id="",hostname="192.168.10.100",interface="org.apache.dubbo.springboot.demo.DemoService:1.0.1",ip="192.168.10.100",} 1.0
# HELP jvm_gc_max_data_size_bytes Max size of long-lived heap memory pool
# TYPE jvm_gc_max_data_size_bytes gauge
jvm_gc_max_data_size_bytes{application_name="dubbo-springboot-demo-provider",} 2.863661056E9
# HELP dubbo_thread_pool_core_size Thread Pool Core Size
# TYPE dubbo_thread_pool_core_size gauge
dubbo_thread_pool_core_size{application_name="dubbo-springboot-demo-provider",hostname="192.168.10.100",ip="192.168.10.100",pid="25941",thread_pool_name="DubboServerHandler-20880",} 200.0
dubbo_thread_pool_core_size{application_name="dubbo-springboot-demo-provider",hostname="192.168.10.100",ip="192.168.10.100",pid="25941",thread_pool_name="sharedExecutor",} 0.0
dubbo_thread_pool_core_size{application_name="dubbo-springboot-demo-provider",hostname="192.168.10.100",ip="192.168.10.100",pid="25941",thread_pool_name="DubboServerHandler-dubbo-springboot-demo-provider/org.apache.dubbo.metrics.service.MetricsService:1.0.0",} 0.0
dubbo_thread_pool_core_size{application_name="dubbo-springboot-demo-provider",hostname="192.168.10.100",ip="192.168.10.100",pid="25941",thread_pool_name="DubboServerHandler-dubbo-springboot-demo-provider/org.apache.dubbo.metadata.MetadataService:1.0.0",} 0.0
# HELP jvm_gc_pause_seconds Time spent in GC pause
# TYPE jvm_gc_pause_seconds summary
jvm_gc_pause_seconds_count{action="end of minor GC",application_name="dubbo-springboot-demo-provider",cause="Metadata GC Threshold",gc="PS Scavenge",} 2.0
jvm_gc_pause_seconds_sum{action="end of minor GC",application_name="dubbo-springboot-demo-provider",cause="Metadata GC Threshold",gc="PS Scavenge",} 0.026
jvm_gc_pause_seconds_count{action="end of major GC",application_name="dubbo-springboot-demo-provider",cause="Metadata GC Threshold",gc="PS MarkSweep",} 2.0
jvm_gc_pause_seconds_sum{action="end of major GC",application_name="dubbo-springboot-demo-provider",cause="Metadata GC Threshold",gc="PS MarkSweep",} 0.134
# HELP jvm_gc_pause_seconds_max Time spent in GC pause
# TYPE jvm_gc_pause_seconds_max gauge
jvm_gc_pause_seconds_max{action="end of minor GC",application_name="dubbo-springboot-demo-provider",cause="Metadata GC Threshold",gc="PS Scavenge",} 0.013
jvm_gc_pause_seconds_max{action="end of major GC",application_name="dubbo-springboot-demo-provider",cause="Metadata GC Threshold",gc="PS MarkSweep",} 0.067
# HELP dubbo_thread_pool_largest_size Thread Pool Largest Size
# TYPE dubbo_thread_pool_largest_size gauge
dubbo_thread_pool_largest_size{application_name="dubbo-springboot-demo-provider",hostname="192.168.10.100",ip="192.168.10.100",pid="25941",thread_pool_name="DubboServerHandler-20880",} 0.0
dubbo_thread_pool_largest_size{application_name="dubbo-springboot-demo-provider",hostname="192.168.10.100",ip="192.168.10.100",pid="25941",thread_pool_name="sharedExecutor",} 0.0
dubbo_thread_pool_largest_size{application_name="dubbo-springboot-demo-provider",hostname="192.168.10.100",ip="192.168.10.100",pid="25941",thread_pool_name="DubboServerHandler-dubbo-springboot-demo-provider/org.apache.dubbo.metrics.service.MetricsService:1.0.0",} 0.0
dubbo_thread_pool_largest_size{application_name="dubbo-springboot-demo-provider",hostname="192.168.10.100",ip="192.168.10.100",pid="25941",thread_pool_name="DubboServerHandler-dubbo-springboot-demo-provider/org.apache.dubbo.metadata.MetadataService:1.0.0",} 0.0
# HELP dubbo_store_provider_interface_rt_milliseconds_min Min Response Time
# TYPE dubbo_store_provider_interface_rt_milliseconds_min gauge
dubbo_store_provider_interface_rt_milliseconds_min{application_module_id="1.1",application_name="dubbo-springboot-demo-provider",application_version="",git_commit_id="",hostname="192.168.10.100",interface="org.apache.dubbo.springboot.demo.DemoService:1.0.1",ip="192.168.10.100",} 149.0
# HELP dubbo_registry_register_service_succeed_total Succeed Service-Level Register Requests
# TYPE dubbo_registry_register_service_succeed_total gauge
dubbo_registry_register_service_succeed_total{application_module_id="1.1",application_name="dubbo-springboot-demo-provider",application_version="",git_commit_id="",hostname="192.168.10.100",interface="dubbo-springboot-demo-provider/org.apache.dubbo.metadata.MetadataService:1.0.0",ip="192.168.10.100",} 1.0
dubbo_registry_register_service_succeed_total{application_module_id="1.1",application_name="dubbo-springboot-demo-provider",application_version="",git_commit_id="",hostname="192.168.10.100",interface="dubbo-springboot-demo-provider/org.apache.dubbo.metrics.service.MetricsService:1.0.0",ip="192.168.10.100",} 1.0
dubbo_registry_register_service_succeed_total{application_module_id="1.1",application_name="dubbo-springboot-demo-provider",application_version="",git_commit_id="",hostname="192.168.10.100",interface="org.apache.dubbo.springboot.demo.DemoService:1.0.1",ip="192.168.10.100",} 1.0
# HELP dubbo_store_provider_interface_rt_milliseconds_last Last Response Time
# TYPE dubbo_store_provider_interface_rt_milliseconds_last gauge
dubbo_store_provider_interface_rt_milliseconds_last{application_module_id="1.1",application_name="dubbo-springboot-demo-provider",application_version="",git_commit_id="",hostname="192.168.10.100",interface="org.apache.dubbo.springboot.demo.DemoService:1.0.1",ip="192.168.10.100",} 149.0
# HELP system_load_average_1m The sum of the number of runnable entities queued to available processors and the number of runnable entities running on the available processors averaged over a period of time
# TYPE system_load_average_1m gauge
system_load_average_1m{application_name="dubbo-springboot-demo-provider",} 3.66259765625
# HELP dubbo_configcenter_total Config Changed Total
# TYPE dubbo_configcenter_total gauge
dubbo_configcenter_total{application_name="dubbo-springboot-demo-provider",change_type="added",config_center="zookeeper",group="dubbo-springboot-demo-provider",hostname="192.168.10.100",ip="192.168.10.100",key="dubbo.properties",} 0.0
dubbo_configcenter_total{application_name="dubbo-springboot-demo-provider",change_type="added",config_center="zookeeper",group="dubbo",hostname="192.168.10.100",ip="192.168.10.100",key="dubbo.properties",} 0.0
# HELP dubbo_registry_subscribe_num_succeed_total Succeed Subscribe Num
# TYPE dubbo_registry_subscribe_num_succeed_total gauge
dubbo_registry_subscribe_num_succeed_total{application_module_id="1.1",application_name="dubbo-springboot-demo-provider",application_version="",git_commit_id="",hostname="192.168.10.100",ip="192.168.10.100",} 0.0
# HELP dubbo_register_rt_milliseconds_sum Sum Response Time
# TYPE dubbo_register_rt_milliseconds_sum gauge
dubbo_register_rt_milliseconds_sum{application_module_id="1.1",application_name="dubbo-springboot-demo-provider",application_version="",git_commit_id="",hostname="192.168.10.100",ip="192.168.10.100",} 16.0
# HELP dubbo_register_rt_milliseconds_max Max Response Time
# TYPE dubbo_register_rt_milliseconds_max gauge
dubbo_register_rt_milliseconds_max{application_module_id="1.1",application_name="dubbo-springboot-demo-provider",application_version="",git_commit_id="",hostname="192.168.10.100",ip="192.168.10.100",} 16.0
# HELP jvm_memory_max_bytes The maximum amount of memory in bytes that can be used for memory management
# TYPE jvm_memory_max_bytes gauge
jvm_memory_max_bytes{application_name="dubbo-springboot-demo-provider",area="nonheap",id="Metaspace",} -1.0
jvm_memory_max_bytes{application_name="dubbo-springboot-demo-provider",area="heap",id="PS Old Gen",} 2.863661056E9
jvm_memory_max_bytes{application_name="dubbo-springboot-demo-provider",area="heap",id="PS Survivor Space",} 9961472.0
jvm_memory_max_bytes{application_name="dubbo-springboot-demo-provider",area="nonheap",id="Compressed Class Space",} 1.073741824E9
jvm_memory_max_bytes{application_name="dubbo-springboot-demo-provider",area="heap",id="PS Eden Space",} 1.409810432E9
jvm_memory_max_bytes{application_name="dubbo-springboot-demo-provider",area="nonheap",id="Code Cache",} 2.5165824E8
# HELP dubbo_metadata_push_num_total Total Push Num
# TYPE dubbo_metadata_push_num_total gauge
dubbo_metadata_push_num_total{application_module_id="1.1",application_name="dubbo-springboot-demo-provider",application_version="",git_commit_id="",hostname="192.168.10.100",ip="192.168.10.100",} 0.0
# HELP dubbo_metadata_store_provider_succeed_total Succeed Store Provider Metadata
# TYPE dubbo_metadata_store_provider_succeed_total gauge
dubbo_metadata_store_provider_succeed_total{application_module_id="1.1",application_name="dubbo-springboot-demo-provider",application_version="",git_commit_id="",hostname="192.168.10.100",interface="org.apache.dubbo.springboot.demo.DemoService:1.0.1",ip="192.168.10.100",} 1.0
# HELP jvm_threads_started_threads_total The total number of application threads started in the JVM
# TYPE jvm_threads_started_threads_total counter
jvm_threads_started_threads_total{application_name="dubbo-springboot-demo-provider",} 52.0
# HELP process_start_time_seconds Start time of the process since unix epoch.
# TYPE process_start_time_seconds gauge
process_start_time_seconds{application_name="dubbo-springboot-demo-provider",} 1.687589422548E9
# HELP jvm_gc_live_data_size_bytes Size of long-lived heap memory pool after reclamation
# TYPE jvm_gc_live_data_size_bytes gauge
jvm_gc_live_data_size_bytes{application_name="dubbo-springboot-demo-provider",} 1.6133776E7
# HELP dubbo_store_provider_interface_rt_milliseconds_avg Average Response Time
# TYPE dubbo_store_provider_interface_rt_milliseconds_avg gauge
dubbo_store_provider_interface_rt_milliseconds_avg{application_module_id="1.1",application_name="dubbo-springboot-demo-provider",application_version="",git_commit_id="",hostname="192.168.10.100",interface="org.apache.dubbo.springboot.demo.DemoService:1.0.1",ip="192.168.10.100",} 149.0
# HELP dubbo_thread_pool_queue_size Thread Pool Queue Size
# TYPE dubbo_thread_pool_queue_size gauge
dubbo_thread_pool_queue_size{application_name="dubbo-springboot-demo-provider",hostname="192.168.10.100",ip="192.168.10.100",pid="25941",thread_pool_name="DubboServerHandler-20880",} 0.0
dubbo_thread_pool_queue_size{application_name="dubbo-springboot-demo-provider",hostname="192.168.10.100",ip="192.168.10.100",pid="25941",thread_pool_name="sharedExecutor",} 0.0
dubbo_thread_pool_queue_size{application_name="dubbo-springboot-demo-provider",hostname="192.168.10.100",ip="192.168.10.100",pid="25941",thread_pool_name="DubboServerHandler-dubbo-springboot-demo-provider/org.apache.dubbo.metrics.service.MetricsService:1.0.0",} 0.0
dubbo_thread_pool_queue_size{application_name="dubbo-springboot-demo-provider",hostname="192.168.10.100",ip="192.168.10.100",pid="25941",thread_pool_name="DubboServerHandler-dubbo-springboot-demo-provider/org.apache.dubbo.metadata.MetadataService:1.0.0",} 0.0
# HELP dubbo_metadata_subscribe_num_total Total Metadata Subscribe Num
# TYPE dubbo_metadata_subscribe_num_total gauge
dubbo_metadata_subscribe_num_total{application_module_id="1.1",application_name="dubbo-springboot-demo-provider",application_version="",git_commit_id="",hostname="192.168.10.100",ip="192.168.10.100",} 0.0
# HELP dubbo_registry_subscribe_service_num_succeed_total Succeed Service-Level Num
# TYPE dubbo_registry_subscribe_service_num_succeed_total gauge
dubbo_registry_subscribe_service_num_succeed_total{application_module_id="1.1",application_name="dubbo-springboot-demo-provider",application_version="",git_commit_id="",hostname="192.168.10.100",interface="dubbo-springboot-demo-provider/org.apache.dubbo.metadata.MetadataService:1.0.0",ip="192.168.10.100",} 0.0
dubbo_registry_subscribe_service_num_succeed_total{application_module_id="1.1",application_name="dubbo-springboot-demo-provider",application_version="",git_commit_id="",hostname="192.168.10.100",interface="dubbo-springboot-demo-provider/org.apache.dubbo.metrics.service.MetricsService:1.0.0",ip="192.168.10.100",} 0.0
dubbo_registry_subscribe_service_num_succeed_total{application_module_id="1.1",application_name="dubbo-springboot-demo-provider",application_version="",git_commit_id="",hostname="192.168.10.100",interface="org.apache.dubbo.springboot.demo.DemoService:1.0.1",ip="192.168.10.100",} 0.0
# HELP dubbo_registry_register_service_failed_total Failed Service-Level Register Requests
# TYPE dubbo_registry_register_service_failed_total gauge
dubbo_registry_register_service_failed_total{application_module_id="1.1",application_name="dubbo-springboot-demo-provider",application_version="",git_commit_id="",hostname="192.168.10.100",interface="dubbo-springboot-demo-provider/org.apache.dubbo.metadata.MetadataService:1.0.0",ip="192.168.10.100",} 0.0
dubbo_registry_register_service_failed_total{application_module_id="1.1",application_name="dubbo-springboot-demo-provider",application_version="",git_commit_id="",hostname="192.168.10.100",interface="dubbo-springboot-demo-provider/org.apache.dubbo.metrics.service.MetricsService:1.0.0",ip="192.168.10.100",} 0.0
dubbo_registry_register_service_failed_total{application_module_id="1.1",application_name="dubbo-springboot-demo-provider",application_version="",git_commit_id="",hostname="192.168.10.100",interface="org.apache.dubbo.springboot.demo.DemoService:1.0.1",ip="192.168.10.100",} 0.0
# HELP dubbo_metadata_subscribe_num_succeed_total Succeed Metadata Subscribe Num
# TYPE dubbo_metadata_subscribe_num_succeed_total gauge
dubbo_metadata_subscribe_num_succeed_total{application_module_id="1.1",application_name="dubbo-springboot-demo-provider",application_version="",git_commit_id="",hostname="192.168.10.100",ip="192.168.10.100",} 0.0
# HELP jvm_memory_committed_bytes The amount of memory in bytes that is committed for the Java virtual machine to use
# TYPE jvm_memory_committed_bytes gauge
jvm_memory_committed_bytes{application_name="dubbo-springboot-demo-provider",area="nonheap",id="Metaspace",} 4.3687936E7
jvm_memory_committed_bytes{application_name="dubbo-springboot-demo-provider",area="heap",id="PS Old Gen",} 1.12197632E8
jvm_memory_committed_bytes{application_name="dubbo-springboot-demo-provider",area="heap",id="PS Survivor Space",} 9961472.0
jvm_memory_committed_bytes{application_name="dubbo-springboot-demo-provider",area="nonheap",id="Compressed Class Space",} 5947392.0
jvm_memory_committed_bytes{application_name="dubbo-springboot-demo-provider",area="heap",id="PS Eden Space",} 4.93879296E8
jvm_memory_committed_bytes{application_name="dubbo-springboot-demo-provider",area="nonheap",id="Code Cache",} 8781824.0
# HELP jvm_buffer_memory_used_bytes An estimate of the memory that the Java virtual machine is using for this buffer pool
# TYPE jvm_buffer_memory_used_bytes gauge
jvm_buffer_memory_used_bytes{application_name="dubbo-springboot-demo-provider",id="direct",} 10964.0
jvm_buffer_memory_used_bytes{application_name="dubbo-springboot-demo-provider",id="mapped",} 0.0
# HELP dubbo_thread_pool_max_size Thread Pool Max Size
# TYPE dubbo_thread_pool_max_size gauge
dubbo_thread_pool_max_size{application_name="dubbo-springboot-demo-provider",hostname="192.168.10.100",ip="192.168.10.100",pid="25941",thread_pool_name="DubboServerHandler-20880",} 200.0
dubbo_thread_pool_max_size{application_name="dubbo-springboot-demo-provider",hostname="192.168.10.100",ip="192.168.10.100",pid="25941",thread_pool_name="sharedExecutor",} 2.147483647E9
dubbo_thread_pool_max_size{application_name="dubbo-springboot-demo-provider",hostname="192.168.10.100",ip="192.168.10.100",pid="25941",thread_pool_name="DubboServerHandler-dubbo-springboot-demo-provider/org.apache.dubbo.metrics.service.MetricsService:1.0.0",} 100.0
dubbo_thread_pool_max_size{application_name="dubbo-springboot-demo-provider",hostname="192.168.10.100",ip="192.168.10.100",pid="25941",thread_pool_name="DubboServerHandler-dubbo-springboot-demo-provider/org.apache.dubbo.metadata.MetadataService:1.0.0",} 100.0
# HELP dubbo_register_rt_milliseconds_avg Average Response Time
# TYPE dubbo_register_rt_milliseconds_avg gauge
dubbo_register_rt_milliseconds_avg{application_module_id="1.1",application_name="dubbo-springboot-demo-provider",application_version="",git_commit_id="",hostname="192.168.10.100",ip="192.168.10.100",} 16.0
# HELP jvm_classes_unloaded_classes_total The total number of classes unloaded since the Java virtual machine has started execution
# TYPE jvm_classes_unloaded_classes_total counter
jvm_classes_unloaded_classes_total{application_name="dubbo-springboot-demo-provider",} 0.0
# HELP dubbo_register_service_rt_milliseconds_avg Average Response Time
# TYPE dubbo_register_service_rt_milliseconds_avg gauge
dubbo_register_service_rt_milliseconds_avg{application_module_id="1.1",application_name="dubbo-springboot-demo-provider",application_version="",git_commit_id="",hostname="192.168.10.100",interface="dubbo-springboot-demo-provider/org.apache.dubbo.metadata.MetadataService:1.0.0",ip="192.168.10.100",} 128.0
dubbo_register_service_rt_milliseconds_avg{application_module_id="1.1",application_name="dubbo-springboot-demo-provider",application_version="",git_commit_id="",hostname="192.168.10.100",interface="dubbo-springboot-demo-provider/org.apache.dubbo.metrics.service.MetricsService:1.0.0",ip="192.168.10.100",} 169.0
dubbo_register_service_rt_milliseconds_avg{application_module_id="1.1",application_name="dubbo-springboot-demo-provider",application_version="",git_commit_id="",hostname="192.168.10.100",interface="org.apache.dubbo.springboot.demo.DemoService:1.0.1",ip="192.168.10.100",} 796.0
# HELP dubbo_register_rt_milliseconds_min Min Response Time
# TYPE dubbo_register_rt_milliseconds_min gauge
dubbo_register_rt_milliseconds_min{application_module_id="1.1",application_name="dubbo-springboot-demo-provider",application_version="",git_commit_id="",hostname="192.168.10.100",ip="192.168.10.100",} 16.0
# HELP jvm_threads_states_threads The current number of threads
# TYPE jvm_threads_states_threads gauge
jvm_threads_states_threads{application_name="dubbo-springboot-demo-provider",state="blocked",} 0.0
jvm_threads_states_threads{application_name="dubbo-springboot-demo-provider",state="waiting",} 13.0
jvm_threads_states_threads{application_name="dubbo-springboot-demo-provider",state="runnable",} 12.0
jvm_threads_states_threads{application_name="dubbo-springboot-demo-provider",state="timed-waiting",} 13.0
jvm_threads_states_threads{application_name="dubbo-springboot-demo-provider",state="terminated",} 0.0
jvm_threads_states_threads{application_name="dubbo-springboot-demo-provider",state="new",} 0.0
# HELP system_cpu_usage The "recent cpu usage" of the system the application is running in
# TYPE system_cpu_usage gauge
system_cpu_usage{application_name="dubbo-springboot-demo-provider",} 0.0
# HELP dubbo_registry_register_service_total Total Service-Level Register Requests
# TYPE dubbo_registry_register_service_total gauge
dubbo_registry_register_service_total{application_module_id="1.1",application_name="dubbo-springboot-demo-provider",application_version="",git_commit_id="",hostname="192.168.10.100",interface="dubbo-springboot-demo-provider/org.apache.dubbo.metadata.MetadataService:1.0.0",ip="192.168.10.100",} 1.0
dubbo_registry_register_service_total{application_module_id="1.1",application_name="dubbo-springboot-demo-provider",application_version="",git_commit_id="",hostname="192.168.10.100",interface="dubbo-springboot-demo-provider/org.apache.dubbo.metrics.service.MetricsService:1.0.0",ip="192.168.10.100",} 1.0
dubbo_registry_register_service_total{application_module_id="1.1",application_name="dubbo-springboot-demo-provider",application_version="",git_commit_id="",hostname="192.168.10.100",interface="org.apache.dubbo.springboot.demo.DemoService:1.0.1",ip="192.168.10.100",} 1.0
# HELP dubbo_registry_directory_num_to_reconnect_total ToReconnect Directory Urls
# TYPE dubbo_registry_directory_num_to_reconnect_total gauge
dubbo_registry_directory_num_to_reconnect_total{application_module_id="1.1",application_name="dubbo-springboot-demo-provider",application_version="",git_commit_id="",hostname="192.168.10.100",interface="dubbo-springboot-demo-provider/org.apache.dubbo.metadata.MetadataService:1.0.0",ip="192.168.10.100",} 0.0
dubbo_registry_directory_num_to_reconnect_total{application_module_id="1.1",application_name="dubbo-springboot-demo-provider",application_version="",git_commit_id="",hostname="192.168.10.100",interface="dubbo-springboot-demo-provider/org.apache.dubbo.metrics.service.MetricsService:1.0.0",ip="192.168.10.100",} 0.0
dubbo_registry_directory_num_to_reconnect_total{application_module_id="1.1",application_name="dubbo-springboot-demo-provider",application_version="",git_commit_id="",hostname="192.168.10.100",interface="org.apache.dubbo.springboot.demo.DemoService:1.0.1",ip="192.168.10.100",} 0.0
# HELP dubbo_registry_directory_num_valid_total Valid Directory Urls
# TYPE dubbo_registry_directory_num_valid_total gauge
dubbo_registry_directory_num_valid_total{application_module_id="1.1",application_name="dubbo-springboot-demo-provider",application_version="",git_commit_id="",hostname="192.168.10.100",interface="dubbo-springboot-demo-provider/org.apache.dubbo.metadata.MetadataService:1.0.0",ip="192.168.10.100",} 0.0
dubbo_registry_directory_num_valid_total{application_module_id="1.1",application_name="dubbo-springboot-demo-provider",application_version="",git_commit_id="",hostname="192.168.10.100",interface="dubbo-springboot-demo-provider/org.apache.dubbo.metrics.service.MetricsService:1.0.0",ip="192.168.10.100",} 0.0
dubbo_registry_directory_num_valid_total{application_module_id="1.1",application_name="dubbo-springboot-demo-provider",application_version="",git_commit_id="",hostname="192.168.10.100",interface="org.apache.dubbo.springboot.demo.DemoService:1.0.1",ip="192.168.10.100",} 0.0
# HELP jvm_gc_memory_allocated_bytes_total Incremented for an increase in the size of the (young) heap memory pool after one GC to before the next
# TYPE jvm_gc_memory_allocated_bytes_total counter
jvm_gc_memory_allocated_bytes_total{application_name="dubbo-springboot-demo-provider",} 3.80674512E8
# HELP system_cpu_count The number of processors available to the Java virtual machine
# TYPE system_cpu_count gauge
system_cpu_count{application_name="dubbo-springboot-demo-provider",} 8.0
# HELP process_cpu_usage The "recent cpu usage" for the Java Virtual Machine process
# TYPE process_cpu_usage gauge
process_cpu_usage{application_name="dubbo-springboot-demo-provider",} 0.0
# HELP dubbo_metadata_subscribe_num_failed_total Failed Metadata Subscribe Num
# TYPE dubbo_metadata_subscribe_num_failed_total gauge
dubbo_metadata_subscribe_num_failed_total{application_module_id="1.1",application_name="dubbo-springboot-demo-provider",application_version="",git_commit_id="",hostname="192.168.10.100",ip="192.168.10.100",} 0.0
# HELP dubbo_registry_subscribe_num_failed_total Failed Subscribe Num
# TYPE dubbo_registry_subscribe_num_failed_total gauge
dubbo_registry_subscribe_num_failed_total{application_module_id="1.1",application_name="dubbo-springboot-demo-provider",application_version="",git_commit_id="",hostname="192.168.10.100",ip="192.168.10.100",} 0.0
# HELP dubbo_application_info_total Total Application Info
# TYPE dubbo_application_info_total counter
dubbo_application_info_total{application_name="dubbo-springboot-demo-provider",application_version="",git_commit_id="",hostname="192.168.10.100",ip="192.168.10.100",} 1.0
# HELP process_uptime_seconds The uptime of the Java virtual machine
# TYPE process_uptime_seconds gauge
process_uptime_seconds{application_name="dubbo-springboot-demo-provider",} 13.16
# HELP dubbo_metadata_push_num_failed_total Failed Push Num
# TYPE dubbo_metadata_push_num_failed_total gauge
dubbo_metadata_push_num_failed_total{application_module_id="1.1",application_name="dubbo-springboot-demo-provider",application_version="",git_commit_id="",hostname="192.168.10.100",ip="192.168.10.100",} 0.0
# HELP dubbo_registry_notify_num_last Last Notify Nums
# TYPE dubbo_registry_notify_num_last gauge
dubbo_registry_notify_num_last{application_module_id="1.1",application_name="dubbo-springboot-demo-provider",application_version="",git_commit_id="",hostname="192.168.10.100",interface="dubbo-springboot-demo-provider/org.apache.dubbo.metadata.MetadataService:1.0.0",ip="192.168.10.100",} 0.0
dubbo_registry_notify_num_last{application_module_id="1.1",application_name="dubbo-springboot-demo-provider",application_version="",git_commit_id="",hostname="192.168.10.100",interface="dubbo-springboot-demo-provider/org.apache.dubbo.metrics.service.MetricsService:1.0.0",ip="192.168.10.100",} 0.0
dubbo_registry_notify_num_last{application_module_id="1.1",application_name="dubbo-springboot-demo-provider",application_version="",git_commit_id="",hostname="192.168.10.100",interface="org.apache.dubbo.springboot.demo.DemoService:1.0.1",ip="192.168.10.100",} 0.0
# HELP dubbo_registry_notify_requests_total Total Notify Requests
# TYPE dubbo_registry_notify_requests_total gauge
dubbo_registry_notify_requests_total{application_module_id="1.1",application_name="dubbo-springboot-demo-provider",application_version="",git_commit_id="",hostname="192.168.10.100",ip="192.168.10.100",} 0.0
# HELP dubbo_thread_pool_thread_count Thread Pool Thread Count
# TYPE dubbo_thread_pool_thread_count gauge
dubbo_thread_pool_thread_count{application_name="dubbo-springboot-demo-provider",hostname="192.168.10.100",ip="192.168.10.100",pid="25941",thread_pool_name="DubboServerHandler-20880",} 0.0
dubbo_thread_pool_thread_count{application_name="dubbo-springboot-demo-provider",hostname="192.168.10.100",ip="192.168.10.100",pid="25941",thread_pool_name="sharedExecutor",} 0.0
dubbo_thread_pool_thread_count{application_name="dubbo-springboot-demo-provider",hostname="192.168.10.100",ip="192.168.10.100",pid="25941",thread_pool_name="DubboServerHandler-dubbo-springboot-demo-provider/org.apache.dubbo.metrics.service.MetricsService:1.0.0",} 0.0
dubbo_thread_pool_thread_count{application_name="dubbo-springboot-demo-provider",hostname="192.168.10.100",ip="192.168.10.100",pid="25941",thread_pool_name="DubboServerHandler-dubbo-springboot-demo-provider/org.apache.dubbo.metadata.MetadataService:1.0.0",} 0.0
# HELP dubbo_thread_pool_active_size Thread Pool Active Size
# TYPE dubbo_thread_pool_active_size gauge
dubbo_thread_pool_active_size{application_name="dubbo-springboot-demo-provider",hostname="192.168.10.100",ip="192.168.10.100",pid="25941",thread_pool_name="DubboServerHandler-20880",} 0.0
dubbo_thread_pool_active_size{application_name="dubbo-springboot-demo-provider",hostname="192.168.10.100",ip="192.168.10.100",pid="25941",thread_pool_name="sharedExecutor",} 0.0
dubbo_thread_pool_active_size{application_name="dubbo-springboot-demo-provider",hostname="192.168.10.100",ip="192.168.10.100",pid="25941",thread_pool_name="DubboServerHandler-dubbo-springboot-demo-provider/org.apache.dubbo.metrics.service.MetricsService:1.0.0",} 0.0
dubbo_thread_pool_active_size{application_name="dubbo-springboot-demo-provider",hostname="192.168.10.100",ip="192.168.10.100",pid="25941",thread_pool_name="DubboServerHandler-dubbo-springboot-demo-provider/org.apache.dubbo.metadata.MetadataService:1.0.0",} 0.0
# HELP dubbo_register_service_rt_milliseconds_max Max Response Time
# TYPE dubbo_register_service_rt_milliseconds_max gauge
dubbo_register_service_rt_milliseconds_max{application_module_id="1.1",application_name="dubbo-springboot-demo-provider",application_version="",git_commit_id="",hostname="192.168.10.100",interface="dubbo-springboot-demo-provider/org.apache.dubbo.metadata.MetadataService:1.0.0",ip="192.168.10.100",} 796.0
dubbo_register_service_rt_milliseconds_max{application_module_id="1.1",application_name="dubbo-springboot-demo-provider",application_version="",git_commit_id="",hostname="192.168.10.100",interface="dubbo-springboot-demo-provider/org.apache.dubbo.metrics.service.MetricsService:1.0.0",ip="192.168.10.100",} 796.0
dubbo_register_service_rt_milliseconds_max{application_module_id="1.1",application_name="dubbo-springboot-demo-provider",application_version="",git_commit_id="",hostname="192.168.10.100",interface="org.apache.dubbo.springboot.demo.DemoService:1.0.1",ip="192.168.10.100",} 796.0
# HELP jvm_threads_live_threads The current number of live threads including both daemon and non-daemon threads
# TYPE jvm_threads_live_threads gauge
jvm_threads_live_threads{application_name="dubbo-springboot-demo-provider",} 38.0
# HELP dubbo_registry_register_requests_total Total Register Requests
# TYPE dubbo_registry_register_requests_total gauge
dubbo_registry_register_requests_total{application_module_id="1.1",application_name="dubbo-springboot-demo-provider",application_version="",git_commit_id="",hostname="192.168.10.100",ip="192.168.10.100",} 1.0
# HELP dubbo_metadata_store_provider_failed_total Failed Store Provider Metadata
# TYPE dubbo_metadata_store_provider_failed_total gauge
dubbo_metadata_store_provider_failed_total{application_module_id="1.1",application_name="dubbo-springboot-demo-provider",application_version="",git_commit_id="",hostname="192.168.10.100",interface="org.apache.dubbo.springboot.demo.DemoService:1.0.1",ip="192.168.10.100",} 0.0
# HELP dubbo_register_rt_milliseconds_last Last Response Time
# TYPE dubbo_register_rt_milliseconds_last gauge
dubbo_register_rt_milliseconds_last{application_module_id="1.1",application_name="dubbo-springboot-demo-provider",application_version="",git_commit_id="",hostname="192.168.10.100",ip="192.168.10.100",} 16.0
# HELP dubbo_register_service_rt_milliseconds_min Min Response Time
# TYPE dubbo_register_service_rt_milliseconds_min gauge
dubbo_register_service_rt_milliseconds_min{application_module_id="1.1",application_name="dubbo-springboot-demo-provider",application_version="",git_commit_id="",hostname="192.168.10.100",interface="dubbo-springboot-demo-provider/org.apache.dubbo.metadata.MetadataService:1.0.0",ip="192.168.10.100",} 128.0
dubbo_register_service_rt_milliseconds_min{application_module_id="1.1",application_name="dubbo-springboot-demo-provider",application_version="",git_commit_id="",hostname="192.168.10.100",interface="dubbo-springboot-demo-provider/org.apache.dubbo.metrics.service.MetricsService:1.0.0",ip="192.168.10.100",} 128.0
dubbo_register_service_rt_milliseconds_min{application_module_id="1.1",application_name="dubbo-springboot-demo-provider",application_version="",git_commit_id="",hostname="192.168.10.100",interface="org.apache.dubbo.springboot.demo.DemoService:1.0.1",ip="192.168.10.100",} 128.0
# HELP dubbo_store_provider_interface_rt_milliseconds_sum Sum Response Time
# TYPE dubbo_store_provider_interface_rt_milliseconds_sum gauge
dubbo_store_provider_interface_rt_milliseconds_sum{application_module_id="1.1",application_name="dubbo-springboot-demo-provider",application_version="",git_commit_id="",hostname="192.168.10.100",interface="org.apache.dubbo.springboot.demo.DemoService:1.0.1",ip="192.168.10.100",} 149.0
# HELP dubbo_registry_subscribe_service_num_failed_total Failed Service-Level Num
# TYPE dubbo_registry_subscribe_service_num_failed_total gauge
dubbo_registry_subscribe_service_num_failed_total{application_module_id="1.1",application_name="dubbo-springboot-demo-provider",application_version="",git_commit_id="",hostname="192.168.10.100",interface="dubbo-springboot-demo-provider/org.apache.dubbo.metadata.MetadataService:1.0.0",ip="192.168.10.100",} 0.0
dubbo_registry_subscribe_service_num_failed_total{application_module_id="1.1",application_name="dubbo-springboot-demo-provider",application_version="",git_commit_id="",hostname="192.168.10.100",interface="dubbo-springboot-demo-provider/org.apache.dubbo.metrics.service.MetricsService:1.0.0",ip="192.168.10.100",} 0.0
dubbo_registry_subscribe_service_num_failed_total{application_module_id="1.1",application_name="dubbo-springboot-demo-provider",application_version="",git_commit_id="",hostname="192.168.10.100",interface="org.apache.dubbo.springboot.demo.DemoService:1.0.1",ip="192.168.10.100",} 0.0
# HELP dubbo_registry_directory_num_disable_total Disable Directory Urls
# TYPE dubbo_registry_directory_num_disable_total gauge
dubbo_registry_directory_num_disable_total{application_module_id="1.1",application_name="dubbo-springboot-demo-provider",application_version="",git_commit_id="",hostname="192.168.10.100",interface="dubbo-springboot-demo-provider/org.apache.dubbo.metadata.MetadataService:1.0.0",ip="192.168.10.100",} 0.0
dubbo_registry_directory_num_disable_total{application_module_id="1.1",application_name="dubbo-springboot-demo-provider",application_version="",git_commit_id="",hostname="192.168.10.100",interface="dubbo-springboot-demo-provider/org.apache.dubbo.metrics.service.MetricsService:1.0.0",ip="192.168.10.100",} 0.0
dubbo_registry_directory_num_disable_total{application_module_id="1.1",application_name="dubbo-springboot-demo-provider",application_version="",git_commit_id="",hostname="192.168.10.100",interface="org.apache.dubbo.springboot.demo.DemoService:1.0.1",ip="192.168.10.100",} 0.0
# HELP jvm_buffer_count_buffers An estimate of the number of buffers in the pool
# TYPE jvm_buffer_count_buffers gauge
jvm_buffer_count_buffers{application_name="dubbo-springboot-demo-provider",id="direct",} 7.0
jvm_buffer_count_buffers{application_name="dubbo-springboot-demo-provider",id="mapped",} 0.0
# HELP jvm_memory_used_bytes The amount of used memory
# TYPE jvm_memory_used_bytes gauge
jvm_memory_used_bytes{application_name="dubbo-springboot-demo-provider",area="nonheap",id="Metaspace",} 4.0679592E7
jvm_memory_used_bytes{application_name="dubbo-springboot-demo-provider",area="heap",id="PS Old Gen",} 1.6133776E7
jvm_memory_used_bytes{application_name="dubbo-springboot-demo-provider",area="heap",id="PS Survivor Space",} 0.0
jvm_memory_used_bytes{application_name="dubbo-springboot-demo-provider",area="nonheap",id="Compressed Class Space",} 5328120.0
jvm_memory_used_bytes{application_name="dubbo-springboot-demo-provider",area="heap",id="PS Eden Space",} 2.50638688E8
jvm_memory_used_bytes{application_name="dubbo-springboot-demo-provider",area="nonheap",id="Code Cache",} 8740864.0
# HELP dubbo_store_provider_interface_rt_milliseconds_max Max Response Time
# TYPE dubbo_store_provider_interface_rt_milliseconds_max gauge
dubbo_store_provider_interface_rt_milliseconds_max{application_module_id="1.1",application_name="dubbo-springboot-demo-provider",application_version="",git_commit_id="",hostname="192.168.10.100",interface="org.apache.dubbo.springboot.demo.DemoService:1.0.1",ip="192.168.10.100",} 149.0
```