### PR TITLE
Fix URL parse pwd failed when the pwd contains '#'

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/URLStrParser.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/URLStrParser.java
@@ -42,8 +42,8 @@ public final class URLStrParser {
     }
 
     /**
-     * @param decodedURLStr : after {@link URL#decode} string
-     *                      decodedURLStr format: protocol://username:password@host:port/path?k1=v1&k2=v2
+     * @param decodedURLStr : after {@link URL#decode} string decodedURLStr format:
+     *                      protocol://username:password@host:port/path?k1=v1&k2=v2
      *                      [protocol://][username:password@][host:port]/[path][?k1=v1&k2=v2]
      */
     public static URL parseDecodedStr(String decodedURLStr) {
@@ -103,7 +103,9 @@ public final class URLStrParser {
         int starIdx = 0, endIdx = decodedBody.length();
         // ignore the url content following '#'
         int poundIndex = decodedBody.indexOf('#');
-        if (poundIndex != -1) {
+        int pwdEndIdx = lastIndexOf(decodedBody, '@', starIdx, endIdx);
+
+        if (poundIndex != -1 && poundIndex > pwdEndIdx) {
             endIdx = poundIndex;
         }
 
@@ -136,7 +138,7 @@ public final class URLStrParser {
 
         String username = null;
         String password = null;
-        int pwdEndIdx = lastIndexOf(decodedBody, '@', starIdx, endIdx);
+        pwdEndIdx = lastIndexOf(decodedBody, '@', starIdx, endIdx);
         if (pwdEndIdx > 0) {
             int passwordStartIdx = indexOf(decodedBody, ':', starIdx, pwdEndIdx);
             if (passwordStartIdx != -1) { // tolerate incomplete user pwd input, like '1234@'
@@ -203,8 +205,8 @@ public final class URLStrParser {
     }
 
     /**
-     * @param encodedURLStr : after {@link URL#encode(String)} string
-     *                      encodedURLStr after decode format: protocol://username:password@host:port/path?k1=v1&k2=v2
+     * @param encodedURLStr : after {@link URL#encode(String)} string encodedURLStr after decode format:
+     *                      protocol://username:password@host:port/path?k1=v1&k2=v2
      *                      [protocol://][username:password@][host:port]/[path][?k1=v1&k2=v2]
      */
     public static URL parseEncodedStr(String encodedURLStr) {

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/URLStrParserTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/URLStrParserTest.java
@@ -48,6 +48,7 @@ class URLStrParserTest {
         testCases.add("nacos://192.168.1.1:8848?username=&password=");
         testCases.add("dubbo://127.0.0.1?timeout=1234&default.timeout=5678");
         testCases.add("dubbo://127.0.0.1?default.timeout=5678");
+        testCases.add("zookeeper://test:test#1223@10.301.216.302:2181");
 
         errorDecodedCases.add("dubbo:192.168.1.1");
         errorDecodedCases.add("://192.168.1.1");


### PR DESCRIPTION
## What is the purpose of the change

close https://github.com/apache/dubbo/issues/11422

## Brief changelog


## Verifying this change


<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [ ] GitHub Actions works fine on your own branch.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
