### PR TITLE
Support exclude fastjson2 or hessian2 serialization dependencies

### DIFF
--- a/dubbo-serialization/dubbo-serialization-fastjson2/src/main/java/org/apache/dubbo/common/serialize/fastjson2/FastJson2Serialization.java
+++ b/dubbo-serialization/dubbo-serialization-fastjson2/src/main/java/org/apache/dubbo/common/serialize/fastjson2/FastJson2Serialization.java
@@ -17,9 +17,12 @@
 package org.apache.dubbo.common.serialize.fastjson2;
 
 import org.apache.dubbo.common.URL;
+import org.apache.dubbo.common.logger.Logger;
+import org.apache.dubbo.common.logger.LoggerFactory;
 import org.apache.dubbo.common.serialize.ObjectInput;
 import org.apache.dubbo.common.serialize.ObjectOutput;
 import org.apache.dubbo.common.serialize.Serialization;
+import org.apache.dubbo.common.utils.ClassUtils;
 import org.apache.dubbo.rpc.model.FrameworkModel;
 
 import java.io.IOException;
@@ -37,6 +40,18 @@ import static org.apache.dubbo.common.serialize.Constants.FASTJSON2_SERIALIZATIO
  * </pre>
  */
 public class FastJson2Serialization implements Serialization {
+    private final static Logger logger = LoggerFactory.getLogger(FastJson2Serialization.class);
+
+    static {
+        Class<?> aClass = null;
+        try {
+            aClass = ClassUtils.forName("com.alibaba.fastjson2.JSONB");
+        } catch (Throwable ignored) { }
+        if (aClass == null) {
+            logger.info("Failed to load com.alibaba.fastjson2.JSONB, fastjson2 serialization will be disabled.");
+            throw new IllegalStateException("The fastjson2 is not in classpath.");
+        }
+    }
 
     @Override
     public byte getContentTypeId() {

--- a/dubbo-serialization/dubbo-serialization-fastjson2/src/main/java/org/apache/dubbo/common/serialize/fastjson2/Fastjson2ScopeModelInitializer.java
+++ b/dubbo-serialization/dubbo-serialization-fastjson2/src/main/java/org/apache/dubbo/common/serialize/fastjson2/Fastjson2ScopeModelInitializer.java
@@ -17,6 +17,9 @@
 package org.apache.dubbo.common.serialize.fastjson2;
 
 import org.apache.dubbo.common.beans.factory.ScopeBeanFactory;
+import org.apache.dubbo.common.logger.Logger;
+import org.apache.dubbo.common.logger.LoggerFactory;
+import org.apache.dubbo.common.utils.ClassUtils;
 import org.apache.dubbo.rpc.model.ApplicationModel;
 import org.apache.dubbo.rpc.model.FrameworkModel;
 import org.apache.dubbo.rpc.model.ModuleModel;
@@ -26,9 +29,16 @@ public class Fastjson2ScopeModelInitializer implements ScopeModelInitializer {
 
     @Override
     public void initializeFrameworkModel(FrameworkModel frameworkModel) {
-        ScopeBeanFactory beanFactory = frameworkModel.getBeanFactory();
-        beanFactory.registerBean(Fastjson2CreatorManager.class);
-        beanFactory.registerBean(Fastjson2SecurityManager.class);
+        Class<?> aClass = null;
+        try {
+            aClass = ClassUtils.forName("com.alibaba.fastjson2.JSONB");
+        } catch (Throwable ignored) { }
+
+        if (aClass != null) {
+            ScopeBeanFactory beanFactory = frameworkModel.getBeanFactory();
+            beanFactory.registerBean(Fastjson2CreatorManager.class);
+            beanFactory.registerBean(Fastjson2SecurityManager.class);
+        }
     }
 
     @Override

--- a/dubbo-serialization/dubbo-serialization-hessian2/src/main/java/org/apache/dubbo/common/serialize/hessian2/Hessian2ScopeModelInitializer.java
+++ b/dubbo-serialization/dubbo-serialization-hessian2/src/main/java/org/apache/dubbo/common/serialize/hessian2/Hessian2ScopeModelInitializer.java
@@ -17,6 +17,7 @@
 package org.apache.dubbo.common.serialize.hessian2;
 
 import org.apache.dubbo.common.beans.factory.ScopeBeanFactory;
+import org.apache.dubbo.common.utils.ClassUtils;
 import org.apache.dubbo.rpc.model.ApplicationModel;
 import org.apache.dubbo.rpc.model.FrameworkModel;
 import org.apache.dubbo.rpc.model.ModuleModel;
@@ -25,10 +26,17 @@ import org.apache.dubbo.rpc.model.ScopeModelInitializer;
 public class Hessian2ScopeModelInitializer implements ScopeModelInitializer {
     @Override
     public void initializeFrameworkModel(FrameworkModel frameworkModel) {
-        ScopeBeanFactory beanFactory = frameworkModel.getBeanFactory();
-        beanFactory.registerBean(Hessian2FactoryManager.class);
+        Class<?> aClass = null;
+        try {
+            aClass = ClassUtils.forName("com.alibaba.com.caucho.hessian.io.Hessian2Output");
+        } catch (Throwable ignored) { }
 
-        frameworkModel.addClassLoaderListener(new Hessian2ClassLoaderListener());
+        if (aClass != null) {
+            ScopeBeanFactory beanFactory = frameworkModel.getBeanFactory();
+            beanFactory.registerBean(Hessian2FactoryManager.class);
+
+            frameworkModel.addClassLoaderListener(new Hessian2ClassLoaderListener());
+        }
     }
 
     @Override

--- a/dubbo-serialization/dubbo-serialization-hessian2/src/main/java/org/apache/dubbo/common/serialize/hessian2/Hessian2Serialization.java
+++ b/dubbo-serialization/dubbo-serialization-hessian2/src/main/java/org/apache/dubbo/common/serialize/hessian2/Hessian2Serialization.java
@@ -17,9 +17,12 @@
 package org.apache.dubbo.common.serialize.hessian2;
 
 import org.apache.dubbo.common.URL;
+import org.apache.dubbo.common.logger.Logger;
+import org.apache.dubbo.common.logger.LoggerFactory;
 import org.apache.dubbo.common.serialize.ObjectInput;
 import org.apache.dubbo.common.serialize.ObjectOutput;
 import org.apache.dubbo.common.serialize.Serialization;
+import org.apache.dubbo.common.utils.ClassUtils;
 import org.apache.dubbo.rpc.model.FrameworkModel;
 
 import java.io.IOException;
@@ -37,6 +40,18 @@ import static org.apache.dubbo.common.serialize.Constants.HESSIAN2_SERIALIZATION
  * </pre>
  */
 public class Hessian2Serialization implements Serialization {
+    private final static Logger logger = LoggerFactory.getLogger(Hessian2Serialization.class);
+
+    static {
+        Class<?> aClass = null;
+        try {
+            aClass = ClassUtils.forName("com.alibaba.com.caucho.hessian.io.Hessian2Output");
+        } catch (Throwable ignored) { }
+        if (aClass == null) {
+            logger.info("Failed to load com.alibaba.com.caucho.hessian.io.Hessian2Output, hessian2 serialization will be disabled.");
+            throw new IllegalStateException("The hessian2 is not in classpath.");
+        }
+    }
 
     @Override
     public byte getContentTypeId() {


### PR DESCRIPTION
## What is the purpose of the change

- When exclude fastjson2 or hessian2 on runtime, `ClassNotFound` exception will occurred when init
- Should failed serialization when load extensions, due to prefer serialzation will depend on it.

## Brief changelog


## Verifying this change


<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [ ] GitHub Actions works fine on your own branch.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
