### PR TITLE
fix(pom): Exclude unnecessary transitive dependencies for zookeeper

### DIFF
--- a/.github/workflows/build-and-test-pr.yml
+++ b/.github/workflows/build-and-test-pr.yml
@@ -193,7 +193,7 @@ jobs:
           openssl rsautl -decrypt -in ${{ github.workspace }}/.tmp/encrypted-sonarcloud-token -out ${{ github.workspace }}/.tmp/decrypted-sonarcloud-token -inkey ${{ github.workspace }}/.tmp/rsa/rsa_private.pem
       - name: "Test with Maven with SonarCloud Scan"
         if: ${{ github.repository == 'apache/dubbo' }}
-        timeout-minutes: 70
+        timeout-minutes: 90
         env:
           # Needed to get some information about the pull request, if any
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -202,7 +202,7 @@ jobs:
           ./mvnw --batch-mode --no-snapshot-updates -e --no-transfer-progress --fail-fast clean test verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Pjacoco,jdk15ge-simple,'!jdk15ge',jacoco089 -Dsonar.host.url=https://sonarcloud.io -Dsonar.organization=apache -Dsonar.projectKey=apache_dubbo -DtrimStackTrace=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120 -Dmaven.wagon.http.retryHandler.count=5 -DskipTests=false -DskipIntegrationTests=false -Dcheckstyle.skip=false -Dcheckstyle_unix.skip=false -Drat.skip=false -Dmaven.javadoc.skip=true -DembeddedZookeeperPath=${{ github.workspace }}/.tmp/zookeeper -Dsonar.coverage.jacoco.xmlReportPaths=dubbo-test/dubbo-dependencies-all/target/site/jacoco-aggregate/jacoco.xml -Dsonar.login=${SONAR_TOKEN}
       - name: "Test with Maven without SonarCloud Scan"
         if: ${{ github.repository != 'apache/dubbo' }}
-        timeout-minutes: 70
+        timeout-minutes: 90
         run: |
           ./mvnw --batch-mode --no-snapshot-updates -e --no-transfer-progress --fail-fast clean test verify -Dmaven.wagon.httpconnectionManager.ttlSeconds=120 -Pjacoco,jdk15ge-simple,'!jdk15ge',jacoco089 -DtrimStackTrace=false -Dmaven.wagon.http.retryHandler.count=5 -DskipTests=false -DskipIntegrationTests=false -Dcheckstyle.skip=false -Dcheckstyle_unix.skip=false -Drat.skip=false -Dmaven.javadoc.skip=true -DembeddedZookeeperPath=${{ github.workspace }}/.tmp/zookeeper
       - name: "Upload coverage result"

--- a/dubbo-annotation-processor/pom.xml
+++ b/dubbo-annotation-processor/pom.xml
@@ -28,8 +28,8 @@
     <version>1.0.0</version>
 
     <properties>
-        <maven.compiler.source>8</maven.compiler.source>
-        <maven.compiler.target>8</maven.compiler.target>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <!--  System dependencies may cause problems in checkstyle. -->
@@ -37,7 +37,6 @@
         <checkstyle_unix.skip>true</checkstyle_unix.skip>
         <rat.skip>true</rat.skip>
         <jacoco.skip>true</jacoco.skip>
-
         <maven.deploy.skip>true</maven.deploy.skip>
 
         <junit_jupiter_version>5.9.0</junit_jupiter_version>

