### PR TITLE
(reopened) feat: fix #13327

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/constants/CommonConstants.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/constants/CommonConstants.java
@@ -619,9 +619,8 @@ public interface CommonConstants {
     String EXECUTOR_MANAGEMENT_MODE_ISOLATION = "isolation";
 
     /**
-     *
      * used in JVMUtil.java ,Control stack print lines, default is 32 lines
-     *
+     * if set to a negative number (e.g. -1), all lines will be printed
      */
     String DUBBO_JSTACK_MAXLINE = "dubbo.jstack-dump.max-line";
 

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/utils/JVMUtilTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/utils/JVMUtilTest.java
@@ -16,4 +16,60 @@
  */
 package org.apache.dubbo.common.utils;
 
-class JVMUtilTest {}
+import org.apache.dubbo.common.logger.ErrorTypeAwareLogger;
+import org.apache.dubbo.common.logger.LoggerFactory;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+import org.junit.jupiter.api.Test;
+
+import static org.apache.dubbo.common.constants.CommonConstants.DUBBO_JSTACK_MAXLINE;
+import static org.apache.dubbo.common.constants.CommonConstants.OS_NAME_KEY;
+import static org.apache.dubbo.common.constants.CommonConstants.OS_WIN_PREFIX;
+import static org.apache.dubbo.common.constants.LoggerCodeConstants.COMMON_UNEXPECTED_CREATE_DUMP;
+import static org.apache.dubbo.common.utils.JVMUtil.jstack;
+
+class JVMUtilTest {
+
+    protected static final ErrorTypeAwareLogger logger = LoggerFactory.getErrorTypeAwareLogger(JVMUtilTest.class);
+
+    @Test
+    void testPrintStackTraceWithSpecifiedDepth() {
+        test(10);
+    }
+
+    @Test
+    void testPrintStackTraceWithUnlimitedDepth() {
+        test(-1);
+    }
+
+    private void test(Integer depth) {
+        SimpleDateFormat sdf;
+        String os = System.getProperty(OS_NAME_KEY).toLowerCase();
+        // window system don't support ":" in file name
+        if (os.contains(OS_WIN_PREFIX)) {
+            sdf = new SimpleDateFormat("yyyy-MM-dd_HH-mm-ss .SSS");
+        } else {
+            sdf = new SimpleDateFormat("yyyy-MM-dd_HH:mm:ss .SSS");
+        }
+        String dateStr = sdf.format(new Date());
+
+        String property = System.getProperty(DUBBO_JSTACK_MAXLINE);
+        System.setProperty(DUBBO_JSTACK_MAXLINE, depth.toString());
+        try (FileOutputStream jStackStream =
+                 new FileOutputStream(new File("/tmp", "Dubbo_JStack.log" + "." + dateStr))) {
+            jstack(jStackStream);
+        } catch (Exception e) {
+            logger.error(COMMON_UNEXPECTED_CREATE_DUMP, "", "", "dump jStack error", e);
+        } finally {
+            if (property == null) {
+                System.clearProperty(DUBBO_JSTACK_MAXLINE);
+            } else {
+                System.setProperty(DUBBO_JSTACK_MAXLINE, property);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Moved from #13334 due to branch operation error.

## What is the purpose of the change
fix #13327 
- `dubbo.jstack-dump.max-line` can be used to indicate that all stack trace lines should be printed now by setting it to a negative number, -1 for example.
- write stack trace info directly into OutputStream instead of building a String.
- Add tests in `JVMUtilTest`.

## Brief changelog
- Support custom print stack depth and write error messages directly into OutputStream in `org.apache.dubbo.common.utils.JVMUtil`.
- Add tests in `org.apache.dubbo.common.utils.JVMUtilTest`.

## Verifying this change


<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [x] Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature. (will do after it is merged)
- [ ] GitHub Actions works fine on your own branch.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
