### PR TITLE
Judging qos is in started state when stopping qos

### DIFF
--- a/dubbo-plugin/dubbo-qos/src/main/java/org/apache/dubbo/qos/protocol/QosProtocolWrapper.java
+++ b/dubbo-plugin/dubbo-qos/src/main/java/org/apache/dubbo/qos/protocol/QosProtocolWrapper.java
@@ -153,7 +153,9 @@ public class QosProtocolWrapper implements Protocol, ScopeModelAware {
     /*package*/ void stopServer() {
         if (hasStarted.compareAndSet(true, false)) {
             Server server = frameworkModel.getBeanFactory().getBean(Server.class);
-            server.stop();
+            if (server.isStarted()) {
+                server.stop();
+            }
         }
     }
 }


### PR DESCRIPTION
## What is the purpose of the change
![image](https://github.com/apache/dubbo/assets/18413695/1f921bbe-8b9f-4382-a02e-438bff788262)
If qos server isn't in started state, wouldn't stop it and log stop info.


## Brief changelog


## Verifying this change


<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [ ] GitHub Actions works fine on your own branch.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
