### PR TITLE
Using safe serialize executor in triple protocol

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/threadpool/serial/CloseableRunnable.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/threadpool/serial/CloseableRunnable.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.dubbo.common.threadpool.serial;
+
+import java.io.Closeable;
+
+public interface CloseableRunnable extends Runnable, Closeable {
+
+    @Override
+    void close();
+
+}

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/threadpool/serial/SafeSerializingExecutor.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/threadpool/serial/SafeSerializingExecutor.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.dubbo.common.threadpool.serial;
+
+import java.util.concurrent.Executor;
+
+import static org.apache.dubbo.common.utils.ExecutorUtil.isShutdown;
+
+/**
+ * If the thread pool is in a shutdown state, won't submit task, so it doesn't throw reject exception
+ */
+public class SafeSerializingExecutor extends SerializingExecutor {
+
+    /**
+     * Creates a SerializingExecutor, running tasks using {@code executor}.
+     *
+     * @param executor Executor in which tasks should be run. Must not be null.
+     */
+    public SafeSerializingExecutor(Executor executor) {
+        super(executor);
+    }
+
+    @Override
+    protected boolean submitTask() {
+        if (isShutdown(executor)) {
+            return false;
+        }
+        return super.submitTask();
+    }
+}

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/threadpool/serial/SerializingExecutor.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/threadpool/serial/SerializingExecutor.java
@@ -122,8 +122,6 @@ public abstract class SerializingExecutor implements Executor, Runnable {
         }
     }
 
-    protected boolean submitTask() {
-        executor.execute(this);
-        return true;
-    }
+    protected abstract boolean submitTask();
+
 }

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/threadpool/serial/SerializingExecutor.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/threadpool/serial/SerializingExecutor.java
@@ -32,7 +32,7 @@ import static org.apache.dubbo.common.constants.LoggerCodeConstants.COMMON_ERROR
  * using the provided {@link Executor}, and serially such that no two will ever be
  * running at the same time.
  */
-public class SerializingExecutor implements Executor, Runnable {
+public abstract class SerializingExecutor implements Executor, Runnable {
 
     private static final ErrorTypeAwareLogger LOGGER = LoggerFactory.getErrorTypeAwareLogger(SerializingExecutor.class);
 

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/threadpool/serial/SerializingExecutor.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/threadpool/serial/SerializingExecutor.java
@@ -89,7 +89,7 @@ public class SerializingExecutor implements Executor, Runnable {
                     // fails to submit a task. For example, if the thread pool is in a shutdown state
                     // and submits a task to handle ByteBuf, the thread pool will reject the processing
                     // and throw an exception. A CloseableRunnable can be passed in to trigger resource cleaning.
-                    // If there are no resources to clean up, Runnable can be used
+                    // If there are no resources to clean up, Runnable can be used.
                     if (removable instanceof CloseableRunnable) {
                         ((CloseableRunnable) removable).close();
                     }

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/threadpool/serial/SubmitSafeSerializingExecutor.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/threadpool/serial/SubmitSafeSerializingExecutor.java
@@ -40,6 +40,7 @@ public class SubmitSafeSerializingExecutor extends SerializingExecutor {
         if (isShutdown(executor)) {
             return false;
         }
-        return super.submitTask();
+        executor.execute(this);
+        return true;
     }
 }

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/threadpool/serial/SubmitSafeSerializingExecutor.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/threadpool/serial/SubmitSafeSerializingExecutor.java
@@ -24,14 +24,14 @@ import static org.apache.dubbo.common.utils.ExecutorUtil.isShutdown;
 /**
  * If the thread pool is in a shutdown state, won't submit task, so it doesn't throw reject exception
  */
-public class SafeSerializingExecutor extends SerializingExecutor {
+public class SubmitSafeSerializingExecutor extends SerializingExecutor {
 
     /**
      * Creates a SerializingExecutor, running tasks using {@code executor}.
      *
      * @param executor Executor in which tasks should be run. Must not be null.
      */
-    public SafeSerializingExecutor(Executor executor) {
+    public SubmitSafeSerializingExecutor(Executor executor) {
         super(executor);
     }
 

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/threadpool/serial/SerializingExecutorTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/threadpool/serial/SerializingExecutorTest.java
@@ -47,7 +47,8 @@ class SerializingExecutorTest {
         serializingExecutor = new SerializingExecutor(service) {
             @Override
             protected boolean submitTask() {
-                return super.submitTask();
+                executor.execute(this);
+                return true;
             }
         };
         submitSafeSerializingExecutor = new SubmitSafeSerializingExecutor(service);

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/threadpool/serial/SerializingExecutorTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/threadpool/serial/SerializingExecutorTest.java
@@ -25,7 +25,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Random;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;

--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/stream/AbstractStream.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/stream/AbstractStream.java
@@ -17,7 +17,7 @@
 
 package org.apache.dubbo.rpc.protocol.tri.stream;
 
-import org.apache.dubbo.common.threadpool.serial.SafeSerializingExecutor;
+import org.apache.dubbo.common.threadpool.serial.SubmitSafeSerializingExecutor;
 import org.apache.dubbo.common.utils.ClassUtils;
 import org.apache.dubbo.rpc.model.FrameworkModel;
 
@@ -35,12 +35,12 @@ public abstract class AbstractStream implements Stream {
     private static final boolean HAS_PROTOBUF = hasProtobuf();
 
     public AbstractStream(Executor executor, FrameworkModel frameworkModel) {
-        this.executor = new SafeSerializingExecutor(executor);
+        this.executor = new SubmitSafeSerializingExecutor(executor);
         this.frameworkModel = frameworkModel;
     }
 
     public void setExecutor(Executor executor) {
-        this.executor = new SafeSerializingExecutor(executor);
+        this.executor = new SubmitSafeSerializingExecutor(executor);
     }
 
     public static boolean getGrpcStatusDetailEnabled() {

--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/stream/AbstractStream.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/stream/AbstractStream.java
@@ -17,7 +17,7 @@
 
 package org.apache.dubbo.rpc.protocol.tri.stream;
 
-import org.apache.dubbo.common.threadpool.serial.SerializingExecutor;
+import org.apache.dubbo.common.threadpool.serial.SafeSerializingExecutor;
 import org.apache.dubbo.common.utils.ClassUtils;
 import org.apache.dubbo.rpc.model.FrameworkModel;
 
@@ -35,12 +35,12 @@ public abstract class AbstractStream implements Stream {
     private static final boolean HAS_PROTOBUF = hasProtobuf();
 
     public AbstractStream(Executor executor, FrameworkModel frameworkModel) {
-        this.executor = new SerializingExecutor(executor);
+        this.executor = new SafeSerializingExecutor(executor);
         this.frameworkModel = frameworkModel;
     }
 
     public void setExecutor(Executor executor) {
-        this.executor = new SerializingExecutor(executor);
+        this.executor = new SafeSerializingExecutor(executor);
     }
 
     public static boolean getGrpcStatusDetailEnabled() {


### PR DESCRIPTION
## What is the purpose of the change
When using the triple protocol to process HTTP/2 frames, if the thread pool is in a shutdown state, the task can be directly discarded

## Brief changelog


## Verifying this change


<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [ ] GitHub Actions works fine on your own branch.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
