### PR TITLE
Fix proto `package` and ` java_package` issue

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/config/AbstractServiceConfig.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/config/AbstractServiceConfig.java
@@ -176,7 +176,7 @@ public abstract class AbstractServiceConfig extends AbstractInterfaceConfig {
         if (dynamic == null) {
             dynamic = true;
         }
-        if(useJavaPackageAsPath == null){
+        if (useJavaPackageAsPath == null) {
             useJavaPackageAsPath = false;
         }
         if (StringUtils.isBlank(preferSerialization)) {

--- a/dubbo-common/src/main/java/org/apache/dubbo/config/AbstractServiceConfig.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/config/AbstractServiceConfig.java
@@ -155,6 +155,12 @@ public abstract class AbstractServiceConfig extends AbstractInterfaceConfig {
      */
     private Integer payload;
 
+    /**
+     * Whether to use java_package in IDL as path. Default use package.
+     * This param only available when service using native stub.
+     */
+    private Boolean useJavaPackageAsPath;
+
     public AbstractServiceConfig() {}
 
     public AbstractServiceConfig(ModuleModel moduleModel) {
@@ -170,7 +176,9 @@ public abstract class AbstractServiceConfig extends AbstractInterfaceConfig {
         if (dynamic == null) {
             dynamic = true;
         }
-
+        if(useJavaPackageAsPath == null){
+            useJavaPackageAsPath = false;
+        }
         if (StringUtils.isBlank(preferSerialization)) {
             preferSerialization = serialization;
         }
@@ -387,5 +395,14 @@ public abstract class AbstractServiceConfig extends AbstractInterfaceConfig {
 
     public void setPayload(Integer payload) {
         this.payload = payload;
+    }
+
+    public Boolean getUseJavaPackageAsPath() {
+        return useJavaPackageAsPath;
+    }
+
+    @Parameter(excluded = true)
+    public void setUseJavaPackageAsPath(Boolean useJavaPackageAsPath) {
+        this.useJavaPackageAsPath = useJavaPackageAsPath;
     }
 }

--- a/dubbo-common/src/main/java/org/apache/dubbo/config/ProviderConfig.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/config/ProviderConfig.java
@@ -164,6 +164,14 @@ public class ProviderConfig extends AbstractServiceConfig {
     private Integer exportThreadNum;
 
     /**
+     * Whether to use java_package in IDL as path. Default use package.
+     * This param only available when service using native stub.
+     *
+     * @see ProviderConfig#contextpath
+     */
+    private Boolean useJavaPackageAsPath;
+
+    /**
      * Whether export should run in background or not.
      *
      * @deprecated replace with {@link ModuleConfig#setBackground(Boolean)}
@@ -409,6 +417,15 @@ public class ProviderConfig extends AbstractServiceConfig {
 
     public void setWait(Integer wait) {
         this.wait = wait;
+    }
+
+    public Boolean getUseJavaPackageAsPath() {
+        return useJavaPackageAsPath;
+    }
+
+    @Parameter(excluded = true)
+    public void setUseJavaPackageAsPath(Boolean useJavaPackageAsPath) {
+        this.useJavaPackageAsPath = useJavaPackageAsPath;
     }
 
     @Deprecated

--- a/dubbo-common/src/main/java/org/apache/dubbo/config/ProviderConfig.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/config/ProviderConfig.java
@@ -166,10 +166,8 @@ public class ProviderConfig extends AbstractServiceConfig {
     /**
      * Whether to use java_package in IDL as path. Default use package.
      * This param only available when service using native stub.
-     *
-     * @see ProviderConfig#contextpath
      */
-    private Boolean useJavaPackageAsPath;
+    private Boolean useJavaPackageAsPath = false;
 
     /**
      * Whether export should run in background or not.

--- a/dubbo-common/src/main/java/org/apache/dubbo/config/ProviderConfig.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/config/ProviderConfig.java
@@ -163,11 +163,6 @@ public class ProviderConfig extends AbstractServiceConfig {
      */
     private Integer exportThreadNum;
 
-    /**
-     * Whether to use java_package in IDL as path. Default use package.
-     * This param only available when service using native stub.
-     */
-    private Boolean useJavaPackageAsPath = false;
 
     /**
      * Whether export should run in background or not.
@@ -415,15 +410,6 @@ public class ProviderConfig extends AbstractServiceConfig {
 
     public void setWait(Integer wait) {
         this.wait = wait;
-    }
-
-    public Boolean getUseJavaPackageAsPath() {
-        return useJavaPackageAsPath;
-    }
-
-    @Parameter(excluded = true)
-    public void setUseJavaPackageAsPath(Boolean useJavaPackageAsPath) {
-        this.useJavaPackageAsPath = useJavaPackageAsPath;
     }
 
     @Deprecated

--- a/dubbo-common/src/main/java/org/apache/dubbo/config/ProviderConfig.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/config/ProviderConfig.java
@@ -163,7 +163,6 @@ public class ProviderConfig extends AbstractServiceConfig {
      */
     private Integer exportThreadNum;
 
-
     /**
      * Whether export should run in background or not.
      *

--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/ServiceConfig.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/ServiceConfig.java
@@ -554,7 +554,7 @@ public class ServiceConfig<T> extends ServiceConfigBase<T> {
                     .orElse((ProviderConfig)
                             getScopeModel().getConfigManager().getProviders().toArray()[0]);
             if (!providerConfig.getUseJavaPackageAsPath()) {
-                //for stub service, path always interface name or IDL package name
+                // for stub service, path always interface name or IDL package name
                 this.path = serviceDescriptor.getInterfaceName();
             }
             repository.registerService(serviceDescriptor);

--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/ServiceConfig.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/ServiceConfig.java
@@ -550,7 +550,7 @@ public class ServiceConfig<T> extends ServiceConfigBase<T> {
             serviceDescriptor = ((ServerService) ref).getServiceDescriptor();
             ProviderConfig providerConfig = getScopeModel()
                     .getConfigManager()
-                    .getProvider(getId())
+                    .getProvider(getId() == null ? "" : getId())
                     .orElse((ProviderConfig)
                             getScopeModel().getConfigManager().getProviders().toArray()[0]);
             if (!providerConfig.getUseJavaPackageAsPath()) {

--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/ServiceConfig.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/ServiceConfig.java
@@ -548,12 +548,7 @@ public class ServiceConfig<T> extends ServiceConfigBase<T> {
         final boolean serverService = ref instanceof ServerService;
         if (serverService) {
             serviceDescriptor = ((ServerService) ref).getServiceDescriptor();
-            ProviderConfig providerConfig = getScopeModel()
-                    .getConfigManager()
-                    .getProvider(getId() == null ? "" : getId())
-                    .orElse((ProviderConfig)
-                            getScopeModel().getConfigManager().getProviders().toArray()[0]);
-            if (providerConfig.getUseJavaPackageAsPath() == null || !providerConfig.getUseJavaPackageAsPath()) {
+            if (this.provider.getUseJavaPackageAsPath()) {
                 // for stub service, path always interface name or IDL package name
                 this.path = serviceDescriptor.getInterfaceName();
             }

--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/ServiceConfig.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/ServiceConfig.java
@@ -553,7 +553,7 @@ public class ServiceConfig<T> extends ServiceConfigBase<T> {
                     .getProvider(getId() == null ? "" : getId())
                     .orElse((ProviderConfig)
                             getScopeModel().getConfigManager().getProviders().toArray()[0]);
-            if (!providerConfig.getUseJavaPackageAsPath()) {
+            if (providerConfig.getUseJavaPackageAsPath() == null || !providerConfig.getUseJavaPackageAsPath()) {
                 // for stub service, path always interface name or IDL package name
                 this.path = serviceDescriptor.getInterfaceName();
             }

--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/ServiceConfig.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/ServiceConfig.java
@@ -548,7 +548,7 @@ public class ServiceConfig<T> extends ServiceConfigBase<T> {
         final boolean serverService = ref instanceof ServerService;
         if (serverService) {
             serviceDescriptor = ((ServerService) ref).getServiceDescriptor();
-            if (this.provider.getUseJavaPackageAsPath()) {
+            if (!this.provider.getUseJavaPackageAsPath()) {
                 // for stub service, path always interface name or IDL package name
                 this.path = serviceDescriptor.getInterfaceName();
             }

--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/ServiceConfig.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/ServiceConfig.java
@@ -548,6 +548,15 @@ public class ServiceConfig<T> extends ServiceConfigBase<T> {
         final boolean serverService = ref instanceof ServerService;
         if (serverService) {
             serviceDescriptor = ((ServerService) ref).getServiceDescriptor();
+            ProviderConfig providerConfig = getScopeModel()
+                    .getConfigManager()
+                    .getProvider(getId())
+                    .orElse((ProviderConfig)
+                            getScopeModel().getConfigManager().getProviders().toArray()[0]);
+            if (!providerConfig.getUseJavaPackageAsPath()) {
+                //for stub service, path always interface name or IDL package name
+                this.path = serviceDescriptor.getInterfaceName();
+            }
             repository.registerService(serviceDescriptor);
         } else {
             serviceDescriptor = repository.registerService(getInterfaceClass());


### PR DESCRIPTION
Fix issue https://github.com/apache/dubbo/issues/13496

* Add provider config `useJavaPackageAsPath`
* `useJavaPackageAsPath=ture` : Provider will export with java_package as path, which will cause exception when `package` and `java_package` are different.
* `useJavaPackageAsPath=false` (default) : Provider will export with package as path.

