### PR TITLE
feat: Validator supports automatic switch

### DIFF
--- a/dubbo-filter/dubbo-filter-validation/src/main/java/org/apache/dubbo/validation/Validator.java
+++ b/dubbo-filter/dubbo-filter-validation/src/main/java/org/apache/dubbo/validation/Validator.java
@@ -23,4 +23,6 @@ package org.apache.dubbo.validation;
 public interface Validator {
 
     void validate(String methodName, Class<?>[] parameterTypes, Object[] arguments) throws Exception;
+
+    boolean isSupport();
 }

--- a/dubbo-filter/dubbo-filter-validation/src/main/java/org/apache/dubbo/validation/support/jvalidation/JValidation.java
+++ b/dubbo-filter/dubbo-filter-validation/src/main/java/org/apache/dubbo/validation/support/jvalidation/JValidation.java
@@ -20,6 +20,9 @@ import org.apache.dubbo.common.URL;
 import org.apache.dubbo.validation.Validator;
 import org.apache.dubbo.validation.support.AbstractValidation;
 
+import java.util.Arrays;
+import java.util.List;
+
 /**
  * Creates a new instance of {@link Validator} using input argument url.
  * @see AbstractValidation
@@ -28,12 +31,23 @@ import org.apache.dubbo.validation.support.AbstractValidation;
 public class JValidation extends AbstractValidation {
 
     /**
-     * Return new instance of {@link JValidator}
+     * Return new instance of {@link Validator}
      * @param url Valid URL instance
-     * @return Instance of JValidator
+     * @return Instance of Validator
      */
     @Override
     protected Validator createValidator(URL url) {
-        return new JValidator(url);
+        List<Class<? extends Validator>> validatorList = Arrays.asList(JValidator.class, JValidatorNew.class);
+        for (Class<? extends Validator> instance : validatorList) {
+            try {
+                Validator validator = instance.getConstructor(URL.class).newInstance(url);
+                if (validator.isSupport()) {
+                    return validator;
+                }
+            } catch (Throwable ignore) {
+            }
+        }
+        throw new IllegalArgumentException("Failed to load jakarta.validation.Validation or javax.validation.Validation from env. "
+                + "Please import at least one validator");
     }
 }

--- a/dubbo-filter/dubbo-filter-validation/src/main/java/org/apache/dubbo/validation/support/jvalidation/JValidation.java
+++ b/dubbo-filter/dubbo-filter-validation/src/main/java/org/apache/dubbo/validation/support/jvalidation/JValidation.java
@@ -47,7 +47,8 @@ public class JValidation extends AbstractValidation {
             } catch (Throwable ignore) {
             }
         }
-        throw new IllegalArgumentException("Failed to load jakarta.validation.Validation or javax.validation.Validation from env. "
-                + "Please import at least one validator");
+        throw new IllegalArgumentException(
+                "Failed to load jakarta.validation.Validation or javax.validation.Validation from env. "
+                        + "Please import at least one validator");
     }
 }

--- a/dubbo-filter/dubbo-filter-validation/src/main/java/org/apache/dubbo/validation/support/jvalidation/JValidator.java
+++ b/dubbo-filter/dubbo-filter-validation/src/main/java/org/apache/dubbo/validation/support/jvalidation/JValidator.java
@@ -309,6 +309,16 @@ public class JValidator implements Validator {
         }
     }
 
+    @Override
+    public boolean isSupport() {
+        Class<?> cls = null;
+        try {
+            cls = javax.validation.Validation.class;
+        } catch (Throwable ignore) {
+        }
+        return cls != null;
+    }
+
     private Class<?> methodClass(String methodName) {
         Class<?> methodClass = null;
         String methodClassName = clazz.getName() + "$" + toUpperMethodName(methodName);

--- a/dubbo-filter/dubbo-filter-validation/src/main/java/org/apache/dubbo/validation/support/jvalidation/JValidatorNew.java
+++ b/dubbo-filter/dubbo-filter-validation/src/main/java/org/apache/dubbo/validation/support/jvalidation/JValidatorNew.java
@@ -309,6 +309,16 @@ public class JValidatorNew implements Validator {
         }
     }
 
+    @Override
+    public boolean isSupport() {
+        Class<?> cls = null;
+        try {
+            cls = jakarta.validation.Validation.class;
+        } catch (Throwable ignore) {
+        }
+        return cls != null;
+    }
+
     private Class<?> methodClass(String methodName) {
         Class<?> methodClass = null;
         String methodClassName = clazz.getName() + "$" + toUpperMethodName(methodName);

--- a/dubbo-filter/dubbo-filter-validation/src/main/resources/META-INF/dubbo/internal/org.apache.dubbo.validation.Validation
+++ b/dubbo-filter/dubbo-filter-validation/src/main/resources/META-INF/dubbo/internal/org.apache.dubbo.validation.Validation
@@ -1,2 +1,1 @@
 jvalidation=org.apache.dubbo.validation.support.jvalidation.JValidation
-jvalidationNew=org.apache.dubbo.validation.support.jvalidation.JValidationNew

--- a/dubbo-filter/dubbo-filter-validation/src/test/java/org/apache/dubbo/validation/support/jvalidation/JValidationTest.java
+++ b/dubbo-filter/dubbo-filter-validation/src/test/java/org/apache/dubbo/validation/support/jvalidation/JValidationTest.java
@@ -20,8 +20,6 @@ import org.apache.dubbo.common.URL;
 import org.apache.dubbo.validation.Validation;
 import org.apache.dubbo.validation.Validator;
 
-import javax.validation.ValidationException;
-
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -31,7 +29,7 @@ import static org.hamcrest.core.Is.is;
 class JValidationTest {
     @Test
     void testReturnTypeWithInvalidValidationProvider() {
-        Assertions.assertThrows(ValidationException.class, () -> {
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
             Validation jValidation = new JValidation();
             URL url = URL.valueOf("test://test:11/org.apache.dubbo.validation.support.jvalidation.JValidation?"
                     + "jvalidation=org.apache.dubbo.validation.Validation");


### PR DESCRIPTION
## What is the purpose of the change

In the newer versions of Hibernate-validator, the package names of the relevant validation implementation classes have been migrated from `javax` to `jakarta`.

Dubbo has been support new validator with `jakarta` in #9552 , but the setting of default validator is implement with `javax`, if the user is not configured to use a new validator under the SpringBoot3, an `NoClassDefFoundError` will be throw.

If the validator supports automatic switch, this will reduce a lot of configuration processes for users.

related with #12401 #12465

## Brief changelog


## Verifying this change


<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [ ] GitHub Actions works fine on your own branch.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