--- a/dubbo-cluster/pom.xml
+++ b/dubbo-cluster/pom.xml
@@ -93,5 +93,10 @@
             <version>${nashorn-core.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/dubbo-common/pom.xml
+++ b/dubbo-common/pom.xml
@@ -100,5 +100,16 @@
             <groupId>javax.annotation</groupId>
             <artifactId>javax.annotation-api</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>cglib</groupId>
+            <artifactId>cglib-nodep</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/dubbo-compatible/pom.xml
+++ b/dubbo-compatible/pom.xml
@@ -59,6 +59,11 @@
             <version>${project.parent.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
             <groupId>org.apache.dubbo</groupId>
             <artifactId>dubbo-serialization-hessian2</artifactId>
             <version>${project.parent.version}</version>

--- a/dubbo-config/dubbo-config-api/pom.xml
+++ b/dubbo-config/dubbo-config-api/pom.xml
@@ -170,6 +170,11 @@
             <artifactId>zookeeper</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+            <scope>test</scope>
+        </dependency>
 
         <dependency>
             <groupId>org.apache.dubbo</groupId>
@@ -258,7 +263,5 @@
             <artifactId>resteasy-jackson-provider</artifactId>
             <scope>test</scope>
         </dependency>
-
-
     </dependencies>
 </project>

--- a/dubbo-config/dubbo-config-spring/pom.xml
+++ b/dubbo-config/dubbo-config-spring/pom.xml
@@ -197,15 +197,20 @@
             <scope>test</scope>
             <exclusions>
                 <exclusion>
-                    <artifactId>junit-vintage-engine</artifactId>
-                    <groupId>org.junit.vintage</groupId>
+                    <artifactId>logback-classic</artifactId>
+                    <groupId>ch.qos.logback</groupId>
                 </exclusion>
-                <!-- Fix the bug of log4j refer:https://github.com/apache/logging-log4j2/pull/608 -->
                 <exclusion>
+                    <artifactId>log4j-to-slf4j</artifactId>
                     <groupId>org.apache.logging.log4j</groupId>
-                    <artifactId>log4j-api</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+            <scope>test</scope>
         </dependency>
 
         <!-- Zookeeper dependencies for testing -->

--- a/dubbo-config/dubbo-config-spring6/pom.xml
+++ b/dubbo-config/dubbo-config-spring6/pom.xml
@@ -27,7 +27,6 @@
     <properties>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <spring.version>6.0.11</spring.version>
         <spring-boot.version>3.0.9</spring-boot.version>
     </properties>
@@ -78,17 +77,20 @@
             <scope>test</scope>
             <exclusions>
                 <exclusion>
-                    <artifactId>junit-vintage-engine</artifactId>
-                    <groupId>org.junit.vintage</groupId>
+                    <artifactId>logback-classic</artifactId>
+                    <groupId>ch.qos.logback</groupId>
                 </exclusion>
-                <!-- Fix the bug of log4j refer:https://github.com/apache/logging-log4j2/pull/608 -->
                 <exclusion>
+                    <artifactId>log4j-to-slf4j</artifactId>
                     <groupId>org.apache.logging.log4j</groupId>
-                    <artifactId>log4j-api</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
-
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/dubbo-container/dubbo-container-spring/pom.xml
+++ b/dubbo-container/dubbo-container-spring/pom.xml
@@ -41,12 +41,7 @@
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
+            <artifactId>slf4j-log4j12</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/dubbo-demo/dubbo-demo-annotation/dubbo-demo-annotation-provider/pom.xml
+++ b/dubbo-demo/dubbo-demo-annotation/dubbo-demo-annotation-provider/pom.xml
@@ -31,7 +31,6 @@
 
     <properties>
         <skip_maven_deploy>true</skip_maven_deploy>
-        <slf4j-log4j12.version>1.7.33</slf4j-log4j12.version>
     </properties>
 
     <dependencies>
@@ -103,19 +102,6 @@
             <groupId>org.apache.dubbo</groupId>
             <artifactId>dubbo-serialization-fastjson2</artifactId>
             <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
-            <version>${slf4j-log4j12.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
         </dependency>
     </dependencies>
 

--- a/dubbo-demo/dubbo-demo-api/dubbo-demo-api-provider/pom.xml
+++ b/dubbo-demo/dubbo-demo-api/dubbo-demo-api-provider/pom.xml
@@ -32,7 +32,6 @@
 
     <properties>
         <skip_maven_deploy>true</skip_maven_deploy>
-        <slf4j-log4j12.version>1.7.33</slf4j-log4j12.version>
     </properties>
 
     <dependencies>
@@ -101,6 +100,5 @@
             <artifactId>dubbo-serialization-fastjson2</artifactId>
             <version>${project.version}</version>
         </dependency>
-
     </dependencies>
 </project>

--- a/dubbo-demo/dubbo-demo-interface/pom.xml
+++ b/dubbo-demo/dubbo-demo-interface/pom.xml
@@ -26,6 +26,7 @@
     <packaging>jar</packaging>
     <name>${project.artifactId}</name>
     <description>The demo module of dubbo project</description>
+
     <properties>
         <skip_maven_deploy>true</skip_maven_deploy>
     </properties>
@@ -48,6 +49,5 @@
             <groupId>org.springframework</groupId>
             <artifactId>spring-web</artifactId>
         </dependency>
-
     </dependencies>
 </project>

--- a/dubbo-demo/dubbo-demo-native/dubbo-demo-native-consumer/pom.xml
+++ b/dubbo-demo/dubbo-demo-native/dubbo-demo-native-consumer/pom.xml
@@ -146,37 +146,6 @@
             <artifactId>dubbo-native</artifactId>
             <version>${project.version}</version>
         </dependency>
-
-        <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
-            <version>1.2.17</version>
-            <scope>compile</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-            <version>1.7.36</version>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
-            <version>1.7.33</version>
-            <scope>compile</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
     </dependencies>
 
     <profiles>
@@ -234,12 +203,8 @@
                             <mainClass>org.apache.dubbo.demo.graalvm.consumer.Application</mainClass>
                         </configuration>
                     </plugin>
-
                 </plugins>
             </build>
         </profile>
-
     </profiles>
-
-
 </project>

--- a/dubbo-demo/dubbo-demo-native/dubbo-demo-native-provider/pom.xml
+++ b/dubbo-demo/dubbo-demo-native/dubbo-demo-native-provider/pom.xml
@@ -143,39 +143,7 @@
             <artifactId>dubbo-native</artifactId>
             <version>${project.version}</version>
         </dependency>
-
-        <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
-            <version>1.2.17</version>
-            <scope>compile</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-            <version>1.7.36</version>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
-            <version>1.7.33</version>
-            <scope>compile</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
     </dependencies>
-
 
     <profiles>
         <profile>
@@ -232,13 +200,8 @@
                             <mainClass>org.apache.dubbo.demo.graalvm.provider.Application</mainClass>
                         </configuration>
                     </plugin>
-
                 </plugins>
             </build>
-
         </profile>
-
     </profiles>
-
-
 </project>

--- a/dubbo-demo/dubbo-demo-spring-boot/dubbo-demo-spring-boot-consumer/pom.xml
+++ b/dubbo-demo/dubbo-demo-spring-boot/dubbo-demo-spring-boot-consumer/pom.xml
@@ -28,10 +28,6 @@
     <artifactId>dubbo-demo-spring-boot-consumer</artifactId>
 
     <properties>
-        <maven.compiler.source>8</maven.compiler.source>
-        <maven.compiler.target>8</maven.compiler.target>
-        <slf4j-log4j12.version>1.7.33</slf4j-log4j12.version>
-        <spring-boot.version>2.7.16</spring-boot.version>
         <skip_maven_deploy>true</skip_maven_deploy>
     </properties>
 
@@ -97,41 +93,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-autoconfigure</artifactId>
-            <version>${spring-boot.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-logging</artifactId>
-            <version>${spring-boot.version}</version>
-            <exclusions>
-                <!-- Fix the bug of log4j refer:https://github.com/apache/logging-log4j2/pull/608 -->
-                <exclusion>
-                    <groupId>org.apache.logging.log4j</groupId>
-                    <artifactId>log4j-api</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
-            <version>${slf4j-log4j12.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>org.apache.dubbo</groupId>
             <artifactId>dubbo-tracing-otel-zipkin-spring-boot-starter</artifactId>
             <version>${project.version}</version>
@@ -142,7 +103,6 @@
             <artifactId>dubbo-qos</artifactId>
             <version>${project.version}</version>
         </dependency>
-
     </dependencies>
 
     <build>

--- a/dubbo-demo/dubbo-demo-spring-boot/dubbo-demo-spring-boot-interface/pom.xml
+++ b/dubbo-demo/dubbo-demo-spring-boot/dubbo-demo-spring-boot-interface/pom.xml
@@ -28,8 +28,6 @@
     <artifactId>dubbo-demo-spring-boot-interface</artifactId>
 
     <properties>
-        <maven.compiler.source>8</maven.compiler.source>
-        <maven.compiler.target>8</maven.compiler.target>
         <skip_maven_deploy>true</skip_maven_deploy>
     </properties>
 

--- a/dubbo-demo/dubbo-demo-spring-boot/dubbo-demo-spring-boot-provider/pom.xml
+++ b/dubbo-demo/dubbo-demo-spring-boot/dubbo-demo-spring-boot-provider/pom.xml
@@ -28,10 +28,6 @@
     <artifactId>dubbo-demo-spring-boot-provider</artifactId>
 
     <properties>
-        <maven.compiler.source>8</maven.compiler.source>
-        <maven.compiler.target>8</maven.compiler.target>
-        <slf4j-log4j12.version>1.7.33</slf4j-log4j12.version>
-        <spring-boot.version>2.7.16</spring-boot.version>
         <skip_maven_deploy>true</skip_maven_deploy>
     </properties>
 
@@ -84,46 +80,6 @@
             <version>${project.version}</version>
         </dependency>
 
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter</artifactId>
-            <version>${spring-boot.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-autoconfigure</artifactId>
-            <version>${spring-boot.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-logging</artifactId>
-            <version>${spring-boot.version}</version>
-            <exclusions>
-                <!-- Fix the bug of log4j refer:https://github.com/apache/logging-log4j2/pull/608 -->
-                <exclusion>
-                    <groupId>org.apache.logging.log4j</groupId>
-                    <artifactId>log4j-api</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
-            <version>${slf4j-log4j12.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
-        </dependency>
-
         <!-- Observability -->
         <dependency>
             <groupId>org.apache.dubbo</groupId>
@@ -137,6 +93,10 @@
             <version>${project.version}</version>
         </dependency>
 
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/dubbo-demo/dubbo-demo-spring-boot/pom.xml
+++ b/dubbo-demo/dubbo-demo-spring-boot/pom.xml
@@ -33,13 +33,13 @@
     </modules>
 
     <properties>
-        <maven.compiler.source>8</maven.compiler.source>
-        <maven.compiler.target>8</maven.compiler.target>
         <skip_maven_deploy>true</skip_maven_deploy>
         <spring-boot.version>2.7.16</spring-boot.version>
+        <slf4j-log4j12_version>1.7.33</slf4j-log4j12_version>
         <spring-boot-maven-plugin.version>2.7.16</spring-boot-maven-plugin.version>
         <micrometer-core.version>1.11.5</micrometer-core.version>
     </properties>
+
     <dependencyManagement>
         <dependencies>
             <dependency>
@@ -50,13 +50,30 @@
                 <scope>import</scope>
             </dependency>
             <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-starter-logging</artifactId>
+                <version>${spring-boot.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <artifactId>logback-classic</artifactId>
+                        <groupId>ch.qos.logback</groupId>
+                    </exclusion>
+                    <exclusion>
+                        <artifactId>log4j-to-slf4j</artifactId>
+                        <groupId>org.apache.logging.log4j</groupId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-log4j12</artifactId>
+                <version>${slf4j-log4j12_version}</version>
+            </dependency>
+            <dependency>
                 <groupId>io.micrometer</groupId>
                 <artifactId>micrometer-core</artifactId>
                 <version>${micrometer-core.version}</version>
             </dependency>
         </dependencies>
-
     </dependencyManagement>
-
-
 </project>

--- a/dubbo-demo/dubbo-demo-triple/pom.xml
+++ b/dubbo-demo/dubbo-demo-triple/pom.xml
@@ -32,9 +32,6 @@
 
     <properties>
         <skip_maven_deploy>true</skip_maven_deploy>
-        <source.level>1.8</source.level>
-        <target.level>1.8</target.level>
-        <maven-compiler-plugin.version>3.11.0</maven-compiler-plugin.version>
     </properties>
 
     <dependencies>
@@ -153,42 +150,14 @@
                 <artifactId>protobuf-maven-plugin</artifactId>
                 <version>${maven_protobuf_plugin_version}</version>
                 <configuration>
-                    <protocArtifact>com.google.protobuf:protoc:${protobuf-java_version}:exe:${os.detected.classifier}</protocArtifact>
+                    <protocArtifact>com.google.protobuf:protoc:${protobuf-protoc_version}:exe:${os.detected.classifier}</protocArtifact>
                     <pluginId>triple-java</pluginId>
-                    <outputDirectory>build/generated/source/proto/main/java</outputDirectory>
                 </configuration>
                 <executions>
                     <execution>
                         <goals>
                             <goal>compile</goal>
-                            <goal>test-compile</goal>
                         </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>${maven-compiler-plugin.version}</version>
-                <configuration>
-                    <source>${source.level}</source>
-                    <target>${target.level}</target>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>build-helper-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <phase>generate-sources</phase>
-                        <goals>
-                            <goal>add-source</goal>
-                        </goals>
-                        <configuration>
-                            <sources>
-                                <source>build/generated/source/proto/main/java</source>
-                            </sources>
-                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/dubbo-demo/dubbo-demo-xml/dubbo-demo-jaxrs-rest-consumer/pom.xml
+++ b/dubbo-demo/dubbo-demo-xml/dubbo-demo-jaxrs-rest-consumer/pom.xml
@@ -34,8 +34,8 @@
 
     <properties>
         <skip_maven_deploy>true</skip_maven_deploy>
-        <slf4j-log4j12.version>1.7.33</slf4j-log4j12.version>
     </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.springframework</groupId>
@@ -119,19 +119,6 @@
             <groupId>org.apache.dubbo</groupId>
             <artifactId>dubbo-serialization-jdk</artifactId>
             <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
-            <version>${slf4j-log4j12.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
         </dependency>
 
         <dependency>

--- a/dubbo-demo/dubbo-demo-xml/dubbo-demo-jaxrs-rest-provider/pom.xml
+++ b/dubbo-demo/dubbo-demo-xml/dubbo-demo-jaxrs-rest-provider/pom.xml
@@ -34,8 +34,8 @@
 
     <properties>
         <skip_maven_deploy>true</skip_maven_deploy>
-        <slf4j-log4j12.version>1.7.33</slf4j-log4j12.version>
     </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.springframework</groupId>
@@ -119,19 +119,6 @@
             <groupId>org.apache.dubbo</groupId>
             <artifactId>dubbo-serialization-jdk</artifactId>
             <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
-            <version>${slf4j-log4j12.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
         </dependency>
 
         <dependency>

--- a/dubbo-demo/dubbo-demo-xml/dubbo-demo-spring-mvc-rest-consumer/pom.xml
+++ b/dubbo-demo/dubbo-demo-xml/dubbo-demo-spring-mvc-rest-consumer/pom.xml
@@ -34,8 +34,8 @@
 
     <properties>
         <skip_maven_deploy>true</skip_maven_deploy>
-        <slf4j-log4j12.version>1.7.33</slf4j-log4j12.version>
     </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.springframework</groupId>
@@ -119,19 +119,6 @@
             <groupId>org.apache.dubbo</groupId>
             <artifactId>dubbo-serialization-jdk</artifactId>
             <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
-            <version>${slf4j-log4j12.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
         </dependency>
 
         <dependency>

--- a/dubbo-demo/dubbo-demo-xml/dubbo-demo-spring-mvc-rest-provider/pom.xml
+++ b/dubbo-demo/dubbo-demo-xml/dubbo-demo-spring-mvc-rest-provider/pom.xml
@@ -34,8 +34,8 @@
 
     <properties>
         <skip_maven_deploy>true</skip_maven_deploy>
-        <slf4j-log4j12.version>1.7.33</slf4j-log4j12.version>
     </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.springframework</groupId>
@@ -119,19 +119,6 @@
             <groupId>org.apache.dubbo</groupId>
             <artifactId>dubbo-serialization-jdk</artifactId>
             <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
-            <version>${slf4j-log4j12.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
         </dependency>
 
         <dependency>

--- a/dubbo-demo/dubbo-demo-xml/dubbo-demo-xml-provider/pom.xml
+++ b/dubbo-demo/dubbo-demo-xml/dubbo-demo-xml-provider/pom.xml
@@ -27,9 +27,9 @@
     <packaging>jar</packaging>
     <name>${project.artifactId}</name>
     <description>The demo provider module of dubbo project</description>
+
     <properties>
         <skip_maven_deploy>true</skip_maven_deploy>
-        <slf4j-log4j12.version>1.7.33</slf4j-log4j12.version>
     </properties>
 
     <dependencies>
@@ -111,19 +111,6 @@
             <groupId>org.apache.dubbo</groupId>
             <artifactId>dubbo-serialization-jdk</artifactId>
             <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
-            <version>${slf4j-log4j12.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.dubbo</groupId>

--- a/dubbo-demo/dubbo-demo-xml/pom.xml
+++ b/dubbo-demo/dubbo-demo-xml/pom.xml
@@ -44,7 +44,6 @@
         <module>dubbo-demo-spring-mvc-rest-provider</module>
     </modules>
 
-
     <build>
         <plugins>
             <plugin>

--- a/dubbo-demo/pom.xml
+++ b/dubbo-demo/pom.xml
@@ -26,6 +26,7 @@
     <packaging>pom</packaging>
     <name>${project.artifactId}</name>
     <description>The demo module of dubbo project</description>
+
     <properties>
         <skip_maven_deploy>true</skip_maven_deploy>
     </properties>
@@ -41,4 +42,10 @@
         <module>dubbo-demo-spring-boot</module>
     </modules>
 
+    <dependencies>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+        </dependency>
+    </dependencies>
 </project>

--- a/dubbo-dependencies-bom/pom.xml
+++ b/dubbo-dependencies-bom/pom.xml
@@ -158,12 +158,15 @@
         <mustache_version>0.9.10</mustache_version>
         <!-- Log libs -->
         <slf4j_version>1.7.36</slf4j_version>
+        <!-- Do not upgrade the log4j12 version, or else reload4j and log4j will coexist -->
+        <slf4j-log4j12_version>1.7.33</slf4j-log4j12_version>
         <jcl_version>1.2</jcl_version>
         <log4j_version>1.2.17</log4j_version>
         <logback_version>1.2.11</logback_version>
         <!-- Fix the bug of log4j refer:https://github.com/apache/logging-log4j2/pull/608 -->
         <log4j2_version>2.20.0</log4j2_version>
         <commons_io_version>2.11.0</commons_io_version>
+        <commons-codec_version>1.16.0</commons-codec_version>
 
         <embedded_redis_version>0.13.0</embedded_redis_version>
 
@@ -175,6 +178,13 @@
 
         <!-- Alibaba -->
         <alibaba_spring_context_support_version>1.0.11</alibaba_spring_context_support_version>
+
+        <!-- Test libs -->
+        <junit_jupiter_version>5.9.3</junit_jupiter_version>
+        <awaitility_version>4.2.0</awaitility_version>
+        <hamcrest_version>2.2</hamcrest_version>
+        <cglib_version>2.2.2</cglib_version>
+        <mockito_version>4.11.0</mockito_version>
 
         <jaxb_version>2.2.7</jaxb_version>
         <activation_version>1.2.0</activation_version>
@@ -305,8 +315,28 @@
                 <version>${zookeeper_version}</version>
                 <exclusions>
                     <exclusion>
+                        <artifactId>slf4j-log4j12</artifactId>
+                        <groupId>org.slf4j</groupId>
+                    </exclusion>
+                    <exclusion>
+                        <artifactId>log4j</artifactId>
+                        <groupId>log4j</groupId>
+                    </exclusion>
+                    <exclusion>
+                        <artifactId>logback-core</artifactId>
+                        <groupId>ch.qos.logback</groupId>
+                    </exclusion>
+                    <exclusion>
+                        <artifactId>logback-classic</artifactId>
+                        <groupId>ch.qos.logback</groupId>
+                    </exclusion>
+                    <exclusion>
+                        <artifactId>audience-annotations</artifactId>
+                        <groupId>org.apache.yetus</groupId>
+                    </exclusion>
+                    <exclusion>
+                        <artifactId>*</artifactId>
                         <groupId>io.netty</groupId>
-                        <artifactId>netty</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>
@@ -616,6 +646,11 @@
                 <version>${slf4j_version}</version>
             </dependency>
             <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-log4j12</artifactId>
+                <version>${slf4j-log4j12_version}</version>
+            </dependency>
+            <dependency>
                 <groupId>commons-logging</groupId>
                 <artifactId>commons-logging</artifactId>
                 <version>${jcl_version}</version>
@@ -624,6 +659,11 @@
                 <groupId>commons-io</groupId>
                 <artifactId>commons-io</artifactId>
                 <version>${commons_io_version}</version>
+            </dependency>
+            <dependency>
+                <groupId>commons-codec</groupId>
+                <artifactId>commons-codec</artifactId>
+                <version>${commons-codec_version}</version>
             </dependency>
             <dependency>
                 <groupId>log4j</groupId>
@@ -751,7 +791,61 @@
                 <scope>test</scope>
             </dependency>
 
-            <!-- Test lib -->
+            <!-- Test libs -->
+            <dependency>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter-engine</artifactId>
+                <version>${junit_jupiter_version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter-api</artifactId>
+                <version>${junit_jupiter_version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter-params</artifactId>
+                <version>${junit_jupiter_version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.junit.vintage</groupId>
+                <artifactId>junit-vintage-engine</artifactId>
+                <version>${junit_jupiter_version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.awaitility</groupId>
+                <artifactId>awaitility</artifactId>
+                <version>${awaitility_version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.hamcrest</groupId>
+                <artifactId>hamcrest</artifactId>
+                <version>${hamcrest_version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-core</artifactId>
+                <version>${mockito_version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-inline</artifactId>
+                <version>${mockito_version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>cglib</groupId>
+                <artifactId>cglib-nodep</artifactId>
+                <version>${cglib_version}</version>
+                <scope>test</scope>
+            </dependency>
             <dependency>
                 <groupId>com.github.codemonstur</groupId>
                 <artifactId>embedded-redis</artifactId>
@@ -764,6 +858,7 @@
                 <version>${spring_version}</version>
                 <scope>test</scope>
             </dependency>
+
             <dependency>
                 <groupId>com.google.code.gson</groupId>
                 <artifactId>gson</artifactId>
@@ -967,6 +1062,12 @@
                 <configuration>
                     <updatePomFile>true</updatePomFile>
                     <flattenMode>bom</flattenMode>
+                    <pomElements>
+                        <dependencyManagement>expand</dependencyManagement>
+                        <properties>remove</properties>
+                        <repositories>remove</repositories>
+                        <profiles>remove</profiles>
+                    </pomElements>
                 </configuration>
                 <executions>
                     <execution>

--- a/dubbo-dependencies/dubbo-dependencies-zookeeper-curator5/pom.xml
+++ b/dubbo-dependencies/dubbo-dependencies-zookeeper-curator5/pom.xml
@@ -34,6 +34,7 @@
     <properties>
         <revision>3.3.0-beta.1-SNAPSHOT</revision>
         <maven_flatten_version>1.5.0</maven_flatten_version>
+        <slf4j_version>1.7.36</slf4j_version>
         <curator5_version>5.1.0</curator5_version>
         <zookeeper_version>3.8.1</zookeeper_version>
     </properties>
@@ -55,6 +56,20 @@
             <groupId>org.apache.curator</groupId>
             <artifactId>curator-x-discovery</artifactId>
             <version>${curator5_version}</version>
+            <exclusions>
+                <exclusion>
+                    <artifactId>zookeeper</artifactId>
+                    <groupId>org.apache.zookeeper</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>slf4j-api</artifactId>
+                    <groupId>org.slf4j</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>listenablefuture</artifactId>
+                    <groupId>com.google.guava</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.zookeeper</groupId>
@@ -62,55 +77,35 @@
             <version>${zookeeper_version}</version>
             <exclusions>
                 <exclusion>
-                    <groupId>io.netty</groupId>
-                    <artifactId>netty-handler</artifactId>
+                    <artifactId>logback-classic</artifactId>
+                    <groupId>ch.qos.logback</groupId>
                 </exclusion>
                 <exclusion>
+                    <artifactId>logback-core</artifactId>
+                    <groupId>ch.qos.logback</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>audience-annotations</artifactId>
+                    <groupId>org.apache.yetus</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>*</artifactId>
                     <groupId>io.netty</groupId>
-                    <artifactId>netty-transport-native-epoll</artifactId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>slf4j-api</artifactId>
+                    <groupId>org.slf4j</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>commons-io</artifactId>
+                    <groupId>commons-io</groupId>
                 </exclusion>
             </exclusions>
         </dependency>
-
         <dependency>
-            <groupId>com.github.spotbugs</groupId>
-            <artifactId>spotbugs-annotations</artifactId>
-            <optional>true</optional>
-        </dependency>
-
-        <dependency>
-            <groupId>commons-cli</groupId>
-            <artifactId>commons-cli</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.eclipse.jetty</groupId>
-            <artifactId>jetty-server</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.eclipse.jetty</groupId>
-            <artifactId>jetty-servlet</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.eclipse.jetty</groupId>
-            <artifactId>jetty-client</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>jline</groupId>
-            <artifactId>jline</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>io.dropwizard.metrics</groupId>
-            <artifactId>metrics-core</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.xerial.snappy</groupId>
-            <artifactId>snappy-java</artifactId>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>${slf4j_version}</version>
         </dependency>
     </dependencies>
 
@@ -122,7 +117,7 @@
                 <version>${maven_flatten_version}</version>
                 <configuration>
                     <updatePomFile>true</updatePomFile>
-                    <flattenMode>resolveCiFriendliesOnly</flattenMode>
+                    <flattenMode>oss</flattenMode>
                 </configuration>
                 <executions>
                     <execution>

--- a/dubbo-dependencies/dubbo-dependencies-zookeeper/pom.xml
+++ b/dubbo-dependencies/dubbo-dependencies-zookeeper/pom.xml
@@ -34,6 +34,7 @@
     <properties>
         <revision>3.3.0-beta.1-SNAPSHOT</revision>
         <maven_flatten_version>1.5.0</maven_flatten_version>
+        <slf4j_version>1.7.36</slf4j_version>
         <curator_version>4.3.0</curator_version>
         <zookeeper_version>3.4.14</zookeeper_version>
     </properties>
@@ -43,11 +44,60 @@
             <groupId>org.apache.curator</groupId>
             <artifactId>curator-x-discovery</artifactId>
             <version>${curator_version}</version>
+            <exclusions>
+                <exclusion>
+                    <artifactId>zookeeper</artifactId>
+                    <groupId>org.apache.zookeeper</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>slf4j-api</artifactId>
+                    <groupId>org.slf4j</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>listenablefuture</artifactId>
+                    <groupId>com.google.guava</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.zookeeper</groupId>
             <artifactId>zookeeper</artifactId>
             <version>${zookeeper_version}</version>
+            <exclusions>
+                <exclusion>
+                    <artifactId>slf4j-log4j12</artifactId>
+                    <groupId>org.slf4j</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>log4j</artifactId>
+                    <groupId>log4j</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>spotbugs-annotations</artifactId>
+                    <groupId>com.github.spotbugs</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>audience-annotations</artifactId>
+                    <groupId>org.apache.yetus</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>jline</artifactId>
+                    <groupId>jline</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>*</artifactId>
+                    <groupId>io.netty</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>slf4j-api</artifactId>
+                    <groupId>org.slf4j</groupId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>${slf4j_version}</version>
         </dependency>
     </dependencies>
 
@@ -59,7 +109,7 @@
                 <version>${maven_flatten_version}</version>
                 <configuration>
                     <updatePomFile>true</updatePomFile>
-                    <flattenMode>resolveCiFriendliesOnly</flattenMode>
+                    <flattenMode>oss</flattenMode>
                 </configuration>
                 <executions>
                     <execution>

--- a/dubbo-distribution/dubbo-all-shaded/pom.xml
+++ b/dubbo-distribution/dubbo-all-shaded/pom.xml
@@ -469,28 +469,6 @@
             <groupId>com.alibaba.fastjson2</groupId>
             <artifactId>fastjson2</artifactId>
         </dependency>
-
-        <!-- Temporarily add this part to exclude transitive dependency -->
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-engine</artifactId>
-            <version>${junit_jupiter_version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-params</artifactId>
-            <version>${junit_jupiter_version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>cglib</groupId>
-            <artifactId>cglib-nodep</artifactId>
-            <version>${cglib_version}</version>
-            <scope>test</scope>
-            <optional>true</optional>
-        </dependency>
-
     </dependencies>
     <build>
         <plugins>

--- a/dubbo-distribution/dubbo-all/pom.xml
+++ b/dubbo-distribution/dubbo-all/pom.xml
@@ -638,28 +638,6 @@
             <groupId>com.alibaba.fastjson2</groupId>
             <artifactId>fastjson2</artifactId>
         </dependency>
-
-        <!-- Temporarily add this part to exclude transitive dependency -->
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-engine</artifactId>
-            <version>${junit_jupiter_version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-params</artifactId>
-            <version>${junit_jupiter_version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>cglib</groupId>
-            <artifactId>cglib-nodep</artifactId>
-            <version>${cglib_version}</version>
-            <scope>test</scope>
-            <optional>true</optional>
-        </dependency>
-
     </dependencies>
     <build>
         <plugins>

--- a/dubbo-distribution/dubbo-bom/pom.xml
+++ b/dubbo-distribution/dubbo-bom/pom.xml
@@ -66,6 +66,7 @@
                 <groupId>org.apache.dubbo</groupId>
                 <artifactId>dubbo-config</artifactId>
                 <version>${project.version}</version>
+                <type>pom</type>
             </dependency>
             <dependency>
                 <groupId>org.apache.dubbo</groupId>
@@ -89,6 +90,7 @@
                 <groupId>org.apache.dubbo</groupId>
                 <artifactId>dubbo-configcenter</artifactId>
                 <version>${project.version}</version>
+                <type>pom</type>
             </dependency>
             <dependency>
                 <groupId>org.apache.dubbo</groupId>
@@ -116,6 +118,7 @@
                 <groupId>org.apache.dubbo</groupId>
                 <artifactId>dubbo-container</artifactId>
                 <version>${project.version}</version>
+                <type>pom</type>
             </dependency>
             <dependency>
                 <groupId>org.apache.dubbo</groupId>
@@ -138,11 +141,13 @@
                 <groupId>org.apache.dubbo</groupId>
                 <artifactId>dubbo-dependencies-zookeeper</artifactId>
                 <version>${project.version}</version>
+                <type>pom</type>
             </dependency>
             <dependency>
                 <groupId>org.apache.dubbo</groupId>
                 <artifactId>dubbo-dependencies-zookeeper-curator5</artifactId>
                 <version>${project.version}</version>
+                <type>pom</type>
             </dependency>
 
             <!-- dependencies-bom -->
@@ -157,6 +162,7 @@
                 <groupId>org.apache.dubbo</groupId>
                 <artifactId>dubbo-distribution</artifactId>
                 <version>${project.version}</version>
+                <type>pom</type>
             </dependency>
             <dependency>
                 <groupId>org.apache.dubbo</groupId>
@@ -179,6 +185,7 @@
                 <groupId>org.apache.dubbo</groupId>
                 <artifactId>dubbo-filter</artifactId>
                 <version>${project.version}</version>
+                <type>pom</type>
             </dependency>
             <dependency>
                 <groupId>org.apache.dubbo</groupId>
@@ -203,6 +210,7 @@
                 <groupId>org.apache.dubbo</groupId>
                 <artifactId>dubbo-metadata</artifactId>
                 <version>${project.version}</version>
+                <type>pom</type>
             </dependency>
             <dependency>
                 <groupId>org.apache.dubbo</groupId>
@@ -245,6 +253,7 @@
                 <groupId>org.apache.dubbo</groupId>
                 <artifactId>dubbo-metrics</artifactId>
                 <version>${project.version}</version>
+                <type>pom</type>
             </dependency>
             <dependency>
                 <groupId>org.apache.dubbo</groupId>
@@ -299,6 +308,7 @@
                 <groupId>org.apache.dubbo</groupId>
                 <artifactId>dubbo-monitor</artifactId>
                 <version>${project.version}</version>
+                <type>pom</type>
             </dependency>
             <dependency>
                 <groupId>org.apache.dubbo</groupId>
@@ -457,12 +467,12 @@
                 <version>${project.version}</version>
             </dependency>
 
-
             <!-- registry -->
             <dependency>
                 <groupId>org.apache.dubbo</groupId>
                 <artifactId>dubbo-registry</artifactId>
                 <version>${project.version}</version>
+                <type>pom</type>
             </dependency>
             <dependency>
                 <groupId>org.apache.dubbo</groupId>
@@ -495,6 +505,7 @@
                 <groupId>org.apache.dubbo</groupId>
                 <artifactId>dubbo-remoting</artifactId>
                 <version>${project.version}</version>
+                <type>pom</type>
             </dependency>
             <dependency>
                 <groupId>org.apache.dubbo</groupId>
@@ -537,6 +548,7 @@
                 <groupId>org.apache.dubbo</groupId>
                 <artifactId>dubbo-rpc</artifactId>
                 <version>${project.version}</version>
+                <type>pom</type>
             </dependency>
             <dependency>
                 <groupId>org.apache.dubbo</groupId>
@@ -570,6 +582,7 @@
                 <groupId>org.apache.dubbo</groupId>
                 <artifactId>dubbo-serialization</artifactId>
                 <version>${project.version}</version>
+                <type>pom</type>
             </dependency>
             <dependency>
                 <groupId>org.apache.dubbo</groupId>
@@ -597,6 +610,7 @@
                 <groupId>org.apache.dubbo</groupId>
                 <artifactId>dubbo-spring-boot</artifactId>
                 <version>${project.version}</version>
+                <type>pom</type>
             </dependency>
             <dependency>
                 <groupId>org.apache.dubbo</groupId>
@@ -612,6 +626,7 @@
                 <groupId>org.apache.dubbo</groupId>
                 <artifactId>dubbo-spring-boot-compatible</artifactId>
                 <version>${project.version}</version>
+                <type>pom</type>
             </dependency>
             <dependency>
                 <groupId>org.apache.dubbo</groupId>
@@ -635,19 +650,15 @@
             </dependency>
             <dependency>
                 <groupId>org.apache.dubbo</groupId>
-                <artifactId>dubbo-dependencies-zookeeper</artifactId>
-                <type>pom</type>
-                <version>${project.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.dubbo</groupId>
                 <artifactId>dubbo-spring-boot-starters</artifactId>
                 <version>${project.version}</version>
+                <type>pom</type>
             </dependency>
             <dependency>
                 <groupId>org.apache.dubbo</groupId>
                 <artifactId>dubbo-observability-spring-boot-starters</artifactId>
                 <version>${project.version}</version>
+                <type>pom</type>
             </dependency>
             <dependency>
                 <groupId>org.apache.dubbo</groupId>
@@ -705,6 +716,7 @@
                 <groupId>org.apache.dubbo</groupId>
                 <artifactId>dubbo-test</artifactId>
                 <version>${project.version}</version>
+                <type>pom</type>
             </dependency>
             <dependency>
                 <groupId>org.apache.dubbo</groupId>
@@ -751,7 +763,6 @@
         </dependencies>
     </dependencyManagement>
 
-
     <build>
         <plugins>
             <plugin>
@@ -761,6 +772,12 @@
                 <configuration>
                     <updatePomFile>true</updatePomFile>
                     <flattenMode>bom</flattenMode>
+                    <pomElements>
+                        <dependencyManagement>expand</dependencyManagement>
+                        <properties>remove</properties>
+                        <repositories>remove</repositories>
+                        <profiles>remove</profiles>
+                    </pomElements>
                 </configuration>
                 <executions>
                     <execution>

--- a/dubbo-kubernetes/pom.xml
+++ b/dubbo-kubernetes/pom.xml
@@ -77,5 +77,4 @@
         </dependency>
     </dependencies>
 
-
 </project>

--- a/dubbo-maven-plugin/pom.xml
+++ b/dubbo-maven-plugin/pom.xml
@@ -24,9 +24,6 @@
     </parent>
 
     <artifactId>dubbo-maven-plugin</artifactId>
-
-    <properties>
-    </properties>
     <description>Dubbo Maven Plugin</description>
     <packaging>maven-plugin</packaging>
 
@@ -43,7 +40,6 @@
             <version>3.9.1</version>
             <scope>provided</scope>
         </dependency>
-
 
         <dependency>
             <groupId>org.apache.maven.plugin-tools</groupId>
@@ -63,7 +59,6 @@
             <artifactId>dubbo-common</artifactId>
             <version>${project.version}</version>
         </dependency>
-
 
         <dependency>
             <groupId>commons-io</groupId>
@@ -106,16 +101,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <source>8</source>
-                    <target>8</target>
-                </configuration>
-            </plugin>
         </plugins>
-
     </build>
-
 </project>

--- a/dubbo-metadata/dubbo-metadata-definition-protobuf/pom.xml
+++ b/dubbo-metadata/dubbo-metadata-definition-protobuf/pom.xml
@@ -24,7 +24,6 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>dubbo-metadata-definition-protobuf</artifactId>
 
-
     <dependencies>
         <dependency>
             <groupId>com.google.protobuf</groupId>

--- a/dubbo-metadata/dubbo-metadata-processor/pom.xml
+++ b/dubbo-metadata/dubbo-metadata-processor/pom.xml
@@ -54,59 +54,18 @@
             <version>${project.parent.version}</version>
             <exclusions>
                 <exclusion>
-                    <groupId>javax.annotation</groupId>
-                    <artifactId>javax.annotation-api</artifactId>
-                </exclusion>
-
-                <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-api</artifactId>
-                </exclusion>
-
-                <exclusion>
-                    <groupId>commons-logging</groupId>
-                    <artifactId>commons-logging</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>log4j</groupId>
-                    <artifactId>log4j</artifactId>
-                </exclusion>
-
-                <exclusion>
-                    <groupId>org.apache.logging.log4j</groupId>
-                    <artifactId>log4j-api</artifactId>
-                </exclusion>
-
-                <exclusion>
-                    <groupId>org.apache.logging.log4j</groupId>
-                    <artifactId>log4j-core</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.javassist</groupId>
-                    <artifactId>javassist</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.alibaba</groupId>
-                    <artifactId>hessian-lite</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.esotericsoftware</groupId>
-                    <artifactId>kryo</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>de.javakaffee</groupId>
-                    <artifactId>kryo-serializers</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>de.ruedigermoeller</groupId>
-                    <artifactId>fst</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>commons-io</groupId>
                     <artifactId>commons-io</artifactId>
+                    <groupId>commons-io</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>javassist</artifactId>
+                    <groupId>org.javassist</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>javax.annotation-api</artifactId>
+                    <groupId>javax.annotation</groupId>
                 </exclusion>
             </exclusions>
-
         </dependency>
 
         <!-- Test -->
@@ -168,7 +127,6 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <fork>true</fork>
                     <proc>none</proc>
                 </configuration>
             </plugin>

--- a/dubbo-metrics/dubbo-tracing/pom.xml
+++ b/dubbo-metrics/dubbo-tracing/pom.xml
@@ -31,9 +31,6 @@
     <description>The tracing module of dubbo project</description>
 
     <properties>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <skip_maven_deploy>false</skip_maven_deploy>
     </properties>
 

--- a/dubbo-monitor/dubbo-monitor-default/pom.xml
+++ b/dubbo-monitor/dubbo-monitor-default/pom.xml
@@ -77,5 +77,10 @@
             <artifactId>gson</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/dubbo-plugin/dubbo-auth/pom.xml
+++ b/dubbo-plugin/dubbo-auth/pom.xml
@@ -27,7 +27,6 @@
     <packaging>jar</packaging>
 
     <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <skip_maven_deploy>false</skip_maven_deploy>
     </properties>
 

--- a/dubbo-plugin/dubbo-compiler/pom.xml
+++ b/dubbo-plugin/dubbo-compiler/pom.xml
@@ -69,10 +69,6 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
                     <compilerArgument>-proc:none</compilerArgument>
-                    <fork>true</fork>
-                    <source>${java_source_version}</source>
-                    <target>${java_target_version}</target>
-                    <encoding>${file_encoding}</encoding>
                 </configuration>
             </plugin>
 

--- a/dubbo-plugin/dubbo-filter-cache/pom.xml
+++ b/dubbo-plugin/dubbo-filter-cache/pom.xml
@@ -27,6 +27,7 @@
     <description>The cache module of dubbo project</description>
     <properties>
         <skip_maven_deploy>false</skip_maven_deploy>
+        <hazelcast_version>3.12.13</hazelcast_version>
     </properties>
     <dependencies>
         <dependency>

--- a/dubbo-plugin/dubbo-filter-validation/pom.xml
+++ b/dubbo-plugin/dubbo-filter-validation/pom.xml
@@ -27,6 +27,9 @@
     <description>The validation module of dubbo project</description>
     <properties>
         <skip_maven_deploy>false</skip_maven_deploy>
+        <hibernate_validator_version>5.2.4.Final</hibernate_validator_version>
+        <el_api_version>2.2.5</el_api_version>
+        <jaxb_api_version>2.2.7</jaxb_api_version>
     </properties>
     <dependencies>
         <dependency>
@@ -45,8 +48,8 @@
         <dependency>
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-validator</artifactId>
-            <scope>test</scope>
             <version>${hibernate_validator_version}</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>javax.el</groupId>

--- a/dubbo-plugin/dubbo-native/pom.xml
+++ b/dubbo-plugin/dubbo-native/pom.xml
@@ -28,7 +28,6 @@
     <artifactId>dubbo-native</artifactId>
     <packaging>jar</packaging>
 
-
     <dependencies>
         <dependency>
             <groupId>org.apache.dubbo</groupId>

--- a/dubbo-plugin/dubbo-plugin-access-log/pom.xml
+++ b/dubbo-plugin/dubbo-plugin-access-log/pom.xml
@@ -27,10 +27,6 @@
     <artifactId>dubbo-plugin-access-log</artifactId>
     <packaging>jar</packaging>
 
-    <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.dubbo</groupId>

--- a/dubbo-plugin/dubbo-plugin-classloader-filter/pom.xml
+++ b/dubbo-plugin/dubbo-plugin-classloader-filter/pom.xml
@@ -27,10 +27,6 @@
     <artifactId>dubbo-plugin-classloader-filter</artifactId>
     <packaging>jar</packaging>
 
-    <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.dubbo</groupId>

--- a/dubbo-plugin/dubbo-plugin-cluster-mergeable/pom.xml
+++ b/dubbo-plugin/dubbo-plugin-cluster-mergeable/pom.xml
@@ -27,10 +27,6 @@
     <artifactId>dubbo-plugin-cluster-mergeable</artifactId>
     <packaging>jar</packaging>
 
-    <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.dubbo</groupId>

--- a/dubbo-plugin/dubbo-plugin-context/pom.xml
+++ b/dubbo-plugin/dubbo-plugin-context/pom.xml
@@ -27,10 +27,6 @@
     <artifactId>dubbo-plugin-context</artifactId>
     <packaging>jar</packaging>
 
-    <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.dubbo</groupId>

--- a/dubbo-plugin/dubbo-plugin-generic-invoke/pom.xml
+++ b/dubbo-plugin/dubbo-plugin-generic-invoke/pom.xml
@@ -27,10 +27,6 @@
     <artifactId>dubbo-plugin-generic-invoke</artifactId>
     <packaging>jar</packaging>
 
-    <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.dubbo</groupId>

--- a/dubbo-plugin/dubbo-plugin-loadbalance-adaptive/pom.xml
+++ b/dubbo-plugin/dubbo-plugin-loadbalance-adaptive/pom.xml
@@ -27,10 +27,6 @@
     <artifactId>dubbo-plugin-loadbalance-adaptive</artifactId>
     <packaging>jar</packaging>
 
-    <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.dubbo</groupId>

--- a/dubbo-plugin/dubbo-plugin-loom/pom.xml
+++ b/dubbo-plugin/dubbo-plugin-loom/pom.xml
@@ -29,8 +29,6 @@
     <artifactId>dubbo-plugin-loom</artifactId>
 
     <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <skip_maven_deploy>false</skip_maven_deploy>
     </properties>
 

--- a/dubbo-plugin/dubbo-plugin-mock/pom.xml
+++ b/dubbo-plugin/dubbo-plugin-mock/pom.xml
@@ -27,10 +27,6 @@
     <artifactId>dubbo-plugin-mock</artifactId>
     <packaging>jar</packaging>
 
-    <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.dubbo</groupId>

--- a/dubbo-plugin/dubbo-plugin-proxy-bytebuddy/pom.xml
+++ b/dubbo-plugin/dubbo-plugin-proxy-bytebuddy/pom.xml
@@ -27,10 +27,6 @@
     <artifactId>dubbo-plugin-proxy-bytebuddy</artifactId>
     <packaging>jar</packaging>
 
-    <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.dubbo</groupId>

--- a/dubbo-plugin/dubbo-plugin-qos-trace/pom.xml
+++ b/dubbo-plugin/dubbo-plugin-qos-trace/pom.xml
@@ -27,10 +27,6 @@
     <artifactId>dubbo-plugin-qos-trace</artifactId>
     <packaging>jar</packaging>
 
-    <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.dubbo</groupId>

--- a/dubbo-plugin/dubbo-plugin-router-condition/pom.xml
+++ b/dubbo-plugin/dubbo-plugin-router-condition/pom.xml
@@ -27,10 +27,6 @@
     <artifactId>dubbo-plugin-router-condition</artifactId>
     <packaging>jar</packaging>
 
-    <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.dubbo</groupId>

--- a/dubbo-plugin/dubbo-plugin-router-mesh/pom.xml
+++ b/dubbo-plugin/dubbo-plugin-router-mesh/pom.xml
@@ -27,10 +27,6 @@
     <artifactId>dubbo-plugin-router-mesh</artifactId>
     <packaging>jar</packaging>
 
-    <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.dubbo</groupId>

--- a/dubbo-plugin/dubbo-plugin-router-script/pom.xml
+++ b/dubbo-plugin/dubbo-plugin-router-script/pom.xml
@@ -27,10 +27,6 @@
     <artifactId>dubbo-plugin-router-script</artifactId>
     <packaging>jar</packaging>
 
-    <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.dubbo</groupId>

--- a/dubbo-plugin/dubbo-plugin-router-tag/pom.xml
+++ b/dubbo-plugin/dubbo-plugin-router-tag/pom.xml
@@ -27,10 +27,6 @@
     <artifactId>dubbo-plugin-router-tag</artifactId>
     <packaging>jar</packaging>
 
-    <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.dubbo</groupId>

--- a/dubbo-plugin/dubbo-plugin-token/pom.xml
+++ b/dubbo-plugin/dubbo-plugin-token/pom.xml
@@ -27,10 +27,6 @@
     <artifactId>dubbo-plugin-token</artifactId>
     <packaging>jar</packaging>
 
-    <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.dubbo</groupId>

--- a/dubbo-plugin/dubbo-plugin-tps/pom.xml
+++ b/dubbo-plugin/dubbo-plugin-tps/pom.xml
@@ -27,10 +27,6 @@
     <artifactId>dubbo-plugin-tps</artifactId>
     <packaging>jar</packaging>
 
-    <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.dubbo</groupId>

--- a/dubbo-plugin/dubbo-security/pom.xml
+++ b/dubbo-plugin/dubbo-security/pom.xml
@@ -26,8 +26,6 @@
 
     <properties>
         <skip_maven_deploy>false</skip_maven_deploy>
-        <protobuf-java.version>3.22.2</protobuf-java.version>
-        <grpc.version>1.55.1</grpc.version>
     </properties>
 
     <artifactId>dubbo-security</artifactId>
@@ -52,7 +50,6 @@
             <version>${project.version}</version>
         </dependency>
         <!-- dubbo -->
-
 
         <dependency>
             <groupId>io.grpc</groupId>
@@ -110,11 +107,11 @@
             <plugin>
                 <groupId>org.xolstice.maven.plugins</groupId>
                 <artifactId>protobuf-maven-plugin</artifactId>
-                <version>0.6.1</version>
+                <version>${maven_protobuf_plugin_version}</version>
                 <configuration>
-                    <protocArtifact>com.google.protobuf:protoc:${protobuf-java.version}:exe:${os.detected.classifier}</protocArtifact>
+                    <protocArtifact>com.google.protobuf:protoc:${protobuf-protoc_version}:exe:${os.detected.classifier}</protocArtifact>
                     <pluginId>grpc-java</pluginId>
-                    <pluginArtifact>io.grpc:protoc-gen-grpc-java:${grpc.version}:exe:${os.detected.classifier}</pluginArtifact>
+                    <pluginArtifact>io.grpc:protoc-gen-grpc-java:${grpc_version}:exe:${os.detected.classifier}</pluginArtifact>
                 </configuration>
                 <executions>
                     <execution>

--- a/dubbo-plugin/pom.xml
+++ b/dubbo-plugin/pom.xml
@@ -66,6 +66,11 @@
             <version>${project.parent.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <profiles>

--- a/dubbo-registry/dubbo-registry-api/pom.xml
+++ b/dubbo-registry/dubbo-registry-api/pom.xml
@@ -118,5 +118,11 @@
             <version>${project.parent.version}</version>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/dubbo-remoting/dubbo-remoting-api/pom.xml
+++ b/dubbo-remoting/dubbo-remoting-api/pom.xml
@@ -52,5 +52,10 @@
             <version>${project.parent.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/dubbo-remoting/dubbo-remoting-http/pom.xml
+++ b/dubbo-remoting/dubbo-remoting-http/pom.xml
@@ -59,6 +59,11 @@
             <version>4.5.14</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+            <scope>test</scope>
+        </dependency>
 
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>

--- a/dubbo-remoting/dubbo-remoting-netty/pom.xml
+++ b/dubbo-remoting/dubbo-remoting-netty/pom.xml
@@ -40,6 +40,11 @@
             <artifactId>netty</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.apache.dubbo</groupId>
             <artifactId>dubbo-serialization-hessian2</artifactId>
             <version>${project.parent.version}</version>

--- a/dubbo-remoting/dubbo-remoting-netty4/pom.xml
+++ b/dubbo-remoting/dubbo-remoting-netty4/pom.xml
@@ -68,6 +68,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-transport-classes-epoll</artifactId>
             <scope>compile</scope>

--- a/dubbo-remoting/dubbo-remoting-zookeeper/pom.xml
+++ b/dubbo-remoting/dubbo-remoting-zookeeper/pom.xml
@@ -68,12 +68,6 @@
             <groupId>org.apache.zookeeper</groupId>
             <artifactId>zookeeper</artifactId>
             <version>${zookeeper_version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-log4j12</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
         <dependency>

--- a/dubbo-rpc/dubbo-rpc-api/pom.xml
+++ b/dubbo-rpc/dubbo-rpc-api/pom.xml
@@ -50,6 +50,10 @@
             <artifactId>hessian-lite</artifactId>
             <scope>test</scope>
         </dependency>
-
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/dubbo-rpc/dubbo-rpc-dubbo/pom.xml
+++ b/dubbo-rpc/dubbo-rpc-dubbo/pom.xml
@@ -90,6 +90,11 @@
             <artifactId>javax.el</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/dubbo-rpc/dubbo-rpc-rest/pom.xml
+++ b/dubbo-rpc/dubbo-rpc-rest/pom.xml
@@ -123,7 +123,6 @@
             <scope>test</scope>
         </dependency>
 
-
         <dependency>
             <groupId>org.apache.dubbo</groupId>
             <artifactId>dubbo-metadata-rest</artifactId>

--- a/dubbo-rpc/dubbo-rpc-triple/pom.xml
+++ b/dubbo-rpc/dubbo-rpc-triple/pom.xml
@@ -69,6 +69,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-compress</artifactId>
         </dependency>
@@ -96,7 +101,7 @@
             <groupId>org.apache.dubbo</groupId>
             <artifactId>dubbo-compiler</artifactId>
             <version>${project.parent.version}</version>
-            <scope>compile</scope>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
     <build>
@@ -120,7 +125,7 @@
                 <version>${maven_protobuf_plugin_version}</version>
                 <configuration>
                     <protocArtifact>
-                        com.google.protobuf:protoc:${protobuf-java_version}:exe:${os.detected.classifier}
+                        com.google.protobuf:protoc:${protobuf-protoc_version}:exe:${os.detected.classifier}
                     </protocArtifact>
                     <protocPlugins>
                         <protocPlugin>

--- a/dubbo-spring-boot/dubbo-spring-boot-actuator/pom.xml
+++ b/dubbo-spring-boot/dubbo-spring-boot-actuator/pom.xml
@@ -43,19 +43,6 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
             <optional>true</optional>
-            <exclusions>
-                <!-- Fix the bug of log4j refer:https://github.com/apache/logging-log4j2/pull/608 -->
-                <exclusion>
-                    <groupId>org.apache.logging.log4j</groupId>
-                    <artifactId>log4j-api</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-api</artifactId>
-            <version>${log4j2_version}</version>
-            <optional>true</optional>
         </dependency>
 
         <dependency>
@@ -131,13 +118,6 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
-            <exclusions>
-                <!-- Fix the bug of log4j refer:https://github.com/apache/logging-log4j2/pull/608 -->
-                <exclusion>
-                    <groupId>org.apache.logging.log4j</groupId>
-                    <artifactId>log4j-api</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
         <dependency>

--- a/dubbo-spring-boot/dubbo-spring-boot-autoconfigure/pom.xml
+++ b/dubbo-spring-boot/dubbo-spring-boot-autoconfigure/pom.xml
@@ -30,7 +30,6 @@
     <packaging>jar</packaging>
     <description>Apache Dubbo Spring Boot Auto-Configure</description>
 
-
     <dependencies>
 
         <!-- Spring Boot Auto-Configuration -->
@@ -51,13 +50,6 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-logging</artifactId>
             <optional>true</optional>
-            <exclusions>
-                <!-- Fix the bug of log4j refer:https://github.com/apache/logging-log4j2/pull/608 -->
-                <exclusion>
-                    <groupId>org.apache.logging.log4j</groupId>
-                    <artifactId>log4j-api</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
         <!-- Dubbo -->
@@ -86,13 +78,6 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
-            <exclusions>
-                <!-- Fix the bug of log4j refer:https://github.com/apache/logging-log4j2/pull/608 -->
-                <exclusion>
-                    <groupId>org.apache.logging.log4j</groupId>
-                    <artifactId>log4j-api</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
     </dependencies>

--- a/dubbo-spring-boot/dubbo-spring-boot-compatible/actuator/pom.xml
+++ b/dubbo-spring-boot/dubbo-spring-boot-compatible/actuator/pom.xml
@@ -101,13 +101,6 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
-            <exclusions>
-                <!-- Fix the bug of log4j refer:https://github.com/apache/logging-log4j2/pull/608 -->
-                <exclusion>
-                    <groupId>org.apache.logging.log4j</groupId>
-                    <artifactId>log4j-api</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
     </dependencies>

--- a/dubbo-spring-boot/dubbo-spring-boot-compatible/autoconfigure/pom.xml
+++ b/dubbo-spring-boot/dubbo-spring-boot-compatible/autoconfigure/pom.xml
@@ -48,13 +48,6 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-logging</artifactId>
             <optional>true</optional>
-            <exclusions>
-                <!-- Fix the bug of log4j refer:https://github.com/apache/logging-log4j2/pull/608 -->
-                <exclusion>
-                    <groupId>org.apache.logging.log4j</groupId>
-                    <artifactId>log4j-api</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
         <!-- @ConfigurationProperties annotation processing (metadata for IDEs) -->
@@ -89,13 +82,6 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
-            <exclusions>
-                <!-- Fix the bug of log4j refer:https://github.com/apache/logging-log4j2/pull/608 -->
-                <exclusion>
-                    <groupId>org.apache.logging.log4j</groupId>
-                    <artifactId>log4j-api</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
     </dependencies>

--- a/dubbo-spring-boot/dubbo-spring-boot-compatible/pom.xml
+++ b/dubbo-spring-boot/dubbo-spring-boot-compatible/pom.xml
@@ -60,7 +60,8 @@
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
                             <useSystemClassLoader>true</useSystemClassLoader>
-                            <forkMode>once</forkMode>
+                            <forkCount>1</forkCount>
+                            <reuseForks>false</reuseForks>
                             <argLine>${argline} ${jacocoArgLine}
                                 --add-opens java.base/java.lang=ALL-UNNAMED
                                 --add-opens java.base/java.math=ALL-UNNAMED

--- a/dubbo-spring-boot/dubbo-spring-boot-interceptor/pom.xml
+++ b/dubbo-spring-boot/dubbo-spring-boot-interceptor/pom.xml
@@ -49,5 +49,4 @@
         </dependency>
     </dependencies>
 
-
 </project>

--- a/dubbo-spring-boot/dubbo-spring-boot-starter/pom.xml
+++ b/dubbo-spring-boot/dubbo-spring-boot-starter/pom.xml
@@ -30,25 +30,11 @@
     <packaging>jar</packaging>
     <description>Apache Dubbo Spring Boot Starter</description>
 
-
     <dependencies>
         <!-- Spring Boot dependencies -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter</artifactId>
-            <optional>true</optional>
-            <exclusions>
-                <!-- Fix the bug of log4j refer:https://github.com/apache/logging-log4j2/pull/608 -->
-                <exclusion>
-                    <groupId>org.apache.logging.log4j</groupId>
-                    <artifactId>log4j-api</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-api</artifactId>
-            <version>${log4j2_version}</version>
             <optional>true</optional>
         </dependency>
 

--- a/dubbo-spring-boot/dubbo-spring-boot-starters/dubbo-zookeeper-curator5-spring-boot-starter/pom.xml
+++ b/dubbo-spring-boot/dubbo-spring-boot-starters/dubbo-zookeeper-curator5-spring-boot-starter/pom.xml
@@ -58,58 +58,6 @@
             <groupId>org.apache.zookeeper</groupId>
             <artifactId>zookeeper</artifactId>
             <version>${zookeeper_version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>io.netty</groupId>
-                    <artifactId>netty-handler</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>io.netty</groupId>
-                    <artifactId>netty-transport-native-epoll</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-
-        <dependency>
-            <groupId>com.github.spotbugs</groupId>
-            <artifactId>spotbugs-annotations</artifactId>
-            <optional>true</optional>
-        </dependency>
-
-        <dependency>
-            <groupId>commons-cli</groupId>
-            <artifactId>commons-cli</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.eclipse.jetty</groupId>
-            <artifactId>jetty-server</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.eclipse.jetty</groupId>
-            <artifactId>jetty-servlet</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.eclipse.jetty</groupId>
-            <artifactId>jetty-client</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>jline</groupId>
-            <artifactId>jline</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>io.dropwizard.metrics</groupId>
-            <artifactId>metrics-core</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.xerial.snappy</groupId>
-            <artifactId>snappy-java</artifactId>
         </dependency>
     </dependencies>
-
 </project>

--- a/dubbo-spring-boot/dubbo-spring-boot-starters/dubbo-zookeeper-spring-boot-starter/pom.xml
+++ b/dubbo-spring-boot/dubbo-spring-boot-starters/dubbo-zookeeper-spring-boot-starter/pom.xml
@@ -32,6 +32,7 @@
     <description>Apache Dubbo Zookeeper Spring Boot Starter</description>
 
     <properties>
+        <zookeeper_version>3.8.3</zookeeper_version>
     </properties>
 
     <dependencies>
@@ -42,6 +43,7 @@
         <dependency>
             <groupId>org.apache.zookeeper</groupId>
             <artifactId>zookeeper</artifactId>
+            <version>${zookeeper_version}</version>
         </dependency>
     </dependencies>
 

--- a/dubbo-spring-boot/pom.xml
+++ b/dubbo-spring-boot/pom.xml
@@ -42,11 +42,10 @@
 
     <properties>
         <spring-boot.version>2.7.16</spring-boot.version>
-        <dubbo.version>${revision}</dubbo.version>
-        <!-- Fix the bug of log4j refer:https://github.com/apache/logging-log4j2/pull/608 -->
-        <log4j2_version>2.20.0</log4j2_version>
         <!-- Spring boot buddy is lower than the delivery dependency package version and can only show the defined dependency version -->
         <byte-buddy.version>1.14.9</byte-buddy.version>
+        <slf4j-log4j12_version>1.7.33</slf4j-log4j12_version>
+        <mockito_version>4.11.0</mockito_version>
     </properties>
 
     <dependencyManagement>
@@ -59,28 +58,50 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-starter-logging</artifactId>
+                <version>${spring-boot.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <artifactId>logback-classic</artifactId>
+                        <groupId>ch.qos.logback</groupId>
+                    </exclusion>
+                    <exclusion>
+                        <artifactId>log4j-to-slf4j</artifactId>
+                        <groupId>org.apache.logging.log4j</groupId>
+                    </exclusion>
+                    <exclusion>
+                        <artifactId>log4j-over-slf4j</artifactId>
+                        <groupId>org.slf4j</groupId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-log4j12</artifactId>
+                <version>${slf4j-log4j12_version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-core</artifactId>
+                <version>${mockito_version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-inline</artifactId>
+                <version>${mockito_version}</version>
+                <scope>test</scope>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
     <dependencies>
-        <!--JUnit Jupiter Engine to depend on the JUnit5 engine and JUnit 5 API -->
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-engine</artifactId>
-            <version>${junit_jupiter_version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-params</artifactId>
-            <version>${junit_jupiter_version}</version>
-            <scope>test</scope>
-        </dependency>
         <!--JUnit Jupiter Engine to depend on the JUnit4 engine and JUnit 4 API  -->
         <dependency>
             <groupId>org.junit.vintage</groupId>
             <artifactId>junit-vintage-engine</artifactId>
-            <version>${junit_jupiter_version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -99,6 +120,12 @@
             <groupId>org.apache.dubbo</groupId>
             <artifactId>dubbo-test-check</artifactId>
             <version>${project.parent.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+            <version>${slf4j-log4j12_version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -164,21 +191,6 @@
                             <Implementation-Version>${project.version}</Implementation-Version>
                         </manifestEntries>
                     </archive>
-                </configuration>
-            </plugin>
-
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>${maven_compiler_version}</version>
-                <configuration>
-                    <compilerArgs>
-                        <compilerArg>-parameters</compilerArg>
-                    </compilerArgs>
-                    <fork>true</fork>
-                    <source>${java_source_version}</source>
-                    <target>${java_target_version}</target>
-                    <encoding>${file_encoding}</encoding>
                 </configuration>
             </plugin>
         </plugins>

--- a/dubbo-test/dubbo-dependencies-all/pom.xml
+++ b/dubbo-test/dubbo-dependencies-all/pom.xml
@@ -377,7 +377,6 @@
             <version>${project.version}</version>
         </dependency>
 
-
         <!-- registry -->
         <dependency>
             <groupId>org.apache.dubbo</groupId>

--- a/dubbo-test/dubbo-test-check/pom.xml
+++ b/dubbo-test/dubbo-test-check/pom.xml
@@ -29,8 +29,6 @@
     <artifactId>dubbo-test-check</artifactId>
 
     <properties>
-        <maven.compiler.source>8</maven.compiler.source>
-        <maven.compiler.target>8</maven.compiler.target>
         <skip_maven_deploy>true</skip_maven_deploy>
         <curator.test.version>4.2.0</curator.test.version>
         <zookeeper.version>3.7.2</zookeeper.version>

--- a/dubbo-test/dubbo-test-common/pom.xml
+++ b/dubbo-test/dubbo-test-common/pom.xml
@@ -28,8 +28,6 @@
     <artifactId>dubbo-test-common</artifactId>
 
     <properties>
-        <maven.compiler.source>8</maven.compiler.source>
-        <maven.compiler.target>8</maven.compiler.target>
         <skip_maven_deploy>true</skip_maven_deploy>
     </properties>
 
@@ -37,12 +35,6 @@
         <dependency>
             <groupId>org.apache.zookeeper</groupId>
             <artifactId>zookeeper</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-log4j12</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
         <dependency>

--- a/dubbo-test/dubbo-test-spring/pom.xml
+++ b/dubbo-test/dubbo-test-spring/pom.xml
@@ -29,7 +29,6 @@
 
     <properties>
         <skip_maven_deploy>true</skip_maven_deploy>
-        <slf4j-log4j12.version>1.7.33</slf4j-log4j12.version>
         <spring_version>3.2.18.RELEASE</spring_version>
         <!--<spring_version>4.0.9.RELEASE</spring_version>-->
         <!--<spring_version>4.1.9.RELEASE</spring_version>-->
@@ -133,77 +132,55 @@
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
-            <version>${slf4j-log4j12.version}</version>
         </dependency>
-        <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
-        </dependency>
-
 
         <!--JUnit Jupiter Engine to depend on the JUnit5 engine and JUnit 5 API -->
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>${junit_jupiter_version}</version>
-            <!--<scope>test</scope>-->
+            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-params</artifactId>
-            <version>${junit_jupiter_version}</version>
-            <!--<scope>test</scope>-->
+            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest</artifactId>
-            <version>${hamcrest_version}</version>
-            <!--<scope>test</scope>-->
+            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
-            <version>${junit_jupiter_version}</version>
-<!--            <scope>test</scope>-->
+            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>${mockito_version}</version>
-            <!--<scope>test</scope>-->
+            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-inline</artifactId>
-            <version>${mockito_version}</version>
-            <!--<scope>test</scope>-->
-        </dependency>
-        <dependency>
-            <groupId>cglib</groupId>
-            <artifactId>cglib-nodep</artifactId>
-            <version>${cglib_version}</version>
-            <!--<scope>test</scope>-->
+            <scope>compile</scope>
         </dependency>
 
         <dependency>
             <groupId>org.apache.curator</groupId>
             <artifactId>curator-framework</artifactId>
-<!--            <scope>test</scope>-->
+            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.curator</groupId>
             <artifactId>curator-recipes</artifactId>
-<!--            <scope>test</scope>-->
+            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.zookeeper</groupId>
             <artifactId>zookeeper</artifactId>
-<!--            <scope>test</scope>-->
+            <scope>compile</scope>
         </dependency>
     </dependencies>
 

--- a/dubbo-test/dubbo-test-spring3.2/pom.xml
+++ b/dubbo-test/dubbo-test-spring3.2/pom.xml
@@ -97,7 +97,8 @@
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
                             <useSystemClassLoader>true</useSystemClassLoader>
-                            <forkMode>once</forkMode>
+                            <forkCount>1</forkCount>
+                            <reuseForks>false</reuseForks>
                             <argLine>${argline} ${jacocoArgLine}
                                 --add-opens java.base/java.lang=ALL-UNNAMED
                                 --add-opens java.base/java.math=ALL-UNNAMED

--- a/dubbo-test/dubbo-test-spring4.1/pom.xml
+++ b/dubbo-test/dubbo-test-spring4.1/pom.xml
@@ -51,11 +51,12 @@
             <artifactId>dubbo-test-spring</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>
-        </dependency>        <dependency>
-        <groupId>org.apache.curator</groupId>
-        <artifactId>curator-framework</artifactId>
-        <!--            <scope>test</scope>-->
-    </dependency>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.curator</groupId>
+            <artifactId>curator-framework</artifactId>
+            <!--            <scope>test</scope>-->
+        </dependency>
         <dependency>
             <groupId>org.apache.curator</groupId>
             <artifactId>curator-recipes</artifactId>
@@ -96,7 +97,8 @@
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
                             <useSystemClassLoader>true</useSystemClassLoader>
-                            <forkMode>once</forkMode>
+                            <forkCount>1</forkCount>
+                            <reuseForks>false</reuseForks>
                             <argLine>${argline} ${jacocoArgLine}
                                 --add-opens java.base/java.lang=ALL-UNNAMED
                                 --add-opens java.base/java.math=ALL-UNNAMED

--- a/dubbo-test/dubbo-test-spring4.2/pom.xml
+++ b/dubbo-test/dubbo-test-spring4.2/pom.xml
@@ -51,11 +51,12 @@
             <artifactId>dubbo-test-spring</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>
-        </dependency>        <dependency>
-        <groupId>org.apache.curator</groupId>
-        <artifactId>curator-framework</artifactId>
-        <!--            <scope>test</scope>-->
-    </dependency>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.curator</groupId>
+            <artifactId>curator-framework</artifactId>
+            <!--            <scope>test</scope>-->
+        </dependency>
         <dependency>
             <groupId>org.apache.curator</groupId>
             <artifactId>curator-recipes</artifactId>
@@ -96,7 +97,8 @@
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
                             <useSystemClassLoader>true</useSystemClassLoader>
-                            <forkMode>once</forkMode>
+                            <forkCount>1</forkCount>
+                            <reuseForks>false</reuseForks>
                             <argLine>${argline} ${jacocoArgLine}
                                 --add-opens java.base/java.lang=ALL-UNNAMED
                                 --add-opens java.base/java.math=ALL-UNNAMED

--- a/dubbo-test/pom.xml
+++ b/dubbo-test/pom.xml
@@ -39,8 +39,6 @@
     </modules>
 
     <properties>
-        <maven.compiler.source>8</maven.compiler.source>
-        <maven.compiler.target>8</maven.compiler.target>
         <skip_maven_deploy>true</skip_maven_deploy>
     </properties>
 

--- a/dubbo-xds/pom.xml
+++ b/dubbo-xds/pom.xml
@@ -106,7 +106,7 @@
                 <artifactId>protobuf-maven-plugin</artifactId>
                 <version>${maven_protobuf_plugin_version}</version>
                 <configuration>
-                    <protocArtifact>com.google.protobuf:protoc:${protobuf-java_version}:exe:${os.detected.classifier}</protocArtifact>
+                    <protocArtifact>com.google.protobuf:protoc:${protobuf-protoc_version}:exe:${os.detected.classifier}</protocArtifact>
                     <pluginId>grpc-java</pluginId>
                     <pluginArtifact>io.grpc:protoc-gen-grpc-java:${grpc_version}:exe:${os.detected.classifier}</pluginArtifact>
                 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -87,30 +87,25 @@
     </issueManagement>
 
     <properties>
-        <!-- Test libs -->
-        <junit_jupiter_version>5.9.3</junit_jupiter_version>
-        <awaitility_version>4.2.0</awaitility_version>
-        <hazelcast_version>3.12.13</hazelcast_version>
-        <hamcrest_version>2.2</hamcrest_version>
-        <hibernate_validator_version>5.2.4.Final</hibernate_validator_version>
-        <el_api_version>2.2.5</el_api_version>
-        <jaxb_api_version>2.2.7</jaxb_api_version>
-        <cglib_version>2.2.2</cglib_version>
-        <mockito_version>4.11.0</mockito_version>
         <!-- Build args -->
-        <argline>-server -Xms256m -Xmx512m -Dfile.encoding=UTF-8
-            -Djava.net.preferIPv4Stack=true -XX:MetaspaceSize=64m -XX:MaxMetaspaceSize=128m
-        </argline>
-        <skip_maven_deploy>false</skip_maven_deploy>
-        <updateReleaseInfo>true</updateReleaseInfo>
-        <project.build.sourceEncoding>${file_encoding}</project.build.sourceEncoding>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.outputTimestamp>2020-04-01T08:04:00Z</project.build.outputTimestamp>
-
+        <argline>-server -Xms256m -Xmx512m -XX:MetaspaceSize=64m -XX:MaxMetaspaceSize=128m -Dfile.encoding=UTF-8
+            -Djava.net.preferIPv4Stack=true
+        </argline>
+        <arguments />
+        <jacocoArgLine />
         <profile.name>oss</profile.name>
-        <!-- for maven compiler plugin -->
-        <java_source_version>1.8</java_source_version>
-        <java_target_version>1.8</java_target_version>
-        <file_encoding>UTF-8</file_encoding>
+        <updateReleaseInfo>true</updateReleaseInfo>
+        <skip_maven_deploy>false</skip_maven_deploy>
+        <checkstyle.skip>true</checkstyle.skip>
+        <checkstyle_unix.skip>true</checkstyle_unix.skip>
+        <rat.skip>true</rat.skip>
+        <jacoco.skip>true</jacoco.skip>
+
         <!-- Maven plugins -->
         <maven_jar_version>3.3.0</maven_jar_version>
         <maven_surefire_version>3.0.0</maven_surefire_version>
@@ -128,15 +123,10 @@
         <dubbo_annotation_processor_version>1.0.0</dubbo_annotation_processor_version>
         <maven_os_plugin_version>1.7.1</maven_os_plugin_version>
         <maven_protobuf_plugin_version>0.6.1</maven_protobuf_plugin_version>
-        <arguments />
-        <checkstyle.skip>true</checkstyle.skip>
-        <checkstyle_unix.skip>true</checkstyle_unix.skip>
-        <rat.skip>true</rat.skip>
-        <jacoco.skip>true</jacoco.skip>
 
-        <jprotoc_version>1.2.2</jprotoc_version>
-        <protobuf-java_version>3.22.3</protobuf-java_version>
+        <protobuf-protoc_version>3.22.3</protobuf-protoc_version>
         <grpc_version>1.54.0</grpc_version>
+
         <revision>3.3.0-beta.1-SNAPSHOT</revision>
     </properties>
 
@@ -180,7 +170,6 @@
     </dependencyManagement>
 
     <dependencies>
-
         <dependency>
             <groupId>org.apache.dubbo</groupId>
             <artifactId>dubbo-annotation-processor</artifactId>
@@ -192,49 +181,31 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>${junit_jupiter_version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-api</artifactId>
-            <version>${junit_jupiter_version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-params</artifactId>
-            <version>${junit_jupiter_version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.awaitility</groupId>
             <artifactId>awaitility</artifactId>
-            <version>${awaitility_version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest</artifactId>
-            <version>${hamcrest_version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>${mockito_version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-inline</artifactId>
-            <version>${mockito_version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>cglib</groupId>
-            <artifactId>cglib-nodep</artifactId>
-            <version>${cglib_version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -324,7 +295,6 @@
                                 <configuration>
                                     <configLocation>codestyle/checkstyle.xml</configLocation>
                                     <suppressionsLocation>codestyle/checkstyle-suppressions.xml</suppressionsLocation>
-                                    <encoding>UTF-8</encoding>
                                     <consoleOutput>true</consoleOutput>
                                     <failOnViolation>true</failOnViolation>
                                     <skip>${checkstyle.skip}</skip>
@@ -387,7 +357,6 @@
                                 <phase>validate</phase>
                                 <configuration>
                                     <configLocation>codestyle/checkstyle_unix.xml</configLocation>
-                                    <encoding>UTF-8</encoding>
                                     <consoleOutput>true</consoleOutput>
                                     <failOnViolation>true</failOnViolation>
                                     <skip>${checkstyle_unix.skip}</skip>
@@ -483,7 +452,7 @@
                             <docencoding>UTF-8</docencoding>
                             <source>${maven_source_version}</source>
                             <links>
-                                <link>http://docs.oracle.com/javase/8/docs/api</link>
+                                <link>https://docs.oracle.com/javase/8/docs/api</link>
                             </links>
                             <doclint>none</doclint>
                             <excludePackageNames>
@@ -559,7 +528,8 @@
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
                             <useSystemClassLoader>true</useSystemClassLoader>
-                            <forkMode>once</forkMode>
+                            <forkCount>1</forkCount>
+                            <reuseForks>false</reuseForks>
                             <argLine>${argline} ${jacocoArgLine}
                                 --add-opens java.base/java.lang=ALL-UNNAMED
                                 --add-opens java.base/java.math=ALL-UNNAMED
@@ -584,7 +554,8 @@
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
                             <useSystemClassLoader>true</useSystemClassLoader>
-                            <forkMode>once</forkMode>
+                            <forkCount>1</forkCount>
+                            <reuseForks>false</reuseForks>
                             <argLine>${argline} ${jacocoArgLine}
                             </argLine>
                             <systemProperties>
@@ -703,7 +674,8 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <useSystemClassLoader>true</useSystemClassLoader>
-                    <forkMode>once</forkMode>
+                    <forkCount>1</forkCount>
+                    <reuseForks>false</reuseForks>
                     <argLine>${argline} ${jacocoArgLine}</argLine>
                     <systemProperties>
                         <!-- common shared -->
@@ -727,9 +699,6 @@
                         <compilerArg>-parameters</compilerArg>
                     </compilerArgs>
                     <fork>true</fork>
-                    <source>${java_source_version}</source>
-                    <target>${java_target_version}</target>
-                    <encoding>${file_encoding}</encoding>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
## What is the purpose of the change
See: #13188 

## Brief changelog
Exclude the relevant log jars. In a properly configured application, it will directly include the required log jars. Indirectly dependencies can leading to jar version mistake.

## Verifying this change
The example app work fine without exclude log jars.
Has been tested with samples:
* https://github.com/chickenlj/dubbo-samples/tree/3.3.0-beta.1-sae/3-extensions/registry/dubbo-samples-zookeeper
* https://github.com/chickenlj/dubbo-samples/tree/3.3.0-beta.1-sae/2-advanced/dubbo-samples-native-image

<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [ ] GitHub Actions works fine on your own branch.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
