### PR TITLE
SslServerTlsHandler#decode early return

### DIFF
--- a/dubbo-remoting/dubbo-remoting-netty4/src/main/java/org/apache/dubbo/remoting/transport/netty4/ssl/SslServerTlsHandler.java
+++ b/dubbo-remoting/dubbo-remoting-netty4/src/main/java/org/apache/dubbo/remoting/transport/netty4/ssl/SslServerTlsHandler.java
@@ -105,8 +105,7 @@ public class SslServerTlsHandler extends ByteToMessageDecoder {
                 url, channelHandlerContext.channel().remoteAddress());
 
         if (providerConnectionConfig == null) {
-            ChannelPipeline p = channelHandlerContext.pipeline();
-            p.remove(this);
+            channelHandlerContext.pipeline().remove(this);
             return;
         }
 
@@ -117,8 +116,8 @@ public class SslServerTlsHandler extends ByteToMessageDecoder {
         }
 
         if (providerConnectionConfig.getAuthPolicy() == AuthPolicy.NONE) {
-            ChannelPipeline p = channelHandlerContext.pipeline();
-            p.remove(this);
+            channelHandlerContext.pipeline().remove(this);
+            return;
         }
 
         logger.error(INTERNAL_ERROR, "", "", "TLS negotiation failed when trying to accept new connection.");


### PR DESCRIPTION
…ode should remove and return instead of printing the error log.

## What is the purpose of the change
When I read part of the Dubbo netty4 source code, I found SslServerTlsHandler#decode method in dealing with "providerConnectionConfig.getAuthPolicy() == AuthPolicy.NONE" not timely return，
this will cause it to print the error log


## Brief changelog


## Verifying this change


<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [ ] GitHub Actions works fine on your own branch.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
