### PR TITLE
ProtocolBuilder add sslEnabled and extProtocol fields

### DIFF
--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/bootstrap/builders/ProtocolBuilder.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/bootstrap/builders/ProtocolBuilder.java
@@ -180,6 +180,13 @@ public class ProtocolBuilder extends AbstractBuilder<ProtocolConfig, ProtocolBui
      */
     private Map<String, String> parameters;
 
+    private Boolean sslEnabled;
+
+    /*
+     * Extra Protocol for this service, using Port Unification Server
+     */
+    private String extProtocol;
+
     /**
      * If it's default
      */
@@ -375,6 +382,16 @@ public class ProtocolBuilder extends AbstractBuilder<ProtocolConfig, ProtocolBui
         return getThis();
     }
 
+    public ProtocolBuilder isSslEnabled(Boolean sslEnabled) {
+        this.sslEnabled = sslEnabled;
+        return getThis();
+    }
+
+    public ProtocolBuilder extProtocol(String extProtocol) {
+        this.extProtocol = extProtocol;
+        return getThis();
+    }
+
     public ProtocolBuilder isDefault(Boolean isDefault) {
         this.isDefault = isDefault;
         return getThis();
@@ -416,6 +433,8 @@ public class ProtocolBuilder extends AbstractBuilder<ProtocolConfig, ProtocolBui
         protocolConfig.setThreadpool(threadpool);
         protocolConfig.setThreads(threads);
         protocolConfig.setTransporter(transporter);
+        protocolConfig.setSslEnabled(sslEnabled);
+        protocolConfig.setExtProtocol(extProtocol);
 
         return protocolConfig;
     }


### PR DESCRIPTION
## What is the purpose of the change
ProtocolBuilder add sslEnabled and extProtocol fields, aligned with ProtocolConfig.


## Brief changelog


## Verifying this change


<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [ ] GitHub Actions works fine on your own branch.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
