### PR TITLE
The handling of jsr310 times (package names start with java.time) is open to customization with dubbo's own spi implementation, which provides a default implementation in spring that allows you to configure date formats

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/convert/jsr310/AbstractTemporalAccessorConverter.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/convert/jsr310/AbstractTemporalAccessorConverter.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.common.convert.jsr310;
+
+
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.TemporalAccessor;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.BiFunction;
+
+public abstract class AbstractTemporalAccessorConverter {
+
+    private final List<DateTimeFormatter> dateTimeFormatterSet;
+
+    public AbstractTemporalAccessorConverter() {
+        this.dateTimeFormatterSet = Collections.emptyList();
+    }
+
+    public AbstractTemporalAccessorConverter(List<DateTimeFormatter> dateTimeFormatterSet) {
+        this.dateTimeFormatterSet = dateTimeFormatterSet;
+    }
+
+    public Object generalize(TemporalAccessor accessor) {
+        for (DateTimeFormatter dateTimeFormatter : dateTimeFormatterSet) {
+            try {
+                return dateTimeFormatter.format(accessor);
+            } catch (Exception ignore) {
+            }
+        }
+        return accessor.toString();
+    }
+
+    public <T extends TemporalAccessor> T realize(Object obj, BiFunction<String, DateTimeFormatter, T> parse, DateTimeFormatter defaultDateTimeFormatter) {
+        String text = obj.toString();
+        for (DateTimeFormatter dateTimeFormatter : dateTimeFormatterSet) {
+            try {
+                return parse.apply(text, dateTimeFormatter);
+            } catch (Exception ignore) {
+            }
+        }
+        return parse.apply(text, defaultDateTimeFormatter);
+    }
+
+}

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/convert/jsr310/DefaultLocalDateConverter.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/convert/jsr310/DefaultLocalDateConverter.java
@@ -1,0 +1,44 @@
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.common.convert.jsr310;
+
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+public class DefaultLocalDateConverter extends AbstractTemporalAccessorConverter implements LocalDateConverter {
+
+    public DefaultLocalDateConverter() {
+    }
+
+    public DefaultLocalDateConverter(List<DateTimeFormatter> dateTimeFormatterSet) {
+        super(dateTimeFormatterSet);
+    }
+
+    @Override
+    public Object generalize(LocalDate localDate) {
+        return super.generalize(localDate);
+    }
+
+    @Override
+    public LocalDate realize(Object obj) {
+        return super.realize(obj, LocalDate::parse, DateTimeFormatter.ISO_LOCAL_DATE);
+    }
+
+}

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/convert/jsr310/DefaultLocalDateTimeConverter.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/convert/jsr310/DefaultLocalDateTimeConverter.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.common.convert.jsr310;
+
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+public class DefaultLocalDateTimeConverter extends AbstractTemporalAccessorConverter implements LocalDateTimeConverter {
+
+    public DefaultLocalDateTimeConverter() {
+    }
+
+    public DefaultLocalDateTimeConverter(List<DateTimeFormatter> dateTimeFormatterSet) {
+        super(dateTimeFormatterSet);
+    }
+
+    @Override
+    public Object generalize(LocalDateTime localDateTime) {
+        return super.generalize(localDateTime);
+    }
+
+    @Override
+    public LocalDateTime realize(Object obj) {
+        return super.realize(obj, LocalDateTime::parse, DateTimeFormatter.ISO_LOCAL_DATE_TIME);
+    }
+
+}

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/convert/jsr310/DefaultLocalTimeConverter.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/convert/jsr310/DefaultLocalTimeConverter.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.common.convert.jsr310;
+
+
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+public class DefaultLocalTimeConverter extends AbstractTemporalAccessorConverter implements LocalTimeConverter {
+
+    public DefaultLocalTimeConverter() {
+    }
+
+    public DefaultLocalTimeConverter(List<DateTimeFormatter> dateTimeFormatterSet) {
+        super(dateTimeFormatterSet);
+    }
+
+    @Override
+    public Object generalize(LocalTime localTime) {
+        return super.generalize(localTime);
+    }
+
+    @Override
+    public LocalTime realize(Object obj) {
+        return super.realize(obj, LocalTime::parse, DateTimeFormatter.ISO_LOCAL_TIME);
+    }
+
+}

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/convert/jsr310/Jsr310Converter.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/convert/jsr310/Jsr310Converter.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.common.convert.jsr310;
+
+public interface Jsr310Converter<T> {
+
+    Object generalize(T t);
+
+    T realize(Object obj);
+
+}

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/convert/jsr310/LocalDateConverter.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/convert/jsr310/LocalDateConverter.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.common.convert.jsr310;
+
+import org.apache.dubbo.common.extension.SPI;
+
+import java.time.LocalDate;
+
+@SPI("default")
+public interface LocalDateConverter extends Jsr310Converter<LocalDate> {
+
+}

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/convert/jsr310/LocalDateTimeConverter.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/convert/jsr310/LocalDateTimeConverter.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.common.convert.jsr310;
+
+import org.apache.dubbo.common.extension.SPI;
+
+import java.time.LocalDateTime;
+
+@SPI("default")
+public interface LocalDateTimeConverter extends Jsr310Converter<LocalDateTime> {
+
+}

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/convert/jsr310/LocalTimeConverter.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/convert/jsr310/LocalTimeConverter.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.common.convert.jsr310;
+
+import org.apache.dubbo.common.extension.SPI;
+
+import java.time.LocalTime;
+
+@SPI("default")
+public interface LocalTimeConverter extends Jsr310Converter<LocalTime> {
+
+}

