### PR TITLE
1.修复AbortPolicyWithReport类中Semaphore漏释放 2.使用原生线程替换线程池，加快性能

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/threadpool/support/AbortPolicyWithReport.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/threadpool/support/AbortPolicyWithReport.java
@@ -160,30 +160,31 @@ public class AbortPolicyWithReport extends ThreadPoolExecutor.AbortPolicy {
                 return;
             }
             new Thread(() -> {
-                String dumpPath = getDumpPath();
+                        String dumpPath = getDumpPath();
 
-                SimpleDateFormat sdf;
+                        SimpleDateFormat sdf;
 
-                String os = System.getProperty(OS_NAME_KEY).toLowerCase();
+                        String os = System.getProperty(OS_NAME_KEY).toLowerCase();
 
-                // window system don't support ":" in file name
-                if (os.contains(OS_WIN_PREFIX)) {
-                    sdf = new SimpleDateFormat(WIN_DATETIME_FORMAT);
-                } else {
-                    sdf = new SimpleDateFormat(DEFAULT_DATETIME_FORMAT);
-                }
+                        // window system don't support ":" in file name
+                        if (os.contains(OS_WIN_PREFIX)) {
+                            sdf = new SimpleDateFormat(WIN_DATETIME_FORMAT);
+                        } else {
+                            sdf = new SimpleDateFormat(DEFAULT_DATETIME_FORMAT);
+                        }
 
-                String dateStr = sdf.format(new Date());
-                // try-with-resources
-                try (FileOutputStream jStackStream =
-                         new FileOutputStream(new File(dumpPath, "Dubbo_JStack.log" + "." + dateStr))) {
-                    jstack(jStackStream);
-                } catch (Exception t) {
-                    logger.error(COMMON_UNEXPECTED_CREATE_DUMP, "", "", "dump jStack error", t);
-                } finally {
-                    lastPrintTime = System.currentTimeMillis();
-                }
-            }).start();
+                        String dateStr = sdf.format(new Date());
+                        // try-with-resources
+                        try (FileOutputStream jStackStream =
+                                new FileOutputStream(new File(dumpPath, "Dubbo_JStack.log" + "." + dateStr))) {
+                            jstack(jStackStream);
+                        } catch (Exception t) {
+                            logger.error(COMMON_UNEXPECTED_CREATE_DUMP, "", "", "dump jStack error", t);
+                        } finally {
+                            lastPrintTime = System.currentTimeMillis();
+                        }
+                    })
+                    .start();
         } finally {
             guard.release();
         }


### PR DESCRIPTION
issue:https://github.com/apache/dubbo/issues/13605
## What is the purpose of the change
修复Semaphore漏释放
使用原生线程替换singleThreadExecutor线程池，加快性能
## Brief changelog
![image](https://github.com/apache/dubbo/assets/133181918/500f7815-8117-4668-aad1-5d082e16ae03)
## Verifying this change


