### PR TITLE
fix_win11_aot_compile_NoSuchFileException,because of File.separator

### DIFF
--- a/dubbo-native/src/main/java/org/apache/dubbo/aot/generate/JarScanner.java
+++ b/dubbo-native/src/main/java/org/apache/dubbo/aot/generate/JarScanner.java
@@ -139,7 +139,6 @@ public class JarScanner {
     }
 
     private String toClassName(String path) {
-        return path.substring(0, path.length() - 6).replace(File.separator, ".");
+        return path.contains(File.separator) ? path.substring(0, path.length() - 6).replace(File.separator, ".") : path.substring(0, path.length() - 6).replace("/", ".");
     }
-
 }


### PR DESCRIPTION
## What is the purpose of the change
fix win11 graalvm17 dubbo aot compile throws java.nio.file.NoSuchFileException


## Brief changelog
Because in Windows OS ,   file separator is  "\\" .
However in jvm/graalvm ,  .class file  URL is always  splited by  "/"
<img width="926" alt="1" src="https://github.com/apache/dubbo/assets/28709322/0fe16648-fd99-4007-a492-e97cf361a741">
<img width="923" alt="2" src="https://github.com/apache/dubbo/assets/28709322/0587df56-40f5-4e71-b840-ce293b75fe1a">


So the   following code does not work in Windows 


org.apache.dubbo.aot.generate.JarScanner#toClassName(String path)
```java
path.substring(0, path.length() - 6).replace(File.separator, ".")
```
I change to 
```java
path.contains(File.separator) ? path.substring(0, path.length() - 6).replace(File.separator, ".") : path.substring(0, path.length() - 6).replace("/", ".");
```



<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
[y] [dubbo_issue: win11 graalvm17 dubbo aot compile throws java.nio.file.NoSuchFileException](https://github.com/apache/dubbo/issues/12768) 