### PR TITLE
fix digest thread_safe bug

### DIFF
--- a/dubbo-metrics/dubbo-metrics-api/src/main/java/org/apache/dubbo/metrics/aggregate/DubboMergingDigest.java
+++ b/dubbo-metrics/dubbo-metrics-api/src/main/java/org/apache/dubbo/metrics/aggregate/DubboMergingDigest.java
@@ -322,7 +322,7 @@ public class DubboMergingDigest extends DubboAbstractTDigest {
         throw new MetricsNeverHappenException("Method not used");
     }
 
-    private synchronized void mergeNewValues() {
+    private void mergeNewValues() {
         mergeNewValues(false, compression);
     }
 

--- a/dubbo-metrics/dubbo-metrics-api/src/main/java/org/apache/dubbo/metrics/aggregate/DubboMergingDigest.java
+++ b/dubbo-metrics/dubbo-metrics-api/src/main/java/org/apache/dubbo/metrics/aggregate/DubboMergingDigest.java
@@ -286,15 +286,11 @@ public class DubboMergingDigest extends DubboAbstractTDigest {
         if (Double.isNaN(x)) {
             throw new IllegalArgumentException("Cannot add NaN to t-digest");
         }
-        while (merging) {
-            try {
-                Thread.sleep(10);
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
+
+        synchronized (this) {
+            if (tempUsed.get() >= tempWeight.length - lastUsedCell.get() - 1) {
+                mergeNewValues();
             }
-        }
-        if (tempUsed.get() >= tempWeight.length - lastUsedCell.get() - 1) {
-            mergeNewValues();
         }
         int where = tempUsed.getAndIncrement();
         tempWeight[where] = w;
@@ -327,12 +323,7 @@ public class DubboMergingDigest extends DubboAbstractTDigest {
     }
 
     private synchronized void mergeNewValues() {
-        merging = true;
-        try {
-            mergeNewValues(false, compression);
-        } finally {
-            merging = false;
-        }
+        mergeNewValues(false, compression);
     }
 
     private void mergeNewValues(boolean force, double compression) {

--- a/dubbo-metrics/dubbo-metrics-api/src/main/java/org/apache/dubbo/metrics/aggregate/DubboMergingDigest.java
+++ b/dubbo-metrics/dubbo-metrics-api/src/main/java/org/apache/dubbo/metrics/aggregate/DubboMergingDigest.java
@@ -119,8 +119,6 @@ public class DubboMergingDigest extends DubboAbstractTDigest {
     // weight limits.
     public static boolean useWeightLimit = true;
 
-    private volatile boolean merging = false;
-
     /**
      * Allocates a buffer merging t-digest.  This is the normally used constructor that
      * allocates default sized internal arrays.  Other versions are available, but should

--- a/dubbo-metrics/dubbo-metrics-api/src/main/java/org/apache/dubbo/metrics/aggregate/DubboMergingDigest.java
+++ b/dubbo-metrics/dubbo-metrics-api/src/main/java/org/apache/dubbo/metrics/aggregate/DubboMergingDigest.java
@@ -286,6 +286,7 @@ public class DubboMergingDigest extends DubboAbstractTDigest {
         }
 
         synchronized (this) {
+            // There is a small probability of entering here
             if (tempUsed.get() >= tempWeight.length - lastUsedCell.get() - 1) {
                 mergeNewValues();
             }

--- a/dubbo-metrics/dubbo-metrics-api/src/test/java/org/apache/dubbo/metrics/aggregate/TimeWindowQuantileTest.java
+++ b/dubbo-metrics/dubbo-metrics-api/src/test/java/org/apache/dubbo/metrics/aggregate/TimeWindowQuantileTest.java
@@ -46,8 +46,9 @@ class TimeWindowQuantileTest {
         while (index < 100) {
             for (int i = 0; i < 100; i++) {
                 int finalI = i;
+                Assertions.assertDoesNotThrow(() -> quantile.add(finalI));
                 executorService.execute(() ->
-                    Assertions.assertDoesNotThrow(() -> quantile.add(finalI)));
+                    quantile.add(finalI));
             }
             index++;
             try {


### PR DESCRIPTION
## What is the purpose of the change
Due to the testcase problem of #12223, the concurrency bug of digest was not completely solved.
Because the exception thrown by the thread pool will not be transmitted to the main thread.

## Brief changelog
Cause Analysis：
In the following code snippet, about every thousand times, the condition tempUsed.get() >= tempWeight.length - lastUsedCell.get() - 1 will be satisfied, and the merge operation will be performed.
The mergeNewValues method and the following codes simultaneously modify shared variables, such as tempUsed. Then every thousand or so times, a thread-safe event occurs, causing the error.
```java
private void add(double x, int w, List<Double> history) {
    if (Double.isNaN(x)) {
        throw new IllegalArgumentException("Cannot add NaN to t-digest");
    }

    if (tempUsed.get() >= tempWeight.length - lastUsedCell.get() - 1) {
        mergeNewValues();
     }
    int where = tempUsed.getAndIncrement();
    tempWeight[where] = w;
    tempMean[where] = x;
    unmergedWeight.addAndGet(w);
   // ....
}
```

#12223 Try to use spin lock to solve this problem, because the frequency of merge is 1/1000, and the thread always gets the lock optimistically to ensure the execution performance.

```java
private volatile boolean merging = false;

private void add(double x, int w, List<Double> history) {
    if (Double.isNaN(x)) {
        throw new IllegalArgumentException("Cannot add NaN to t-digest");
    }
   //spin lock
   while (merging) {
            try {
                Thread.sleep(10);
            } catch (InterruptedException e) {
                Thread.currentThread().interrupt();
            }
    }
    if (tempUsed.get() >= tempWeight.length - lastUsedCell.get() - 1) {
        mergeNewValues();
     }
    int where = tempUsed.getAndIncrement();
    tempWeight[where] = w;
    tempMean[where] = x;
    unmergedWeight.addAndGet(w);
   // ....
}

private synchronized void mergeNewValues() {
        merging = true;
        try {
            mergeNewValues(false, compression);
        } finally {
            merging = false;
        }
    }
```

There is a problem here. When a thread enters the merge (1/1000 probability), it can prevent most of the threads from executing the code after the merge to prevent errors, but some early threads will bypass the spin lock at the same time as the merge thread, and at the same time during the merge process Changed the tempUsed variable (unfinished merge), these early threads bypassed the merge judgment, executed the following code at the same time as the merge, and updated the shared variable at the same time, causing an error.

What we need to do is to incorporate the judgment condition of merge into the lock range to prevent the above errors. Here we directly use a synchronized pessimistic lock

## Verifying this change.
The unit test can pass normally after modification.
The synchronized here has a certain impact on performance, because every request will be executed, but fortunately, there is only a one-thousandth probability that it will be locked for a long time


