### PR TITLE
Fix netty close when init count is 0

### DIFF
--- a/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/api/connection/AbstractConnectionClient.java
+++ b/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/api/connection/AbstractConnectionClient.java
@@ -49,6 +49,9 @@ public abstract class AbstractConnectionClient extends AbstractClient {
 
     protected AbstractConnectionClient(URL url, ChannelHandler handler) throws RemotingException {
         super(url, handler);
+    }
+
+    public final void increase() {
         COUNTER_UPDATER.set(this, 1L);
     }
 

--- a/dubbo-remoting/dubbo-remoting-netty4/src/main/java/org/apache/dubbo/remoting/transport/netty4/NettyConnectionClient.java
+++ b/dubbo-remoting/dubbo-remoting-netty4/src/main/java/org/apache/dubbo/remoting/transport/netty4/NettyConnectionClient.java
@@ -89,6 +89,7 @@ public class NettyConnectionClient extends AbstractConnectionClient {
         this.channel = new AtomicReference<>();
         this.closePromise = new DefaultPromise<>(GlobalEventExecutor.INSTANCE);
         this.init = new AtomicBoolean(false);
+        this.increase();
     }
 
     @Override


### PR DESCRIPTION
## What is the purpose of the change

When netty client connect failed at init, `org.apache.dubbo.remoting.transport.netty4.NettyConnectionClient.ConnectionListener#operationComplete` will check connection is used. But `NettyConnectionClient` has not been initialized and count has not been set.

Fix https://github.com/apache/dubbo/issues/12658

## Brief changelog


## Verifying this change


<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [ ] GitHub Actions works fine on your own branch.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
