### PR TITLE
solved Maven ‘parent.relativePath‘ of POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,12 +19,12 @@
 
   <modelVersion>4.0.0</modelVersion>
 
-  <parent>
-    <groupId>org.apache</groupId>
-    <artifactId>apache</artifactId>
-    <version>23</version>
-    <relativePath/>
-  </parent>
+    <parent>
+        <groupId>org.apache</groupId>
+        <artifactId>apache</artifactId>
+        <version>23</version>
+        <relativePath/>
+    </parent>
 
   <groupId>org.apache.dubbo</groupId>
   <artifactId>dubbo-parent</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,7 @@
     <groupId>org.apache</groupId>
     <artifactId>apache</artifactId>
     <version>23</version>
+    <relativePath/>
   </parent>
 
   <groupId>org.apache.dubbo</groupId>


### PR DESCRIPTION
## What is the purpose of the change
If relativePath is missing, an error may be reported. The current purpose is to fix this error.
error:
'parent.relativePath' of POM org.apache.dubbo:dubbo-parent:${revision} (D:\java\dubbo\pom.xml) points at com.example:leetcode instead of org.apache:apache, please verify your project structure

## Brief changelog


## Verifying this change


<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [ ] GitHub Actions works fine on your own branch.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
