### PR TITLE
Fix dubbo.tag override by consumer.tag in NacosRegistry

### DIFF
--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/support/CacheableFailbackRegistry.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/support/CacheableFailbackRegistry.java
@@ -32,7 +32,6 @@ import org.apache.dubbo.common.utils.ConcurrentHashMapUtils;
 import org.apache.dubbo.common.utils.StringUtils;
 import org.apache.dubbo.common.utils.UrlUtils;
 import org.apache.dubbo.registry.NotifyListener;
-import org.apache.dubbo.registry.ProviderFirstParams;
 import org.apache.dubbo.rpc.model.ScopeModel;
 
 import java.util.ArrayList;
@@ -41,7 +40,6 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ScheduledExecutorService;
@@ -317,20 +315,6 @@ public abstract class CacheableFailbackRegistry extends FailbackRegistry {
 
     protected ServiceAddressURL createServiceURL(URLAddress address, URLParam param, URL consumerURL) {
         return new DubboServiceAddressURL(address, param, consumerURL, null);
-    }
-
-    protected URL removeParamsFromConsumer(URL consumer) {
-        Set<ProviderFirstParams> providerFirstParams = consumer.getOrDefaultApplicationModel()
-                .getExtensionLoader(ProviderFirstParams.class)
-                .getSupportedExtensionInstances();
-        if (CollectionUtils.isEmpty(providerFirstParams)) {
-            return consumer;
-        }
-
-        for (ProviderFirstParams paramsFilter : providerFirstParams) {
-            consumer = consumer.removeParameters(paramsFilter.params());
-        }
-        return consumer;
     }
 
     private String stripOffVariableKeys(String rawProvider) {

--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/support/FailbackRegistry.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/support/FailbackRegistry.java
@@ -21,6 +21,7 @@ import org.apache.dubbo.common.timer.HashedWheelTimer;
 import org.apache.dubbo.common.utils.CollectionUtils;
 import org.apache.dubbo.common.utils.NamedThreadFactory;
 import org.apache.dubbo.registry.NotifyListener;
+import org.apache.dubbo.registry.ProviderFirstParams;
 import org.apache.dubbo.registry.retry.FailedRegisteredTask;
 import org.apache.dubbo.registry.retry.FailedSubscribedTask;
 import org.apache.dubbo.registry.retry.FailedUnregisteredTask;
@@ -175,6 +176,20 @@ public abstract class FailbackRegistry extends AbstractRegistry {
         if (f != null) {
             f.cancel();
         }
+    }
+
+    protected URL removeParamsFromConsumer(URL consumer) {
+        Set<ProviderFirstParams> providerFirstParams = consumer.getOrDefaultApplicationModel()
+                .getExtensionLoader(ProviderFirstParams.class)
+                .getSupportedExtensionInstances();
+        if (CollectionUtils.isEmpty(providerFirstParams)) {
+            return consumer;
+        }
+
+        for (ProviderFirstParams paramsFilter : providerFirstParams) {
+            consumer = consumer.removeParameters(paramsFilter.params());
+        }
+        return consumer;
     }
 
     ConcurrentMap<URL, FailedRegisteredTask> getFailedRegistered() {

--- a/dubbo-registry/dubbo-registry-nacos/src/main/java/org/apache/dubbo/registry/nacos/NacosRegistry.java
+++ b/dubbo-registry/dubbo-registry-nacos/src/main/java/org/apache/dubbo/registry/nacos/NacosRegistry.java
@@ -573,6 +573,7 @@ public class NacosRegistry extends FailbackRegistry {
     }
 
     private List<URL> toUrlWithEmpty(URL consumerURL, Collection<Instance> instances) {
+        consumerURL = removeParamsFromConsumer(consumerURL);
         List<URL> urls = buildURLs(consumerURL, instances);
         // Nacos does not support configurators and routers from registry, so all notifications are of providers type.
         if (urls.size() == 0 && !getUrl().getParameter(ENABLE_EMPTY_PROTECTION_KEY, DEFAULT_ENABLE_EMPTY_PROTECTION)) {


### PR DESCRIPTION
Fix https://github.com/apache/dubbo/issues/13184  
(`dubbo.tag` override by `consumer.tag` in `NacosRegistry`, which causes `TagStateRouter` not worked properly when provider using interface-level registry.)

