### PR TITLE
Fix when the Accept header is "*/*" or null, adapt the Content-type to application/json

### DIFF
--- a/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/message/codec/CodecUtils.java
+++ b/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/message/codec/CodecUtils.java
@@ -130,8 +130,8 @@ public class CodecUtils {
 
     public static String getEncodeMediaType(HttpHeaders headers) {
         String mediaType = headers.getAccept();
-        if (mediaType == null) {
-            mediaType = headers.getContentType();
+        if (mediaType == null || MediaType.ALL_VALUE.getName().equals(mediaType)) {
+            mediaType = MediaType.APPLICATION_JSON_VALUE.getName();
         }
         return mediaType;
     }

--- a/dubbo-remoting/dubbo-remoting-http12/src/test/java/org/apache/dubbo/remoting/http12/message/codec/CodeUtilsTest.java
+++ b/dubbo-remoting/dubbo-remoting-http12/src/test/java/org/apache/dubbo/remoting/http12/message/codec/CodeUtilsTest.java
@@ -18,7 +18,6 @@ package org.apache.dubbo.remoting.http12.message.codec;
 
 import org.apache.dubbo.remoting.http12.HttpHeaderNames;
 import org.apache.dubbo.remoting.http12.HttpHeaders;
-import org.apache.dubbo.remoting.http12.exception.UnsupportedMediaTypeException;
 import org.apache.dubbo.remoting.http12.message.HttpMessageDecoder;
 import org.apache.dubbo.remoting.http12.message.HttpMessageEncoder;
 import org.apache.dubbo.remoting.http12.message.MediaType;

--- a/dubbo-remoting/dubbo-remoting-http12/src/test/java/org/apache/dubbo/remoting/http12/message/codec/CodeUtilsTest.java
+++ b/dubbo-remoting/dubbo-remoting-http12/src/test/java/org/apache/dubbo/remoting/http12/message/codec/CodeUtilsTest.java
@@ -57,9 +57,10 @@ public class CodeUtilsTest {
                 codecUtils.determineHttpMessageDecoder(FrameworkModel.defaultModel(), headers1.getContentType(), null);
         Assertions.assertNotNull(decoder);
         Assertions.assertEquals(MultipartDecoder.class, decoder.getClass());
-        Assertions.assertThrows(
-                UnsupportedMediaTypeException.class,
-                () -> codecUtils.determineHttpMessageEncoder(FrameworkModel.defaultModel(), headers1, null));
+
+        encoder = codecUtils.determineHttpMessageEncoder(FrameworkModel.defaultModel(), headers1, null);
+        Assertions.assertNotNull(encoder);
+        Assertions.assertEquals(JsonPbCodec.class, encoder.getClass());
 
         headers1.put(
                 HttpHeaderNames.ACCEPT.getName(),


### PR DESCRIPTION
## What is the purpose of the change

- When the Accept header is "\*/\*" or null, adapt the Content-type to application/json