### PR TITLE
Fix streamobserver actual type

### DIFF
--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/ReflectionPackableMethod.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/ReflectionPackableMethod.java
@@ -33,6 +33,7 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.stream.Stream;
@@ -72,19 +73,18 @@ public class ReflectionPackableMethod implements PackableMethod {
         switch (method.getRpcType()) {
             case CLIENT_STREAM:
             case BI_STREAM:
-                actualRequestTypes = new Class<?>[] {
-                    (Class<?>)
-                            ((ParameterizedType) method.getMethod().getGenericReturnType()).getActualTypeArguments()[0]
-                };
-                actualResponseType =
-                        (Class<?>) ((ParameterizedType) method.getMethod().getGenericParameterTypes()[0])
-                                .getActualTypeArguments()[0];
+                actualRequestTypes = new Class<?>[]{obtainActualTypeInStreamObserver(
+                    ((ParameterizedType) method.getMethod().getGenericReturnType())
+                        .getActualTypeArguments()[0])};
+                actualResponseType = obtainActualTypeInStreamObserver(
+                    ((ParameterizedType) method.getMethod().getGenericParameterTypes()[0])
+                        .getActualTypeArguments()[0]);
                 break;
             case SERVER_STREAM:
                 actualRequestTypes = method.getMethod().getParameterTypes();
-                actualResponseType =
-                        (Class<?>) ((ParameterizedType) method.getMethod().getGenericParameterTypes()[1])
-                                .getActualTypeArguments()[0];
+                actualResponseType = obtainActualTypeInStreamObserver(
+                    ((ParameterizedType) method.getMethod().getGenericParameterTypes()[1])
+                        .getActualTypeArguments()[0]);
                 break;
             case UNARY:
                 actualRequestTypes = method.getParameterClasses();
@@ -288,6 +288,11 @@ public class ReflectionPackableMethod implements PackableMethod {
             return TripleConstant.HESSIAN2;
         }
         return serializeType;
+    }
+
+    static Class<?> obtainActualTypeInStreamObserver(Type typeInStreamObserver) {
+        return (Class<?>) (typeInStreamObserver instanceof ParameterizedType ?
+            ((ParameterizedType) typeInStreamObserver).getRawType() : typeInStreamObserver);
     }
 
     @Override

--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/ReflectionPackableMethod.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/ReflectionPackableMethod.java
@@ -73,18 +73,19 @@ public class ReflectionPackableMethod implements PackableMethod {
         switch (method.getRpcType()) {
             case CLIENT_STREAM:
             case BI_STREAM:
-                actualRequestTypes = new Class<?>[]{obtainActualTypeInStreamObserver(
-                    ((ParameterizedType) method.getMethod().getGenericReturnType())
-                        .getActualTypeArguments()[0])};
+                actualRequestTypes = new Class<?>[] {
+                    obtainActualTypeInStreamObserver(
+                            ((ParameterizedType) method.getMethod().getGenericReturnType()).getActualTypeArguments()[0])
+                };
                 actualResponseType = obtainActualTypeInStreamObserver(
-                    ((ParameterizedType) method.getMethod().getGenericParameterTypes()[0])
-                        .getActualTypeArguments()[0]);
+                        ((ParameterizedType) method.getMethod().getGenericParameterTypes()[0])
+                                .getActualTypeArguments()[0]);
                 break;
             case SERVER_STREAM:
                 actualRequestTypes = method.getMethod().getParameterTypes();
                 actualResponseType = obtainActualTypeInStreamObserver(
-                    ((ParameterizedType) method.getMethod().getGenericParameterTypes()[1])
-                        .getActualTypeArguments()[0]);
+                        ((ParameterizedType) method.getMethod().getGenericParameterTypes()[1])
+                                .getActualTypeArguments()[0]);
                 break;
             case UNARY:
                 actualRequestTypes = method.getParameterClasses();
@@ -291,8 +292,10 @@ public class ReflectionPackableMethod implements PackableMethod {
     }
 
     static Class<?> obtainActualTypeInStreamObserver(Type typeInStreamObserver) {
-        return (Class<?>) (typeInStreamObserver instanceof ParameterizedType ?
-            ((ParameterizedType) typeInStreamObserver).getRawType() : typeInStreamObserver);
+        return (Class<?>)
+                (typeInStreamObserver instanceof ParameterizedType
+                        ? ((ParameterizedType) typeInStreamObserver).getRawType()
+                        : typeInStreamObserver);
     }
 
     @Override

--- a/dubbo-rpc/dubbo-rpc-triple/src/test/java/org/apache/dubbo/rpc/protocol/tri/DataWrapper.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/test/java/org/apache/dubbo/rpc/protocol/tri/DataWrapper.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.rpc.protocol.tri;
+
+public class DataWrapper<T> {
+    public T data;
+}

--- a/dubbo-rpc/dubbo-rpc-triple/src/test/java/org/apache/dubbo/rpc/protocol/tri/DescriptorService.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/test/java/org/apache/dubbo/rpc/protocol/tri/DescriptorService.java
@@ -68,6 +68,17 @@ public interface DescriptorService {
 
     void sayHelloServerStream2(Object request, StreamObserver<Object> reply);
 
+    /**
+     * obtain actual type in streamObserver
+     */
+    void serverStream1(Object request, StreamObserver<String> streamObserver);
+
+    void serverStream2(Object request, StreamObserver<DataWrapper<String>> streamObserver);
+
+    StreamObserver<String> biStream1(StreamObserver<String> streamObserver);
+
+    StreamObserver<DataWrapper<String>> biStream2(StreamObserver<DataWrapper<String>> streamObserver);
+
     /***********************grpc******************************/
     java.util.Iterator<HelloReply> iteratorServerStream(HelloReply request);
 

--- a/dubbo-rpc/dubbo-rpc-triple/src/test/java/org/apache/dubbo/rpc/protocol/tri/ReflectionPackableMethodTest.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/test/java/org/apache/dubbo/rpc/protocol/tri/ReflectionPackableMethodTest.java
@@ -129,36 +129,30 @@ class ReflectionPackableMethodTest {
 
         Method method1 = DescriptorService.class.getMethod("serverStream1", Object.class, StreamObserver.class);
         Class<?> clazz1 = ReflectionPackableMethod.obtainActualTypeInStreamObserver(
-            ((ParameterizedType) method1.getGenericParameterTypes()[1])
-                .getActualTypeArguments()[0]);
+                ((ParameterizedType) method1.getGenericParameterTypes()[1]).getActualTypeArguments()[0]);
         Assertions.assertEquals(clazz1.getName(), String.class.getName());
 
         Method method2 = DescriptorService.class.getMethod("serverStream2", Object.class, StreamObserver.class);
         Class<?> clazz2 = ReflectionPackableMethod.obtainActualTypeInStreamObserver(
-            ((ParameterizedType) method2.getGenericParameterTypes()[1])
-                .getActualTypeArguments()[0]);
+                ((ParameterizedType) method2.getGenericParameterTypes()[1]).getActualTypeArguments()[0]);
         Assertions.assertEquals(clazz2.getName(), DataWrapper.class.getName());
 
         Method method3 = DescriptorService.class.getMethod("biStream1", StreamObserver.class);
         Class<?> clazz31 = ReflectionPackableMethod.obtainActualTypeInStreamObserver(
-            ((ParameterizedType) method3.getGenericReturnType())
-                .getActualTypeArguments()[0]);
+                ((ParameterizedType) method3.getGenericReturnType()).getActualTypeArguments()[0]);
         Assertions.assertEquals(clazz31.getName(), String.class.getName());
 
         Class<?> clazz32 = ReflectionPackableMethod.obtainActualTypeInStreamObserver(
-            ((ParameterizedType) method3.getGenericParameterTypes()[0])
-                .getActualTypeArguments()[0]);
+                ((ParameterizedType) method3.getGenericParameterTypes()[0]).getActualTypeArguments()[0]);
         Assertions.assertEquals(clazz32.getName(), String.class.getName());
 
         Method method4 = DescriptorService.class.getMethod("biStream2", StreamObserver.class);
         Class<?> clazz41 = ReflectionPackableMethod.obtainActualTypeInStreamObserver(
-            ((ParameterizedType) method4.getGenericReturnType())
-                .getActualTypeArguments()[0]);
+                ((ParameterizedType) method4.getGenericReturnType()).getActualTypeArguments()[0]);
         Assertions.assertEquals(clazz41.getName(), DataWrapper.class.getName());
 
         Class<?> clazz42 = ReflectionPackableMethod.obtainActualTypeInStreamObserver(
-            ((ParameterizedType) method4.getGenericParameterTypes()[0])
-                .getActualTypeArguments()[0]);
+                ((ParameterizedType) method4.getGenericParameterTypes()[0]).getActualTypeArguments()[0]);
         Assertions.assertEquals(clazz42.getName(), DataWrapper.class.getName());
     }
 