--- a/dubbo-common/src/main/resources/META-INF/dubbo/internal/org.apache.dubbo.common.convert.jsr310.LocalDateConverter
+++ b/dubbo-common/src/main/resources/META-INF/dubbo/internal/org.apache.dubbo.common.convert.jsr310.LocalDateConverter
@@ -1,0 +1,1 @@
+default=org.apache.dubbo.common.convert.jsr310.DefaultLocalDateConverter

--- a/dubbo-common/src/main/resources/META-INF/dubbo/internal/org.apache.dubbo.common.convert.jsr310.LocalDateTimeConverter
+++ b/dubbo-common/src/main/resources/META-INF/dubbo/internal/org.apache.dubbo.common.convert.jsr310.LocalDateTimeConverter
@@ -1,0 +1,1 @@
+default=org.apache.dubbo.common.convert.jsr310.DefaultLocalDateTimeConverter

--- a/dubbo-common/src/main/resources/META-INF/dubbo/internal/org.apache.dubbo.common.convert.jsr310.LocalTimeConverter
+++ b/dubbo-common/src/main/resources/META-INF/dubbo/internal/org.apache.dubbo.common.convert.jsr310.LocalTimeConverter
@@ -1,0 +1,1 @@
+default=org.apache.dubbo.common.convert.jsr310.DefaultLocalTimeConverter

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/utils/PojoUtilsTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/utils/PojoUtilsTest.java
@@ -16,24 +16,8 @@
  */
 package org.apache.dubbo.common.utils;
 
-import java.io.Serializable;
-import java.lang.reflect.Method;
-import java.lang.reflect.Type;
-import java.text.SimpleDateFormat;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.LocalTime;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.LinkedHashMap;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
-
+import org.apache.dubbo.common.convert.jsr310.DefaultLocalDateTimeConverter;
+import org.apache.dubbo.common.convert.jsr310.DefaultLocalTimeConverter;
 import org.apache.dubbo.common.model.Person;
 import org.apache.dubbo.common.model.SerializablePerson;
 import org.apache.dubbo.common.model.User;
@@ -42,10 +26,30 @@ import org.apache.dubbo.common.model.person.FullAddress;
 import org.apache.dubbo.common.model.person.PersonInfo;
 import org.apache.dubbo.common.model.person.PersonStatus;
 import org.apache.dubbo.common.model.person.Phone;
