### PR TITLE
register application name mapping to metadata center

### DIFF
--- a/dubbo-metadata/dubbo-metadata-api/src/main/java/org/apache/dubbo/metadata/ServiceNameMapping.java
+++ b/dubbo-metadata/dubbo-metadata-api/src/main/java/org/apache/dubbo/metadata/ServiceNameMapping.java
@@ -45,8 +45,9 @@ public interface ServiceNameMapping extends Destroyable {
 
     /**
      * Map the specified Dubbo service interface, group, version and protocol to current Dubbo service name
+     * @throws InterruptedException
      */
-    boolean map(URL url);
+    boolean map(URL url) throws InterruptedException;
 
     boolean hasValidMetadataCenter();
 

--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/metadata/MetadataServiceNameMapping.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/metadata/MetadataServiceNameMapping.java
@@ -169,7 +169,7 @@ public class MetadataServiceNameMapping extends AbstractServiceNameMapping {
         if (registryCluster == null) {
             registryCluster = DEFAULT_KEY;
         }
-        int i = registryCluster.indexOf(",");
+        int i = registryCluster.indexOf(COMMA_SEPARATOR);
         if (i > 0) {
             registryCluster = registryCluster.substring(0, i);
         }
@@ -217,7 +217,7 @@ public class MetadataServiceNameMapping extends AbstractServiceNameMapping {
         if (StringUtils.isEmpty(oldConfigContent)) {
             return value;
         }
-        String[] oldValues = oldConfigContent.split(",");
+        String[] oldValues = oldConfigContent.split(COMMA_SEPARATOR);
         if (oldValues.length > 0) {
             for (String oldValue : oldValues) {
                 if (oldValue.equals(value)) {

--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/metadata/MetadataServiceNameMapping.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/metadata/MetadataServiceNameMapping.java
@@ -186,21 +186,13 @@ public class MetadataServiceNameMapping extends AbstractServiceNameMapping {
 
         boolean succeeded = false;
         int currentRetryTimes = 1;
-        String newConfigContent = value;
         do {
             ConfigItem configItem = metadataReport.getConfigItem(dataId, DEFAULT_MAPPING_GROUP);
             String oldConfigContent = configItem.getContent();
-            if (StringUtils.isNotEmpty(oldConfigContent)) {
-                String[] oldValues = oldConfigContent.split(",");
-                if (oldValues.length > 0) {
-                    for (String oldValue : oldValues) {
-                        if (oldValue.equals(value)) {
-                            // the value is already registered.
-                            return true;
-                        }
-                    }
-                }
-                newConfigContent = oldConfigContent + COMMA_SEPARATOR + value;
+            String newConfigContent = getNewConfigContent(oldConfigContent, value);
+            if (newConfigContent == null) {
+                // the value is already registered.
+                return true;
             }
             succeeded = metadataReport.registerServiceAppMapping(
                     dataId, DEFAULT_MAPPING_GROUP, newConfigContent, configItem.getTicket());
@@ -219,6 +211,22 @@ public class MetadataServiceNameMapping extends AbstractServiceNameMapping {
         } while (!succeeded && currentRetryTimes++ <= casRetryTimes);
 
         return succeeded;
+    }
+
+    private static String getNewConfigContent(String oldConfigContent, String value) {
+        if (StringUtils.isEmpty(oldConfigContent)) {
+            return value;
+        }
+        String[] oldValues = oldConfigContent.split(",");
+        if (oldValues.length > 0) {
+            for (String oldValue : oldValues) {
+                if (oldValue.equals(value)) {
+                    // return null to notice the value is already registered.
+                    return null;
+                }
+            }
+        }
+        return oldConfigContent + COMMA_SEPARATOR + value;
     }
 
     public static String getAppNameWithPrefix(String appName) {

--- a/dubbo-registry/dubbo-registry-api/src/test/java/org/apache/dubbo/registry/client/metadata/MetadataServiceNameMappingTest.java
+++ b/dubbo-registry/dubbo-registry-api/src/test/java/org/apache/dubbo/registry/client/metadata/MetadataServiceNameMappingTest.java
@@ -120,9 +120,11 @@ class MetadataServiceNameMappingTest {
         assertTrue(mapping.map(url));
 
         // metadata report succeeded directly for Service Interface mapping as it is already registered.
-        ConfigItem cfgItem = new ConfigItem();
-        cfgItem.setContent(appName);
-        when(metadataReport.getConfigItem(any(), any())).thenReturn(cfgItem, new ConfigItem());
+        ConfigItem serviceInterfaceMappingCfg = new ConfigItem();
+        serviceInterfaceMappingCfg.setContent(appName);
+        ConfigItem appNameMappingCfg = new ConfigItem();
+        appNameMappingCfg.setContent("otherInterface");
+        when(metadataReport.getConfigItem(any(), any())).thenReturn(serviceInterfaceMappingCfg, appNameMappingCfg);
         // metadata report using cas and retry, failed after 11 times retry for Application Name mapping.
         when(metadataReport.registerServiceAppMapping(any(), any(), any(), any()))
                 .thenReturn(false);

--- a/dubbo-registry/dubbo-registry-api/src/test/java/org/apache/dubbo/registry/client/metadata/MetadataServiceNameMappingTest.java
+++ b/dubbo-registry/dubbo-registry-api/src/test/java/org/apache/dubbo/registry/client/metadata/MetadataServiceNameMappingTest.java
@@ -99,9 +99,7 @@ class MetadataServiceNameMappingTest {
 
         // metadata report using cas and retry.
         when(metadataReport.registerServiceAppMapping(any(), any(), any())).thenReturn(false);
-        ConfigItem cfgItem = new ConfigItem();
-        cfgItem.setContent("otherApp");
-        when(metadataReport.getConfigItem(any(), any())).thenReturn(cfgItem);
+        when(metadataReport.getConfigItem(any(), any())).thenReturn(new ConfigItem());
         when(metadataReport.registerServiceAppMapping(any(), any(), any(), any()))
                 .thenAnswer(new Answer<Boolean>() {
                     private int counter = 0;
@@ -122,8 +120,9 @@ class MetadataServiceNameMappingTest {
         assertTrue(mapping.map(url));
 
         // metadata report succeeded directly for Service Interface mapping as it is already registered.
+        ConfigItem cfgItem = new ConfigItem();
         cfgItem.setContent(appName);
-        when(metadataReport.getConfigItem(any(), any())).thenReturn(cfgItem);
+        when(metadataReport.getConfigItem(any(), any())).thenReturn(cfgItem, new ConfigItem());
         // metadata report using cas and retry, failed after 11 times retry for Application Name mapping.
         when(metadataReport.registerServiceAppMapping(any(), any(), any(), any()))
                 .thenReturn(false);

--- a/dubbo-registry/dubbo-registry-api/src/test/java/org/apache/dubbo/registry/client/metadata/MetadataServiceNameMappingTest.java
+++ b/dubbo-registry/dubbo-registry-api/src/test/java/org/apache/dubbo/registry/client/metadata/MetadataServiceNameMappingTest.java
@@ -78,7 +78,8 @@ class MetadataServiceNameMappingTest {
 
         when(configManager.getMetadataConfigs()).thenReturn(Collections.emptyList());
         Mockito.when(mockedApplicationModel.getApplicationConfigManager()).thenReturn(configManager);
-        Mockito.when(mockedApplicationModel.getCurrentConfig()).thenReturn(new ApplicationConfig("test"));
+        String appName = "test";
+        Mockito.when(mockedApplicationModel.getCurrentConfig()).thenReturn(new ApplicationConfig(appName));
 
         // metadata report config not found
         mapping.setApplicationModel(mockedApplicationModel);
@@ -120,10 +121,12 @@ class MetadataServiceNameMappingTest {
                 });
         assertTrue(mapping.map(url));
 
-        // metadata report using cas and retry, failed after 11 times retry for Service Interface mapping.
+        // metadata report succeeded directly for Service Interface mapping as it is already registered.
+        cfgItem.setContent(appName);
+        when(metadataReport.getConfigItem(any(), any())).thenReturn(cfgItem);
+        // metadata report using cas and retry, failed after 11 times retry for Application Name mapping.
         when(metadataReport.registerServiceAppMapping(any(), any(), any(), any()))
                 .thenReturn(false);
-        Exception exceptionExpected = null;
         assertFalse(mapping.map(url));
     }
 

--- a/dubbo-registry/dubbo-registry-api/src/test/java/org/apache/dubbo/registry/client/metadata/MetadataServiceNameMappingTest.java
+++ b/dubbo-registry/dubbo-registry-api/src/test/java/org/apache/dubbo/registry/client/metadata/MetadataServiceNameMappingTest.java
@@ -98,7 +98,9 @@ class MetadataServiceNameMappingTest {
 
         // metadata report using cas and retry.
         when(metadataReport.registerServiceAppMapping(any(), any(), any())).thenReturn(false);
-        when(metadataReport.getConfigItem(any(), any())).thenReturn(new ConfigItem());
+        ConfigItem cfgItem = new ConfigItem();
+        cfgItem.setContent("otherApp");
+        when(metadataReport.getConfigItem(any(), any())).thenReturn(cfgItem);
         when(metadataReport.registerServiceAppMapping(any(), any(), any(), any()))
                 .thenAnswer(new Answer<Boolean>() {
                     private int counter = 0;

--- a/dubbo-registry/dubbo-registry-api/src/test/java/org/apache/dubbo/registry/client/metadata/MetadataServiceNameMappingTest.java
+++ b/dubbo-registry/dubbo-registry-api/src/test/java/org/apache/dubbo/registry/client/metadata/MetadataServiceNameMappingTest.java
@@ -73,7 +73,7 @@ class MetadataServiceNameMappingTest {
     }
 
     @Test
-    void testMap() {
+    void testMap() throws InterruptedException {
         ApplicationModel mockedApplicationModel = spy(applicationModel);
 
         when(configManager.getMetadataConfigs()).thenReturn(Collections.emptyList());
@@ -96,7 +96,7 @@ class MetadataServiceNameMappingTest {
         result = mapping.map(url);
         assertTrue(result);
 
-        // metadata report using cas and retry, succeeded after retried 10 times
+        // metadata report using cas and retry.
         when(metadataReport.registerServiceAppMapping(any(), any(), any())).thenReturn(false);
         when(metadataReport.getConfigItem(any(), any())).thenReturn(new ConfigItem());
         when(metadataReport.registerServiceAppMapping(any(), any(), any(), any()))
@@ -105,7 +105,12 @@ class MetadataServiceNameMappingTest {
 
                     @Override
                     public Boolean answer(InvocationOnMock invocationOnMock) {
-                        if (++counter == 10) {
+                        ++counter;
+                        if (counter == 10) {
+                            // succeeded after retried 10 times for Service Interface mapping.
+                            return true;
+                        } else if (counter == 20) {
+                            // succeeded after retried 10 times for Application Name mapping.
                             return true;
                         }
                         return false;
@@ -113,7 +118,7 @@ class MetadataServiceNameMappingTest {
                 });
         assertTrue(mapping.map(url));
 
-        // metadata report using cas and retry, failed after 11 times retry
+        // metadata report using cas and retry, failed after 11 times retry for Service Interface mapping.
         when(metadataReport.registerServiceAppMapping(any(), any(), any(), any()))
                 .thenReturn(false);
         Exception exceptionExpected = null;


### PR DESCRIPTION
## What is the purpose of the change
register  app-serviceInterfaces mapping to metadata center for synchronizing serviceInterface metadata from source metadata center to dest metadata center based on application name. 
see more details at  https://github.com/apache/dubbo/issues/13298

## Brief changelog
* add app-serviceInterfaces mapping registration at function exportServices() of DefaultModuleDeployer.java
* record serviceInterfaces at function map(url) of MetadataServiceNameMapping.java
* add function registerAppServiceMapping() in MetadataServiceNameMapping.java

## Verifying this change
Tested on nacos2.3.0-BETA

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [x] Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [ ] GitHub Actions works fine on your own branch.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).