### PR TITLE
Fixes #13684: delete outdated metrics port assertions

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/config/AbstractInterfaceConfig.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/config/AbstractInterfaceConfig.java
@@ -21,7 +21,6 @@ import org.apache.dubbo.common.Version;
 import org.apache.dubbo.common.config.ConfigurationUtils;
 import org.apache.dubbo.common.config.Environment;
 import org.apache.dubbo.common.config.InmemoryConfiguration;
-import org.apache.dubbo.common.utils.Assert;
 import org.apache.dubbo.common.utils.ClassUtils;
 import org.apache.dubbo.common.utils.CollectionUtils;
 import org.apache.dubbo.common.utils.ConfigUtils;
@@ -54,7 +53,6 @@ import static org.apache.dubbo.common.constants.CommonConstants.RELEASE_KEY;
 import static org.apache.dubbo.common.constants.CommonConstants.TAG_KEY;
 import static org.apache.dubbo.common.constants.CommonConstants.TIMESTAMP_KEY;
 import static org.apache.dubbo.common.constants.LoggerCodeConstants.CONFIG_NO_METHOD_FOUND;
-import static org.apache.dubbo.common.constants.MetricsConstants.PROTOCOL_PROMETHEUS;
 
 /**
  * AbstractDefaultConfig
@@ -264,23 +262,6 @@ public abstract class AbstractInterfaceConfig extends AbstractMethodConfig {
         map.put(TIMESTAMP_KEY, String.valueOf(System.currentTimeMillis()));
         if (ConfigUtils.getPid() > 0) {
             map.put(PID_KEY, String.valueOf(ConfigUtils.getPid()));
-        }
-    }
-
-    /**
-     * @deprecated After metrics config is refactored.
-     * This method should no longer use and will be deleted in the future.
-     */
-    @Deprecated
-    protected void appendMetricsCompatible(Map<String, String> map) {
-        MetricsConfig metricsConfig = getConfigManager().getMetrics().orElse(null);
-        if (metricsConfig != null) {
-            String protocol = Optional.ofNullable(metricsConfig.getProtocol()).orElse(PROTOCOL_PROMETHEUS);
-            if (!StringUtils.isEquals(protocol, PROTOCOL_PROMETHEUS)) {
-                Assert.notEmptyString(metricsConfig.getPort(), "Metrics port cannot be null");
-                map.put("metrics.protocol", protocol);
-                map.put("metrics.port", metricsConfig.getPort());
-            }
         }
     }
 

--- a/dubbo-common/src/main/java/org/apache/dubbo/config/MetricsConfig.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/config/MetricsConfig.java
@@ -77,13 +77,6 @@ public class MetricsConfig extends AbstractConfig {
     private Integer collectorSyncPeriod;
 
     /**
-     * @deprecated After metrics config is refactored.
-     * This parameter should no longer use and will be deleted in the future.
-     */
-    @Deprecated
-    private String port;
-
-    /**
      * The prometheus metrics config
      */
     @Nested
@@ -164,14 +157,6 @@ public class MetricsConfig extends AbstractConfig {
 
     public void setEnableRegistry(Boolean enableRegistry) {
         this.enableRegistry = enableRegistry;
-    }
-
-    public String getPort() {
-        return port;
-    }
-
-    public void setPort(String port) {
-        this.port = port;
     }
 
     public PrometheusConfig getPrometheus() {

--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/ReferenceConfig.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/ReferenceConfig.java
@@ -442,7 +442,6 @@ public class ReferenceConfig<T> extends ReferenceConfigBase<T> {
         AbstractConfig.appendParameters(map, getModule());
         AbstractConfig.appendParameters(map, consumer);
         AbstractConfig.appendParameters(map, this);
-        appendMetricsCompatible(map);
 
         String hostToRegistry = ConfigUtils.getSystemProperty(DUBBO_IP_TO_REGISTRY);
         if (StringUtils.isEmpty(hostToRegistry)) {

--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/ServiceConfig.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/ServiceConfig.java
@@ -663,7 +663,6 @@ public class ServiceConfig<T> extends ServiceConfigBase<T> {
         AbstractConfig.appendParameters(map, provider);
         AbstractConfig.appendParameters(map, protocolConfig);
         AbstractConfig.appendParameters(map, this);
-        appendMetricsCompatible(map);
 
         // append params with method configs,
         if (CollectionUtils.isNotEmpty(getMethods())) {

--- a/dubbo-config/dubbo-config-spring/src/main/resources/META-INF/dubbo.xsd
+++ b/dubbo-config/dubbo-config-spring/src/main/resources/META-INF/dubbo.xsd
@@ -1103,12 +1103,6 @@
             </xsd:annotation>
         </xsd:attribute>
 
-        <xsd:attribute name="port" type="xsd:string">
-            <xsd:annotation>
-                <xsd:documentation><![CDATA[ Deprecated. No longer use. ]]></xsd:documentation>
-            </xsd:annotation>
-        </xsd:attribute>
-
         <xsd:attribute name="enable-rpc" type="xsd:boolean" default="true">
             <xsd:annotation>
                 <xsd:documentation><![CDATA[ Enable record rpc metrics. ]]></xsd:documentation>


### PR DESCRIPTION
## What is the purpose of the change

Fixes #13684

## Brief changelog

https://github.com/bitgorust/dubbo/commit/d862f166a1cf659734797266b6699846aad8982b
Outdated methods and fields are deleted as discussed in https://github.com/apache/dubbo/issues/13684