+
+import com.alibaba.fastjson.JSONObject;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import com.alibaba.fastjson.JSONObject;
+import java.io.Serializable;
+import java.lang.reflect.Method;
+import java.lang.reflect.Type;
+import java.text.SimpleDateFormat;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
@@ -785,7 +789,8 @@ public class PojoUtilsTest {
 
         Parent parent = PojoUtils.mapToPojo(map, Parent.class);
 
-        assertEquals(parent.gender, "male");;
+        assertEquals(parent.gender, "male");
+        ;
         assertEquals(parent.getAge(), 40);
         assertEquals(parent.getChildren().size(), 1);
         assertEquals(parent.getChildren().get(0).gender, "male");
@@ -798,7 +803,7 @@ public class PojoUtilsTest {
 
     @Test
     public void testJava8Time() {
-        
+
         Object localDateTimeGen = PojoUtils.generalize(LocalDateTime.now());
         Object localDateTime = PojoUtils.realize(localDateTimeGen, LocalDateTime.class);
         assertEquals(localDateTimeGen, localDateTime.toString());
@@ -810,6 +815,29 @@ public class PojoUtilsTest {
         Object localTimeGen = PojoUtils.generalize(LocalTime.now());
         Object localTime = PojoUtils.realize(localTimeGen, LocalTime.class);
         assertEquals(localTimeGen, localTime.toString());
+    }
+
+    @Test
+    public void testJava8TimeWithCustomFormat() {
+        String localDateTimeFormat = "yyyy-MM-dd HH:mm:ss";
+        List<DateTimeFormatter> dateTimeFormatterList = Collections.singletonList(DateTimeFormatter.ofPattern(localDateTimeFormat));
+        PojoUtils.registerJsr310Converter(LocalDateTime.class, new DefaultLocalDateTimeConverter(dateTimeFormatterList));
+
+        String localTimeFormat = "HH:mm:ss";
+        List<DateTimeFormatter> localTimeFormatterList = Collections.singletonList(DateTimeFormatter.ofPattern(localTimeFormat));
+        PojoUtils.registerJsr310Converter(LocalTime.class, new DefaultLocalTimeConverter(localTimeFormatterList));
+
+        LocalDateTime now = LocalDateTime.now();
+        Object localDateTimeGen = PojoUtils.generalize(now);
+        Object localDateTime = PojoUtils.realize(localDateTimeGen, LocalDateTime.class);
+        assertTrue(localDateTime instanceof LocalDateTime);
+        assertEquals(localDateTimeGen.toString().length(), localDateTimeFormat.length());
+
+        LocalTime nowTime = LocalTime.now();
+        Object localTimeGen = PojoUtils.generalize(nowTime);
+        Object localTime = PojoUtils.realize(localTimeGen, LocalTime.class);
+        assertTrue(localTime instanceof LocalTime);
+        assertEquals(localTimeGen.toString().length(), localTimeFormat.length());
     }
 
     public enum Day {

--- a/dubbo-spring-boot/dubbo-spring-boot-compatible/autoconfigure/src/main/java/org/apache/dubbo/spring/boot/context/event/Jsr310ConverterApplicationListener.java
+++ b/dubbo-spring-boot/dubbo-spring-boot-compatible/autoconfigure/src/main/java/org/apache/dubbo/spring/boot/context/event/Jsr310ConverterApplicationListener.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.spring.boot.context.event;
+
+
+import org.apache.dubbo.common.convert.jsr310.DefaultLocalDateConverter;
+import org.apache.dubbo.common.convert.jsr310.DefaultLocalDateTimeConverter;
+import org.apache.dubbo.common.convert.jsr310.DefaultLocalTimeConverter;
+import org.apache.dubbo.common.utils.PojoUtils;
+import org.apache.dubbo.common.utils.StringUtils;
+
+import org.springframework.boot.context.event.ApplicationEnvironmentPreparedEvent;
+import org.springframework.context.ApplicationListener;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Role;
+import org.springframework.core.env.ConfigurableEnvironment;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
+
+import static org.springframework.beans.factory.config.BeanDefinition.ROLE_INFRASTRUCTURE;
+
+/**
+ * @author: Ares
+ * @time: 2023-09-13 19:41:51
+ * @description: Specify the time format based on the configuration when generic invoke
+ * @since 2.7.24
+ */
+@Configuration
+@Role(value = ROLE_INFRASTRUCTURE)
+public class Jsr310ConverterApplicationListener implements ApplicationListener<ApplicationEnvironmentPreparedEvent> {
+
+    private static final String DOUBLE_HYPHEN = "\\|\\|";
+    private static final AtomicBoolean PROCESSED = new AtomicBoolean(false);
+
+    @Override
+    public void onApplicationEvent(ApplicationEnvironmentPreparedEvent event) {
+        if (PROCESSED.compareAndSet(false, true)) {
+            ConfigurableEnvironment environment = event.getEnvironment();
+
+            String localDateTimeFormat = environment.resolvePlaceholders("${dubbo.generic.local-date-time-format:}");
+            if (StringUtils.isNotEmpty(localDateTimeFormat)) {
+                List<DateTimeFormatter> localDateTimeFormatterList = Arrays.stream(localDateTimeFormat.split(DOUBLE_HYPHEN))
+                        .map(DateTimeFormatter::ofPattern).collect(Collectors.toList());
+                PojoUtils.registerJsr310Converter(LocalDateTime.class, new DefaultLocalDateTimeConverter(localDateTimeFormatterList));
+            }
+
+            String localDateFormat = environment.resolvePlaceholders("${dubbo.generic.local-date-format:}");
+            if (StringUtils.isNotEmpty(localDateFormat)) {
+                List<DateTimeFormatter> localDateFormatterList = Arrays.stream(localDateFormat.split(DOUBLE_HYPHEN))
+                        .map(DateTimeFormatter::ofPattern).collect(Collectors.toList());
+                PojoUtils.registerJsr310Converter(LocalDate.class, new DefaultLocalDateConverter(localDateFormatterList));
+            }
+
+            String localTimeFormat = environment.resolvePlaceholders("${dubbo.generic.local-time-format:}");
+            if (StringUtils.isNotEmpty(localTimeFormat)) {
+                List<DateTimeFormatter> localTimeFormatterList = Arrays.stream(localTimeFormat.split(DOUBLE_HYPHEN))
+                        .map(DateTimeFormatter::ofPattern).collect(Collectors.toList());
+                PojoUtils.registerJsr310Converter(LocalTime.class, new DefaultLocalTimeConverter(localTimeFormatterList));
+            }
+        }
+    }
+
+}

--- a/dubbo-spring-boot/dubbo-spring-boot-compatible/autoconfigure/src/main/resources/META-INF/spring-configuration-metadata.json
+++ b/dubbo-spring-boot/dubbo-spring-boot-compatible/autoconfigure/src/main/resources/META-INF/spring-configuration-metadata.json
@@ -1,0 +1,33 @@
+{
+    "groups":
+    [
+        {
+            "name": "Specify the time format based on the configuration when generic invoke",
+            "type": "org.apache.dubbo.spring.boot.context.event.Jsr310ConverterApplicationListener",
+            "sourceType": "org.apache.dubbo.spring.boot.context.event.Jsr310ConverterApplicationListener"
+        }
+    ],
+    "properties":
+    [
+        {
+            "name": "dubbo.generic.local-date-time-format",
+            "description": "LocalDateTime use this format when generic invoke",
+            "type": "java.lang.String",
+            "sourceType": "org.apache.dubbo.spring.boot.context.event.Jsr310ConverterApplicationListener"
+        },
+        {
+            "name": "dubbo.generic.local-date-format",
+            "description": "LocalDate use this format when generic invoke",
+            "type": "java.lang.String",
+            "sourceType": "org.apache.dubbo.spring.boot.context.event.Jsr310ConverterApplicationListener"
+        },
+        {
+            "name": "dubbo.generic.local-time-format",
+            "description": "LocalTime use this format when generic invoke",
+            "type": "java.lang.String",
+            "sourceType": "org.apache.dubbo.spring.boot.context.event.Jsr310ConverterApplicationListener"
+        }
+    ],
+    "hints":
+    []
+}

--- a/dubbo-spring-boot/dubbo-spring-boot-compatible/autoconfigure/src/main/resources/META-INF/spring.factories
+++ b/dubbo-spring-boot/dubbo-spring-boot-compatible/autoconfigure/src/main/resources/META-INF/spring.factories
@@ -5,7 +5,8 @@ org.springframework.context.ApplicationListener=\
 org.apache.dubbo.spring.boot.context.event.OverrideDubboConfigApplicationListener,\
 org.apache.dubbo.spring.boot.context.event.DubboConfigBeanDefinitionConflictApplicationListener,\
 org.apache.dubbo.spring.boot.context.event.WelcomeLogoApplicationListener,\
-org.apache.dubbo.spring.boot.context.event.AwaitingNonWebApplicationListener
+org.apache.dubbo.spring.boot.context.event.AwaitingNonWebApplicationListener,\
+org.apache.dubbo.spring.boot.context.event.Jsr310ConverterApplicationListener
 org.springframework.boot.env.EnvironmentPostProcessor=\
 org.apache.dubbo.spring.boot.env.DubboDefaultPropertiesEnvironmentPostProcessor
 org.springframework.context.ApplicationContextInitializer=\

--- a/dubbo-spring-boot/dubbo-spring-boot-compatible/autoconfigure/src/test/java/org/apache/dubbo/spring/boot/context/event/Jsr310ConverterApplicationListenerTest.java
+++ b/dubbo-spring-boot/dubbo-spring-boot-compatible/autoconfigure/src/test/java/org/apache/dubbo/spring/boot/context/event/Jsr310ConverterApplicationListenerTest.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.spring.boot.context.event;
+
+import org.apache.dubbo.common.utils.PojoUtils;
+import org.apache.dubbo.rpc.model.ApplicationModel;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * @author: Ares
+ * @time: 2023-09-13 20:00:03
+ * {@link Jsr310ConverterApplicationListener} Test
+ * @see Jsr310ConverterApplicationListener
+ * @since 2.7.24
+ */
+@RunWith(SpringRunner.class)
+@TestPropertySource(
+        properties = {
+                "dubbo.generic.local-date-time-format = yyyy-MM-dd HH:mm:ss.SSS",
+                "dubbo.generic.local-time-format = HH:mm:ss||HH:mm:ss.SSS"}
+)
+@SpringBootTest(
+        classes = {Jsr310ConverterApplicationListener.class}
+)
+public class Jsr310ConverterApplicationListenerTest {
+
+    @BeforeClass
+    public static void init() {
+        ApplicationModel.reset();
+    }
+
+    @AfterClass
+    public static void destroy() {
+        ApplicationModel.reset();
+    }
+
+    @Test
+    public void testOnApplicationEvent() {
+        LocalDateTime now = LocalDateTime.now();
+        Object localDateTimeGen = PojoUtils.generalize(now);
+        Object localDateTime = PojoUtils.realize(localDateTimeGen, LocalDateTime.class);
+        assertEquals(localDateTimeGen.toString().length(), "yyyy-MM-dd HH:mm:ss.SSS".length());
+        assertTrue(localDateTime instanceof LocalDateTime);
+
+        LocalTime nowTime = LocalTime.now();
+        Object localTimeGen = PojoUtils.generalize(nowTime);
+        Object localTime = PojoUtils.realize(localTimeGen, LocalTime.class);
+        assertTrue(localTime instanceof LocalTime);
+        assertEquals(localTimeGen.toString().length(), 8);
+
+        localTime = PojoUtils.realize(localTimeGen + ".001", LocalTime.class);
+        assertTrue(localTime instanceof LocalTime);
+        assertEquals(localTime.toString().length(), 12);
+    }
+
+}

--- a/dubbo-spring-boot/dubbo-spring-boot-compatible/autoconfigure/src/test/resources/META-INF/dubbo.properties
+++ b/dubbo-spring-boot/dubbo-spring-boot-compatible/autoconfigure/src/test/resources/META-INF/dubbo.properties
@@ -1,1 +1,2 @@
 dubbo.application.id = test-dubbo-application-id
+dubbo.generic.local-date-time-format=yyyy-MM-dd HH:mm:ss.SSS


### PR DESCRIPTION
## What is the purpose of the change

Specify the jsr310 time format based on the configuration when generic invoke

## Verifying this change

org.apache.dubbo.spring.boot.context.event.Jsr310ConverterApplicationListenerTest

<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->
