### PR TITLE
fix native image build error when mainClass is not set

### DIFF
--- a/dubbo-maven-plugin/src/main/java/org/apache/dubbo/maven/plugin/aot/DubboProcessAotMojo.java
+++ b/dubbo-maven-plugin/src/main/java/org/apache/dubbo/maven/plugin/aot/DubboProcessAotMojo.java
@@ -85,7 +85,7 @@ public class DubboProcessAotMojo extends AbstractAotMojo {
 
     private String[] getAotArguments(String applicationClass) {
         List<String> aotArguments = new ArrayList<>();
-        aotArguments.add(applicationClass);
+        aotArguments.add(applicationClass != null ? applicationClass : "");
         aotArguments.add(this.generatedSources.toString());
         aotArguments.add(this.generatedResources.toString());
         aotArguments.add(this.generatedClasses.toString());


### PR DESCRIPTION
fix native image build error when mainClass is not set

## What is the purpose of the change

Fix #13365 

mainClass config is not used in dubbo-maven-plugin and dubbo-native module,but if not set it will cause wrong arguments index for generate Aot Assets, so add an empty string as a placeholder when mainClass is not set to prevent build error

## Brief changelog


## Verifying this change


<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [ ] GitHub Actions works fine on your own branch.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
