### PR TITLE
Fix reference bean has not been init if deployer is early started

### DIFF
--- a/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/reference/ReferenceBeanManager.java
+++ b/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/reference/ReferenceBeanManager.java
@@ -189,6 +189,7 @@ public class ReferenceBeanManager implements ApplicationContextAware {
 
             // register ReferenceConfig
             moduleModel.getConfigManager().addReference(referenceConfig);
+            moduleModel.getDeployer().setPending();
         }
 
         // associate referenceConfig to referenceBean


### PR DESCRIPTION
## What is the purpose of the change

Test cases: https://github.com/apache/dubbo-samples/pull/876

If reference has been trigger when starting, application deployer will start early. When `ApplicationContextRefeshed` event published, application deployer will not being start again. This will cause some later built reference config not being `get` when start.

## Brief changelog


## Verifying this change


<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [ ] GitHub Actions works fine on your own branch.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
