### PR TITLE
fix loading process cannot load environment variables.

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/config/ConfigurationUtils.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/config/ConfigurationUtils.java
@@ -317,7 +317,7 @@ public final class ConfigurationUtils {
         }
         for (Map.Entry<String, V> entry : copy.entrySet()) {
             String key = entry.getKey();
-            if (StringUtils.startsWithIgnoreCase(key, prefix)
+            if ((StringUtils.startsWithIgnoreCase(key, prefix) || StringUtils.startsWithIgnoreCase(key, StringUtils.toOSStyleKey(prefix)))
                 && key.length() > prefix.length()
                 && !ConfigurationUtils.isEmptyValue(entry.getValue())) {
                 return true;

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/config/ConfigurationUtils.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/config/ConfigurationUtils.java
@@ -277,7 +277,7 @@ public final class ConfigurationUtils {
             for (Map.Entry<String, V> entry : copy.entrySet()) {
                 String key = entry.getKey();
                 V val = entry.getValue();
-                if (StringUtils.startsWithIgnoreCase(key, prefix)
+                if ((StringUtils.startsWithIgnoreCase(key, prefix) || StringUtils.startsWithIgnoreCase(key, StringUtils.toOSStyleKey(prefix)))
                     && key.length() > prefix.length()
                     && !ConfigurationUtils.isEmptyValue(val)) {
 

--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/deploy/DefaultApplicationDeployer.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/deploy/DefaultApplicationDeployer.java
@@ -863,6 +863,7 @@ public class DefaultApplicationDeployer extends AbstractDeployer<ApplicationMode
                 String appConfigFile = null;
                 Optional<ApplicationConfig> applicationOptional = getApplication();
                 if (applicationOptional.isPresent()) {
+                    appGroup = applicationOptional.get().getName();
                     if (isNotEmpty(appGroup)) {
                         appConfigFile = isNotEmpty(configCenter.getAppConfigFile()) ? configCenter.getAppConfigFile() : configCenter.getConfigFile();
                         appConfigContent = dynamicConfiguration.getProperties(appConfigFile, appGroup);

--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/deploy/DefaultApplicationDeployer.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/deploy/DefaultApplicationDeployer.java
@@ -187,7 +187,7 @@ public class DefaultApplicationDeployer extends AbstractDeployer<ApplicationMode
      * by default is false.
      */
     private boolean isRegisterConsumerInstance() {
-        Boolean registerConsumer = getApplication().getRegisterConsumer();
+        Boolean registerConsumer = getApplicationOrElseThrow().getRegisterConsumer();
         if (registerConsumer == null) {
             return false;
         }
@@ -310,7 +310,7 @@ public class DefaultApplicationDeployer extends AbstractDeployer<ApplicationMode
 
         useRegistryAsMetadataCenterIfNecessary();
 
-        ApplicationConfig applicationConfig = getApplication();
+        ApplicationConfig applicationConfig = getApplicationOrElseThrow();
 
         String metadataType = applicationConfig.getMetadataType();
         // FIXME, multiple metadata config support.
@@ -858,14 +858,17 @@ public class DefaultApplicationDeployer extends AbstractDeployer<ApplicationMode
                 if (StringUtils.isNotEmpty(configContent)) {
                     logger.info(String.format("Got global remote configuration from config center with key-%s and group-%s: \n %s", configCenter.getConfigFile(), configCenter.getGroup(), configContent));
                 }
-                String appGroup = getApplication().getName();
+                String appGroup = "";
                 String appConfigContent = null;
                 String appConfigFile = null;
-                if (isNotEmpty(appGroup)) {
-                    appConfigFile = isNotEmpty(configCenter.getAppConfigFile()) ? configCenter.getAppConfigFile() : configCenter.getConfigFile();
-                    appConfigContent = dynamicConfiguration.getProperties(appConfigFile, appGroup);
-                    if (StringUtils.isNotEmpty(appConfigContent)) {
-                        logger.info(String.format("Got application specific remote configuration from config center with key %s and group %s: \n %s", appConfigFile, appGroup, appConfigContent));
+                Optional<ApplicationConfig> applicationOptional = getApplication();
+                if (applicationOptional.isPresent()) {
+                    if (isNotEmpty(appGroup)) {
+                        appConfigFile = isNotEmpty(configCenter.getAppConfigFile()) ? configCenter.getAppConfigFile() : configCenter.getConfigFile();
+                        appConfigContent = dynamicConfiguration.getProperties(appConfigFile, appGroup);
+                        if (StringUtils.isNotEmpty(appConfigContent)) {
+                            logger.info(String.format("Got application specific remote configuration from config center with key %s and group %s: \n %s", appConfigFile, appGroup, appConfigContent));
+                        }
                     }
                 }
                 try {
@@ -1322,9 +1325,12 @@ public class DefaultApplicationDeployer extends AbstractDeployer<ApplicationMode
         }
     }
 
-    private ApplicationConfig getApplication() {
+    private ApplicationConfig getApplicationOrElseThrow() {
         return configManager.getApplicationOrElseThrow();
     }
 
+    private Optional<ApplicationConfig> getApplication() {
+        return configManager.getApplication();
+    }
 
 }

--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/integration/RegistryProtocol.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/integration/RegistryProtocol.java
@@ -917,7 +917,7 @@ public class RegistryProtocol implements Protocol, ScopeModelAware {
         public ProviderConfigurationListener(ModuleModel moduleModel) {
             super(moduleModel);
             this.moduleModel = moduleModel;
-            if (moduleModel.modelEnvironment().getConfiguration().convert(Boolean.class, ENABLE_CONFIGURATION_LISTEN, true)) {
+            if (moduleModel.modelEnvironment().getConfiguration().getBoolean(ENABLE_CONFIGURATION_LISTEN, true)) {
                 this.initWith(moduleModel.getApplicationModel().getApplicationName() + CONFIGURATORS_SUFFIX);
             }
         }


### PR DESCRIPTION
For example, environment variable `DUBBO_REGISTRY_ADDRESS=zookeeper://127.0.0.1:2182` should override same configuration in dubbo.properties `dubbo.registry.address=zookeeper://127.0.0.1:2181`.