### PR TITLE
optimize AbstractConfigTest

### DIFF
--- a/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/AbstractConfigTest.java
+++ b/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/AbstractConfigTest.java
@@ -61,70 +61,6 @@ class AbstractConfigTest {
         SysProps.clear();
     }
 
-    //FIXME
-    /*@Test
-    public void testAppendProperties1() throws Exception {
-        try {
-            System.setProperty("dubbo.properties.i", "1");
-            System.setProperty("dubbo.properties.c", "c");
-            System.setProperty("dubbo.properties.b", "2");
-            System.setProperty("dubbo.properties.d", "3");
-            System.setProperty("dubbo.properties.f", "4");
-            System.setProperty("dubbo.properties.l", "5");
-            System.setProperty("dubbo.properties.s", "6");
-            System.setProperty("dubbo.properties.str", "dubbo");
-            System.setProperty("dubbo.properties.bool", "true");
-            PropertiesConfig config = new PropertiesConfig();
-            AbstractConfig.appendProperties(config);
-            Assertions.assertEquals(1, config.getI());
-            Assertions.assertEquals('c', config.getC());
-            Assertions.assertEquals((byte) 0x02, config.getB());
-            Assertions.assertEquals(3d, config.getD());
-            Assertions.assertEquals(4f, config.getF());
-            Assertions.assertEquals(5L, config.getL());
-            Assertions.assertEquals(6, config.getS());
-            Assertions.assertEquals("dubbo", config.getStr());
-            Assertions.assertTrue(config.isBool());
-        } finally {
-            System.clearProperty("dubbo.properties.i");
-            System.clearProperty("dubbo.properties.c");
-            System.clearProperty("dubbo.properties.b");
-            System.clearProperty("dubbo.properties.d");
-            System.clearProperty("dubbo.properties.f");
-            System.clearProperty("dubbo.properties.l");
-            System.clearProperty("dubbo.properties.s");
-            System.clearProperty("dubbo.properties.str");
-            System.clearProperty("dubbo.properties.bool");
-        }
-    }
-
-    @Test
-    void testAppendProperties2() throws Exception {
-        try {
-            System.setProperty("dubbo.properties.two.i", "2");
-            PropertiesConfig config = new PropertiesConfig("two");
-            AbstractConfig.appendProperties(config);
-            Assertions.assertEquals(2, config.getI());
-        } finally {
-            System.clearProperty("dubbo.properties.two.i");
-        }
-    }
-
-    @Test
-    void testAppendProperties3() throws Exception {
-        try {
-            Properties p = new Properties();
-            p.put("dubbo.properties.str", "dubbo");
-            ConfigUtils.setProperties(p);
-            PropertiesConfig config = new PropertiesConfig();
-            AbstractConfig.appendProperties(config);
-            Assertions.assertEquals("dubbo", config.getStr());
-        } finally {
-            System.clearProperty(Constants.DUBBO_PROPERTIES_KEY);
-            ConfigUtils.setProperties(null);
-        }
-    }*/
-
     @Test
     void testValidateProtocolConfig() {
         ProtocolConfig protocolConfig = new ProtocolConfig();
@@ -798,97 +734,6 @@ class AbstractConfigTest {
         }
     }
 
-    private static class PropertiesConfig extends AbstractConfig {
-        private char c;
-        private boolean bool;
-        private byte b;
-        private int i;
-        private long l;
-        private float f;
-        private double d;
-        private short s;
-        private String str;
-
-        PropertiesConfig() {
-        }
-
-        PropertiesConfig(String id) {
-            this.setId(id);
-        }
-
-        public char getC() {
-            return c;
-        }
-
-        public void setC(char c) {
-            this.c = c;
-        }
-
-        public boolean isBool() {
-            return bool;
-        }
-
-        public void setBool(boolean bool) {
-            this.bool = bool;
-        }
-
-        public byte getB() {
-            return b;
-        }
-
-        public void setB(byte b) {
-            this.b = b;
-        }
-
-        public int getI() {
-            return i;
-        }
-
-        public void setI(int i) {
-            this.i = i;
-        }
-
-        public long getL() {
-            return l;
-        }
-
-        public void setL(long l) {
-            this.l = l;
-        }
-
-        public float getF() {
-            return f;
-        }
-
-        public void setF(float f) {
-            this.f = f;
-        }
-
-        public double getD() {
-            return d;
-        }
-
-        public void setD(double d) {
-            this.d = d;
-        }
-
-        public String getStr() {
-            return str;
-        }
-
-        public void setStr(String str) {
-            this.str = str;
-        }
-
-        public short getS() {
-            return s;
-        }
-
-        public void setS(short s) {
-            this.s = s;
-        }
-    }
-
     private static class ParameterConfig {
         private int number;
         private String name;
@@ -1052,11 +897,88 @@ class AbstractConfigTest {
         }
     }
 
