### PR TITLE
Feat custom generic include class

### DIFF
--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/filter/GenericFilter.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/filter/GenericFilter.java
@@ -52,12 +52,14 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Type;
 import java.util.stream.IntStream;
 
+import static java.lang.Boolean.FALSE;
 import static org.apache.dubbo.common.constants.CommonConstants.$INVOKE;
 import static org.apache.dubbo.common.constants.CommonConstants.$INVOKE_ASYNC;
 import static org.apache.dubbo.common.constants.CommonConstants.GENERIC_SERIALIZATION_BEAN;
 import static org.apache.dubbo.common.constants.CommonConstants.GENERIC_SERIALIZATION_GSON;
 import static org.apache.dubbo.common.constants.CommonConstants.GENERIC_SERIALIZATION_NATIVE_JAVA;
 import static org.apache.dubbo.common.constants.CommonConstants.GENERIC_SERIALIZATION_PROTOBUF;
+import static org.apache.dubbo.common.constants.CommonConstants.GENERIC_WITH_CLZ_KEY;
 import static org.apache.dubbo.rpc.Constants.GENERIC_KEY;
 
 /**
@@ -259,7 +261,15 @@ public class GenericFilter implements Filter, Filter.Listener {
             } else if (ProtocolUtils.isGenericReturnRawResult(generic)) {
                 return;
             } else {
-                appResponse.setValue(PojoUtils.generalize(appResponse.getValue()));
+                String genericWithClzStr = inv.getAttachment(GENERIC_WITH_CLZ_KEY);
+                Object response = appResponse.getValue();
+                if ("true".equals(genericWithClzStr) || "false".equals(genericWithClzStr)) {
+                    boolean genericWithClz = Boolean.parseBoolean(genericWithClzStr);
+                    response = PojoUtils.generalize(response, genericWithClz);
+                } else {
+                    response = PojoUtils.generalize(response);
+                }
+                appResponse.setValue(response);
             }
         }
     }


### PR DESCRIPTION
## What is the purpose of the change

Can set 'generic.include.class' in a single call to control whether the class field is included in the response when generic invoke.

## Verifying this change

org.apache.dubbo.rpc.filter.GenericFilterTest#testInvokeRemoveClassField

## issue
https://github.com/apache/dubbo/issues/13048