--- a/dubbo-rpc/dubbo-rpc-triple/src/test/java/org/apache/dubbo/rpc/protocol/tri/ReflectionPackableMethodTest.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/test/java/org/apache/dubbo/rpc/protocol/tri/ReflectionPackableMethodTest.java
@@ -125,6 +125,44 @@ class ReflectionPackableMethodTest {
     }
 
     @Test
+    void testObtainActualType() throws NoSuchMethodException {
+
+        Method method1 = DescriptorService.class.getMethod("serverStream1", Object.class, StreamObserver.class);
+        Class<?> clazz1 = ReflectionPackableMethod.obtainActualTypeInStreamObserver(
+            ((ParameterizedType) method1.getGenericParameterTypes()[1])
+                .getActualTypeArguments()[0]);
+        Assertions.assertEquals(clazz1.getName(), String.class.getName());
+
+        Method method2 = DescriptorService.class.getMethod("serverStream2", Object.class, StreamObserver.class);
+        Class<?> clazz2 = ReflectionPackableMethod.obtainActualTypeInStreamObserver(
+            ((ParameterizedType) method2.getGenericParameterTypes()[1])
+                .getActualTypeArguments()[0]);
+        Assertions.assertEquals(clazz2.getName(), DataWrapper.class.getName());
+
+        Method method3 = DescriptorService.class.getMethod("biStream1", StreamObserver.class);
+        Class<?> clazz31 = ReflectionPackableMethod.obtainActualTypeInStreamObserver(
+            ((ParameterizedType) method3.getGenericReturnType())
+                .getActualTypeArguments()[0]);
+        Assertions.assertEquals(clazz31.getName(), String.class.getName());
+
+        Class<?> clazz32 = ReflectionPackableMethod.obtainActualTypeInStreamObserver(
+            ((ParameterizedType) method3.getGenericParameterTypes()[0])
+                .getActualTypeArguments()[0]);
+        Assertions.assertEquals(clazz32.getName(), String.class.getName());
+
+        Method method4 = DescriptorService.class.getMethod("biStream2", StreamObserver.class);
+        Class<?> clazz41 = ReflectionPackableMethod.obtainActualTypeInStreamObserver(
+            ((ParameterizedType) method4.getGenericReturnType())
+                .getActualTypeArguments()[0]);
+        Assertions.assertEquals(clazz41.getName(), DataWrapper.class.getName());
+
+        Class<?> clazz42 = ReflectionPackableMethod.obtainActualTypeInStreamObserver(
+            ((ParameterizedType) method4.getGenericParameterTypes()[0])
+                .getActualTypeArguments()[0]);
+        Assertions.assertEquals(clazz42.getName(), DataWrapper.class.getName());
+    }
+
+    @Test
     void testIsNeedWrap() throws NoSuchMethodException {
         Method method = DescriptorService.class.getMethod("noParameterMethod");
         MethodDescriptor descriptor = new ReflectionMethodDescriptor(method);


### PR DESCRIPTION
## What is the purpose of the change

fix [#13363](https://github.com/apache/dubbo/issues/13363)
obtain actual type that is parameterized type in streamobserver.

## Brief changelog


## Verifying this change

see `org.apache.dubbo.rpc.protocol.tri.ReflectionPackableMethodTest#testObtainActualType`

<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [x] GitHub Actions works fine on your own branch.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
