### PR TITLE
RestServerFactory的createServer方法兼容SPI扩展支持文件com.alibaba.dubbo.remoting…

### DIFF
--- a/dubbo-rpc/dubbo-rpc-rest/src/main/java/com/alibaba/dubbo/rpc/protocol/rest/RestServerFactory.java
+++ b/dubbo-rpc/dubbo-rpc-rest/src/main/java/com/alibaba/dubbo/rpc/protocol/rest/RestServerFactory.java
@@ -18,6 +18,14 @@ package com.alibaba.dubbo.rpc.protocol.rest;
 
 import com.alibaba.dubbo.remoting.http.HttpBinder;
 
+import java.io.IOException;
+import java.net.URL;
+import java.util.Enumeration;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+
 /**
  * Only the server that implements servlet container
  * could support something like @Context injection of servlet objects.
@@ -25,20 +33,44 @@ import com.alibaba.dubbo.remoting.http.HttpBinder;
  */
 public class RestServerFactory {
 
+    private static final String HTTP_BINDER_SPI_LOCATION = "META-INF/dubbo/internal/com.alibaba.dubbo.remoting.http.HttpBinder";
     private HttpBinder httpBinder;
+
+    public RestServerFactory() {
+    }
 
     public void setHttpBinder(HttpBinder httpBinder) {
         this.httpBinder = httpBinder;
     }
 
     public RestServer createServer(String name) {
-        // TODO move names to Constants
-        if ("servlet".equalsIgnoreCase(name) || "jetty".equalsIgnoreCase(name) || "tomcat".equalsIgnoreCase(name)) {
-            return new DubboHttpServer(httpBinder);
-        } else if ("netty".equalsIgnoreCase(name)) {
-            return new NettyServer();
-        } else {
-            throw new IllegalArgumentException("Unrecognized server name: " + name);
+        ClassLoader classLoader = RestServerFactory.class.getClassLoader();
+        try {
+            Enumeration<URL> urls = classLoader.getResources(HTTP_BINDER_SPI_LOCATION);
+            Set<String> result = new HashSet<String>();
+            while (urls.hasMoreElements()) {
+                URL url = urls.nextElement();
+                Properties properties = new Properties();
+                properties.load(url.openStream());
+                for (Map.Entry<?, ?> entry : properties.entrySet()) {
+                    String httpBinderName = ((String) entry.getKey()).trim();
+                    result.add(httpBinderName);
+                }
+            }
+            if (!result.contains(name)) {
+                if ("netty".equalsIgnoreCase(name)) {
+                    return new NettyServer();
+                } else {
+                    throw new IllegalArgumentException("Unrecognized server name: " + name);
+                }
+            } else {
+                return new DubboHttpServer(this.httpBinder);
+            }
+
+
+        } catch (IOException e) {
+            throw new RuntimeException(e);
         }
+
     }
 }


### PR DESCRIPTION
….http.HttpBinder中的全部服务器类型

## What is the purpose of the change
RestServerFactory中写死了jetty,servlet,tomcat三种类型的服务，想将这块开放出来支持更多的服务


## Brief changelog
RestServerFactory中开放更多的服务类型

## Verifying this change
开放后，通过在provider的dubbo.xml配置文件中配置dubbo protocol为rest，server命名为tongweb，配置示例如下：
<dubbo:protocol name="rest" port="20890" server="tongweb"/>
在启动时，能够使RestServerFactory的createServer不再报Unrecognized server name 

<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

