### PR TITLE
Hotfix rest Chinese encoding

### DIFF
--- a/dubbo-remoting/dubbo-remoting-http/src/test/java/org/apache/dubbo/remoting/http/rest/RestClientTest.java
+++ b/dubbo-remoting/dubbo-remoting-http/src/test/java/org/apache/dubbo/remoting/http/rest/RestClientTest.java
@@ -199,6 +199,7 @@ public class RestClientTest {
         HttpServer httpServer = new JettyHttpServer(url, new HttpHandler<HttpServletRequest, HttpServletResponse>() {
             @Override
             public void handle(HttpServletRequest request, HttpServletResponse response) throws IOException {
+                response.setCharacterEncoding("UTF-8");
                 response.getWriter().write(request.getQueryString());
             }
         });
@@ -209,6 +210,7 @@ public class RestClientTest {
         requestTemplate.addParam("age", "18");
         requestTemplate.path("/hello/world");
         
+        // When using the OKHttpRestClient, parameters will be encoded with UTF-8 and appended to the URL
         RestClient restClient = new OKHttpRestClient(new HttpClientConfig());
         
         CompletableFuture<RestResult> send = restClient.send(requestTemplate);
@@ -216,5 +218,23 @@ public class RestClientTest {
         RestResult restResult = send.get();
         
         assertThat(new String(restResult.getBody()), is("name=%E6%9D%8E%E5%BC%BA&age=18"));
+        
+        // When using the HttpClientRestClient, parameters will be encoded with UTF-8 and appended to the URL
+        restClient = new HttpClientRestClient(new HttpClientConfig());
+        
+        send = restClient.send(requestTemplate);
+        
+        restResult = send.get();
+        
+        assertThat(new String(restResult.getBody()), is("name=%E6%9D%8E%E5%BC%BA&age=18"));
+        
+        // When using the URLConnectionRestClient, parameters won't be encoded and still appended to the URL
+        restClient = new URLConnectionRestClient(new HttpClientConfig());
+        
+        send = restClient.send(requestTemplate);
+        
+        restResult = send.get();
+        
+        assertThat(new String(restResult.getBody(), StandardCharsets.UTF_8), is("name=李强&age=18"));
     }
 }

--- a/dubbo-remoting/dubbo-remoting-http/src/test/java/org/apache/dubbo/remoting/http/rest/RestClientTest.java
+++ b/dubbo-remoting/dubbo-remoting-http/src/test/java/org/apache/dubbo/remoting/http/rest/RestClientTest.java
@@ -190,4 +190,31 @@ public class RestClientTest {
                 strings.toArray(new String[0]),
                 requestTemplate.getParam("param").toArray(new String[0]));
     }
+    
+    @Test
+    public void testBuildURL() throws Exception {
+        int port = NetUtils.getAvailablePort();
+        URL url = new ServiceConfigURL(
+            "http", "localhost", port, new String[] {Constants.BIND_PORT_KEY, String.valueOf(port)});
+        HttpServer httpServer = new JettyHttpServer(url, new HttpHandler<HttpServletRequest, HttpServletResponse>() {
+            @Override
+            public void handle(HttpServletRequest request, HttpServletResponse response) throws IOException {
+                response.getWriter().write(request.getQueryString());
+            }
+        });
+        
+        RequestTemplate requestTemplate = new RequestTemplate(null, "POST", "localhost:" + port);
+        
+        requestTemplate.addParam("name", "李强");
+        requestTemplate.addParam("age", "18");
+        requestTemplate.path("/hello/world");
+        
+        RestClient restClient = new OKHttpRestClient(new HttpClientConfig());
+        
+        CompletableFuture<RestResult> send = restClient.send(requestTemplate);
+        
+        RestResult restResult = send.get();
+        
+        assertThat(new String(restResult.getBody()), is("name=%E6%9D%8E%E5%BC%BA&age=18"));
+    }
 }

--- a/dubbo-remoting/dubbo-remoting-http/src/test/java/org/apache/dubbo/remoting/http/rest/RestClientTest.java
+++ b/dubbo-remoting/dubbo-remoting-http/src/test/java/org/apache/dubbo/remoting/http/rest/RestClientTest.java
@@ -190,12 +190,12 @@ public class RestClientTest {
                 strings.toArray(new String[0]),
                 requestTemplate.getParam("param").toArray(new String[0]));
     }
-    
+
     @Test
     public void testBuildURL() throws Exception {
         int port = NetUtils.getAvailablePort();
         URL url = new ServiceConfigURL(
-            "http", "localhost", port, new String[] {Constants.BIND_PORT_KEY, String.valueOf(port)});
+                "http", "localhost", port, new String[] {Constants.BIND_PORT_KEY, String.valueOf(port)});
         HttpServer httpServer = new JettyHttpServer(url, new HttpHandler<HttpServletRequest, HttpServletResponse>() {
             @Override
             public void handle(HttpServletRequest request, HttpServletResponse response) throws IOException {
@@ -203,38 +203,38 @@ public class RestClientTest {
                 response.getWriter().write(request.getQueryString());
             }
         });
-        
+
         RequestTemplate requestTemplate = new RequestTemplate(null, "POST", "localhost:" + port);
-        
+
         requestTemplate.addParam("name", "李强");
         requestTemplate.addParam("age", "18");
         requestTemplate.path("/hello/world");
-        
+
         // When using the OKHttpRestClient, parameters will be encoded with UTF-8 and appended to the URL
         RestClient restClient = new OKHttpRestClient(new HttpClientConfig());
-        
+
         CompletableFuture<RestResult> send = restClient.send(requestTemplate);
-        
+
         RestResult restResult = send.get();
-        
+
         assertThat(new String(restResult.getBody()), is("name=%E6%9D%8E%E5%BC%BA&age=18"));
-        
+
         // When using the HttpClientRestClient, parameters will be encoded with UTF-8 and appended to the URL
         restClient = new HttpClientRestClient(new HttpClientConfig());
-        
+
         send = restClient.send(requestTemplate);
-        
+
         restResult = send.get();
-        
+
         assertThat(new String(restResult.getBody()), is("name=%E6%9D%8E%E5%BC%BA&age=18"));
-        
+
         // When using the URLConnectionRestClient, parameters won't be encoded and still appended to the URL
         restClient = new URLConnectionRestClient(new HttpClientConfig());
-        
+
         send = restClient.send(requestTemplate);
-        
+
         restResult = send.get();
-        
+
         assertThat(new String(restResult.getBody(), StandardCharsets.UTF_8), is("name=李强&age=18"));
     }
 }

--- a/dubbo-remoting/dubbo-remoting-http/src/test/java/org/apache/dubbo/remoting/http/rest/RestClientTest.java
+++ b/dubbo-remoting/dubbo-remoting-http/src/test/java/org/apache/dubbo/remoting/http/rest/RestClientTest.java
@@ -192,7 +192,7 @@ public class RestClientTest {
     }
 
     @Test
