### PR TITLE
fix dubbo aot native-image compile with GraalVM 17.0.7+7.1,throw No constructor or…

### DIFF
--- a/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/ServiceBean.java
+++ b/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/ServiceBean.java
@@ -52,6 +52,10 @@ public class ServiceBean<T> extends ServiceConfig<T> implements InitializingBean
 
     private ApplicationEventPublisher applicationEventPublisher;
 
+    public ServiceBean() {
+        this.service = null;
+    }
+
     public ServiceBean(ApplicationContext applicationContext) {
         super();
         this.service = null;

--- a/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/ServiceBeanTest.java
+++ b/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/ServiceBeanTest.java
@@ -52,4 +52,11 @@ class ServiceBeanTest {
     abstract class TestService implements Service {
 
     }
+
+
+    @Test
+    void testGetServiceWithNoArgs() {
+        ServiceBean serviceBean = new ServiceBean();
+        MatcherAssert.assertThat(serviceBean.getService(), nullValue());
+    }
 }


### PR DESCRIPTION
<!-- If you need to report a security issue please visit https://github.com/apache/dubbo/security/policy -->

- [y] I have searched the [issues](https://github.com/apache/dubbo/issues) of this repository and believe that this is not a duplicate.

### Environment

* Dubbo version: 3.3.0-beta.1
* Operating System version: macos 13.4.1 
* Java version: GraalVM CE 17.0.7+7.1 (build 17.0.7+7-jvmci-23.0-b12, mixed mode, sharing)

### Steps to reproduce this issue

1. compile and install  lastest dubbo 3.3.0-beta.1-snapshot  from github to local maven repository
https://github.com/apache/dubbo/tree/3.3
2. using dubbo aot demo in dubbo demos: 
https://github.com/apache/dubbo-samples/tree/master/1-basic/dubbo-samples-native-image

3. run aot native-image compile command
```shell
mvn clean package -P native native:compile -Dmaven.test.skip=true
```
4. compile error as follows
<img width="1428" alt="comile error" src="https://github.com/apache/dubbo/assets/28709322/ae23540a-6de6-45b2-8d08-2c5a03972a5b">



GitHub address: 1286232441@qq.com

### Expected Behavior

compile successfully 

### Actual Behavior
compile error

If there is an exception, please attach the exception trace:

```shell
Exception in thread "main" java.lang.IllegalStateException: No constructor or factory method candidate found for Root bean: class [org.apache.dubbo.config.spring.ServiceBean]; scope=singleton; abstract=false; lazyInit=null; autowireMode=3; dependencyCheck=0; autowireCandidate=true; primary=false; factoryBeanName=null; factoryMethodName=null; initMethodNames=null; destroyMethodNames=null and argument types []
	at org.springframework.beans.factory.support.ConstructorResolver.resolveConstructorOrFactoryMethod(ConstructorResolver.java:944)
	at org.springframework.beans.factory.support.RegisteredBean.resolveConstructorOrFactoryMethod(RegisteredBean.java:209)
	at org.springframework.beans.factory.aot.BeanDefinitionMethodGenerator.<init>(BeanDefinitionMethodGenerator.java:86)
	at org.springframework.beans.factory.aot.BeanDefinitionMethodGeneratorFactory.getBeanDefinitionMethodGenerator(BeanDefinitionMethodGeneratorFactory.java:100)
	at org.springframework.beans.factory.aot.BeanDefinitionMethodGeneratorFactory.getBeanDefinitionMethodGenerator(BeanDefinitionMethodGeneratorFactory.java:115)
	at org.springframework.beans.factory.aot.BeanRegistrationsAotProcessor.processAheadOfTime(BeanRegistrationsAotProcessor.java:48)
	at org.springframework.beans.factory.aot.BeanRegistrationsAotProcessor.processAheadOfTime(BeanRegistrationsAotProcessor.java:36)
	at org.springframework.context.aot.BeanFactoryInitializationAotContributions.getContributions(BeanFactoryInitializationAotContributions.java:67)
	at org.springframework.context.aot.BeanFactoryInitializationAotContributions.<init>(BeanFactoryInitializationAotContributions.java:49)
	at org.springframework.context.aot.BeanFactoryInitializationAotContributions.<init>(BeanFactoryInitializationAotContributions.java:44)
	at org.springframework.context.aot.ApplicationContextAotGenerator.lambda$processAheadOfTime$0(ApplicationContextAotGenerator.java:58)
	at org.springframework.context.aot.ApplicationContextAotGenerator.withCglibClassHandler(ApplicationContextAotGenerator.java:67)
	at org.springframework.context.aot.ApplicationContextAotGenerator.processAheadOfTime(ApplicationContextAotGenerator.java:53)
	at org.springframework.context.aot.ContextAotProcessor.performAotProcessing(ContextAotProcessor.java:106)
	at org.springframework.context.aot.ContextAotProcessor.doProcess(ContextAotProcessor.java:84)
	at org.springframework.context.aot.ContextAotProcessor.doProcess(ContextAotProcessor.java:49)
	at org.springframework.context.aot.AbstractAotProcessor.process(AbstractAotProcessor.java:82)
	at org.springframework.boot.SpringApplicationAotProcessor.main(SpringApplicationAotProcessor.java:80)
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for dubbo-samples-native-image 1.0-SNAPSHOT:
[INFO] 
[INFO] dubbo-samples-native-image ......................... SUCCESS [  0.241 s]
[INFO] dubbo-samples-native-image-interface ............... SUCCESS [  0.492 s]
[INFO] dubbo-samples-native-image-provider ................ FAILURE [  3.659 s]
[INFO] dubbo-samples-native-image-consumer ................ SKIPPED
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  4.537 s
[INFO] Finished at: 2023-07-16T22:24:41+08:00
[INFO] ------------------------------------------------------------------------

```
