### PR TITLE
Fix server shutdown await timeout

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/config/ConfigurationUtils.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/config/ConfigurationUtils.java
@@ -60,6 +60,8 @@ public final class ConfigurationUtils {
     private static final ErrorTypeAwareLogger logger = LoggerFactory.getErrorTypeAwareLogger(ConfigurationUtils.class);
     private static final List<String> securityKey;
 
+    private static volatile long expectedShutdownTime = Long.MAX_VALUE;
+
     static {
         List<String> keys = new LinkedList<>();
         keys.add("accesslog");
@@ -113,6 +115,9 @@ public final class ConfigurationUtils {
      */
     @SuppressWarnings("deprecation")
     public static int getServerShutdownTimeout(ScopeModel scopeModel) {
+        if (expectedShutdownTime < System.currentTimeMillis()) {
+            return 1;
+        }
         int timeout = DEFAULT_SERVER_SHUTDOWN_TIMEOUT;
         Configuration configuration = getGlobalConfiguration(scopeModel);
         String value = StringUtils.trim(configuration.getString(SHUTDOWN_WAIT_KEY));
@@ -133,7 +138,28 @@ public final class ConfigurationUtils {
                 }
             }
         }
+
+        if (expectedShutdownTime - System.currentTimeMillis() < timeout) {
+            return (int) Math.max(1, expectedShutdownTime - System.currentTimeMillis());
+        }
+
         return timeout;
+    }
+
+    public static int reCalShutdownTime(int expectedShutdownTime) {
+        if (expectedShutdownTime < System.currentTimeMillis()) {
+            return 1;
+        }
+
+        if (expectedShutdownTime - System.currentTimeMillis() < expectedShutdownTime) {
+            return (int) Math.max(1, expectedShutdownTime - System.currentTimeMillis());
+        }
+
+        return expectedShutdownTime;
+    }
+
+    public static void setExpectedShutdownTime(long expectedShutdownTime) {
+        ConfigurationUtils.expectedShutdownTime = expectedShutdownTime;
     }
 
     public static String getCachedDynamicProperty(ScopeModel realScopeModel, String key, String defaultValue) {

--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/DubboShutdownHook.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/DubboShutdownHook.java
@@ -82,6 +82,9 @@ public class DubboShutdownHook extends Thread {
     }
 
     private void doDestroy() {
+        int timeout = ConfigurationUtils.getServerShutdownTimeout(applicationModel);
+        ConfigurationUtils.setExpectedShutdownTime(System.currentTimeMillis() + timeout);
+
         // send readonly for shutdown hook
         List<GracefulShutdown> gracefulShutdowns = GracefulShutdown.getGracefulShutdowns(applicationModel.getFrameworkModel());
         for (GracefulShutdown gracefulShutdown : gracefulShutdowns) {
@@ -97,7 +100,6 @@ public class DubboShutdownHook extends Thread {
             }
         }
         if (hasModuleBindSpring) {
-            int timeout = ConfigurationUtils.getServerShutdownTimeout(applicationModel);
             if (timeout > 0) {
                 long start = System.currentTimeMillis();
                 /*

--- a/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/exchange/support/header/HeaderExchangeChannel.java
+++ b/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/exchange/support/header/HeaderExchangeChannel.java
@@ -50,7 +50,7 @@ final class HeaderExchangeChannel implements ExchangeChannel {
 
     private final Channel channel;
 
-    private final long shutdownTimeout;
+    private final int shutdownTimeout;
 
     private volatile boolean closed = false;
 
@@ -167,7 +167,7 @@ final class HeaderExchangeChannel implements ExchangeChannel {
         closed = true;
         try {
             // graceful close
-            DefaultFuture.closeChannel(channel, shutdownTimeout);
+            DefaultFuture.closeChannel(channel, ConfigurationUtils.reCalShutdownTime(shutdownTimeout));
         } catch (Exception e) {
             logger.warn(TRANSPORT_FAILED_CLOSE, "", "", e.getMessage(), e);
         }

--- a/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/exchange/support/header/HeaderExchangeHandler.java
+++ b/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/exchange/support/header/HeaderExchangeHandler.java
@@ -148,7 +148,7 @@ public class HeaderExchangeHandler implements ChannelHandlerDelegate {
             if (timeoutObj instanceof Integer) {
                 shutdownTimeout = (Integer) timeoutObj;
             }
-            DefaultFuture.closeChannel(channel, shutdownTimeout);
+            DefaultFuture.closeChannel(channel, ConfigurationUtils.reCalShutdownTime(shutdownTimeout));
             HeaderExchangeChannel.removeChannel(channel);
         }
     }

--- a/dubbo-remoting/dubbo-remoting-netty4/src/main/java/org/apache/dubbo/remoting/transport/netty4/NettyPortUnificationServer.java
+++ b/dubbo-remoting/dubbo-remoting-netty4/src/main/java/org/apache/dubbo/remoting/transport/netty4/NettyPortUnificationServer.java
@@ -178,7 +178,7 @@ public class NettyPortUnificationServer extends AbstractPortUnificationServer {
 
         try {
             if (bootstrap != null) {
-                long timeout = serverShutdownTimeoutMills;
+                long timeout = ConfigurationUtils.reCalShutdownTime(serverShutdownTimeoutMills);
                 long quietPeriod = Math.min(2000L, timeout);
                 Future<?> bossGroupShutdownFuture = bossGroup.shutdownGracefully(quietPeriod,
                     timeout, MILLISECONDS);

--- a/dubbo-remoting/dubbo-remoting-netty4/src/main/java/org/apache/dubbo/remoting/transport/netty4/NettyServer.java
+++ b/dubbo-remoting/dubbo-remoting-netty4/src/main/java/org/apache/dubbo/remoting/transport/netty4/NettyServer.java
@@ -174,7 +174,7 @@ public class NettyServer extends AbstractServer {
         }
         try {
             if (bootstrap != null) {
-                long timeout = serverShutdownTimeoutMills;
+                long timeout = ConfigurationUtils.reCalShutdownTime(serverShutdownTimeoutMills);
                 long quietPeriod = Math.min(2000L, timeout);
                 Future<?> bossGroupShutdownFuture = bossGroup.shutdownGracefully(quietPeriod, timeout, MILLISECONDS);
                 Future<?> workerGroupShutdownFuture = workerGroup.shutdownGracefully(quietPeriod, timeout, MILLISECONDS);

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/protocol/ReferenceCountInvokerWrapper.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/protocol/ReferenceCountInvokerWrapper.java
@@ -17,6 +17,7 @@
 package org.apache.dubbo.rpc.protocol;
 
 import org.apache.dubbo.common.URL;
+import org.apache.dubbo.common.config.ConfigurationUtils;
 import org.apache.dubbo.common.constants.LoggerCodeConstants;
 import org.apache.dubbo.common.logger.ErrorTypeAwareLogger;
 import org.apache.dubbo.common.logger.LoggerFactory;
@@ -25,6 +26,7 @@ import org.apache.dubbo.rpc.Invoker;
 import org.apache.dubbo.rpc.Result;
 import org.apache.dubbo.rpc.RpcException;
 
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
@@ -53,8 +55,16 @@ public class ReferenceCountInvokerWrapper<T> implements Invoker<T> {
     @Override
     public void destroy() {
         try {
-            lock.writeLock().lock();
+            int timeout = ConfigurationUtils.getServerShutdownTimeout(invoker.getUrl().getScopeModel());
+            boolean locked = lock.writeLock().tryLock(
+                timeout, TimeUnit.MILLISECONDS);
+            if (!locked) {
+                logger.warn(LoggerCodeConstants.PROTOCOL_CLOSED_SERVER, "", "",
+                    "Failed to wait for invocation end in " + timeout + "ms.");
+            }
             destroyed.set(true);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
         } finally {
             lock.writeLock().unlock();
         }

--- a/dubbo-rpc/dubbo-rpc-dubbo/src/main/java/org/apache/dubbo/rpc/protocol/dubbo/DubboInvoker.java
+++ b/dubbo-rpc/dubbo-rpc-dubbo/src/main/java/org/apache/dubbo/rpc/protocol/dubbo/DubboInvoker.java
@@ -179,7 +179,7 @@ public class DubboInvoker<T> extends AbstractInvoker<T> {
                 if (invokers != null) {
                     invokers.remove(this);
                 }
-                clientsProvider.close(serverShutdownTimeout);
+                clientsProvider.close(ConfigurationUtils.reCalShutdownTime(serverShutdownTimeout));
             } finally {
                 destroyLock.unlock();
             }

--- a/dubbo-rpc/dubbo-rpc-dubbo/src/main/java/org/apache/dubbo/rpc/protocol/dubbo/DubboProtocol.java
+++ b/dubbo-rpc/dubbo-rpc-dubbo/src/main/java/org/apache/dubbo/rpc/protocol/dubbo/DubboProtocol.java
@@ -554,7 +554,7 @@ public class DubboProtocol extends AbstractProtocol {
                     logger.info("Closing dubbo server: " + server.getLocalAddress());
                 }
 
-                server.close(getServerShutdownTimeout(protocolServer));
+                server.close(ConfigurationUtils.reCalShutdownTime(getServerShutdownTimeout(protocolServer)));
 
             } catch (Throwable t) {
                 logger.warn(PROTOCOL_ERROR_CLOSE_SERVER, "", "", "Close dubbo server [" + server.getLocalAddress() + "] failed: " + t.getMessage(), t);

--- a/dubbo-rpc/dubbo-rpc-dubbo/src/main/java/org/apache/dubbo/rpc/protocol/dubbo/SharedClientsProvider.java
+++ b/dubbo-rpc/dubbo-rpc-dubbo/src/main/java/org/apache/dubbo/rpc/protocol/dubbo/SharedClientsProvider.java
@@ -16,6 +16,7 @@
  */
 package org.apache.dubbo.rpc.protocol.dubbo;
 
+import org.apache.dubbo.common.config.ConfigurationUtils;
 import org.apache.dubbo.common.logger.ErrorTypeAwareLogger;
 import org.apache.dubbo.common.logger.LoggerFactory;
 import org.apache.dubbo.common.utils.CollectionUtils;
@@ -116,7 +117,7 @@ public class SharedClientsProvider implements ClientsProvider {
                 logger.info("Close dubbo connect: " + client.getLocalAddress() + "-->" + client.getRemoteAddress());
             }
 
-            client.close(client.getShutdownWaitTime());
+            client.close(ConfigurationUtils.reCalShutdownTime(client.getShutdownWaitTime()));
 
             // TODO
             /*


### PR DESCRIPTION
## What is the purpose of the change

- Use shutdown timeout to `ReferenceCountInvokerWrapper`
- Cal shutdown time in shutdown hook and reset all shutdown timeout

## Brief changelog


## Verifying this change


<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [ ] GitHub Actions works fine on your own branch.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
