### PR TITLE
Enable spring bean autowired to get scope model in advance

### DIFF
--- a/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/ServiceBean.java
+++ b/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/ServiceBean.java
@@ -52,24 +52,30 @@ public class ServiceBean<T> extends ServiceConfig<T> implements InitializingBean
 
     private ApplicationEventPublisher applicationEventPublisher;
 
-    public ServiceBean() {
+    public ServiceBean(ApplicationContext applicationContext) {
         super();
         this.service = null;
+        this.applicationContext = applicationContext;
+        this.setScopeModel(DubboBeanUtils.getModuleModel(applicationContext));
     }
 
-    public ServiceBean(ModuleModel moduleModel) {
+    public ServiceBean(ApplicationContext applicationContext, ModuleModel moduleModel) {
         super(moduleModel);
         this.service = null;
+        this.applicationContext = applicationContext;
     }
 
-    public ServiceBean(Service service) {
+    public ServiceBean(ApplicationContext applicationContext, Service service) {
         super(service);
         this.service = service;
+        this.applicationContext = applicationContext;
+        this.setScopeModel(DubboBeanUtils.getModuleModel(applicationContext));
     }
 
-    public ServiceBean(ModuleModel moduleModel, Service service) {
+    public ServiceBean(ApplicationContext applicationContext, ModuleModel moduleModel, Service service) {
         super(moduleModel, service);
         this.service = service;
+        this.applicationContext = applicationContext;
     }
 
     @Override

--- a/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/beans/factory/annotation/ServiceAnnotationPostProcessor.java
+++ b/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/beans/factory/annotation/ServiceAnnotationPostProcessor.java
@@ -428,6 +428,7 @@ public class ServiceAnnotationPostProcessor implements BeanDefinitionRegistryPos
         BeanDefinitionBuilder builder = rootBeanDefinition(ServiceBean.class);
 
         AbstractBeanDefinition beanDefinition = builder.getBeanDefinition();
+        beanDefinition.setAutowireMode(AbstractBeanDefinition.AUTOWIRE_CONSTRUCTOR);
 
         MutablePropertyValues propertyValues = beanDefinition.getPropertyValues();
 

--- a/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/schema/DubboBeanDefinitionParser.java
+++ b/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/schema/DubboBeanDefinitionParser.java
@@ -98,6 +98,7 @@ public class DubboBeanDefinitionParser implements BeanDefinitionParser {
         RootBeanDefinition beanDefinition = new RootBeanDefinition();
         beanDefinition.setBeanClass(beanClass);
         beanDefinition.setLazyInit(false);
+        beanDefinition.setAutowireMode(AbstractBeanDefinition.AUTOWIRE_CONSTRUCTOR);
         // config id
         String configId = resolveAttribute(element, "id", parserContext);
         if (StringUtils.isNotEmpty(configId)) {

--- a/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/schema/DubboBeanDefinitionParser.java
+++ b/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/schema/DubboBeanDefinitionParser.java
@@ -98,7 +98,9 @@ public class DubboBeanDefinitionParser implements BeanDefinitionParser {
         RootBeanDefinition beanDefinition = new RootBeanDefinition();
         beanDefinition.setBeanClass(beanClass);
         beanDefinition.setLazyInit(false);
-        beanDefinition.setAutowireMode(AbstractBeanDefinition.AUTOWIRE_CONSTRUCTOR);
+        if (ServiceBean.class.equals(beanClass)) {
+            beanDefinition.setAutowireMode(AbstractBeanDefinition.AUTOWIRE_CONSTRUCTOR);
+        }
         // config id
         String configId = resolveAttribute(element, "id", parserContext);
         if (StringUtils.isNotEmpty(configId)) {

--- a/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/util/DubboBeanUtils.java
+++ b/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/util/DubboBeanUtils.java
@@ -181,7 +181,7 @@ public interface DubboBeanUtils {
 
     static DubboSpringInitContext getInitializationContext(BeanFactory beanFactory) {
         String beanName = DubboSpringInitContext.class.getName();
-        if (beanFactory.containsBean(beanName)) {
+        if (beanFactory != null && beanFactory.containsBean(beanName)) {
             return beanFactory.getBean(beanName, DubboSpringInitContext.class);
         }
         return null;
@@ -189,7 +189,7 @@ public interface DubboBeanUtils {
 
     static ApplicationModel getApplicationModel(BeanFactory beanFactory) {
         String beanName = ApplicationModel.class.getName();
-        if (beanFactory.containsBean(beanName)) {
+        if (beanFactory != null && beanFactory.containsBean(beanName)) {
             return beanFactory.getBean(beanName, ApplicationModel.class);
         }
         return null;
@@ -197,7 +197,7 @@ public interface DubboBeanUtils {
 
     static ModuleModel getModuleModel(BeanFactory beanFactory) {
         String beanName = ModuleModel.class.getName();
-        if (beanFactory.containsBean(beanName)) {
+        if (beanFactory != null && beanFactory.containsBean(beanName)) {
             return beanFactory.getBean(beanName, ModuleModel.class);
         }
         return null;

--- a/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/ServiceBeanTest.java
+++ b/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/ServiceBeanTest.java
@@ -43,7 +43,7 @@ class ServiceBeanTest {
     @Test
     void testGetService() {
         TestService service = mock(TestService.class);
-        ServiceBean serviceBean = new ServiceBean(service);
+        ServiceBean serviceBean = new ServiceBean(null, service);
 
         Service beanService = serviceBean.getService();
         MatcherAssert.assertThat(beanService, not(nullValue()));

--- a/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/status/DataSourceStatusCheckerTest.java
+++ b/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/status/DataSourceStatusCheckerTest.java
@@ -51,7 +51,7 @@ class DataSourceStatusCheckerTest {
     public void setUp() throws Exception {
         initMocks(this);
         this.dataSourceStatusChecker = new DataSourceStatusChecker(applicationContext);
-        new ServiceBean<Object>().setApplicationContext(applicationContext);
+        new ServiceBean<Object>(applicationContext).setApplicationContext(applicationContext);
     }
 
     @AfterEach


### PR DESCRIPTION
## What is the purpose of the change

- Prevent set `ApplicationConfig` to `ConfigManager` when initialize `ServiceBean`

## Brief changelog


## Verifying this change


<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [ ] GitHub Actions works fine on your own branch.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
