### PR TITLE
multiple registration cannot be achieved when nacos application level registration

### DIFF
--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/AbstractServiceDiscoveryFactory.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/AbstractServiceDiscoveryFactory.java
@@ -50,13 +50,14 @@ public abstract class AbstractServiceDiscoveryFactory implements ServiceDiscover
 
     @Override
     public ServiceDiscovery getServiceDiscovery(URL registryURL) {
-        String key = registryURL.toServiceStringWithoutResolving();
+        String key = createRegistryCacheKey(registryURL);
         return ConcurrentHashMapUtils.computeIfAbsent(discoveries, key, k -> createDiscovery(registryURL));
+    }
+
+    protected String createRegistryCacheKey(URL url) {
+        return url.toServiceStringWithoutResolving();
     }
 
     protected abstract ServiceDiscovery createDiscovery(URL registryURL);
 
-    protected ConcurrentMap<String, ServiceDiscovery> getDiscoveries() {
-        return discoveries;
-    }
 }

--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/AbstractServiceDiscoveryFactory.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/AbstractServiceDiscoveryFactory.java
@@ -55,4 +55,8 @@ public abstract class AbstractServiceDiscoveryFactory implements ServiceDiscover
     }
 
     protected abstract ServiceDiscovery createDiscovery(URL registryURL);
+
+    protected ConcurrentMap<String, ServiceDiscovery> getDiscoveries() {
+        return discoveries;
+    }
 }

--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/ServiceDiscoveryRegistryFactory.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/ServiceDiscoveryRegistryFactory.java
@@ -17,14 +17,26 @@
 package org.apache.dubbo.registry.client;
 
 import org.apache.dubbo.common.URL;
+import org.apache.dubbo.common.utils.StringUtils;
 import org.apache.dubbo.common.utils.UrlUtils;
 import org.apache.dubbo.registry.Registry;
 import org.apache.dubbo.registry.support.AbstractRegistryFactory;
 
