### PR TITLE
fix(sec): upgrade org.apache.zookeeper:zookeeper to 3.9.1

### DIFF
--- a/dubbo-dependencies/dubbo-dependencies-zookeeper/pom.xml
+++ b/dubbo-dependencies/dubbo-dependencies-zookeeper/pom.xml
@@ -34,7 +34,7 @@
     <revision>3.2.12-SNAPSHOT</revision>
     <maven_flatten_version>1.6.0</maven_flatten_version>
     <curator_version>4.3.0</curator_version>
-    <zookeeper_version>3.4.14</zookeeper_version>
+    <zookeeper_version>3.9.1</zookeeper_version>
     <spotless-maven-plugin.version>2.43.0</spotless-maven-plugin.version>
     <spotless.action>check</spotless.action>
     <dubbo-shared-resources.version>1.0.0</dubbo-shared-resources.version>

--- a/dubbo-remoting/dubbo-remoting-zookeeper/pom.xml
+++ b/dubbo-remoting/dubbo-remoting-zookeeper/pom.xml
@@ -29,7 +29,7 @@
   <description>The zookeeper remoting module of dubbo project</description>
   <properties>
     <skip_maven_deploy>false</skip_maven_deploy>
-    <zookeeper_version>3.4.14</zookeeper_version>
+    <zookeeper_version>3.9.1</zookeeper_version>
     <curator_version>4.3.0</curator_version>
   </properties>
   <dependencies>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.apache.zookeeper:zookeeper 3.4.14
- [CVE-2023-44981](https://www.oscs1024.com/hd/CVE-2023-44981)


### What did I do？
Upgrade org.apache.zookeeper:zookeeper from 3.4.14 to 3.9.1 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How can we automate the detection of these types of issues?
By using the [GitHub Actions](https://github.com/murphysecurity/actions) configurations provided by murphysec, we can conduct automatic code security checks in our CI pipeline.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS