### PR TITLE
rpc in same zone or rpc in same cell

### DIFF
--- a/dubbo-config/dubbo-config-api/pom.xml
+++ b/dubbo-config/dubbo-config-api/pom.xml
@@ -239,6 +239,10 @@
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+            <groupId>commons-net</groupId>
+            <artifactId>commons-net</artifactId>
+        </dependency>
 
     </dependencies>
 </project>

--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/utils/SubnetUtil.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/utils/SubnetUtil.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.config.utils;
+
+import org.apache.dubbo.common.utils.StringUtils;
+
+import org.apache.commons.net.util.SubnetUtils;
+import org.yaml.snakeyaml.LoaderOptions;
+import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.constructor.SafeConstructor;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+
+public class SubnetUtil {
+    public static final String TAG_SUBNETS_KEY = "tag.subnets";
+
+    private static Map<String, List<SubnetUtils.SubnetInfo>> cellSubnets = new ConcurrentHashMap<>();
+    protected static final ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
+    protected static final ReentrantReadWriteLock.ReadLock readLock = lock.readLock();
+    protected static final ReentrantReadWriteLock.WriteLock writeLock = lock.writeLock();
+
+    public static boolean isEmpty() {
+        try {
+            readLock.lock();
+            return cellSubnets.isEmpty();
+        } finally {
+            readLock.unlock();
+        }
+    }
+
+    public static void init(String content) {
+        if (StringUtils.isBlank(content)) {
+            return;
+        }
+        try {
+            writeLock.lock();
+            Yaml yaml = new Yaml(new SafeConstructor(new LoaderOptions()));
+            cellSubnets = new HashMap<>();
+            Map<String, List<String>> tmpPathSubnet = (Map<String, List<String>>) yaml.load(content);
+            for (Map.Entry<String, List<String>> entry : tmpPathSubnet.entrySet()) {
+                String path = entry.getKey();
+                List<SubnetUtils.SubnetInfo> subnetInfos = cellSubnets.computeIfAbsent(path, f -> new ArrayList<SubnetUtils.SubnetInfo>());
+                entry.getValue().forEach(e -> subnetInfos.add(new SubnetUtils(e.trim()).getInfo()));
+            }
+        } finally {
+            writeLock.unlock();
+        }
+    }
+
+    public static String getTagLevelByHost(String host) {
+        try {
+            readLock.lock();
+            for (Map.Entry<String, List<SubnetUtils.SubnetInfo>> entry : cellSubnets.entrySet()) {
+                for (SubnetUtils.SubnetInfo subnetInfo : entry.getValue()) {
+                    if (subnetInfo.isInRange(host)) {
+                        return entry.getKey();
+                    }
+                }
+            }
+            return null;
+        } finally {
+            readLock.unlock();
+        }
+    }
+}

--- a/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/utils/SubnetUtilTest.java
+++ b/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/utils/SubnetUtilTest.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.config.utils;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+
+public class SubnetUtilTest {
+    @Test
+    public void testLoadContent() {
+        String content = "" +//
+            "cn|cn-northwest|cell-1: \n" +
+            "- 172.37.66.0/24 #cn-northwest-1a\n" +
+            "cn|cn-north|cell-2: \n" +
+            "- 172.37.67.0/24 #cn-northwest-1b\n" +
+            "\"\": \n" +
+            "- 172.37.33.0/24 #cn-north-1a\n";
+        SubnetUtil.init(content);
+        Assert.assertEquals(SubnetUtil.getTagLevelByHost("172.37.66.1"),"cn|cn-northwest|cell-1");
+        Assert.assertEquals(SubnetUtil.getTagLevelByHost("172.37.33.1"),"");
+    }
+}

--- a/dubbo-dependencies-bom/pom.xml
+++ b/dubbo-dependencies-bom/pom.xml
@@ -131,6 +131,7 @@
         <apollo_client_version>2.1.0</apollo_client_version>
         <snakeyaml_version>2.0</snakeyaml_version>
         <commons_lang3_version>3.12.0</commons_lang3_version>
+        <commons_net_version>3.9.0</commons_net_version>
         <protostuff_version>1.8.0</protostuff_version>
         <envoy_api_version>0.1.35</envoy_api_version>
         <micrometer.version>1.11.2</micrometer.version>
@@ -652,6 +653,11 @@
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-lang3</artifactId>
                 <version>${commons_lang3_version}</version>
+            </dependency>
+            <dependency>
+                <groupId>commons-net</groupId>
+                <artifactId>commons-net</artifactId>
+                <version>${commons_net_version}</version>
             </dependency>
             <dependency>
                 <groupId>io.envoyproxy.controlplane</groupId>


### PR DESCRIPTION
## What is the purpose of the change
fix issue: https://github.com/apache/dubbo/issues/12763
### most people depoy service in three zone for HA , we expect service rpc in same zone : 

<img width="929" alt="WeChat59657f69ec05d9cc588af6d033f03e95" src="https://github.com/apache/dubbo/assets/7055460/b2d407f6-b815-4992-b134-fc85089588db">

tag-subnets:
```
cn|shanghai|a:
- 172.37.66.0/24 #zone=cn-shanghai-a
- 172.37.67.0/24 #zone=cn-shanghai-a
cn|shanghai|b:
- 172.37.68.0/24 #zone=cn-shanghai-b
cn|shanghai|c:
- 172.37.69.0/24 #zone=cn-shanghai-c
```
### some company's service are in a big zone , we expect service rpc in same cell : 
<img width="910" alt="WeChata0d541688dc3fb1b8b84931642e6ad33" src="https://github.com/apache/dubbo/assets/7055460/e8de2bf4-ff99-4c12-84bd-a3262c70c8dd">
tag-subnets:

```
cn|shanghai|a|cell-1:
- 172.31.35.0/24 #zone=cn-shanghai-a
cn|shanghai|a|cell-2:
- 172.31.36.0/24 #zone=cn-shanghai-a
cn|shanghai|a|cell-3:
- 172.31.37.0/24 #zone=cn-shanghai-a
```

### some company's service are in serveral city, we expect service prefer rpc in same zone , and rpc special service across zone( such as stock quantity service): 
<img width="910" alt="WeChatacb485d9d2e4cb56bd50c4f3557e83b4" src="https://github.com/apache/dubbo/assets/7055460/53654723-e424-4bcd-bf84-855a67cc15d1">
tag-subnets:

```
cn|shanghai|a:
- 172.37.66.0/24 #zone=cn-shanghai-a
cn|hangzhou|b:
- 172.37.67.0/24 #zone=cn-hangzhou-b
cn|shenzhen|c:
- 172.37.68.0/24 #zone=cn-shenzhen-c
"":
- 172.37.69.0/24 #zone=cn-shanghai-d, as common service
```

## Brief changelog
- add a configuration in configcenter: /dubbo/config/dubbo/tag.subnets , content is :

```
cn|shanghai|a:
- 172.37.66.0/24 #zone=cn-shanghai-a
cn|shanghai|b:
- 172.37.68.0/24 #zone=cn-shanghai-b
cn|shanghai|c:
- 172.37.69.0/24 #zone=cn-shanghai-c
```

- ServiceConfig.java will add a tag by subnet, such as : 
service on host 172.37.66.1 will add a dubbo.tag=cn|shanghai|a

- and then service in cn-shanghai-a will rpc same zone

- pull request https://github.com/apache/dubbo/pull/12673 will help to prefer rpc with long tag-level, for example:
consumer    rpc tag=cn|shanghai|a
prefer1: service tag=cn|shanghai|a 
prefer2: service tag=cn|shanghai
prefer3: service tag=cn
prefer4: service tag=""





## Verifying this change


<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [ ] GitHub Actions works fine on your own branch.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
