### PR TITLE
Dubbo 3.3 support compilation with jdk 1.8

### DIFF
--- a/dubbo-config/pom.xml
+++ b/dubbo-config/pom.xml
@@ -32,7 +32,6 @@
     <modules>
         <module>dubbo-config-api</module>
         <module>dubbo-config-spring</module>
-        <module>dubbo-config-spring6</module>
     </modules>
 
     <dependencies>
@@ -49,4 +48,22 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <profiles>
+        <profile>
+            <id>release</id>
+            <modules>
+                <module>dubbo-config-spring6</module>
+            </modules>
+        </profile>
+        <profile>
+            <id>jdk-version-ge-17</id>
+            <activation>
+                <jdk>17</jdk>
+            </activation>
+            <modules>
+                <module>dubbo-config-spring6</module>
+            </modules>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
## What is the purpose of the change
See: #13226

## Brief changelog
Use maven profile activation to include module  dubbo-config-spring6 only when the jdk version is >= 17.

## Verifying this change
Compile successfully with jdk 1.8

<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [ ] GitHub Actions works fine on your own branch.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