+import static org.apache.dubbo.common.constants.CommonConstants.CONFIG_NAMESPACE_KEY;
 import static org.apache.dubbo.common.constants.RegistryConstants.REGISTRY_KEY;
 import static org.apache.dubbo.registry.Constants.DEFAULT_REGISTRY;
 
 public class ServiceDiscoveryRegistryFactory extends AbstractRegistryFactory {
+
+    @Override
+    protected String createRegistryCacheKey(URL url) {
+        String namespace = url.getParameter(CONFIG_NAMESPACE_KEY);
+        url = URL.valueOf(url.toServiceStringWithoutResolving());
+        if (StringUtils.isNotEmpty(namespace)) {
+            url = url.addParameter(CONFIG_NAMESPACE_KEY, namespace);
+        }
+        return url.toFullString();
+    }
 
     @Override
     protected Registry createRegistry(URL url) {

--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/ServiceDiscoveryRegistryFactory.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/ServiceDiscoveryRegistryFactory.java
@@ -17,12 +17,10 @@
 package org.apache.dubbo.registry.client;
 
 import org.apache.dubbo.common.URL;
-import org.apache.dubbo.common.utils.StringUtils;
 import org.apache.dubbo.common.utils.UrlUtils;
 import org.apache.dubbo.registry.Registry;
 import org.apache.dubbo.registry.support.AbstractRegistryFactory;
 
-import static org.apache.dubbo.common.constants.CommonConstants.CONFIG_NAMESPACE_KEY;
 import static org.apache.dubbo.common.constants.RegistryConstants.REGISTRY_KEY;
 import static org.apache.dubbo.registry.Constants.DEFAULT_REGISTRY;
 
@@ -30,11 +28,6 @@ public class ServiceDiscoveryRegistryFactory extends AbstractRegistryFactory {
 
     @Override
     protected String createRegistryCacheKey(URL url) {
-        String namespace = url.getParameter(CONFIG_NAMESPACE_KEY);
-        url = URL.valueOf(url.toServiceStringWithoutResolving());
-        if (StringUtils.isNotEmpty(namespace)) {
-            url = url.addParameter(CONFIG_NAMESPACE_KEY, namespace);
-        }
         return url.toFullString();
     }
 

--- a/dubbo-registry/dubbo-registry-nacos/src/main/java/org/apache/dubbo/registry/nacos/NacosServiceDiscoveryFactory.java
+++ b/dubbo-registry/dubbo-registry-nacos/src/main/java/org/apache/dubbo/registry/nacos/NacosServiceDiscoveryFactory.java
@@ -17,7 +17,6 @@
 package org.apache.dubbo.registry.nacos;
 
 import org.apache.dubbo.common.URL;
-import org.apache.dubbo.common.utils.ConcurrentHashMapUtils;
 import org.apache.dubbo.common.utils.StringUtils;
 import org.apache.dubbo.registry.client.AbstractServiceDiscoveryFactory;
 import org.apache.dubbo.registry.client.ServiceDiscovery;

--- a/dubbo-registry/dubbo-registry-nacos/src/main/java/org/apache/dubbo/registry/nacos/NacosServiceDiscoveryFactory.java
+++ b/dubbo-registry/dubbo-registry-nacos/src/main/java/org/apache/dubbo/registry/nacos/NacosServiceDiscoveryFactory.java
@@ -17,11 +17,23 @@
 package org.apache.dubbo.registry.nacos;
 
 import org.apache.dubbo.common.URL;
+import org.apache.dubbo.common.utils.ConcurrentHashMapUtils;
+import org.apache.dubbo.common.utils.StringUtils;
 import org.apache.dubbo.registry.client.AbstractServiceDiscoveryFactory;
 import org.apache.dubbo.registry.client.ServiceDiscovery;
 
+import static org.apache.dubbo.common.constants.CommonConstants.CONFIG_NAMESPACE_KEY;
+
 public class NacosServiceDiscoveryFactory extends AbstractServiceDiscoveryFactory {
 
+    public ServiceDiscovery getServiceDiscovery(URL registryURL) {
+        String namespace = registryURL.getParameter(CONFIG_NAMESPACE_KEY);
+        URL url = URL.valueOf(registryURL.toServiceStringWithoutResolving());
+        if (StringUtils.isNotEmpty(namespace)) {
+            url = url.addParameter(CONFIG_NAMESPACE_KEY, namespace);
+        }
+        return ConcurrentHashMapUtils.computeIfAbsent(getDiscoveries(), url.toFullString(), k -> createDiscovery(registryURL));
+    }
     @Override
     protected ServiceDiscovery createDiscovery(URL registryURL) {
         return new NacosServiceDiscovery(applicationModel, registryURL);

--- a/dubbo-registry/dubbo-registry-nacos/src/main/java/org/apache/dubbo/registry/nacos/NacosServiceDiscoveryFactory.java
+++ b/dubbo-registry/dubbo-registry-nacos/src/main/java/org/apache/dubbo/registry/nacos/NacosServiceDiscoveryFactory.java
@@ -27,14 +27,16 @@ import static org.apache.dubbo.common.constants.CommonConstants.CONFIG_NAMESPACE
 public class NacosServiceDiscoveryFactory extends AbstractServiceDiscoveryFactory {
 
     @Override
-    public ServiceDiscovery getServiceDiscovery(URL registryURL) {
-        String namespace = registryURL.getParameter(CONFIG_NAMESPACE_KEY);
-        URL url = URL.valueOf(registryURL.toServiceStringWithoutResolving());
+    protected String createRegistryCacheKey(URL url) {
+        String namespace = url.getParameter(CONFIG_NAMESPACE_KEY);
+        url = URL.valueOf(url.toServiceStringWithoutResolving());
         if (StringUtils.isNotEmpty(namespace)) {
             url = url.addParameter(CONFIG_NAMESPACE_KEY, namespace);
         }
-        return ConcurrentHashMapUtils.computeIfAbsent(getDiscoveries(), url.toFullString(), k -> createDiscovery(registryURL));
+
+        return url.toFullString();
     }
+
     @Override
     protected ServiceDiscovery createDiscovery(URL registryURL) {
         return new NacosServiceDiscovery(applicationModel, registryURL);

--- a/dubbo-registry/dubbo-registry-nacos/src/main/java/org/apache/dubbo/registry/nacos/NacosServiceDiscoveryFactory.java
+++ b/dubbo-registry/dubbo-registry-nacos/src/main/java/org/apache/dubbo/registry/nacos/NacosServiceDiscoveryFactory.java
@@ -26,6 +26,7 @@ import static org.apache.dubbo.common.constants.CommonConstants.CONFIG_NAMESPACE
 
 public class NacosServiceDiscoveryFactory extends AbstractServiceDiscoveryFactory {
 
+    @Override
     public ServiceDiscovery getServiceDiscovery(URL registryURL) {
         String namespace = registryURL.getParameter(CONFIG_NAMESPACE_KEY);
         URL url = URL.valueOf(registryURL.toServiceStringWithoutResolving());


### PR DESCRIPTION
## What is the purpose of the change
解决 nacos 应用级别注册时无法实现多注册的问题，详情见：https://github.com/apache/dubbo/issues/12629


## Brief changelog
1. 通过重写 createRegistryCacheKey 保证不同的 Nacos 配置产生不同的 ServiceDiscoveryRegistryFactory 对象
2. 通过重写 getServiceDiscovery 保证不同的 Nacos 配置产生不同的 NacosServiceDiscoveryFactory 对象

## Verifying this change
验证同一个域名下的多个nacos 配置可以注册到多个命名空间

<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [ ] GitHub Actions works fine on your own branch.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
