### PR TITLE
fix(sec): upgrade org.springframework.boot:spring-boot-autoconfigure to 3.0.7

### DIFF
--- a/dubbo-spring-boot/dubbo-spring-boot-compatible/pom.xml
+++ b/dubbo-spring-boot/dubbo-spring-boot-compatible/pom.xml
@@ -31,7 +31,7 @@
     <description>Apache Dubbo Spring Boot Compatible for Spring Boot 1.x</description>
 
     <properties>
-        <spring-boot.version>1.5.22.RELEASE</spring-boot.version>
+        <spring-boot.version>3.0.7</spring-boot.version>
     </properties>
 
     <modules>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.springframework.boot:spring-boot-autoconfigure 1.5.22.RELEASE
- [CVE-2023-20883](https://www.oscs1024.com/hd/CVE-2023-20883)


### What did I do？
Upgrade org.springframework.boot:spring-boot-autoconfigure from 1.5.22.RELEASE to 3.0.7 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How can we automate the detection of these types of issues?
By using the [GitHub Actions](https://github.com/murphysecurity/actions) configurations provided by murphysec, we can conduct automatic code security checks in our CI pipeline.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS