### PR TITLE
fix: AbortPolicyWithReport concurrency #13042

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/threadpool/support/AbortPolicyWithReport.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/threadpool/support/AbortPolicyWithReport.java
@@ -145,6 +145,10 @@ public class AbortPolicyWithReport extends ThreadPoolExecutor.AbortPolicy {
         if (!guard.tryAcquire()) {
             return;
         }
+        // To avoid multiple dump, check again
+        if (System.currentTimeMillis() - lastPrintTime < TEN_MINUTES_MILLS) {
+            return;
+        }
 
         ExecutorService pool = Executors.newSingleThreadExecutor();
         pool.execute(() -> {
@@ -169,9 +173,9 @@ public class AbortPolicyWithReport extends ThreadPoolExecutor.AbortPolicy {
             } catch (Exception t) {
                 logger.error(COMMON_UNEXPECTED_CREATE_DUMP, "", "", "dump jStack error", t);
             } finally {
+                lastPrintTime = System.currentTimeMillis();
                 guard.release();
             }
-            lastPrintTime = System.currentTimeMillis();
         });
         //must shutdown thread pool ,if not will lead to OOM
         pool.shutdown();


### PR DESCRIPTION
## What is the purpose of the change

to avoid AbortPolicyWithReport dump again

fixed: #13042  https://github.com/apache/dubbo/issues/13042

## Brief changelog

- only update AbortPolicyWithReport.java

## Verifying this change


<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [ ] GitHub Actions works fine on your own branch.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
