### PR TITLE
Revert "check application name"

### DIFF
--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/utils/ConfigValidationUtils.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/utils/ConfigValidationUtils.java
@@ -491,12 +491,6 @@ public class ConfigValidationUtils {
                     + "Please add <dubbo:application name=\"...\" /> to your spring config.");
         }
 
-        String name = config.getName();
-        if (!checkName(NAME, name)) {
-            throw new IllegalStateException(
-                    String.format("please correct dubbo application name: %s at your spring config.", name));
-        }
-
         // backward compatibility
         ScopeModel scopeModel = ScopeModelUtil.getOrDefaultApplicationModel(config.getScopeModel());
         PropertiesConfiguration configuration = scopeModel.modelEnvironment().getPropertiesConfiguration();
@@ -510,6 +504,7 @@ public class ConfigValidationUtils {
             }
         }
 
+        checkName(NAME, config.getName());
         checkMultiName(OWNER, config.getOwner());
         checkName(ORGANIZATION, config.getOrganization());
         checkName(ARCHITECTURE, config.getArchitecture());
@@ -737,8 +732,8 @@ public class ConfigValidationUtils {
         checkProperty(property, value, MAX_PATH_LENGTH, null);
     }
 
-    public static boolean checkName(String property, String value) {
-        return checkProperty(property, value, MAX_LENGTH, PATTERN_NAME);
+    public static void checkName(String property, String value) {
+        checkProperty(property, value, MAX_LENGTH, PATTERN_NAME);
     }
 
     public static void checkHost(String property, String value) {
@@ -794,9 +789,9 @@ public class ConfigValidationUtils {
         }
     }
 
-    public static boolean checkProperty(String property, String value, int maxlength, Pattern pattern) {
+    public static void checkProperty(String property, String value, int maxlength, Pattern pattern) {
         if (StringUtils.isEmpty(value)) {
-            return false;
+            return;
         }
         if (value.length() > maxlength) {
             logger.error(
@@ -805,7 +800,6 @@ public class ConfigValidationUtils {
                     "",
                     "Parameter value format error. Invalid " + property + "=\"" + value + "\" is longer than "
                             + maxlength);
-            return false;
         }
         if (pattern != null) {
             Matcher matcher = pattern.matcher(value);
@@ -817,9 +811,7 @@ public class ConfigValidationUtils {
                         "Parameter value format error. Invalid " + property
                                 + "=\"" + value + "\" contains illegal "
                                 + "character, only digit, letter, '-', '_' or '.' is legal.");
-                return false;
             }
         }
-        return true;
     }
 }

--- a/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/ReferenceConfigTest.java
+++ b/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/ReferenceConfigTest.java
@@ -873,7 +873,7 @@ class ReferenceConfigTest {
         referenceConfig.setGeneric("true");
 
         DubboBootstrap.getInstance()
-                .application("demo-app")
+                .application("demo app")
                 .reference(referenceConfig)
                 .initialize();
 

--- a/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/utils/ConfigValidationUtilsTest.java
+++ b/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/utils/ConfigValidationUtilsTest.java
@@ -100,9 +100,6 @@ class ConfigValidationUtilsTest {
             mockedStatic
                     .when(() -> ConfigValidationUtils.validateApplicationConfig(any()))
                     .thenCallRealMethod();
-            mockedStatic
-                    .when(() -> ConfigValidationUtils.checkName(any(), any()))
-                    .thenReturn(true);
             ApplicationConfig config = new ApplicationConfig();
             Assertions.assertThrows(IllegalStateException.class, () -> {
                 ConfigValidationUtils.validateApplicationConfig(config);


### PR DESCRIPTION
Reverts apache/dubbo#13343

- Duplicated check in org/apache/dubbo/config/utils/ConfigValidationUtils.java:489
- This should now be strictly checked in 3.2.x versions. This is a breaking change.