### PR TITLE
remove jsonrpc4j

### DIFF
--- a/dubbo-dependencies-bom/pom.xml
+++ b/dubbo-dependencies-bom/pom.xml
@@ -185,7 +185,6 @@
         <sofa_registry_version>5.4.3</sofa_registry_version>
         <gson_version>2.10.1</gson_version>
         <jackson_version>2.15.2</jackson_version>
-        <jsonrpc_version>1.6</jsonrpc_version>
         <mortbay_jetty_version>6.1.26</mortbay_jetty_version>
         <portlet_version>2.0</portlet_version>
         <maven_flatten_version>1.5.0</maven_flatten_version>
@@ -770,11 +769,6 @@
                 <groupId>com.fasterxml.jackson.datatype</groupId>
                 <artifactId>jackson-datatype-jsr310</artifactId>
                 <version>${jackson_version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.github.briandilley.jsonrpc4j</groupId>
-                <artifactId>jsonrpc4j</artifactId>
-                <version>${jsonrpc_version}</version>
             </dependency>
             <dependency>
                 <groupId>javax.portlet</groupId>


### PR DESCRIPTION
## What is the purpose of the change
![image](https://github.com/apache/dubbo/assets/18413695/e47bd246-bb6a-424c-94a6-e8dced70e615)
There is a dependency conflict between dubbo and dubbo-spi-extensions. The jsonrpc4j not used in dubbo-dependencies-bom will overwrite the version in the dubbo-http-rpc module


## Brief changelog


## Verifying this change


<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [ ] GitHub Actions works fine on your own branch.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
