### PR TITLE
fix:Dubbo3TripleGenerator use OuterClassName error

### DIFF
--- a/dubbo-plugin/dubbo-compiler/src/main/java/org/apache/dubbo/gen/AbstractGenerator.java
+++ b/dubbo-plugin/dubbo-compiler/src/main/java/org/apache/dubbo/gen/AbstractGenerator.java
@@ -99,8 +99,9 @@ public abstract class AbstractGenerator {
                 serviceContext.packageName = extractPackageName(fileProto);
                 if (!Strings.isNullOrEmpty(fileProto.getOptions().getJavaOuterClassname())) {
                     serviceContext.outerClassName = fileProto.getOptions().getJavaOuterClassname();
-                }else{
-                    serviceContext.outerClassName = ProtoTypeMap.getJavaOuterClassname(fileProto,fileProto.getOptions());
+                } else {
+                    serviceContext.outerClassName =
+                            ProtoTypeMap.getJavaOuterClassname(fileProto, fileProto.getOptions());
                 }
                 serviceContext.commonPackageName = extractCommonPackageName(fileProto);
                 serviceContext.multipleFiles = fileProto.getOptions().getJavaMultipleFiles();

--- a/dubbo-plugin/dubbo-compiler/src/main/java/org/apache/dubbo/gen/AbstractGenerator.java
+++ b/dubbo-plugin/dubbo-compiler/src/main/java/org/apache/dubbo/gen/AbstractGenerator.java
@@ -99,6 +99,8 @@ public abstract class AbstractGenerator {
                 serviceContext.packageName = extractPackageName(fileProto);
                 if (!Strings.isNullOrEmpty(fileProto.getOptions().getJavaOuterClassname())) {
                     serviceContext.outerClassName = fileProto.getOptions().getJavaOuterClassname();
+                }else{
+                    serviceContext.outerClassName = ProtoTypeMap.getJavaOuterClassname(fileProto,fileProto.getOptions());
                 }
                 serviceContext.commonPackageName = extractCommonPackageName(fileProto);
                 serviceContext.multipleFiles = fileProto.getOptions().getJavaMultipleFiles();
@@ -128,7 +130,6 @@ public abstract class AbstractGenerator {
         ServiceContext serviceContext = new ServiceContext();
         serviceContext.fileName = getClassPrefix() + serviceProto.getName() + getClassSuffix() + ".java";
         serviceContext.className = getClassPrefix() + serviceProto.getName() + getClassSuffix();
-        serviceContext.outerClassName = serviceProto.getName() + "OuterClass";
         serviceContext.interfaceFileName = serviceProto.getName() + ".java";
         serviceContext.interfaceClassName = serviceProto.getName();
         serviceContext.serviceName = serviceProto.getName();

--- a/dubbo-plugin/dubbo-compiler/src/main/java/org/apache/dubbo/gen/utils/ProtoTypeMap.java
+++ b/dubbo-plugin/dubbo-compiler/src/main/java/org/apache/dubbo/gen/utils/ProtoTypeMap.java
@@ -62,7 +62,7 @@ public final class ProtoTypeMap {
         return (String)this.types.get(protoTypeName);
     }
 
-    private static String getJavaOuterClassname(DescriptorProtos.FileDescriptorProto fileDescriptor, DescriptorProtos.FileOptions fileOptions) {
+    public static String getJavaOuterClassname(DescriptorProtos.FileDescriptorProto fileDescriptor, DescriptorProtos.FileOptions fileOptions) {
         if (fileOptions.hasJavaOuterClassname()) {
             return fileOptions.getJavaOuterClassname();
         } else {


### PR DESCRIPTION
## What is the purpose of the change
when `option java_outer_classname` is empty and use Dubbo3TripleGenerator generate code , the DubboxxxServiceTriple has error.
My proto file :
```proto
syntax="proto3";
option java_package="com.example.dubbo.proto";
option java_multiple_files=true;
service TestService {
  rpc echo(EchoReq)returns(EchoRes);
}

message EchoReq{
  string name = 1;
}

message EchoRes{
  string msg = 1;
}
```
and protoc-plugin
```xml
  <plugin>
                <groupId>org.xolstice.maven.plugins</groupId>
                <artifactId>protobuf-maven-plugin</artifactId>
                <version>0.6.1</version>
                <configuration>
                    <protocArtifact>com.google.protobuf:protoc:${protoc.version}:exe:${os.detected.classifier}</protocArtifact>
                    <pluginId>grpc-java</pluginId>
                    <protocPlugins>
                        <protocPlugin>
                            <id>dubbo</id>
                            <groupId>org.apache.dubbo</groupId>
                            <artifactId>dubbo-compiler</artifactId>
                            <version>3.0.10</version>
                            <mainClass>org.apache.dubbo.gen.tri.Dubbo3TripleGenerator</mainClass>
                        </protocPlugin>
                    </protocPlugins>
                </configuration>
                <executions>
                    <execution>
                        <goals>
                            <goal>compile</goal>
                            <goal>test-compile</goal>
                            <goal>compile-custom</goal>
                            <goal>test-compile-custom</goal>
                        </goals>
                    </execution>
                </executions>
            </plugin>
```
generated code DubboTestServiceTriple cannot find the TestServiceOuterClass
![WechatIMG24353](https://github.com/apache/dubbo/assets/30964063/0bd421f7-bac7-4835-85f4-72b483be3fea)

fixed: Dubbo3TripleGenerator use OuterClassName error


## Brief changelog
1、change ProtoType util getJavaOuterClassname method from private to public 
2、when `option java_outer_classname` is empty,serviceContext.outerClassName use ProtoType.getJavaOuterClassname method generate.

## Verifying this change


<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [ ] GitHub Actions works fine on your own branch.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
