### PR TITLE
Fix ModuleEnvironment#getDynamicGlobalConfiguration

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/config/ModuleEnvironment.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/config/ModuleEnvironment.java
@@ -93,9 +93,6 @@ public class ModuleEnvironment extends Environment implements ModuleExt {
 
     @Override
     public Configuration getDynamicGlobalConfiguration() {
-        if (dynamicConfiguration == null) {
-            return applicationDelegate.getDynamicGlobalConfiguration();
-        }
         if (dynamicGlobalConfiguration == null) {
             if (dynamicConfiguration == null) {
                 if (logger.isWarnEnabled()) {

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/config/ModuleEnvironment.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/config/ModuleEnvironment.java
@@ -29,8 +29,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import static org.apache.dubbo.common.constants.LoggerCodeConstants.COMMON_UNEXPECTED_EXCEPTION;
-
 public class ModuleEnvironment extends Environment implements ModuleExt {
 
     // delegate
@@ -93,17 +91,14 @@ public class ModuleEnvironment extends Environment implements ModuleExt {
 
     @Override
     public Configuration getDynamicGlobalConfiguration() {
+        if (dynamicConfiguration == null) {
+            CompositeConfiguration configuration = new CompositeConfiguration();
+            configuration.addConfiguration(applicationDelegate.getDynamicGlobalConfiguration());
+            configuration.addConfiguration(orderedPropertiesConfiguration);
+            return configuration;
+        }
+
         if (dynamicGlobalConfiguration == null) {
-            if (dynamicConfiguration == null) {
-                if (logger.isWarnEnabled()) {
-                    logger.warn(
-                            COMMON_UNEXPECTED_EXCEPTION,
-                            "",
-                            "",
-                            "dynamicConfiguration is null , return globalConfiguration.");
-                }
-                return getConfiguration();
-            }
             dynamicGlobalConfiguration = new CompositeConfiguration();
             dynamicGlobalConfiguration.addConfiguration(dynamicConfiguration);
             dynamicGlobalConfiguration.addConfiguration(getConfiguration());

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/config/OrderedPropertiesConfigurationTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/config/OrderedPropertiesConfigurationTest.java
@@ -17,6 +17,8 @@
 package org.apache.dubbo.common.config;
 
 import org.apache.dubbo.rpc.model.ApplicationModel;
+import org.apache.dubbo.rpc.model.FrameworkModel;
+import org.apache.dubbo.rpc.model.ModuleModel;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -31,5 +33,19 @@ class OrderedPropertiesConfigurationTest {
         OrderedPropertiesConfiguration configuration = new OrderedPropertiesConfiguration(
                 ApplicationModel.defaultModel().getDefaultModule());
         Assertions.assertEquals("999", configuration.getInternalProperty("testKey"));
+    }
+
+    @Test
+    void testGetPropertyFromOrderedPropertiesConfiguration() {
+        FrameworkModel frameworkModel = new FrameworkModel();
+
+        ApplicationModel applicationModel = frameworkModel.newApplication();
+
+        ModuleModel moduleModel = applicationModel.newModule();
+        ModuleEnvironment moduleEnvironment = moduleModel.modelEnvironment();
+
+        Configuration configuration = moduleEnvironment.getDynamicGlobalConfiguration();
+        // MockOrderedPropertiesProvider2  initProperties
+        Assertions.assertEquals("999", configuration.getString("testKey"));
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

fix ModuleEnvironment#getDynamicGlobalConfiguration ignore  OrderedPropertiesConfiguration when `dynamicConfiguration` is null  

fix issue: https://github.com/apache/dubbo/issues/13782

## Brief changelog

Fix ModuleEnvironment#getDynamicGlobalConfiguration

## Verifying this change


<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [x] Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [x] GitHub Actions works fine on your own branch.
- [x] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
