### PR TITLE
Revert "DefaultProviderFirstParams add THREADPOOL_KEY"

### DIFF
--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/support/DefaultProviderFirstParams.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/support/DefaultProviderFirstParams.java
@@ -24,24 +24,15 @@ import java.util.HashSet;
 import java.util.Set;
 
 import static org.apache.dubbo.common.constants.CommonConstants.DUBBO_VERSION_KEY;
-import static org.apache.dubbo.common.constants.CommonConstants.EXECUTOR_MANAGEMENT_MODE;
 import static org.apache.dubbo.common.constants.CommonConstants.METHODS_KEY;
 import static org.apache.dubbo.common.constants.CommonConstants.RELEASE_KEY;
 import static org.apache.dubbo.common.constants.CommonConstants.TAG_KEY;
-import static org.apache.dubbo.common.constants.CommonConstants.THREADPOOL_KEY;
 import static org.apache.dubbo.common.constants.CommonConstants.TIMESTAMP_KEY;
 
 public class DefaultProviderFirstParams implements ProviderFirstParams {
     private static final Set<String> PARAMS = Collections.unmodifiableSet(new HashSet<String>() {
         {
-            addAll(Arrays.asList(
-                    RELEASE_KEY,
-                    DUBBO_VERSION_KEY,
-                    METHODS_KEY,
-                    TIMESTAMP_KEY,
-                    TAG_KEY,
-                    THREADPOOL_KEY,
-                    EXECUTOR_MANAGEMENT_MODE));
+            addAll(Arrays.asList(RELEASE_KEY, DUBBO_VERSION_KEY, METHODS_KEY, TIMESTAMP_KEY, TAG_KEY));
         }
     });
 


### PR DESCRIPTION
Reverts apache/dubbo#13637

- This might a breaking change in 3.2.x if some users depend on such bug. Some users will use this bug as a feature.
- @funkye Can you please submit apache/dubbo#13637 again to 3.3.x branch?
- In the new PR, we should sort out all the keys that have been registered in the registration center, and ensure that there will be no new useless keys through the blacklist mechanism and day.