### PR TITLE
Support real RpcException be thrown.

### DIFF
--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/filter/TpsLimitFilter.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/filter/TpsLimitFilter.java
@@ -29,6 +29,8 @@ import org.apache.dubbo.rpc.filter.tps.DefaultTPSLimiter;
 import org.apache.dubbo.rpc.filter.tps.TPSLimiter;
 import org.apache.dubbo.rpc.support.RpcUtils;
 
+import static org.apache.dubbo.rpc.Constants.TPS_LIMIT_RATE_KEY;
+
 /**
  * TpsLimitFilter limit the TPS (transaction per second) for all method of a service or a particular method.
  * Service or method url can define <b>tps</b> or <b>tps.interval</b> to control this control.It use {@link DefaultTPSLimiter}
@@ -36,7 +38,7 @@ import org.apache.dubbo.rpc.support.RpcUtils;
  * if invocation count exceed the configured <b>tps</b> value (default is -1 which means unlimited) then invocation will get
  * RpcException.
  */
-@Activate(group = CommonConstants.PROVIDER)
+@Activate(group = CommonConstants.PROVIDER, value = TPS_LIMIT_RATE_KEY)
 public class TpsLimitFilter implements Filter {
 
     private final TPSLimiter tpsLimiter = new DefaultTPSLimiter();

--- a/dubbo-rpc/dubbo-rpc-api/src/main/resources/META-INF/dubbo/internal/org.apache.dubbo.rpc.Filter
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/resources/META-INF/dubbo/internal/org.apache.dubbo.rpc.Filter
@@ -15,3 +15,4 @@ tps=org.apache.dubbo.rpc.filter.TpsLimitFilter
 profiler-server=org.apache.dubbo.rpc.filter.ProfilerServerFilter
 adaptiveLoadBalance=org.apache.dubbo.rpc.filter.AdaptiveLoadBalanceFilter
 active-limit=org.apache.dubbo.rpc.filter.ActiveLimitFilter
+rpc-exception=org.apache.dubbo.rpc.filter.RpcExceptionFilter

--- a/dubbo-rpc/dubbo-rpc-api/src/test/java/org/apache/dubbo/rpc/filter/tps/TpsLimitFilterTest.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/test/java/org/apache/dubbo/rpc/filter/tps/TpsLimitFilterTest.java
@@ -19,11 +19,11 @@ package org.apache.dubbo.rpc.filter.tps;
 import org.apache.dubbo.common.URL;
 import org.apache.dubbo.rpc.Invocation;
 import org.apache.dubbo.rpc.Invoker;
+import org.apache.dubbo.rpc.Result;
 import org.apache.dubbo.rpc.RpcException;
 import org.apache.dubbo.rpc.filter.TpsLimitFilter;
 import org.apache.dubbo.rpc.support.MockInvocation;
 import org.apache.dubbo.rpc.support.MyInvoker;
-
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -54,12 +54,12 @@ class TpsLimitFilterTest {
             Invoker<TpsLimitFilterTest> invoker = new MyInvoker<TpsLimitFilterTest>(url);
             Invocation invocation = new MockInvocation();
             for (int i = 0; i < 10; i++) {
-                try {
-                    filter.invoke(invoker, invocation);
-                } catch (Exception e) {
-                    assertTrue(i >= 5);
-                    throw e;
+                Result re = filter.invoke(invoker, invocation);
+                if (i >= 5) {
+                    assertTrue(re.hasException());
+                    throw re.getException();
                 }
+
             }
         });
 


### PR DESCRIPTION
## What is the purpose of the change

When Filter throws an `RpcException` on the provider side, the consumer does not get the real `RpcException`, only errorMsg.


## Brief changelog


## Verifying this change


<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [ ] GitHub Actions works fine on your own branch.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
