### PR TITLE
Fix LengthFieldStreamingDecoder#bytesToInt parse error

### DIFF
--- a/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/message/LengthFieldStreamingDecoder.java
+++ b/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/message/LengthFieldStreamingDecoder.java
@@ -182,7 +182,7 @@ public class LengthFieldStreamingDecoder implements StreamingDecoder {
     }
 
     protected static int bytesToInt(byte[] bytes) {
-        return (bytes[0] << 24) & 0xFF | (bytes[1] << 16) & 0xFF | (bytes[2] << 8) & 0xFF | (bytes[3]) & 0xFF;
+        return ((bytes[0] & 0xFF) << 24) | ((bytes[1] & 0xFF) << 16) | ((bytes[2] & 0xFF) << 8) | (bytes[3]) & 0xFF;
     }
 
     private enum DecodeState {


### PR DESCRIPTION
## What is the purpose of the change
bugfix for  error parsing byte array to int 
fix #13809


## Brief changelog
old byteToInt
```
   protected static int bytesToInt(byte[] bytes) {
        return (bytes[0] << 24) & 0xFF | (bytes[1] << 16) & 0xFF | (bytes[2] << 8) & 0xFF | (bytes[3]) & 0xFF;
    }
```

new byteToInt
```
  protected static int bytesToInt(byte[] bytes) {
        return ((bytes[0] & 0xFF) << 24) | ((bytes[1] & 0xFF) << 16) | ((bytes[2] & 0xFF) << 8) | (bytes[3]) & 0xFF;
    }
```
  

## Verifying this change