+    @Test
+    void testRefreshNestedWithIdByExternal() {
+        try {
+            Map<String, String> external = new HashMap<>();
+            external.put("dubbo.outers.test.a1", "1");
+            external.put("dubbo.outers.test.b.b1", "11");
+            external.put("dubbo.outers.test.b.b2", "12");
+
+            ApplicationModel.defaultModel().modelEnvironment().initialize();
+            ApplicationModel.defaultModel().modelEnvironment().setExternalConfigMap(external);
+
+            OuterConfig outerConfig = new OuterConfig("test");
+            outerConfig.refresh();
+
+            Assertions.assertEquals(1, outerConfig.getA1());
+            Assertions.assertEquals(11, outerConfig.getB().getB1());
+            Assertions.assertEquals(12, outerConfig.getB().getB2());
+        } finally {
+            ApplicationModel.defaultModel().modelEnvironment().destroy();
+        }
+    }
+
+    @Test
+    void testRefreshNestedWithIdBySystemProperties() {
+        try {
+            System.setProperty("dubbo.outers.test.a1", "1");
+            System.setProperty("dubbo.outers.test.b.b1", "11");
+            System.setProperty("dubbo.outers.test.b.b2", "12");
+
+            ApplicationModel.defaultModel().modelEnvironment().initialize();
+
+            OuterConfig outerConfig = new OuterConfig("test");
+            outerConfig.refresh();
+
+            Assertions.assertEquals(1, outerConfig.getA1());
+            Assertions.assertEquals(11, outerConfig.getB().getB1());
+            Assertions.assertEquals(12, outerConfig.getB().getB2());
+        } finally {
+            ApplicationModel.defaultModel().modelEnvironment().destroy();
+            System.clearProperty("dubbo.outers.test.a1");
+            System.clearProperty("dubbo.outers.test.b.b1");
+            System.clearProperty("dubbo.outers.test.b.b2");
+        }
+    }
+
+    @Test
+    void testRefreshNestedByProperties() {
+        try {
+            Properties p = new Properties();
+            p.put("dubbo.outer.a1", "1");
+            p.put("dubbo.outer.b.b1", "11");
+            p.put("dubbo.outer.b.b2", "12");
+            System.setProperties(p);
+
+            ApplicationModel.defaultModel().modelEnvironment().initialize();
+
+            OuterConfig outerConfig = new OuterConfig();
+            outerConfig.refresh();
+
+            Assertions.assertEquals(1, outerConfig.getA1());
+            Assertions.assertEquals(11, outerConfig.getB().getB1());
+            Assertions.assertEquals(12, outerConfig.getB().getB2());
+        } finally {
+            ApplicationModel.defaultModel().modelEnvironment().destroy();
+            System.clearProperty("dubbo.outer.a1");
+            System.clearProperty("dubbo.outer.b.b1");
+            System.clearProperty("dubbo.outer.b.b2");
+        }
+    }
+
     private static class OuterConfig extends AbstractConfig {
         private Integer a1;
 
         @Nested
         private InnerConfig b;
+
+        OuterConfig() {
+        }
+
+        OuterConfig(String id) {
+            this.setId(id);
+        }
 
         public Integer getA1() {
             return a1;

--- a/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/AbstractConfigTest.java
+++ b/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/AbstractConfigTest.java
@@ -923,11 +923,10 @@ class AbstractConfigTest {
     @Test
     void testRefreshNestedBySystemProperties() {
         try {
-            Properties p = new Properties();
+            Properties p = System.getProperties();
             p.put("dubbo.outer.a1", "1");
             p.put("dubbo.outer.b.b1", "11");
             p.put("dubbo.outer.b.b2", "12");
-            System.setProperties(p);
 
             ApplicationModel.defaultModel().modelEnvironment().initialize();
 

--- a/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/AbstractConfigTest.java
+++ b/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/AbstractConfigTest.java
@@ -898,29 +898,7 @@ class AbstractConfigTest {
     }
 
     @Test
-    void testRefreshNestedWithIdByExternal() {
-        try {
-            Map<String, String> external = new HashMap<>();
-            external.put("dubbo.outers.test.a1", "1");
-            external.put("dubbo.outers.test.b.b1", "11");
-            external.put("dubbo.outers.test.b.b2", "12");
-
-            ApplicationModel.defaultModel().modelEnvironment().initialize();
-            ApplicationModel.defaultModel().modelEnvironment().setExternalConfigMap(external);
-
-            OuterConfig outerConfig = new OuterConfig("test");
-            outerConfig.refresh();
-
-            Assertions.assertEquals(1, outerConfig.getA1());
-            Assertions.assertEquals(11, outerConfig.getB().getB1());
-            Assertions.assertEquals(12, outerConfig.getB().getB2());
-        } finally {
-            ApplicationModel.defaultModel().modelEnvironment().destroy();
-        }
-    }
-
-    @Test
-    void testRefreshNestedWithIdBySystemProperties() {
+    void testRefreshNestedWithId() {
         try {
             System.setProperty("dubbo.outers.test.a1", "1");
             System.setProperty("dubbo.outers.test.b.b1", "11");
@@ -943,7 +921,7 @@ class AbstractConfigTest {
     }
 
     @Test
-    void testRefreshNestedByProperties() {
+    void testRefreshNestedBySystemProperties() {
         try {
             Properties p = new Properties();
             p.put("dubbo.outer.a1", "1");


### PR DESCRIPTION
## What is the purpose of the change
optimize AbstractConfigTest

## Brief changelog
org.apache.dubbo.config.AbstractConfigTest

- Rewrite `testAppendProperties` related tests because `AbstractConfig.appendProperties` no longer exists.
- Remove unused inner test class `PropertiesConfig`.

## Verifying this change


<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [x] Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [ ] GitHub Actions works fine on your own branch.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
