### PR TITLE
Fix short, byte type can not be deserialized correctly when used as generalization types in hessian2

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/utils/ReflectUtils.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/utils/ReflectUtils.java
@@ -1288,6 +1288,7 @@ public final class ReflectUtils {
 
     /**
      * Check target bean class whether has specify method
+     *
      * @param beanClass
      * @param methodName
      * @return
@@ -1349,6 +1350,7 @@ public final class ReflectUtils {
      * necessary. The {@code setAccessible(true)} method is only called
      * when actually necessary, to avoid unnecessary conflicts with a JVM
      * SecurityManager (if active).
+     *
      * @param method the method to make accessible
      * @see java.lang.reflect.Method#setAccessible
      */
@@ -1362,6 +1364,7 @@ public final class ReflectUtils {
 
     /**
      * Get all field names of target type
+     *
      * @param type
      * @return
      */

--- a/dubbo-common/src/main/java/org/apache/dubbo/rpc/model/MethodDescriptor.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/rpc/model/MethodDescriptor.java
@@ -33,6 +33,8 @@ public interface MethodDescriptor {
 
     Class<?>[] getParameterClasses();
 
+    Type[] getGenericParameterTypes();
+
     Class<?> getReturnClass();
 
     Type[] getReturnTypes();

--- a/dubbo-common/src/main/java/org/apache/dubbo/rpc/model/ReflectionMethodDescriptor.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/rpc/model/ReflectionMethodDescriptor.java
@@ -41,6 +41,7 @@ public class ReflectionMethodDescriptor implements MethodDescriptor {
     public final String methodName;
     private final String[] compatibleParamSignatures;
     private final Class<?>[] parameterClasses;
+    private final Type[] genericParameterTypes;
     private final Class<?> returnClass;
     private final Type[] returnTypes;
     private final String paramDesc;
@@ -53,6 +54,7 @@ public class ReflectionMethodDescriptor implements MethodDescriptor {
         this.method = method;
         this.methodName = method.getName();
         this.parameterClasses = method.getParameterTypes();
+        this.genericParameterTypes = method.getGenericParameterTypes();
         this.returnClass = method.getReturnType();
         Type[] returnTypesResult;
         try {
@@ -114,6 +116,11 @@ public class ReflectionMethodDescriptor implements MethodDescriptor {
     @Override
     public Class<?>[] getParameterClasses() {
         return parameterClasses;
+    }
+
+    @Override
+    public Type[] getGenericParameterTypes() {
+        return genericParameterTypes;
     }
 
     @Override

--- a/dubbo-common/src/main/java/org/apache/dubbo/rpc/model/StubMethodDescriptor.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/rpc/model/StubMethodDescriptor.java
@@ -34,6 +34,7 @@ public class StubMethodDescriptor implements MethodDescriptor, PackableMethod {
     private final String methodName;
     private final String[] compatibleParamSignatures;
     private final Class<?>[] parameterClasses;
+    private final Type[] genericParameterTypes;
     private final Class<?> returnClass;
     private final Type[] returnTypes;
     private final String paramDesc;
@@ -44,14 +45,14 @@ public class StubMethodDescriptor implements MethodDescriptor, PackableMethod {
     private final UnPack responseUnpack;
 
     public StubMethodDescriptor(String methodName,
-        Class<?> requestClass,
-        Class<?> responseClass,
-        StubServiceDescriptor serviceDescriptor,
-        RpcType rpcType,
-        Pack requestPack,
-        Pack responsePack,
-        UnPack requestUnpack,
-        UnPack responseUnpack) {
+                                Class<?> requestClass,
+                                Class<?> responseClass,
+                                StubServiceDescriptor serviceDescriptor,
+                                RpcType rpcType,
+                                Pack requestPack,
+                                Pack responsePack,
+                                UnPack requestUnpack,
+                                UnPack responseUnpack) {
         this.methodName = methodName;
         this.serviceDescriptor = serviceDescriptor;
         this.rpcType = rpcType;
@@ -60,6 +61,7 @@ public class StubMethodDescriptor implements MethodDescriptor, PackableMethod {
         this.responseUnpack = responseUnpack;
         this.requestUnpack = requestUnpack;
         this.parameterClasses = new Class<?>[]{requestClass};
+        this.genericParameterTypes = new Type[]{requestClass};
         this.returnClass = responseClass;
         this.paramDesc = ReflectUtils.getDesc(parameterClasses);
         this.compatibleParamSignatures = Stream.of(parameterClasses).map(Class::getName).toArray(String[]::new);
@@ -86,6 +88,11 @@ public class StubMethodDescriptor implements MethodDescriptor, PackableMethod {
     @Override
     public Class<?>[] getParameterClasses() {
         return parameterClasses;
+    }
+
+    @Override
+    public Type[] getGenericParameterTypes() {
+        return genericParameterTypes;
     }
 
     @Override

--- a/dubbo-serialization/dubbo-serialization-hessian2/src/main/java/org/apache/dubbo/common/serialize/hessian2/Hessian2ObjectInput.java
+++ b/dubbo-serialization/dubbo-serialization-hessian2/src/main/java/org/apache/dubbo/common/serialize/hessian2/Hessian2ObjectInput.java
@@ -110,11 +110,12 @@ public class Hessian2ObjectInput implements ObjectInput, Cleanable {
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public <T> T readObject(Class<T> cls, Type type) throws IOException, ClassNotFoundException {
         if (!mH2i.getSerializerFactory().getClassLoader().equals(Thread.currentThread().getContextClassLoader())) {
             mH2i.setSerializerFactory(hessian2FactoryManager.getSerializerFactory(Thread.currentThread().getContextClassLoader()));
         }
-        return readObject(cls);
+        return (T) mH2i.readObject(cls, (Class<?>) type);
     }
 
     public InputStream readInputStream() throws IOException {
@@ -123,7 +124,7 @@ public class Hessian2ObjectInput implements ObjectInput, Cleanable {
 
     @Override
     public void cleanup() {
-        if(mH2i != null) {
+        if (mH2i != null) {
             mH2i.reset();
         }
     }


### PR DESCRIPTION


## What is the purpose of the change



## Brief changelog


## Verifying this change
Example:
When` List<Short>` is entered, the result of `List<Integer>` deserialized



<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [ ] GitHub Actions works fine on your own branch.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
