### PR TITLE
fix:ConsulRegistry.ConsulNotify can't pull provider.(#9263 #9291)

### DIFF
--- a/dubbo-registry/dubbo-registry-consul/src/main/java/org/apache/dubbo/registry/consul/ConsulRegistry.java
+++ b/dubbo-registry/dubbo-registry-consul/src/main/java/org/apache/dubbo/registry/consul/ConsulRegistry.java
@@ -355,7 +355,7 @@ public class ConsulRegistry extends FailbackRegistry {
         }
 
         private void processService() {
-            String service = url.getServiceKey();
+            String service = url.getServiceInterface();
             Response<List<HealthService>> response = getHealthServices(service, consulIndex, buildWatchTimeout(url));
             Long currentIndex = response.getConsulIndex();
             if (currentIndex != null && currentIndex > consulIndex) {


### PR DESCRIPTION


## What is the purpose of the change
Under the premise of using group and version configurations, ConsulRegistry.doRegister() uses url.getServiceInterface(), 
but ConsulRegistry.ConsulNotify.processService() uses url.getServiceKey(), which prevents the instance from being pulled.
fix ConsulRegistry.ConsulNotify.processService() can pull instance provider.

## Brief changelog


## Verifying this change


<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [ ] GitHub Actions works fine on your own branch.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
