### PR TITLE
enhance forbidden exception when use application level discovery

### DIFF
--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/Directory.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/Directory.java
@@ -98,4 +98,8 @@ public interface Directory<T> extends Node {
     default boolean isNotificationReceived() {
         return false;
     }
+
+    default String subscribedKey() {
+        return getConsumerUrl().getServiceKey();
+    }
 }

--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/support/AbstractClusterInvoker.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/support/AbstractClusterInvoker.java
@@ -364,7 +364,7 @@ public abstract class AbstractClusterInvoker<T> implements ClusterInvoker<T> {
         if (CollectionUtils.isEmpty(invokers)) {
             throw new RpcException(RpcException.NO_INVOKER_AVAILABLE_AFTER_FILTER, "Failed to invoke the method "
                 + RpcUtils.getMethodName(invocation) + " in the service " + getInterface().getName()
-                + ". No provider available for the service " + getDirectory().getConsumerUrl().getServiceKey()
+                + ". No provider available for subscribe " + getDirectory().subscribedKey()
                 + " from registry " + getDirectory()
                 + " on the consumer " + NetUtils.getLocalHost()
                 + " using the dubbo version " + Version.getVersion()

--- a/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/reference/registryNA/provider/DubboXmlProviderTest.java
+++ b/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/reference/registryNA/provider/DubboXmlProviderTest.java
@@ -45,7 +45,7 @@ public class DubboXmlProviderTest {
         HelloService helloService = context2.getBean("helloService", HelloService.class);
         Assertions.assertNotNull(helloService);
         RpcException exception = Assertions.assertThrows(RpcException.class, () -> helloService.sayHello("dubbo"));
-        Assertions.assertTrue(exception.getMessage().contains("Failed to invoke the method sayHello in the service org.apache.dubbo.config.spring.api.HelloService. No provider available for the service org.apache.dubbo.config.spring.api.HelloService"));
+        Assertions.assertTrue(exception.getMessage().contains("Failed to invoke the method sayHello in the service org.apache.dubbo.config.spring.api.HelloService. No provider available for subscribe org.apache.dubbo.config.spring.api.HelloService"));
     }
 
 }

--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/ServiceDiscoveryRegistry.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/ServiceDiscoveryRegistry.java
@@ -393,7 +393,7 @@ public class ServiceDiscoveryRegistry extends FailbackRegistry {
             Lock mappingLock = serviceNameMapping.getMappingLock(event.getServiceKey());
             try {
                 mappingLock.lock();
-                if (CollectionUtils.isEmpty(tempOldApps) && newApps.size() > 0) {
+                if (CollectionUtils.isEmpty(tempOldApps) && CollectionUtils.isNotEmpty(newApps)) {
                     serviceNameMapping.putCachedMapping(ServiceNameMapping.buildMappingKey(url), newApps);
                     subscribeURLs(url, listener, newApps);
                     oldApps = newApps;

--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/ServiceDiscoveryRegistryDirectory.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/ServiceDiscoveryRegistryDirectory.java
@@ -498,6 +498,11 @@ public class ServiceDiscoveryRegistryDirectory<T> extends DynamicDirectory<T> {
         this.destroyInvokers();
     }
 
+    @Override
+    public String subscribedKey() {
+        return CollectionUtils.isEmpty(serviceListener.getServiceNames()) ? super.subscribedKey() : serviceListener.getServiceNames().toString();
+    }
+
     /**
      * Check whether the invoker in the cache needs to be destroyed
      * If set attribute of url: refer.autodestroy=false, the invokers will only increase without decreasing,there may be a refer leak
@@ -566,7 +571,7 @@ public class ServiceDiscoveryRegistryDirectory<T> extends DynamicDirectory<T> {
         }
 
         void addNotifyListener(ServiceDiscoveryRegistryDirectory<?> listener) {
-            if (listeners.size() == 0) {
+            if (listeners.isEmpty()) {
                 this.initWith(moduleModel.getApplicationModel().getApplicationName() + CONFIGURATORS_SUFFIX);
             }
             this.listeners.add(listener);
@@ -574,7 +579,7 @@ public class ServiceDiscoveryRegistryDirectory<T> extends DynamicDirectory<T> {
 
         void removeNotifyListener(ServiceDiscoveryRegistryDirectory<?> listener) {
             this.listeners.remove(listener);
-            if (listeners.size() == 0) {
+            if (listeners.isEmpty()) {
                 this.stopListen(moduleModel.getApplicationModel().getApplicationName() + CONFIGURATORS_SUFFIX);
             }
         }

--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/ServiceDiscoveryRegistryDirectory.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/ServiceDiscoveryRegistryDirectory.java
@@ -500,7 +500,7 @@ public class ServiceDiscoveryRegistryDirectory<T> extends DynamicDirectory<T> {
 
     @Override
     public String subscribedKey() {
-        return CollectionUtils.isEmpty(serviceListener.getServiceNames()) ? super.subscribedKey() : serviceListener.getServiceNames().toString();
+        return serviceListener == null || CollectionUtils.isEmpty(serviceListener.getServiceNames()) ? super.subscribedKey() : serviceListener.getServiceNames().toString();
     }
 
     /**

--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/integration/DynamicDirectory.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/integration/DynamicDirectory.java
@@ -195,8 +195,13 @@ public abstract class DynamicDirectory<T> extends AbstractDirectory<T> implement
                                    BitList<Invoker<T>> invokers, Invocation invocation) {
         if (forbidden && shouldFailFast) {
             // 1. No service provider 2. Service providers are disabled
+            String providerBy = getConsumerUrl().getParameter(PROVIDED_BY);
+            String providerByError = "";
+            if (StringUtils.isNotEmpty(providerBy)) {
+                providerByError = " provide by " + providerBy;
+            }
             throw new RpcException(RpcException.FORBIDDEN_EXCEPTION, "No provider available from registry " +
-                getUrl().getAddress() + " for service " + getConsumerUrl().getParameter(PROVIDED_BY, getConsumerUrl().getServiceKey()) +
+                getUrl().getAddress() + " for service " + getConsumerUrl().getServiceKey() + providerByError +
                 " on consumer " + NetUtils.getLocalHost() + " use dubbo version " + Version.getVersion() +
                 ", please check status of providers(disabled, not registered or in blacklist).");
         }

--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/integration/DynamicDirectory.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/integration/DynamicDirectory.java
@@ -52,7 +52,6 @@ import static org.apache.dubbo.common.constants.LoggerCodeConstants.REGISTRY_FAI
 import static org.apache.dubbo.common.constants.LoggerCodeConstants.REGISTRY_FAILED_DESTROY_UNREGISTER_URL;
 import static org.apache.dubbo.common.constants.RegistryConstants.CATEGORY_KEY;
 import static org.apache.dubbo.common.constants.RegistryConstants.CONSUMERS_CATEGORY;
-import static org.apache.dubbo.common.constants.RegistryConstants.PROVIDED_BY;
 import static org.apache.dubbo.registry.Constants.REGISTER_KEY;
 import static org.apache.dubbo.registry.Constants.SIMPLIFIED_KEY;
 import static org.apache.dubbo.registry.integration.InterfaceCompatibleRegistryProtocol.DEFAULT_REGISTER_CONSUMER_KEYS;

--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/integration/DynamicDirectory.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/integration/DynamicDirectory.java
@@ -195,13 +195,9 @@ public abstract class DynamicDirectory<T> extends AbstractDirectory<T> implement
                                    BitList<Invoker<T>> invokers, Invocation invocation) {
         if (forbidden && shouldFailFast) {
             // 1. No service provider 2. Service providers are disabled
-            String providerBy = getConsumerUrl().getParameter(PROVIDED_BY);
-            String providerByError = "";
-            if (StringUtils.isNotEmpty(providerBy)) {
-                providerByError = " provide by " + providerBy;
-            }
-            throw new RpcException(RpcException.FORBIDDEN_EXCEPTION, "No provider available from registry " +
-                getUrl().getAddress() + " for service " + getConsumerUrl().getServiceKey() + providerByError +
+            throw new RpcException(RpcException.FORBIDDEN_EXCEPTION, "Failed to invoke the method "
+                + invocation.getMethodName() + " in the service " + getInterface().getName()
+                + ".No provider available from registry " + getUrl().getAddress() + " for subscribe " + subscribedKey() +
                 " on consumer " + NetUtils.getLocalHost() + " use dubbo version " + Version.getVersion() +
                 ", please check status of providers(disabled, not registered or in blacklist).");
         }

--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/integration/DynamicDirectory.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/integration/DynamicDirectory.java
@@ -52,6 +52,7 @@ import static org.apache.dubbo.common.constants.LoggerCodeConstants.REGISTRY_FAI
 import static org.apache.dubbo.common.constants.LoggerCodeConstants.REGISTRY_FAILED_DESTROY_UNREGISTER_URL;
 import static org.apache.dubbo.common.constants.RegistryConstants.CATEGORY_KEY;
 import static org.apache.dubbo.common.constants.RegistryConstants.CONSUMERS_CATEGORY;
+import static org.apache.dubbo.common.constants.RegistryConstants.PROVIDED_BY;
 import static org.apache.dubbo.registry.Constants.REGISTER_KEY;
 import static org.apache.dubbo.registry.Constants.SIMPLIFIED_KEY;
 import static org.apache.dubbo.registry.integration.InterfaceCompatibleRegistryProtocol.DEFAULT_REGISTER_CONSUMER_KEYS;
@@ -195,8 +196,8 @@ public abstract class DynamicDirectory<T> extends AbstractDirectory<T> implement
         if (forbidden && shouldFailFast) {
             // 1. No service provider 2. Service providers are disabled
             throw new RpcException(RpcException.FORBIDDEN_EXCEPTION, "No provider available from registry " +
-                getUrl().getAddress() + " for service " + getConsumerUrl().getServiceKey() + " on consumer " +
-                NetUtils.getLocalHost() + " use dubbo version " + Version.getVersion() +
+                getUrl().getAddress() + " for service " + getConsumerUrl().getParameter(PROVIDED_BY, getConsumerUrl().getServiceKey()) +
+                " on consumer " + NetUtils.getLocalHost() + " use dubbo version " + Version.getVersion() +
                 ", please check status of providers(disabled, not registered or in blacklist).");
         }
 


### PR DESCRIPTION
## What is the purpose of the change
When we use application level discovery, if the provider by parameter is configured on the client, the forbidden exception should first display the value of providerBy

## Brief changelog


## Verifying this change


<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [ ] GitHub Actions works fine on your own branch.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
