### PR TITLE
Fixes #13684: remove deprecated port non-null assertion in case start failure 

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/config/AbstractInterfaceConfig.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/config/AbstractInterfaceConfig.java
@@ -21,7 +21,6 @@ import org.apache.dubbo.common.Version;
 import org.apache.dubbo.common.config.ConfigurationUtils;
 import org.apache.dubbo.common.config.Environment;
 import org.apache.dubbo.common.config.InmemoryConfiguration;
-import org.apache.dubbo.common.utils.Assert;
 import org.apache.dubbo.common.utils.ClassUtils;
 import org.apache.dubbo.common.utils.CollectionUtils;
 import org.apache.dubbo.common.utils.ConfigUtils;
@@ -277,9 +276,7 @@ public abstract class AbstractInterfaceConfig extends AbstractMethodConfig {
         if (metricsConfig != null) {
             String protocol = Optional.ofNullable(metricsConfig.getProtocol()).orElse(PROTOCOL_PROMETHEUS);
             if (!StringUtils.isEquals(protocol, PROTOCOL_PROMETHEUS)) {
-                Assert.notEmptyString(metricsConfig.getPort(), "Metrics port cannot be null");
                 map.put("metrics.protocol", protocol);
-                map.put("metrics.port", metricsConfig.getPort());
             }
         }
     }


### PR DESCRIPTION
## What is the purpose of the change

Fixes #13684

## Brief changelog

Remove L280 and L282 in `AbstractInterfaceConfig` https://github.com/bitgorust/dubbo/commit/c375096517b79ab91101f95b7ee145730216f79a

https://github.com/apache/dubbo/blob/5c0b1deb1c2fae2e37b4add093b7122da73f971e/dubbo-common/src/main/java/org/apache/dubbo/config/AbstractInterfaceConfig.java#L279-L283


