### PR TITLE
Dubbo 13743

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/utils/NetUtils.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/utils/NetUtils.java
@@ -388,8 +388,15 @@ public final class NetUtils {
         InetAddress localAddress = getLocalAddressV6();
         if (localAddress != null) {
             return localAddress;
-        } else
+        }
+
+        try {
             return InetAddress.getLocalHost();
+        } catch (Throwable e) {
+            logger.warn(e);
+        }
+
+        return null;
     }
 
     private static Inet6Address getLocalAddress0V6() {

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/utils/NetUtils.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/utils/NetUtils.java
@@ -271,7 +271,8 @@ public final class NetUtils {
             return HOST_ADDRESS;
         }
 
-        return LOCALHOST_VALUE;
+        HOST_ADDRESS = LOCALHOST_VALUE;
+        return HOST_ADDRESS;
     }
 
     public static String getLocalHostV6() {

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/utils/NetUtils.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/utils/NetUtils.java
@@ -365,8 +365,6 @@ public final class NetUtils {
     }
 
     private static InetAddress getLocalAddress0() {
-        InetAddress localAddress = null;
-
         // @since 2.7.6, choose the {@link NetworkInterface} first
         try {
             NetworkInterface networkInterface = findNetworkInterface();
@@ -387,19 +385,11 @@ public final class NetUtils {
             logger.warn(e);
         }
 
-        try {
-            localAddress = InetAddress.getLocalHost();
-            Optional<InetAddress> addressOp = toValidAddress(localAddress);
-            if (addressOp.isPresent()) {
-                return addressOp.get();
-            }
-        } catch (Throwable e) {
-            logger.warn(e);
-        }
-
-        localAddress = getLocalAddressV6();
-
-        return localAddress;
+        InetAddress localAddress = getLocalAddressV6();
+        if (localAddress != null) {
+            return localAddress;
+        } else
+            return InetAddress.getLocalHost();
     }
 
     private static Inet6Address getLocalAddress0V6() {


### PR DESCRIPTION
[issues:13743](https://github.com/apache/dubbo/issues/13743) 修复

## What is the purpose of the change

1、getLocalAddress0() 优先获得IPv4地址，再尝试获得IPv6地址，都获取不到时不再校验getLocalHost的有效性
2、getLocalHost() 只计算一次IP地址，如果getLocalAddress() 返回null， 则用LOCALHOST_VALUE赋值,避免大量的重复计算


