### PR TITLE
feat: can set generic.include.class in a single call to control wheth…

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/utils/PojoUtils.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/utils/PojoUtils.java
@@ -125,11 +125,18 @@ public class PojoUtils {
     }
 
     public static Object generalize(Object pojo) {
-        return generalize(pojo, new IdentityHashMap<>());
+        return generalize(pojo, null);
+    }
+
+    public static Object generalize(Object pojo, Boolean genericWithClz) {
+        if (null == genericWithClz) {
+            genericWithClz = GENERIC_WITH_CLZ;
+        }
+        return generalize(pojo, new IdentityHashMap<Object, Object>(), genericWithClz);
     }
 
     @SuppressWarnings("unchecked")
-    private static Object generalize(Object pojo, Map<Object, Object> history) {
+    private static Object generalize(Object pojo, Map<Object, Object> history, boolean genericWithClz){
         if (pojo == null) {
             return null;
         }
@@ -170,7 +177,7 @@ public class PojoUtils {
             history.put(pojo, dest);
             for (int i = 0; i < len; i++) {
                 Object obj = Array.get(pojo, i);
-                dest[i] = generalize(obj, history);
+                dest[i] = generalize(obj, history, genericWithClz);
             }
             return dest;
         }
@@ -180,7 +187,7 @@ public class PojoUtils {
             Collection<Object> dest = (pojo instanceof List<?>) ? new ArrayList<>(len) : new HashSet<>(len);
             history.put(pojo, dest);
             for (Object obj : src) {
-                dest.add(generalize(obj, history));
+                dest.add(generalize(obj, history, genericWithClz));
             }
             return dest;
         }
@@ -189,20 +196,20 @@ public class PojoUtils {
             Map<Object, Object> dest = createMap(src);
             history.put(pojo, dest);
             for (Map.Entry<Object, Object> obj : src.entrySet()) {
-                dest.put(generalize(obj.getKey(), history), generalize(obj.getValue(), history));
+                dest.put(generalize(obj.getKey(), history, genericWithClz), generalize(obj.getValue(), history, genericWithClz));
             }
             return dest;
         }
         Map<String, Object> map = new HashMap<>();
         history.put(pojo, map);
-        if (GENERIC_WITH_CLZ) {
+        if (genericWithClz) {
             map.put("class", pojo.getClass().getName());
         }
         for (Method method : pojo.getClass().getMethods()) {
             if (ReflectUtils.isBeanPropertyReadMethod(method)) {
                 ReflectUtils.makeAccessible(method);
                 try {
-                    map.put(ReflectUtils.getPropertyNameFromBeanReadMethod(method), generalize(method.invoke(pojo), history));
+                    map.put(ReflectUtils.getPropertyNameFromBeanReadMethod(method), generalize(method.invoke(pojo), history, genericWithClz));
                 } catch (Exception e) {
                     throw new RuntimeException(e.getMessage(), e);
                 }
@@ -221,7 +228,7 @@ public class PojoUtils {
                         }
                     }
                     if (fieldValue != null) {
-                        map.put(field.getName(), generalize(fieldValue, history));
+                        map.put(field.getName(), generalize(fieldValue, history, genericWithClz));
                     }
                 } catch (Exception e) {
                     throw new RuntimeException(e.getMessage(), e);

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/filter/GenericFilter.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/filter/GenericFilter.java
@@ -62,6 +62,7 @@ import static org.apache.dubbo.common.constants.CommonConstants.$INVOKE_ASYNC;
 import static org.apache.dubbo.common.constants.CommonConstants.GENERIC_SERIALIZATION_BEAN;
 import static org.apache.dubbo.common.constants.CommonConstants.GENERIC_SERIALIZATION_NATIVE_JAVA;
 import static org.apache.dubbo.common.constants.CommonConstants.GENERIC_SERIALIZATION_PROTOBUF;
+import static org.apache.dubbo.common.constants.CommonConstants.GENERIC_WITH_CLZ_KEY;
 import static org.apache.dubbo.common.constants.LoggerCodeConstants.CONFIG_FILTER_VALIDATION_EXCEPTION;
 import static org.apache.dubbo.rpc.Constants.GENERIC_KEY;
 
@@ -333,7 +334,15 @@ public class GenericFilter implements Filter, Filter.Listener, ScopeModelAware {
             } else if (ProtocolUtils.isGenericReturnRawResult(generic)) {
                 return;
             } else {
-                appResponse.setValue(PojoUtils.generalize(appResponse.getValue()));
+                String genericWithClzStr = inv.getAttachment(GENERIC_WITH_CLZ_KEY);
+                Object response = appResponse.getValue();
+                if ("true".equals(genericWithClzStr) || "false".equals(genericWithClzStr)) {
+                    boolean genericWithClz = Boolean.parseBoolean(genericWithClzStr);
+                    response = PojoUtils.generalize(response, genericWithClz);
+                } else {
+                    response = PojoUtils.generalize(response);
+                }
+                appResponse.setValue(response);
             }
         }
     }

--- a/dubbo-rpc/dubbo-rpc-api/src/test/java/org/apache/dubbo/rpc/filter/GenericFilterTest.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/test/java/org/apache/dubbo/rpc/filter/GenericFilterTest.java
@@ -17,6 +17,7 @@
 package org.apache.dubbo.rpc.filter;
 
 import org.apache.dubbo.common.URL;
+import org.apache.dubbo.common.constants.CommonConstants;
 import org.apache.dubbo.rpc.AppResponse;
 import org.apache.dubbo.rpc.AsyncRpcResult;
 import org.apache.dubbo.rpc.Invocation;
@@ -147,6 +148,40 @@ class GenericFilterTest {
         Result result = genericFilter.invoke(invoker, invocation);
         Assertions.assertEquals(Person.class, result.getValue().getClass());
         Assertions.assertEquals(10, ((Person) (result.getValue())).getAge());
+    }
+
+    @Test
+    public void testInvokeRemoveClassField() throws Exception {
+
+        Method genericInvoke = GenericService.class.getMethods()[0];
+
+        Map<String, Object> person = new HashMap<String, Object>();
+        person.put("name", "dubbo");
+        person.put("age", 10);
+
+        RpcInvocation invocation = new RpcInvocation($INVOKE, GenericService.class.getName(), "", genericInvoke.getParameterTypes(),
+            new Object[]{"getPerson", new String[]{Person.class.getCanonicalName()}, new Object[]{person}});
+
+        URL url = URL.valueOf("test://test:11/org.apache.dubbo.rpc.support.DemoService?" +
+            "accesslog=true&group=dubbo&version=1.1");
+        Invoker invoker = Mockito.mock(Invoker.class);
+        when(invoker.invoke(any(Invocation.class))).thenReturn(AsyncRpcResult.newDefaultAsyncResult(new Person("person", 10), invocation));
+        when(invoker.getUrl()).thenReturn(url);
+        when(invoker.getInterface()).thenReturn(DemoService.class);
+
+
+        Result asyncResult = genericFilter.invoke(invoker, invocation);
+
+        AppResponse appResponse = (AppResponse) asyncResult.get();
+        genericFilter.onResponse(appResponse, invoker, invocation);
+        Assertions.assertTrue(((HashMap) appResponse.getValue()).containsKey("class"));
+
+        when(invoker.invoke(any(Invocation.class))).thenReturn(AsyncRpcResult.newDefaultAsyncResult(new Person("person", 10), invocation));
+        invocation.setObjectAttachment(CommonConstants.GENERIC_WITH_CLZ_KEY, "false");
+        asyncResult = genericFilter.invoke(invoker, invocation);
+        appResponse = (AppResponse) asyncResult.get();
+        genericFilter.onResponse(appResponse, invoker, invocation);
+        Assertions.assertFalse(((HashMap) appResponse.getValue()).containsKey("class"));
     }
 
 }


### PR DESCRIPTION
## What is the purpose of the change

Can set 'generic.include.class' in a single call to control whether the class field is included in the response when generic invoke.

## Verifying this change

org.apache.dubbo.rpc.filter.GenericFilterTest#testInvokeRemoveClassField

## issue

https://github.com/apache/dubbo/issues/13048