-    public void testBuildURL() throws Exception {
+    void testBuildURL() throws Exception {
         int port = NetUtils.getAvailablePort();
         URL url = new ServiceConfigURL(
                 "http", "localhost", port, new String[] {Constants.BIND_PORT_KEY, String.valueOf(port)});

--- a/dubbo-rpc/dubbo-rpc-rest/src/main/java/org/apache/dubbo/rpc/protocol/rest/constans/RestConstant.java
+++ b/dubbo-rpc/dubbo-rpc-rest/src/main/java/org/apache/dubbo/rpc/protocol/rest/constans/RestConstant.java
@@ -44,6 +44,7 @@ public interface RestConstant {
     String CONTENT_TYPE = "Content-Type";
     String TEXT_PLAIN = "text/plain";
     String ACCEPT_CHARSET = "Accept-Charset";
+    String WEIGHT_IDENTIFIER = ";q=";
     String ACCEPT = "Accept";
     String DEFAULT_ACCEPT = "*/*";
     String REST_HEADER_PREFIX = "rest-service-";

--- a/dubbo-rpc/dubbo-rpc-rest/src/main/java/org/apache/dubbo/rpc/protocol/rest/constans/RestConstant.java
+++ b/dubbo-rpc/dubbo-rpc-rest/src/main/java/org/apache/dubbo/rpc/protocol/rest/constans/RestConstant.java
@@ -56,6 +56,7 @@ public interface RestConstant {
     String MAX_REQUEST_SIZE_PARAM = "max.request.size";
     String IDLE_TIMEOUT_PARAM = "idle.timeout";
     String KEEP_ALIVE_TIMEOUT_PARAM = "keep.alive.timeout";
+    String DEFAULT_CHARSET = "UTF-8";
 
     int MAX_REQUEST_SIZE = 1024 * 1024 * 10;
     int MAX_INITIAL_LINE_LENGTH = 4096;

--- a/dubbo-rpc/dubbo-rpc-rest/src/main/java/org/apache/dubbo/rpc/protocol/rest/constans/RestConstant.java
+++ b/dubbo-rpc/dubbo-rpc-rest/src/main/java/org/apache/dubbo/rpc/protocol/rest/constans/RestConstant.java
@@ -43,6 +43,7 @@ public interface RestConstant {
     String CONNECTION = "Connection";
     String CONTENT_TYPE = "Content-Type";
     String TEXT_PLAIN = "text/plain";
+    String ACCEPT_CHARSET = "Accept-Charset";
     String ACCEPT = "Accept";
     String DEFAULT_ACCEPT = "*/*";
     String REST_HEADER_PREFIX = "rest-service-";

--- a/dubbo-rpc/dubbo-rpc-rest/src/main/java/org/apache/dubbo/rpc/protocol/rest/request/RequestFacade.java
+++ b/dubbo-rpc/dubbo-rpc-rest/src/main/java/org/apache/dubbo/rpc/protocol/rest/request/RequestFacade.java
@@ -57,21 +57,21 @@ public abstract class RequestFacade<T> {
 
     protected void initParameters() {
         String requestURI = getRequestURI();
-        
-        String decodedRequestURI  = requestURI;
+
+        String decodedRequestURI = requestURI;
         try {
-            decodedRequestURI  = URLDecoder.decode(decodedRequestURI , "UTF-8");
-            if (StringUtils.isNotEmpty(decodedRequestURI )) {
-                requestURI = decodedRequestURI ;
+            decodedRequestURI = URLDecoder.decode(decodedRequestURI, "UTF-8");
+            if (StringUtils.isNotEmpty(decodedRequestURI)) {
+                requestURI = decodedRequestURI;
             }
         } catch (UnsupportedEncodingException e) {
             // do nothing
         }
-        
-        if (StringUtils.isNotEmpty(decodedRequestURI )) {
-            requestURI = decodedRequestURI ;
+
+        if (StringUtils.isNotEmpty(decodedRequestURI)) {
+            requestURI = decodedRequestURI;
         }
-        
+
         if (requestURI != null && requestURI.contains("?")) {
 
             String queryString = requestURI.substring(requestURI.indexOf("?") + 1);

--- a/dubbo-rpc/dubbo-rpc-rest/src/main/java/org/apache/dubbo/rpc/protocol/rest/request/RequestFacade.java
+++ b/dubbo-rpc/dubbo-rpc-rest/src/main/java/org/apache/dubbo/rpc/protocol/rest/request/RequestFacade.java
@@ -61,9 +61,6 @@ public abstract class RequestFacade<T> {
         String decodedRequestURI = requestURI;
         try {
             decodedRequestURI = URLDecoder.decode(decodedRequestURI, "UTF-8");
-            if (StringUtils.isNotEmpty(decodedRequestURI)) {
-                requestURI = decodedRequestURI;
-            }
         } catch (UnsupportedEncodingException e) {
             // do nothing
         }

--- a/dubbo-rpc/dubbo-rpc-rest/src/main/java/org/apache/dubbo/rpc/protocol/rest/request/RequestFacade.java
+++ b/dubbo-rpc/dubbo-rpc-rest/src/main/java/org/apache/dubbo/rpc/protocol/rest/request/RequestFacade.java
@@ -16,7 +16,9 @@
  */
 package org.apache.dubbo.rpc.protocol.rest.request;
 
+import org.apache.dubbo.common.utils.CollectionUtils;
 import org.apache.dubbo.common.utils.StringUtils;
+import org.apache.dubbo.rpc.protocol.rest.constans.RestConstant;
 import org.apache.dubbo.rpc.protocol.rest.deploy.ServiceDeployer;
 
 import java.io.IOException;
@@ -57,10 +59,15 @@ public abstract class RequestFacade<T> {
 
     protected void initParameters() {
         String requestURI = getRequestURI();
-
+        
+        String enc = "UTF-8";
+        ArrayList<String> charset = headers.get(RestConstant.ACCEPT_CHARSET);
+        if (CollectionUtils.isNotEmpty(charset) && StringUtils.isNotEmpty(charset.get(0))) {
+            enc = charset.get(0);
+        }
         String decodedRequestURI = requestURI;
         try {
-            decodedRequestURI = URLDecoder.decode(decodedRequestURI, "UTF-8");
+            decodedRequestURI = URLDecoder.decode(decodedRequestURI, enc);
         } catch (UnsupportedEncodingException e) {
             // do nothing
         }

--- a/dubbo-rpc/dubbo-rpc-rest/src/main/java/org/apache/dubbo/rpc/protocol/rest/request/RequestFacade.java
+++ b/dubbo-rpc/dubbo-rpc-rest/src/main/java/org/apache/dubbo/rpc/protocol/rest/request/RequestFacade.java
@@ -59,7 +59,7 @@ public abstract class RequestFacade<T> {
 
     protected void initParameters() {
         String requestURI = getRequestURI();
-        
+
         String enc = "UTF-8";
         ArrayList<String> charset = headers.get(RestConstant.ACCEPT_CHARSET);
         if (CollectionUtils.isNotEmpty(charset) && StringUtils.isNotEmpty(charset.get(0))) {

--- a/dubbo-rpc/dubbo-rpc-rest/src/main/java/org/apache/dubbo/rpc/protocol/rest/request/RequestFacade.java
+++ b/dubbo-rpc/dubbo-rpc-rest/src/main/java/org/apache/dubbo/rpc/protocol/rest/request/RequestFacade.java
@@ -16,13 +16,12 @@
  */
 package org.apache.dubbo.rpc.protocol.rest.request;
 
-import org.apache.dubbo.common.utils.CollectionUtils;
 import org.apache.dubbo.common.utils.StringUtils;
 import org.apache.dubbo.rpc.protocol.rest.constans.RestConstant;
 import org.apache.dubbo.rpc.protocol.rest.deploy.ServiceDeployer;
+import org.apache.dubbo.rpc.protocol.rest.util.DataParseUtils;
 
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.util.ArrayList;
 import java.util.Enumeration;
@@ -59,16 +58,18 @@ public abstract class RequestFacade<T> {
 
     protected void initParameters() {
         String requestURI = getRequestURI();
-
-        String enc = "UTF-8";
-        ArrayList<String> charset = headers.get(RestConstant.ACCEPT_CHARSET);
-        if (CollectionUtils.isNotEmpty(charset) && StringUtils.isNotEmpty(charset.get(0))) {
-            enc = charset.get(0);
-        }
         String decodedRequestURI = requestURI;
+
         try {
+            String enc = "UTF-8";
+            ArrayList<String> charset = headers.get(RestConstant.ACCEPT_CHARSET);
+            // take the highest priority charset
+            String[] parsed = DataParseUtils.parseAcceptCharset(charset);
+            if (parsed != null && parsed.length > 0) {
+                enc = parsed[0].toUpperCase();
+            }
             decodedRequestURI = URLDecoder.decode(decodedRequestURI, enc);
-        } catch (UnsupportedEncodingException e) {
+        } catch (Throwable t) {
             // do nothing, try best to deliver
         }
 

--- a/dubbo-rpc/dubbo-rpc-rest/src/main/java/org/apache/dubbo/rpc/protocol/rest/request/RequestFacade.java
+++ b/dubbo-rpc/dubbo-rpc-rest/src/main/java/org/apache/dubbo/rpc/protocol/rest/request/RequestFacade.java
@@ -69,7 +69,7 @@ public abstract class RequestFacade<T> {
         try {
             decodedRequestURI = URLDecoder.decode(decodedRequestURI, enc);
         } catch (UnsupportedEncodingException e) {
-            // do nothing
+            // do nothing, try best to deliver
         }
 
         if (StringUtils.isNotEmpty(decodedRequestURI)) {

--- a/dubbo-rpc/dubbo-rpc-rest/src/main/java/org/apache/dubbo/rpc/protocol/rest/request/RequestFacade.java
+++ b/dubbo-rpc/dubbo-rpc-rest/src/main/java/org/apache/dubbo/rpc/protocol/rest/request/RequestFacade.java
@@ -58,7 +58,7 @@ public abstract class RequestFacade<T> {
 
     protected void initParameters() {
         String requestURI = getRequestURI();
-        String decodedRequestURI = requestURI;
+        String decodedRequestURI = null;
 
         try {
             String enc = "UTF-8";
@@ -68,7 +68,7 @@ public abstract class RequestFacade<T> {
             if (parsed != null && parsed.length > 0) {
                 enc = parsed[0].toUpperCase();
             }
-            decodedRequestURI = URLDecoder.decode(decodedRequestURI, enc);
+            decodedRequestURI = URLDecoder.decode(requestURI, enc);
         } catch (Throwable t) {
             // do nothing, try best to deliver
         }

--- a/dubbo-rpc/dubbo-rpc-rest/src/main/java/org/apache/dubbo/rpc/protocol/rest/request/RequestFacade.java
+++ b/dubbo-rpc/dubbo-rpc-rest/src/main/java/org/apache/dubbo/rpc/protocol/rest/request/RequestFacade.java
@@ -20,6 +20,8 @@ import org.apache.dubbo.common.utils.StringUtils;
 import org.apache.dubbo.rpc.protocol.rest.deploy.ServiceDeployer;
 
 import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
 import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.HashMap;
@@ -55,7 +57,21 @@ public abstract class RequestFacade<T> {
 
     protected void initParameters() {
         String requestURI = getRequestURI();
-
+        
+        String decodedRequestURI  = requestURI;
+        try {
+            decodedRequestURI  = URLDecoder.decode(decodedRequestURI , "UTF-8");
+            if (StringUtils.isNotEmpty(decodedRequestURI )) {
+                requestURI = decodedRequestURI ;
+            }
+        } catch (UnsupportedEncodingException e) {
+            // do nothing
+        }
+        
+        if (StringUtils.isNotEmpty(decodedRequestURI )) {
+            requestURI = decodedRequestURI ;
+        }
+        
         if (requestURI != null && requestURI.contains("?")) {
 
             String queryString = requestURI.substring(requestURI.indexOf("?") + 1);

--- a/dubbo-rpc/dubbo-rpc-rest/src/main/java/org/apache/dubbo/rpc/protocol/rest/request/RequestFacade.java
+++ b/dubbo-rpc/dubbo-rpc-rest/src/main/java/org/apache/dubbo/rpc/protocol/rest/request/RequestFacade.java
@@ -28,6 +28,8 @@ import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.apache.dubbo.rpc.protocol.rest.constans.RestConstant.DEFAULT_CHARSET;
+
 /**
  * request facade for different request
  *
@@ -61,7 +63,7 @@ public abstract class RequestFacade<T> {
         String decodedRequestURI = null;
 
         try {
-            String enc = "UTF-8";
+            String enc = DEFAULT_CHARSET;
             ArrayList<String> charset = headers.get(RestConstant.ACCEPT_CHARSET);
             // take the highest priority charset
             String[] parsed = DataParseUtils.parseAcceptCharset(charset);

--- a/dubbo-rpc/dubbo-rpc-rest/src/main/java/org/apache/dubbo/rpc/protocol/rest/util/DataParseUtils.java
+++ b/dubbo-rpc/dubbo-rpc-rest/src/main/java/org/apache/dubbo/rpc/protocol/rest/util/DataParseUtils.java
@@ -222,27 +222,23 @@ public class DataParseUtils {
     @Nullable
     public static String[] parseAcceptCharset(List<String> acceptCharsets) {
         if (CollectionUtils.isEmpty(acceptCharsets)) {
-            return null;
+            return new String[0];
         }
 
         SortedMap<Float, Set<String>> encodings = new TreeMap<>(Comparator.reverseOrder());
         float defaultWeight = 1.0f;
         for (String acceptCharset : acceptCharsets) {
-            if (StringUtils.isNotEmpty(acceptCharset)) {
-                String[] charsets = acceptCharset.split(",");
-                for (String charset : charsets) {
-                    charset = charset.trim();
-                    if (StringUtils.isNotEmpty(charset)) {
-                        float weight = defaultWeight;
-                        String enc = charset;
-                        if (charset.contains(WEIGHT_IDENTIFIER)) {
-                            String[] split = charset.split(WEIGHT_IDENTIFIER);
-                            enc = split[0];
-                            weight = Float.parseFloat(split[1]);
-                        }
-                        encodings.computeIfAbsent(weight, k -> new HashSet<>()).add(enc);
-                    }
+            String[] charsets = acceptCharset.split(",");
+            for (String charset : charsets) {
+                charset = charset.trim();
+                float weight = defaultWeight;
+                String enc = charset;
+                if (charset.contains(WEIGHT_IDENTIFIER)) {
+                    String[] split = charset.split(WEIGHT_IDENTIFIER);
+                    enc = split[0];
+                    weight = Float.parseFloat(split[1]);
                 }
+                encodings.computeIfAbsent(weight, k -> new HashSet<>()).add(enc);
             }
         }
 

--- a/dubbo-rpc/dubbo-rpc-rest/src/main/java/org/apache/dubbo/rpc/protocol/rest/util/DataParseUtils.java
+++ b/dubbo-rpc/dubbo-rpc-rest/src/main/java/org/apache/dubbo/rpc/protocol/rest/util/DataParseUtils.java
@@ -16,6 +16,8 @@
  */
 package org.apache.dubbo.rpc.protocol.rest.util;
 
+import org.apache.dubbo.common.lang.Nullable;
+import org.apache.dubbo.common.utils.CollectionUtils;
 import org.apache.dubbo.common.utils.JsonUtils;
 import org.apache.dubbo.common.utils.StringUtils;
 
@@ -29,9 +31,16 @@ import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Comparator;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.SortedMap;
 import java.util.StringTokenizer;
+import java.util.TreeMap;
+
+import static org.apache.dubbo.rpc.protocol.rest.constans.RestConstant.WEIGHT_IDENTIFIER;
 
 public class DataParseUtils {
 
@@ -208,5 +217,37 @@ public class DataParseUtils {
 
     public static String[] toStringArray(Collection<String> collection) {
         return collection == null ? null : collection.toArray(new String[collection.size()]);
+    }
+
+    @Nullable
+    public static String[] parseAcceptCharset(List<String> acceptCharsets) {
+        if (CollectionUtils.isEmpty(acceptCharsets)) {
+            return null;
+        }
+
+        SortedMap<Float, Set<String>> encodings = new TreeMap<>(Comparator.reverseOrder());
+        float defaultWeight = 1.0f;
+        for (String acceptCharset : acceptCharsets) {
+            if (StringUtils.isNotEmpty(acceptCharset)) {
+                String[] charsets = acceptCharset.split(",");
+                for (String charset : charsets) {
+                    charset = charset.trim();
+                    if (StringUtils.isNotEmpty(charset)) {
+                        float weight = defaultWeight;
+                        String enc = charset;
+                        if (charset.contains(WEIGHT_IDENTIFIER)) {
+                            String[] split = charset.split(WEIGHT_IDENTIFIER);
+                            enc = split[0];
+                            weight = Float.parseFloat(split[1]);
+                        }
+                        encodings.computeIfAbsent(weight, k -> new HashSet<>()).add(enc);
+                    }
+                }
+            }
+        }
+
+        List<String> result = new ArrayList<>();
+        encodings.values().forEach(result::addAll);
+        return result.toArray(new String[0]);
     }
 }

--- a/dubbo-rpc/dubbo-rpc-rest/src/test/java/org/apache/dubbo/rpc/protocol/rest/DataParseUtilsTest.java
+++ b/dubbo-rpc/dubbo-rpc-rest/src/test/java/org/apache/dubbo/rpc/protocol/rest/DataParseUtilsTest.java
@@ -19,6 +19,7 @@ package org.apache.dubbo.rpc.protocol.rest;
 import org.apache.dubbo.rpc.protocol.rest.util.DataParseUtils;
 
 import java.io.ByteArrayOutputStream;
+import java.util.Arrays;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -55,5 +56,15 @@ public class DataParseUtilsTest {
         convert = DataParseUtils.stringTypeConvert(Integer.class, "1");
 
         Assertions.assertEquals(1, convert);
+    }
+
+    @Test
+    void testParseAcceptCharset() {
+        String[] parsed = DataParseUtils.parseAcceptCharset(Arrays.asList("iso-8859-1"));
+        Assertions.assertTrue(Arrays.equals(parsed, new String[] {"iso-8859-1"}));
+        parsed = DataParseUtils.parseAcceptCharset(Arrays.asList("utf-8, iso-8859-1;q=0.5"));
+        Assertions.assertTrue(Arrays.equals(parsed, new String[] {"utf-8", "iso-8859-1"}));
+        parsed = DataParseUtils.parseAcceptCharset(Arrays.asList("utf-8, iso-8859-1;q=0.5, *;q=0.1", "utf-16;q=0.5"));
+        Assertions.assertEquals("utf-8", parsed[0]);
     }
 }

--- a/dubbo-rpc/dubbo-rpc-rest/src/test/java/org/apache/dubbo/rpc/protocol/rest/NettyRequestFacadeTest.java
+++ b/dubbo-rpc/dubbo-rpc-rest/src/test/java/org/apache/dubbo/rpc/protocol/rest/NettyRequestFacadeTest.java
@@ -98,33 +98,31 @@ public class NettyRequestFacadeTest {
 
         Assertions.assertEquals("GET", nettyRequestFacade.getMethod());
     }
-    
+
     @Test
     void testChineseDecoding() {
         String uri = "/hello/world?name=%E6%9D%8E%E5%BC%BA&age=18";
         DefaultFullHttpRequest defaultFullHttpRequest =
-            new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, uri);
-        
+                new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, uri);
+
         NettyRequestFacade nettyRequestFacade = new NettyRequestFacade(defaultFullHttpRequest, null);
         assertThat(nettyRequestFacade.getPath(), is("/hello/world"));
         assertThat(nettyRequestFacade.getParameter("name"), is("李强"));
         assertThat(nettyRequestFacade.getParameter("age"), is("18"));
-        
+
         // Applying the decode method to the URI is acceptable, even if the URI is not encoded.
         uri = "/hello/world?name=lily&age=18";
-        defaultFullHttpRequest =
-            new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, uri);
-        
+        defaultFullHttpRequest = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, uri);
+
         nettyRequestFacade = new NettyRequestFacade(defaultFullHttpRequest, null);
         assertThat(nettyRequestFacade.getPath(), is("/hello/world"));
         assertThat(nettyRequestFacade.getParameter("name"), is("lily"));
         assertThat(nettyRequestFacade.getParameter("age"), is("18"));
-        
+
         // When using URLConnectionRestClient, the URI won't be encoded, but it's still acceptable.
         uri = "/hello/world?name=李强&age=18";
-        defaultFullHttpRequest =
-            new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, uri);
-        
+        defaultFullHttpRequest = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, uri);
+
         nettyRequestFacade = new NettyRequestFacade(defaultFullHttpRequest, null);
         assertThat(nettyRequestFacade.getPath(), is("/hello/world"));
         assertThat(nettyRequestFacade.getParameter("name"), is("李强"));

--- a/dubbo-rpc/dubbo-rpc-rest/src/test/java/org/apache/dubbo/rpc/protocol/rest/NettyRequestFacadeTest.java
+++ b/dubbo-rpc/dubbo-rpc-rest/src/test/java/org/apache/dubbo/rpc/protocol/rest/NettyRequestFacadeTest.java
@@ -105,7 +105,7 @@ public class NettyRequestFacadeTest {
         DefaultFullHttpRequest defaultFullHttpRequest =
                 new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, uri);
         defaultFullHttpRequest.headers().add("Accept-Charset", "UTF-8");
-        
+
         NettyRequestFacade nettyRequestFacade = new NettyRequestFacade(defaultFullHttpRequest, null);
         assertThat(nettyRequestFacade.getPath(), is("/hello/world"));
         assertThat(nettyRequestFacade.getParameter("name"), is("李强"));
@@ -123,7 +123,6 @@ public class NettyRequestFacadeTest {
         // When using URLConnectionRestClient, the URI won't be encoded, but it's still acceptable.
         uri = "/hello/world?name=李强&age=18";
         defaultFullHttpRequest = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, uri);
-        
 
         nettyRequestFacade = new NettyRequestFacade(defaultFullHttpRequest, null);
         assertThat(nettyRequestFacade.getPath(), is("/hello/world"));

--- a/dubbo-rpc/dubbo-rpc-rest/src/test/java/org/apache/dubbo/rpc/protocol/rest/NettyRequestFacadeTest.java
+++ b/dubbo-rpc/dubbo-rpc-rest/src/test/java/org/apache/dubbo/rpc/protocol/rest/NettyRequestFacadeTest.java
@@ -104,7 +104,8 @@ public class NettyRequestFacadeTest {
         String uri = "/hello/world?name=%E6%9D%8E%E5%BC%BA&age=18";
         DefaultFullHttpRequest defaultFullHttpRequest =
                 new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, uri);
-        defaultFullHttpRequest.headers().add("Accept-Charset", "UTF-8");
+        defaultFullHttpRequest.headers().add("Accept-Charset", "utf-8, iso-8859-1;q=0.5, *;q=0.1");
+        defaultFullHttpRequest.headers().add("Accept-Charset", "utf-16;q=0.3");
 
         NettyRequestFacade nettyRequestFacade = new NettyRequestFacade(defaultFullHttpRequest, null);
         assertThat(nettyRequestFacade.getPath(), is("/hello/world"));

--- a/dubbo-rpc/dubbo-rpc-rest/src/test/java/org/apache/dubbo/rpc/protocol/rest/NettyRequestFacadeTest.java
+++ b/dubbo-rpc/dubbo-rpc-rest/src/test/java/org/apache/dubbo/rpc/protocol/rest/NettyRequestFacadeTest.java
@@ -106,6 +106,27 @@ public class NettyRequestFacadeTest {
             new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, uri);
         
         NettyRequestFacade nettyRequestFacade = new NettyRequestFacade(defaultFullHttpRequest, null);
+        assertThat(nettyRequestFacade.getPath(), is("/hello/world"));
+        assertThat(nettyRequestFacade.getParameter("name"), is("李强"));
+        assertThat(nettyRequestFacade.getParameter("age"), is("18"));
+        
+        // Applying the decode method to the URI is acceptable, even if the URI is not encoded.
+        uri = "/hello/world?name=lily&age=18";
+        defaultFullHttpRequest =
+            new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, uri);
+        
+        nettyRequestFacade = new NettyRequestFacade(defaultFullHttpRequest, null);
+        assertThat(nettyRequestFacade.getPath(), is("/hello/world"));
+        assertThat(nettyRequestFacade.getParameter("name"), is("lily"));
+        assertThat(nettyRequestFacade.getParameter("age"), is("18"));
+        
+        // When using URLConnectionRestClient, the URI won't be encoded, but it's still acceptable.
+        uri = "/hello/world?name=李强&age=18";
+        defaultFullHttpRequest =
+            new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, uri);
+        
+        nettyRequestFacade = new NettyRequestFacade(defaultFullHttpRequest, null);
+        assertThat(nettyRequestFacade.getPath(), is("/hello/world"));
         assertThat(nettyRequestFacade.getParameter("name"), is("李强"));
         assertThat(nettyRequestFacade.getParameter("age"), is("18"));
     }

--- a/dubbo-rpc/dubbo-rpc-rest/src/test/java/org/apache/dubbo/rpc/protocol/rest/NettyRequestFacadeTest.java
+++ b/dubbo-rpc/dubbo-rpc-rest/src/test/java/org/apache/dubbo/rpc/protocol/rest/NettyRequestFacadeTest.java
@@ -30,6 +30,9 @@ import io.netty.handler.codec.http.HttpVersion;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+
 public class NettyRequestFacadeTest {
 
     @Test
@@ -94,5 +97,16 @@ public class NettyRequestFacadeTest {
         Assertions.assertArrayEquals(new String[] {"d"}, parameterMap.get("d"));
 
         Assertions.assertEquals("GET", nettyRequestFacade.getMethod());
+    }
+    
+    @Test
+    void testChineseDecoding() {
+        String uri = "/hello/world?name=%E6%9D%8E%E5%BC%BA&age=18";
+        DefaultFullHttpRequest defaultFullHttpRequest =
+            new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, uri);
+        
+        NettyRequestFacade nettyRequestFacade = new NettyRequestFacade(defaultFullHttpRequest, null);
+        assertThat(nettyRequestFacade.getParameter("name"), is("李强"));
+        assertThat(nettyRequestFacade.getParameter("age"), is("18"));
     }
 }

--- a/dubbo-rpc/dubbo-rpc-rest/src/test/java/org/apache/dubbo/rpc/protocol/rest/NettyRequestFacadeTest.java
+++ b/dubbo-rpc/dubbo-rpc-rest/src/test/java/org/apache/dubbo/rpc/protocol/rest/NettyRequestFacadeTest.java
@@ -104,7 +104,8 @@ public class NettyRequestFacadeTest {
         String uri = "/hello/world?name=%E6%9D%8E%E5%BC%BA&age=18";
         DefaultFullHttpRequest defaultFullHttpRequest =
                 new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, uri);
-
+        defaultFullHttpRequest.headers().add("Accept-Charset", "UTF-8");
+        
         NettyRequestFacade nettyRequestFacade = new NettyRequestFacade(defaultFullHttpRequest, null);
         assertThat(nettyRequestFacade.getPath(), is("/hello/world"));
         assertThat(nettyRequestFacade.getParameter("name"), is("李强"));
@@ -122,6 +123,7 @@ public class NettyRequestFacadeTest {
         // When using URLConnectionRestClient, the URI won't be encoded, but it's still acceptable.
         uri = "/hello/world?name=李强&age=18";
         defaultFullHttpRequest = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, uri);
+        
 
         nettyRequestFacade = new NettyRequestFacade(defaultFullHttpRequest, null);
         assertThat(nettyRequestFacade.getPath(), is("/hello/world"));


### PR DESCRIPTION
## What is the purpose of the change
When utilizing Dubbo REST with the @QueryParam annotation on parameters, issues with Chinese character decoding may arise. Refer to the [13349 issue](https://github.com/apache/dubbo/issues/13349#issuecomment-1879523852) for a comprehensive and detailed description of the problem, including its cause, solution, and an explanation of why it works.


## Brief changelog
RequestFacade.initParameters will decode the request uri with UTF-8 before parsing uri to parameters.

## Verifying this change
- I add more unit tests , then can pass, and I recommend you refer the [13349 issue](https://github.com/apache/dubbo/issues/13349#issuecomment-1879523852) 

<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [x] Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [x] GitHub Actions works fine on your own branch.
- [x] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
