### PR TITLE
Fix compilation error of YamlCodec in jdk1.8

### DIFF
--- a/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/message/codec/YamlCodec.java
+++ b/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/message/codec/YamlCodec.java
@@ -36,12 +36,13 @@ import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.constructor.Constructor;
 import org.yaml.snakeyaml.representer.Representer;
 
+@SuppressWarnings({"unchecked", "rawtypes"})
 public class YamlCodec implements HttpMessageCodec {
 
     @Override
     public Object decode(InputStream is, Class<?> targetType, Charset charset) throws DecodeException {
         try (InputStreamReader reader = new InputStreamReader(is, charset)) {
-            return createYaml().loadAs(reader, targetType);
+            return createYaml().loadAs(reader, (Class) targetType);
         } catch (Throwable t) {
             throw new DecodeException("Error decoding yaml", t);
         }
@@ -57,7 +58,7 @@ public class YamlCodec implements HttpMessageCodec {
             for (int i = 0; i < len; i++) {
                 if (iterator.hasNext()) {
                     Object result = iterator.next();
-                    Class<?> targetType = targetTypes[i];
+                    Class targetType = targetTypes[i];
                     if (targetType.isInstance(result)) {
                         results[i] = result;
                     } else {


### PR DESCRIPTION
## What is the purpose of the change
Fix compilation error of: no suitable method found for loadAs(String,Class<CAP#1>)
```
[ERROR] dubbo\dubbo-remoting\dubbo-remoting-http12\src\main\java\org\apache\dubbo\remoting\http12\message\codec\YamlCodec.java:[64,41] error: no suitable method found for loadAs(String,Class<CAP#1>)
[ERROR]     method Yaml.<T#1>loadAs(Reader,Class<? super T#1>) is not applicable
[ERROR]       (cannot infer type-variable(s) T#1
[ERROR]         (argument mismatch; String cannot be converted to Reader))
[ERROR]     method Yaml.<T#2>loadAs(String,Class<? super T#2>) is not applicable
[ERROR]       (cannot infer type-variable(s) T#2
[ERROR]         (argument mismatch; Class<CAP#1> cannot be converted to Class<? super T#2>))
[ERROR]     method Yaml.<T#3>loadAs(InputStream,Class<? super T#3>) is not applicable
[ERROR]       (cannot infer type-variable(s) T#3
[ERROR]         (argument mismatch; String cannot be converted to InputStream))
[ERROR]   where T#1,T#2,T#3 are type-variables:
[ERROR]     T#1 extends Object declared in method <T#1>loadAs(Reader,Class<? super T#1>)
[ERROR]     T#2 extends Object declared in method <T#2>loadAs(String,Class<? super T#2>)
[ERROR]     T#3 extends Object declared in method <T#3>loadAs(InputStream,Class<? super T#3>)
[ERROR]   where CAP#1 is a fresh type-variable:
[ERROR]     CAP#1 extends Object from capture of ?
```