### PR TITLE
Fix tag router

### DIFF
--- a/dubbo-config/dubbo-config-api/pom.xml
+++ b/dubbo-config/dubbo-config-api/pom.xml
@@ -243,7 +243,6 @@
             <groupId>org.apache.dubbo</groupId>
             <artifactId>dubbo-plugin-router-tag</artifactId>
             <version>${project.parent.version}</version>
-            <scope>test</scope>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
## What is the purpose of the change
Fix tag router
close issue : #13264

## Brief changelog
Fix pom configuration caused by previous refactoring

## Verifying this change
The previous tag routing rule did not take effect, and took effect after PR

