### PR TITLE
Fix Sonar issue s2293 The diamond operator ('<>') should be used

### DIFF
--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/SingleRouterChain.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/SingleRouterChain.java
@@ -212,7 +212,7 @@ public class SingleRouterChain<T> {
     public RouterSnapshotNode<T> buildRouterSnapshot(
             URL url, BitList<Invoker<T>> availableInvokers, Invocation invocation) {
         BitList<Invoker<T>> resultInvokers = availableInvokers.clone();
-        RouterSnapshotNode<T> parentNode = new RouterSnapshotNode<T>("Parent", resultInvokers.clone());
+        RouterSnapshotNode<T> parentNode = new RouterSnapshotNode<>("Parent", resultInvokers.clone());
         parentNode.setNodeOutputInvokers(resultInvokers.clone());
 
         // 1. route state router
@@ -227,7 +227,7 @@ public class SingleRouterChain<T> {
             return parentNode;
         }
 
-        RouterSnapshotNode<T> commonRouterNode = new RouterSnapshotNode<T>("CommonRouter", resultInvokers.clone());
+        RouterSnapshotNode<T> commonRouterNode = new RouterSnapshotNode<>("CommonRouter", resultInvokers.clone());
         parentNode.appendNode(commonRouterNode);
         List<Invoker<T>> commonRouterResult = resultInvokers;
 
@@ -237,7 +237,7 @@ public class SingleRouterChain<T> {
             List<Invoker<T>> inputInvokers = new ArrayList<>(commonRouterResult);
 
             RouterSnapshotNode<T> currentNode =
-                    new RouterSnapshotNode<T>(router.getClass().getSimpleName(), inputInvokers);
+                    new RouterSnapshotNode<>(router.getClass().getSimpleName(), inputInvokers);
 
             // append to router node chain
             commonRouterNode.appendNode(currentNode);

--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/configurator/AbstractConfigurator.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/configurator/AbstractConfigurator.java
@@ -223,7 +223,7 @@ public abstract class AbstractConfigurator implements Configurator {
     }
 
     private Set<String> genConditionKeys() {
-        Set<String> conditionKeys = new HashSet<String>();
+        Set<String> conditionKeys = new HashSet<>();
         conditionKeys.add(CATEGORY_KEY);
         conditionKeys.add(Constants.CHECK_KEY);
         conditionKeys.add(DYNAMIC_KEY);

--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/loadbalance/ConsistentHashLoadBalance.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/loadbalance/ConsistentHashLoadBalance.java
@@ -46,8 +46,7 @@ public class ConsistentHashLoadBalance extends AbstractLoadBalance {
      */
     public static final String HASH_ARGUMENTS = "hash.arguments";
 
-    private final ConcurrentMap<String, ConsistentHashSelector<?>> selectors =
-            new ConcurrentHashMap<>();
+    private final ConcurrentMap<String, ConsistentHashSelector<?>> selectors = new ConcurrentHashMap<>();
 
     @SuppressWarnings("unchecked")
     @Override

--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/loadbalance/ConsistentHashLoadBalance.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/loadbalance/ConsistentHashLoadBalance.java
@@ -47,7 +47,7 @@ public class ConsistentHashLoadBalance extends AbstractLoadBalance {
     public static final String HASH_ARGUMENTS = "hash.arguments";
 
     private final ConcurrentMap<String, ConsistentHashSelector<?>> selectors =
-            new ConcurrentHashMap<String, ConsistentHashSelector<?>>();
+            new ConcurrentHashMap<>();
 
     @SuppressWarnings("unchecked")
     @Override
@@ -75,7 +75,7 @@ public class ConsistentHashLoadBalance extends AbstractLoadBalance {
         private final int[] argumentIndex;
 
         ConsistentHashSelector(List<Invoker<T>> invokers, String methodName, int identityHashCode) {
-            this.virtualInvokers = new TreeMap<Long, Invoker<T>>();
+            this.virtualInvokers = new TreeMap<>();
             this.identityHashCode = identityHashCode;
             URL url = invokers.get(0).getUrl();
             this.replicaNumber = url.getMethodParameter(methodName, HASH_NODES, 160);

--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/merger/MapMerger.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/merger/MapMerger.java
@@ -32,7 +32,7 @@ public class MapMerger implements Merger<Map<?, ?>> {
         if (ArrayUtils.isEmpty(items)) {
             return Collections.emptyMap();
         }
-        Map<Object, Object> result = new HashMap<Object, Object>();
+        Map<Object, Object> result = new HashMap<>();
         Stream.of(items).filter(Objects::nonNull).forEach(result::putAll);
         return result;
     }

--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/merger/MergerFactory.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/merger/MergerFactory.java
@@ -36,7 +36,7 @@ public class MergerFactory implements ScopeModelAware {
 
     private static final ErrorTypeAwareLogger logger = LoggerFactory.getErrorTypeAwareLogger(MergerFactory.class);
 
-    private ConcurrentMap<Class<?>, Merger<?>> MERGER_CACHE = new ConcurrentHashMap<Class<?>, Merger<?>>();
+    private ConcurrentMap<Class<?>, Merger<?>> MERGER_CACHE = new ConcurrentHashMap<>();
     private ScopeModel scopeModel;
 
     @Override

--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/merger/SetMerger.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/merger/SetMerger.java
@@ -32,7 +32,7 @@ public class SetMerger implements Merger<Set<?>> {
         if (ArrayUtils.isEmpty(items)) {
             return Collections.emptySet();
         }
-        Set<Object> result = new HashSet<Object>();
+        Set<Object> result = new HashSet<>();
         Stream.of(items).filter(Objects::nonNull).forEach(result::addAll);
         return result;
     }

--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/router/condition/ConditionStateRouterFactory.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/router/condition/ConditionStateRouterFactory.java
@@ -30,6 +30,6 @@ public class ConditionStateRouterFactory extends CacheableStateRouterFactory {
 
     @Override
     protected <T> StateRouter<T> createRouter(Class<T> interfaceClass, URL url) {
-        return new ConditionStateRouter<T>(url);
+        return new ConditionStateRouter<>(url);
     }
 }

--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/router/condition/config/ServiceStateRouterFactory.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/router/condition/config/ServiceStateRouterFactory.java
@@ -32,6 +32,6 @@ public class ServiceStateRouterFactory extends CacheableStateRouterFactory {
 
     @Override
     protected <T> StateRouter<T> createRouter(Class<T> interfaceClass, URL url) {
-        return new ServiceStateRouter<T>(url);
+        return new ServiceStateRouter<>(url);
     }
 }

--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/router/mesh/route/MeshRuleCache.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/router/mesh/route/MeshRuleCache.java
@@ -136,7 +136,7 @@ public class MeshRuleCache<T> {
                     Collections.unmodifiableMap(totalSubsetMap),
                     unmatchedInvokers);
         } else {
-            return new MeshRuleCache<T>(
+            return new MeshRuleCache<>(
                     Collections.emptyList(), Collections.emptyMap(), Collections.emptyMap(), invokers);
         }
     }

--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/router/mock/MockStateRouterFactory.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/router/mock/MockStateRouterFactory.java
@@ -30,6 +30,6 @@ public class MockStateRouterFactory implements StateRouterFactory {
 
     @Override
     public <T> StateRouter<T> getRouter(Class<T> interfaceClass, URL url) {
-        return new MockInvokersSelector<T>(url);
+        return new MockInvokersSelector<>(url);
     }
 }

--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/router/tag/TagStateRouterFactory.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/router/tag/TagStateRouterFactory.java
@@ -31,6 +31,6 @@ public class TagStateRouterFactory extends CacheableStateRouterFactory {
 
     @Override
     protected <T> StateRouter<T> createRouter(Class<T> interfaceClass, URL url) {
-        return new TagStateRouter<T>(url);
+        return new TagStateRouter<>(url);
     }
 }

--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/support/FailoverClusterInvoker.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/support/FailoverClusterInvoker.java
@@ -63,8 +63,8 @@ public class FailoverClusterInvoker<T> extends AbstractClusterInvoker<T> {
         int len = calculateInvokeTimes(methodName);
         // retry loop.
         RpcException le = null; // last exception.
-        List<Invoker<T>> invoked = new ArrayList<Invoker<T>>(copyInvokers.size()); // invoked invokers.
-        Set<String> providers = new HashSet<String>(len);
+        List<Invoker<T>> invoked = new ArrayList<>(copyInvokers.size()); // invoked invokers.
+        Set<String> providers = new HashSet<>(len);
         for (int i = 0; i < len; i++) {
             // Reselect before retry to avoid a change of candidate `invokers`.
             // NOTE: if `invokers` changed, then `invoked` also lose accuracy.

--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/support/MergeableCluster.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/support/MergeableCluster.java
@@ -26,6 +26,6 @@ public class MergeableCluster extends AbstractCluster {
 
     @Override
     public <T> AbstractClusterInvoker<T> doJoin(Directory<T> directory) throws RpcException {
-        return new MergeableClusterInvoker<T>(directory);
+        return new MergeableClusterInvoker<>(directory);
     }
 }

--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/support/registry/ZoneAwareCluster.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/support/registry/ZoneAwareCluster.java
@@ -27,6 +27,6 @@ public class ZoneAwareCluster extends AbstractCluster {
 
     @Override
     protected <T> AbstractClusterInvoker<T> doJoin(Directory<T> directory) throws RpcException {
-        return new ZoneAwareClusterInvoker<T>(directory);
+        return new ZoneAwareClusterInvoker<>(directory);
     }
 }

--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/support/wrapper/MockClusterWrapper.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/support/wrapper/MockClusterWrapper.java
@@ -35,7 +35,7 @@ public class MockClusterWrapper implements Cluster {
 
     @Override
     public <T> Invoker<T> join(Directory<T> directory, boolean buildFilterChain) throws RpcException {
-        return new MockClusterInvoker<T>(directory, this.cluster.join(directory, buildFilterChain));
+        return new MockClusterInvoker<>(directory, this.cluster.join(directory, buildFilterChain));
     }
 
     public Cluster getCluster() {

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/Version.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/Version.java
@@ -60,7 +60,7 @@ public final class Version {
     public static final int LOWEST_VERSION_FOR_RESPONSE_ATTACHMENT = 2000200; // 2.0.2
 
     public static final int HIGHEST_PROTOCOL_VERSION = 2009900; // 2.0.99
-    private static final Map<String, Integer> VERSION2INT = new HashMap<String, Integer>();
+    private static final Map<String, Integer> VERSION2INT = new HashMap<>();
 
     static {
         // get dubbo version and last commit id

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/beanutil/JavaBeanSerializeUtil.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/beanutil/JavaBeanSerializeUtil.java
@@ -35,7 +35,7 @@ import java.util.Map;
 public final class JavaBeanSerializeUtil {
 
     private static final Logger logger = LoggerFactory.getLogger(JavaBeanSerializeUtil.class);
-    private static final Map<String, Class<?>> TYPES = new HashMap<String, Class<?>>();
+    private static final Map<String, Class<?>> TYPES = new HashMap<>();
     private static final String ARRAY_PREFIX = "[";
     private static final String REFERENCE_TYPE_PREFIX = "L";
     private static final String REFERENCE_TYPE_SUFFIX = ";";
@@ -72,7 +72,7 @@ public final class JavaBeanSerializeUtil {
         if (obj instanceof JavaBeanDescriptor) {
             return (JavaBeanDescriptor) obj;
         }
-        IdentityHashMap<Object, JavaBeanDescriptor> cache = new IdentityHashMap<Object, JavaBeanDescriptor>();
+        IdentityHashMap<Object, JavaBeanDescriptor> cache = new IdentityHashMap<>();
         return createDescriptorIfAbsent(obj, accessor, cache);
     }
 
@@ -209,7 +209,7 @@ public final class JavaBeanSerializeUtil {
         if (beanDescriptor == null) {
             return null;
         }
-        IdentityHashMap<JavaBeanDescriptor, Object> cache = new IdentityHashMap<JavaBeanDescriptor, Object>();
+        IdentityHashMap<JavaBeanDescriptor, Object> cache = new IdentityHashMap<>();
         Object result = instantiateForDeserialize(beanDescriptor, loader, cache);
         deserializeInternal(result, beanDescriptor, loader, cache);
         return result;

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/bytecode/Mixin.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/bytecode/Mixin.java
@@ -120,7 +120,7 @@ public abstract class Mixin {
 
             Class<?> neighbor = null;
             // impl methods.
-            Set<String> worked = new HashSet<String>();
+            Set<String> worked = new HashSet<>();
             for (int i = 0; i < ics.length; i++) {
                 if (!Modifier.isPublic(ics[i].getModifiers())) {
                     String npkg = ics[i].getPackage().getName();

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/bytecode/Wrapper.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/bytecode/Wrapper.java
@@ -42,7 +42,8 @@ import javassist.CtMethod;
  * Wrapper.
  */
 public abstract class Wrapper {
-    private static final ConcurrentMap<Class<?>, Wrapper> WRAPPER_MAP = new ConcurrentHashMap<>(); // class wrapper map
+    // class wrapper map
+    private static final ConcurrentMap<Class<?>, Wrapper> WRAPPER_MAP = new ConcurrentHashMap<>();
     private static final String[] EMPTY_STRING_ARRAY = new String[0];
     private static final String[] OBJECT_METHODS = new String[] {"getClass", "hashCode", "toString", "equals"};
     private static final Wrapper OBJECT_WRAPPER = new Wrapper() {

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/bytecode/Wrapper.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/bytecode/Wrapper.java
@@ -42,8 +42,7 @@ import javassist.CtMethod;
  * Wrapper.
  */
 public abstract class Wrapper {
-    private static final ConcurrentMap<Class<?>, Wrapper> WRAPPER_MAP =
-            new ConcurrentHashMap<>(); // class wrapper map
+    private static final ConcurrentMap<Class<?>, Wrapper> WRAPPER_MAP = new ConcurrentHashMap<>(); // class wrapper map
     private static final String[] EMPTY_STRING_ARRAY = new String[0];
     private static final String[] OBJECT_METHODS = new String[] {"getClass", "hashCode", "toString", "equals"};
     private static final Wrapper OBJECT_WRAPPER = new Wrapper() {

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/bytecode/Wrapper.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/bytecode/Wrapper.java
@@ -43,7 +43,7 @@ import javassist.CtMethod;
  */
 public abstract class Wrapper {
     private static final ConcurrentMap<Class<?>, Wrapper> WRAPPER_MAP =
-            new ConcurrentHashMap<Class<?>, Wrapper>(); // class wrapper map
+            new ConcurrentHashMap<>(); // class wrapper map
     private static final String[] EMPTY_STRING_ARRAY = new String[0];
     private static final String[] OBJECT_METHODS = new String[] {"getClass", "hashCode", "toString", "equals"};
     private static final Wrapper OBJECT_WRAPPER = new Wrapper() {

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/compiler/support/ClassUtils.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/compiler/support/ClassUtils.java
@@ -392,7 +392,7 @@ public class ClassUtils {
     }
 
     public static <K, V> Map<K, V> toMap(Map.Entry<K, V>[] entries) {
-        Map<K, V> map = new HashMap<K, V>();
+        Map<K, V> map = new HashMap<>();
         if (entries != null && entries.length > 0) {
             for (Map.Entry<K, V> entry : entries) {
                 map.put(entry.getKey(), entry.getValue());

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/threadlocal/InternalThreadLocalMap.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/threadlocal/InternalThreadLocalMap.java
@@ -28,7 +28,7 @@ public final class InternalThreadLocalMap {
 
     private Object[] indexedVariables;
 
-    private static ThreadLocal<InternalThreadLocalMap> slowThreadLocalMap = new ThreadLocal<InternalThreadLocalMap>();
+    private static ThreadLocal<InternalThreadLocalMap> slowThreadLocalMap = new ThreadLocal<>();
 
     private static final AtomicInteger NEXT_INDEX = new AtomicInteger();
 

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/timer/HashedWheelTimer.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/timer/HashedWheelTimer.java
@@ -427,7 +427,7 @@ public class HashedWheelTimer implements Timer {
     }
 
     private final class Worker implements Runnable {
-        private final Set<Timeout> unprocessedTimeouts = new HashSet<Timeout>();
+        private final Set<Timeout> unprocessedTimeouts = new HashSet<>();
 
         private long tick;
 

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/utils/CIDRUtils.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/utils/CIDRUtils.java
@@ -98,7 +98,7 @@ public class CIDRUtils {
 
     private byte[] toBytes(byte[] array, int targetSize) {
         int counter = 0;
-        List<Byte> newArr = new ArrayList<Byte>();
+        List<Byte> newArr = new ArrayList<>();
         while (counter < targetSize && (array.length - 1 - counter >= 0)) {
             newArr.add(0, array[array.length - 1 - counter]);
             counter++;

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/utils/ConfigUtils.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/utils/ConfigUtils.java
@@ -87,7 +87,7 @@ public class ConfigUtils {
      */
     public static List<String> mergeValues(
             ExtensionDirector extensionDirector, Class<?> type, String cfg, List<String> def) {
-        List<String> defaults = new ArrayList<String>();
+        List<String> defaults = new ArrayList<>();
         if (def != null) {
             for (String name : def) {
                 if (extensionDirector.getExtensionLoader(type).hasExtension(name)) {
@@ -96,7 +96,7 @@ public class ConfigUtils {
             }
         }
 
-        List<String> names = new ArrayList<String>();
+        List<String> names = new ArrayList<>();
 
         // add initial values
         String[] configs = (cfg == null || cfg.trim().length() == 0) ? new String[0] : COMMA_SPLIT_PATTERN.split(cfg);

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/utils/IOUtils.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/utils/IOUtils.java
@@ -179,7 +179,7 @@ public class IOUtils {
      * @throws IOException If an I/O error occurs
      */
     public static String[] readLines(InputStream is) throws IOException {
-        List<String> lines = new ArrayList<String>();
+        List<String> lines = new ArrayList<>();
         try (BufferedReader reader = new BufferedReader(new InputStreamReader(is))) {
             String line;
             while ((line = reader.readLine()) != null) {

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/utils/Stack.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/utils/Stack.java
@@ -26,7 +26,7 @@ import java.util.List;
 public class Stack<E> {
     private int mSize = 0;
 
-    private final List<E> mElements = new ArrayList<E>();
+    private final List<E> mElements = new ArrayList<>();
 
     public Stack() {}
 

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/utils/StringUtils.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/utils/StringUtils.java
@@ -861,7 +861,7 @@ public final class StringUtils {
      */
     private static Map<String, String> parseKeyValuePair(String str, String itemSeparator) {
         String[] tmp = str.split(itemSeparator);
-        Map<String, String> map = new HashMap<String, String>(tmp.length);
+        Map<String, String> map = new HashMap<>(tmp.length);
         for (int i = 0; i < tmp.length; i++) {
             Matcher matcher = KVP_PATTERN.matcher(tmp[i]);
             if (!matcher.matches()) {
@@ -885,7 +885,7 @@ public final class StringUtils {
      */
     public static Map<String, String> parseQueryString(String qs) {
         if (isEmpty(qs)) {
-            return new HashMap<String, String>();
+            return new HashMap<>();
         }
         return parseKeyValuePair(qs, "\\&");
     }

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/utils/UrlUtils.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/utils/UrlUtils.java
@@ -181,7 +181,7 @@ public class UrlUtils {
             throw new IllegalArgumentException(
                     "Addresses is not allowed to be empty, please re-enter."); // here won't be empty
         }
-        List<URL> registries = new ArrayList<URL>();
+        List<URL> registries = new ArrayList<>();
         for (String addr : addresses) {
             registries.add(parseURL(addr, defaults));
         }

--- a/dubbo-common/src/main/java/org/apache/dubbo/config/AbstractInterfaceConfig.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/config/AbstractInterfaceConfig.java
@@ -204,7 +204,7 @@ public abstract class AbstractInterfaceConfig extends AbstractMethodConfig {
     /**
      * The url of the reference service
      */
-    protected final transient List<URL> urls = new ArrayList<URL>();
+    protected final transient List<URL> urls = new ArrayList<>();
 
     @Transient
     public List<URL> getExportedUrls() {

--- a/dubbo-common/src/main/java/org/apache/dubbo/config/ApplicationConfig.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/config/ApplicationConfig.java
@@ -361,7 +361,7 @@ public class ApplicationConfig extends AbstractConfig {
     }
 
     public void setRegistry(RegistryConfig registry) {
-        List<RegistryConfig> registries = new ArrayList<RegistryConfig>(1);
+        List<RegistryConfig> registries = new ArrayList<>(1);
         registries.add(registry);
         this.registries = registries;
     }

--- a/dubbo-common/src/main/java/org/apache/dubbo/config/ModuleConfig.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/config/ModuleConfig.java
@@ -186,7 +186,7 @@ public class ModuleConfig extends AbstractConfig {
     }
 
     public void setRegistry(RegistryConfig registry) {
-        List<RegistryConfig> registries = new ArrayList<RegistryConfig>(1);
+        List<RegistryConfig> registries = new ArrayList<>(1);
         registries.add(registry);
         this.registries = registries;
     }

--- a/dubbo-common/src/main/java/org/apache/dubbo/metadata/definition/util/ClassUtils.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/metadata/definition/util/ClassUtils.java
@@ -96,7 +96,7 @@ public final class ClassUtils {
      * @return methods list
      */
     public static List<Method> getPublicNonStaticMethods(final Class<?> clazz) {
-        List<Method> result = new ArrayList<Method>();
+        List<Method> result = new ArrayList<>();
 
         Method[] methods = clazz.getMethods();
         for (Method method : methods) {

--- a/dubbo-common/src/main/java/org/apache/dubbo/rpc/model/ProviderModel.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/rpc/model/ProviderModel.java
@@ -135,7 +135,7 @@ public class ProviderModel extends ServiceModel {
     }
 
     public List<ProviderMethodModel> getAllMethodModels() {
-        List<ProviderMethodModel> result = new ArrayList<ProviderMethodModel>();
+        List<ProviderMethodModel> result = new ArrayList<>();
         for (List<ProviderMethodModel> models : methods.values()) {
             result.addAll(models);
         }

--- a/dubbo-compatible/src/main/java/com/alibaba/dubbo/cache/support/AbstractCacheFactory.java
+++ b/dubbo-compatible/src/main/java/com/alibaba/dubbo/cache/support/AbstractCacheFactory.java
@@ -30,7 +30,7 @@ import static org.apache.dubbo.common.constants.CommonConstants.METHOD_KEY;
 @Deprecated
 public abstract class AbstractCacheFactory implements CacheFactory {
 
-    private final ConcurrentMap<String, Cache> caches = new ConcurrentHashMap<String, Cache>();
+    private final ConcurrentMap<String, Cache> caches = new ConcurrentHashMap<>();
 
     @Override
     public Cache getCache(URL url, Invocation invocation) {

--- a/dubbo-compatible/src/main/java/com/alibaba/dubbo/config/ServiceConfig.java
+++ b/dubbo-compatible/src/main/java/com/alibaba/dubbo/config/ServiceConfig.java
@@ -86,7 +86,7 @@ public class ServiceConfig<T> extends org.apache.dubbo.config.ServiceConfig<T> {
         if (providers == null || providers.isEmpty()) {
             return null;
         }
-        List<ProtocolConfig> protocols = new ArrayList<ProtocolConfig>(providers.size());
+        List<ProtocolConfig> protocols = new ArrayList<>(providers.size());
         for (ProviderConfig provider : providers) {
             protocols.add(convertProviderToProtocol(provider));
         }

--- a/dubbo-compatible/src/main/java/com/alibaba/dubbo/container/page/Page.java
+++ b/dubbo-compatible/src/main/java/com/alibaba/dubbo/container/page/Page.java
@@ -57,8 +57,8 @@ public class Page {
     }
 
     private static List<List<String>> stringToList(String str) {
-        List<List<String>> rows = new ArrayList<List<String>>();
-        List<String> row = new ArrayList<String>();
+        List<List<String>> rows = new ArrayList<>();
+        List<String> row = new ArrayList<>();
         row.add(str);
         rows.add(row);
         return rows;

--- a/dubbo-compatible/src/main/java/com/alibaba/dubbo/container/page/PageServlet.java
+++ b/dubbo-compatible/src/main/java/com/alibaba/dubbo/container/page/PageServlet.java
@@ -49,8 +49,8 @@ public class PageServlet extends HttpServlet {
     private static final long serialVersionUID = -8370312705453328501L;
     private static PageServlet INSTANCE;
     protected final Random random = new Random();
-    protected final Map<String, PageHandler> pages = new ConcurrentHashMap<String, PageHandler>();
-    protected final List<PageHandler> menus = new ArrayList<PageHandler>();
+    protected final Map<String, PageHandler> pages = new ConcurrentHashMap<>();
+    protected final List<PageHandler> menus = new ArrayList<>();
 
     public static PageServlet getInstance() {
         return INSTANCE;

--- a/dubbo-compatible/src/main/java/com/alibaba/dubbo/container/page/ResourceFilter.java
+++ b/dubbo-compatible/src/main/java/com/alibaba/dubbo/container/page/ResourceFilter.java
@@ -46,7 +46,7 @@ public class ResourceFilter implements Filter {
 
     private final long start = System.currentTimeMillis();
 
-    private final List<String> resources = new ArrayList<String>();
+    private final List<String> resources = new ArrayList<>();
 
     public void init(FilterConfig filterConfig) throws ServletException {
         String config = filterConfig.getInitParameter("resources");

--- a/dubbo-compatible/src/main/java/com/alibaba/dubbo/container/page/pages/HomePageHandler.java
+++ b/dubbo-compatible/src/main/java/com/alibaba/dubbo/container/page/pages/HomePageHandler.java
@@ -35,11 +35,11 @@ public class HomePageHandler implements PageHandler {
 
     @Override
     public Page handle(URL url) {
-        List<List<String>> rows = new ArrayList<List<String>>();
+        List<List<String>> rows = new ArrayList<>();
         for (PageHandler handler : PageServlet.getInstance().getMenus()) {
             String uri = ExtensionLoader.getExtensionLoader(PageHandler.class).getExtensionName(handler);
             Menu menu = handler.getClass().getAnnotation(Menu.class);
-            List<String> row = new ArrayList<String>();
+            List<String> row = new ArrayList<>();
             row.add("<a href=\"" + uri + ".html\">" + menu.name() + "</a>");
             row.add(menu.desc());
             rows.add(row);

--- a/dubbo-compatible/src/main/java/com/alibaba/dubbo/container/page/pages/LogPageHandler.java
+++ b/dubbo-compatible/src/main/java/com/alibaba/dubbo/container/page/pages/LogPageHandler.java
@@ -97,8 +97,8 @@ public class LogPageHandler implements PageHandler {
             }
         }
         Level level = LogManager.getRootLogger().getLevel();
-        List<List<String>> rows = new ArrayList<List<String>>();
-        List<String> row = new ArrayList<String>();
+        List<List<String>> rows = new ArrayList<>();
+        List<String> row = new ArrayList<>();
         row.add(content);
         rows.add(row);
         return new Page(

--- a/dubbo-compatible/src/main/java/com/alibaba/dubbo/container/page/pages/StatusPageHandler.java
+++ b/dubbo-compatible/src/main/java/com/alibaba/dubbo/container/page/pages/StatusPageHandler.java
@@ -40,14 +40,14 @@ public class StatusPageHandler implements PageHandler {
 
     @Override
     public Page handle(URL url) {
-        List<List<String>> rows = new ArrayList<List<String>>();
+        List<List<String>> rows = new ArrayList<>();
         Set<String> names =
                 ExtensionLoader.getExtensionLoader(StatusChecker.class).getSupportedExtensions();
-        Map<String, Status> statuses = new HashMap<String, Status>();
+        Map<String, Status> statuses = new HashMap<>();
         for (String name : names) {
             StatusChecker checker =
                     ExtensionLoader.getExtensionLoader(StatusChecker.class).getExtension(name);
-            List<String> row = new ArrayList<String>();
+            List<String> row = new ArrayList<>();
             row.add(name);
             Status status = checker.check();
             if (status != null && !Status.Level.UNKNOWN.equals(status.getLevel())) {
@@ -61,7 +61,7 @@ public class StatusPageHandler implements PageHandler {
         if ("status".equals(url.getPath())) {
             return new Page("", "", "", status.getLevel().toString());
         } else {
-            List<String> row = new ArrayList<String>();
+            List<String> row = new ArrayList<>();
             row.add("summary");
             row.add(getLevelHtml(status.getLevel()));
             row.add("<a href=\"/status\" target=\"_blank\">summary</a>");

--- a/dubbo-compatible/src/main/java/com/alibaba/dubbo/container/page/pages/SystemPageHandler.java
+++ b/dubbo-compatible/src/main/java/com/alibaba/dubbo/container/page/pages/SystemPageHandler.java
@@ -44,49 +44,49 @@ public class SystemPageHandler implements PageHandler {
 
     @Override
     public Page handle(URL url) {
-        List<List<String>> rows = new ArrayList<List<String>>();
+        List<List<String>> rows = new ArrayList<>();
         List<String> row;
 
-        row = new ArrayList<String>();
+        row = new ArrayList<>();
         row.add("Version");
         row.add(Version.getVersion(SystemPageHandler.class, "2.0.0"));
         rows.add(row);
 
-        row = new ArrayList<String>();
+        row = new ArrayList<>();
         row.add("Host");
         String address = NetUtils.getLocalHost();
         row.add(NetUtils.getHostName(address) + "/" + address);
         rows.add(row);
 
-        row = new ArrayList<String>();
+        row = new ArrayList<>();
         row.add("OS");
         row.add(System.getProperty("os.name") + " " + System.getProperty("os.version"));
         rows.add(row);
 
-        row = new ArrayList<String>();
+        row = new ArrayList<>();
         row.add("JVM");
         row.add(System.getProperty("java.runtime.name") + " " + System.getProperty("java.runtime.version") + ",<br/>"
                 + System.getProperty("java.vm.name") + " " + System.getProperty("java.vm.version") + " "
                 + System.getProperty("java.vm.info", ""));
         rows.add(row);
 
-        row = new ArrayList<String>();
+        row = new ArrayList<>();
         row.add("CPU");
         row.add(System.getProperty("os.arch", "") + ", "
                 + String.valueOf(Runtime.getRuntime().availableProcessors()) + " cores");
         rows.add(row);
 
-        row = new ArrayList<String>();
+        row = new ArrayList<>();
         row.add("Locale");
         row.add(Locale.getDefault().toString() + "/" + System.getProperty("file.encoding"));
         rows.add(row);
 
-        row = new ArrayList<String>();
+        row = new ArrayList<>();
         row.add("Uptime");
         row.add(formatUptime(ManagementFactory.getRuntimeMXBean().getUptime()));
         rows.add(row);
 
-        row = new ArrayList<String>();
+        row = new ArrayList<>();
         row.add("Time");
         row.add(new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS Z").format(new Date()));
         rows.add(row);

--- a/dubbo-compatible/src/main/java/com/alibaba/dubbo/rpc/RpcContext.java
+++ b/dubbo-compatible/src/main/java/com/alibaba/dubbo/rpc/RpcContext.java
@@ -353,7 +353,7 @@ public class RpcContext {
                 final T o = callable.call();
                 // local invoke will return directly
                 if (o != null) {
-                    FutureTask<T> f = new FutureTask<T>(new Callable<T>() {
+                    FutureTask<T> f = new FutureTask<>(new Callable<T>() {
                         @Override
                         public T call() throws Exception {
                             return o;

--- a/dubbo-compatible/src/main/java/com/alibaba/dubbo/rpc/RpcInvocation.java
+++ b/dubbo-compatible/src/main/java/com/alibaba/dubbo/rpc/RpcInvocation.java
@@ -162,14 +162,14 @@ public class RpcInvocation implements Invocation, Serializable {
 
     public void setAttachment(String key, String value) {
         if (attachments == null) {
-            attachments = new HashMap<String, String>();
+            attachments = new HashMap<>();
         }
         attachments.put(key, value);
     }
 
     public void setAttachmentIfAbsent(String key, String value) {
         if (attachments == null) {
-            attachments = new HashMap<String, String>();
+            attachments = new HashMap<>();
         }
         if (!attachments.containsKey(key)) {
             attachments.put(key, value);
@@ -181,7 +181,7 @@ public class RpcInvocation implements Invocation, Serializable {
             return;
         }
         if (this.attachments == null) {
-            this.attachments = new HashMap<String, String>();
+            this.attachments = new HashMap<>();
         }
         this.attachments.putAll(attachments);
     }

--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/ServiceConfig.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/ServiceConfig.java
@@ -128,7 +128,7 @@ public class ServiceConfig<T> extends ServiceConfigBase<T> {
     /**
      * A random port cache, the different protocols who have no port specified have different random port
      */
-    private static final Map<String, Integer> RANDOM_PORT_MAP = new HashMap<String, Integer>();
+    private static final Map<String, Integer> RANDOM_PORT_MAP = new HashMap<>();
 
     private Protocol protocolSPI;
 
@@ -651,7 +651,7 @@ public class ServiceConfig<T> extends ServiceConfigBase<T> {
 
     private Map<String, String> buildAttributes(ProtocolConfig protocolConfig) {
 
-        Map<String, String> map = new HashMap<String, String>();
+        Map<String, String> map = new HashMap<>();
         map.put(SIDE_KEY, PROVIDER_SIDE);
 
         // append params with basic configs,

--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/utils/ConfigValidationUtils.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/utils/ConfigValidationUtils.java
@@ -209,7 +209,7 @@ public class ConfigValidationUtils {
                     address = ANYHOST_VALUE;
                 }
                 if (!RegistryConfig.NO_AVAILABLE.equalsIgnoreCase(address)) {
-                    Map<String, String> map = new HashMap<String, String>();
+                    Map<String, String> map = new HashMap<>();
                     AbstractConfig.appendParameters(map, application);
                     AbstractConfig.appendParameters(map, config);
                     map.put(PATH_KEY, RegistryService.class.getName());
@@ -309,7 +309,7 @@ public class ConfigValidationUtils {
     }
 
     public static URL loadMonitor(AbstractInterfaceConfig interfaceConfig, URL registryURL) {
-        Map<String, String> map = new HashMap<String, String>();
+        Map<String, String> map = new HashMap<>();
         map.put(INTERFACE_KEY, MonitorService.class.getName());
         AbstractInterfaceConfig.appendRuntimeParameters(map);
         // set ip

--- a/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/beans/factory/annotation/AbstractAnnotationBeanPostProcessor.java
+++ b/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/beans/factory/annotation/AbstractAnnotationBeanPostProcessor.java
@@ -79,7 +79,7 @@ public abstract class AbstractAnnotationBeanPostProcessor
 
     private final ConcurrentMap<String, AbstractAnnotationBeanPostProcessor.AnnotatedInjectionMetadata>
             injectionMetadataCache = new ConcurrentHashMap<
-                    String, AbstractAnnotationBeanPostProcessor.AnnotatedInjectionMetadata>(CACHE_SIZE);
+            >(CACHE_SIZE);
 
     private ConfigurableListableBeanFactory beanFactory;
 
@@ -98,7 +98,7 @@ public abstract class AbstractAnnotationBeanPostProcessor
     }
 
     private static <T> Collection<T> combine(Collection<? extends T>... elements) {
-        List<T> allElements = new ArrayList<T>();
+        List<T> allElements = new ArrayList<>();
         for (Collection<? extends T> e : elements) {
             allElements.addAll(e);
         }

--- a/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/beans/factory/annotation/AbstractAnnotationBeanPostProcessor.java
+++ b/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/beans/factory/annotation/AbstractAnnotationBeanPostProcessor.java
@@ -78,8 +78,7 @@ public abstract class AbstractAnnotationBeanPostProcessor
     private final Class<? extends Annotation>[] annotationTypes;
 
     private final ConcurrentMap<String, AbstractAnnotationBeanPostProcessor.AnnotatedInjectionMetadata>
-            injectionMetadataCache = new ConcurrentHashMap<
-            >(CACHE_SIZE);
+            injectionMetadataCache = new ConcurrentHashMap<>(CACHE_SIZE);
 
     private ConfigurableListableBeanFactory beanFactory;
 

--- a/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/util/AnnotationUtils.java
+++ b/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/util/AnnotationUtils.java
@@ -87,7 +87,7 @@ public abstract class AnnotationUtils {
 
         Set<String> ignoreAttributeNamesSet = new HashSet<>(Arrays.asList(ignoreAttributeNames));
 
-        Map<String, Object> actualAttributes = new LinkedHashMap<String, Object>();
+        Map<String, Object> actualAttributes = new LinkedHashMap<>();
 
         for (Map.Entry<String, Object> annotationAttribute : annotationAttributes.entrySet()) {
 
@@ -143,7 +143,7 @@ public abstract class AnnotationUtils {
 
         if (ignoreDefaultValue && !isEmpty(annotationAttributes)) {
 
-            List<String> attributeNamesToIgnore = new LinkedList<String>(asList(ignoreAttributeNames));
+            List<String> attributeNamesToIgnore = new LinkedList<>(asList(ignoreAttributeNames));
 
             for (Map.Entry<String, Object> annotationAttribute : annotationAttributes.entrySet()) {
                 String attributeName = annotationAttribute.getKey();

--- a/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/util/PropertySourcesUtils.java
+++ b/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/util/PropertySourcesUtils.java
@@ -103,7 +103,7 @@ public abstract class PropertySourcesUtils {
     public static Map<String, Object> getSubProperties(
             PropertySources propertySources, PropertyResolver propertyResolver, String prefix) {
 
-        Map<String, Object> subProperties = new LinkedHashMap<String, Object>();
+        Map<String, Object> subProperties = new LinkedHashMap<>();
 
         String normalizedPrefix = normalizePrefix(prefix);
 

--- a/dubbo-container/dubbo-container-api/src/main/java/org/apache/dubbo/container/Main.java
+++ b/dubbo-container/dubbo-container-api/src/main/java/org/apache/dubbo/container/Main.java
@@ -60,7 +60,7 @@ public class Main {
                 args = COMMA_SPLIT_PATTERN.split(config);
             }
 
-            final List<Container> containers = new ArrayList<Container>();
+            final List<Container> containers = new ArrayList<>();
             for (int i = 0; i < args.length; i++) {
                 containers.add(LOADER.getExtension(args[i]));
             }

--- a/dubbo-filter/dubbo-filter-cache/src/main/java/org/apache/dubbo/cache/support/AbstractCacheFactory.java
+++ b/dubbo-filter/dubbo-filter-cache/src/main/java/org/apache/dubbo/cache/support/AbstractCacheFactory.java
@@ -42,7 +42,7 @@ public abstract class AbstractCacheFactory implements CacheFactory {
     /**
      * This is used to store factory level-1 cached data.
      */
-    private final ConcurrentMap<String, Cache> caches = new ConcurrentHashMap<String, Cache>();
+    private final ConcurrentMap<String, Cache> caches = new ConcurrentHashMap<>();
 
     private final Object MONITOR = new Object();
 

--- a/dubbo-filter/dubbo-filter-cache/src/main/java/org/apache/dubbo/cache/support/expiring/ExpiringMap.java
+++ b/dubbo-filter/dubbo-filter-cache/src/main/java/org/apache/dubbo/cache/support/expiring/ExpiringMap.java
@@ -158,7 +158,7 @@ public class ExpiringMap<K, V> implements Map<K, V> {
 
     @Override
     public Collection<V> values() {
-        List<V> list = new ArrayList<V>();
+        List<V> list = new ArrayList<>();
         Set<Entry<K, ExpiryObject>> delegatedSet = delegateMap.entrySet();
         for (Entry<K, ExpiryObject> entry : delegatedSet) {
             ExpiryObject value = entry.getValue();

--- a/dubbo-metadata/dubbo-metadata-report-nacos/src/main/java/org/apache/dubbo/metadata/store/nacos/NacosMetadataReport.java
+++ b/dubbo-metadata/dubbo-metadata-report-nacos/src/main/java/org/apache/dubbo/metadata/store/nacos/NacosMetadataReport.java
@@ -258,7 +258,7 @@ public class NacosMetadataReport extends AbstractMetadataReport {
         if (StringUtils.isEmpty(content)) {
             return Collections.emptyList();
         }
-        return new ArrayList<String>(Arrays.asList(URL.decode(content)));
+        return new ArrayList<>(Arrays.asList(URL.decode(content)));
     }
 
     @Override

--- a/dubbo-monitor/dubbo-monitor-api/src/main/java/org/apache/dubbo/monitor/support/AbstractMonitorFactory.java
+++ b/dubbo-monitor/dubbo-monitor-api/src/main/java/org/apache/dubbo/monitor/support/AbstractMonitorFactory.java
@@ -53,9 +53,9 @@ public abstract class AbstractMonitorFactory implements MonitorFactory {
     /**
      * The monitor centers Map<RegistryAddress, Registry>
      */
-    private static final Map<String, Monitor> MONITORS = new ConcurrentHashMap<String, Monitor>();
+    private static final Map<String, Monitor> MONITORS = new ConcurrentHashMap<>();
 
-    private static final Map<String, Future<Monitor>> FUTURES = new ConcurrentHashMap<String, Future<Monitor>>();
+    private static final Map<String, Future<Monitor>> FUTURES = new ConcurrentHashMap<>();
 
     /**
      * The monitor create executor

--- a/dubbo-plugin/dubbo-qos/src/main/java/org/apache/dubbo/qos/command/decoder/HttpCommandDecoder.java
+++ b/dubbo-plugin/dubbo-qos/src/main/java/org/apache/dubbo/qos/command/decoder/HttpCommandDecoder.java
@@ -46,7 +46,7 @@ public class HttpCommandDecoder {
                         commandContext = CommandContextFactory.newInstance(name);
                         commandContext.setHttp(true);
                     } else {
-                        List<String> valueList = new ArrayList<String>();
+                        List<String> valueList = new ArrayList<>();
                         for (List<String> values :
                                 queryStringDecoder.parameters().values()) {
                             valueList.addAll(values);
@@ -56,7 +56,7 @@ public class HttpCommandDecoder {
                     }
                 } else if (request.method() == HttpMethod.POST) {
                     HttpPostRequestDecoder httpPostRequestDecoder = new HttpPostRequestDecoder(request);
-                    List<String> valueList = new ArrayList<String>();
+                    List<String> valueList = new ArrayList<>();
                     for (InterfaceHttpData interfaceHttpData : httpPostRequestDecoder.getBodyHttpDatas()) {
                         if (interfaceHttpData.getHttpDataType() == InterfaceHttpData.HttpDataType.Attribute) {
                             Attribute attribute = (Attribute) interfaceHttpData;

--- a/dubbo-plugin/dubbo-qos/src/main/java/org/apache/dubbo/qos/command/impl/CountTelnet.java
+++ b/dubbo-plugin/dubbo-qos/src/main/java/org/apache/dubbo/qos/command/impl/CountTelnet.java
@@ -155,8 +155,8 @@ public class CountTelnet implements BaseCommand {
 
     private String count(Invoker<?> invoker, String method) {
         URL url = invoker.getUrl();
-        List<List<String>> table = new ArrayList<List<String>>();
-        List<String> header = new ArrayList<String>();
+        List<List<String>> table = new ArrayList<>();
+        List<String> header = new ArrayList<>();
         header.add("method");
         header.add("total");
         header.add("failed");
@@ -188,7 +188,7 @@ public class CountTelnet implements BaseCommand {
     }
 
     private List<String> createRow(String methodName, RpcStatus count) {
-        List<String> row = new ArrayList<String>();
+        List<String> row = new ArrayList<>();
         row.add(methodName);
         row.add(String.valueOf(count.getTotal()));
         row.add(String.valueOf(count.getFailed()));

--- a/dubbo-plugin/dubbo-qos/src/main/java/org/apache/dubbo/qos/command/util/CommandHelper.java
+++ b/dubbo-plugin/dubbo-qos/src/main/java/org/apache/dubbo/qos/command/util/CommandHelper.java
@@ -46,7 +46,7 @@ public class CommandHelper {
     public List<Class<?>> getAllCommandClass() {
         final Set<String> commandList =
                 frameworkModel.getExtensionLoader(BaseCommand.class).getSupportedExtensions();
-        final List<Class<?>> classes = new ArrayList<Class<?>>();
+        final List<Class<?>> classes = new ArrayList<>();
 
         for (String commandName : commandList) {
             BaseCommand command =

--- a/dubbo-plugin/dubbo-qos/src/main/java/org/apache/dubbo/qos/textui/TLadder.java
+++ b/dubbo-plugin/dubbo-qos/src/main/java/org/apache/dubbo/qos/textui/TLadder.java
@@ -35,7 +35,7 @@ public class TLadder implements TComponent {
     // indent length
     private static final int INDENT_STEP = 2;
 
-    private final List<String> items = new LinkedList<String>();
+    private final List<String> items = new LinkedList<>();
 
     @Override
     public String rendering() {

--- a/dubbo-plugin/dubbo-qos/src/main/java/org/apache/dubbo/qos/textui/TTable.java
+++ b/dubbo-plugin/dubbo-qos/src/main/java/org/apache/dubbo/qos/textui/TTable.java
@@ -299,7 +299,7 @@ public class TTable implements TComponent {
         private final Align align;
 
         // data rows
-        private final List<String> rows = new ArrayList<String>();
+        private final List<String> rows = new ArrayList<>();
 
         public ColumnDefine(int width, boolean isAutoResize, Align align) {
             this.width = width;

--- a/dubbo-plugin/dubbo-qos/src/main/java/org/apache/dubbo/qos/textui/TTree.java
+++ b/dubbo-plugin/dubbo-qos/src/main/java/org/apache/dubbo/qos/textui/TTree.java
@@ -181,7 +181,7 @@ public class TTree implements TComponent {
         /**
          * child nodes
          */
-        final List<Node> children = new ArrayList<Node>();
+        final List<Node> children = new ArrayList<>();
 
         /**
          * begin timestamp

--- a/dubbo-plugin/dubbo-reactive/src/main/java/org/apache/dubbo/reactive/calls/ReactorServerCalls.java
+++ b/dubbo-plugin/dubbo-reactive/src/main/java/org/apache/dubbo/reactive/calls/ReactorServerCalls.java
@@ -83,7 +83,7 @@ public final class ReactorServerCalls {
     public static <T, R> StreamObserver<T> manyToOne(
             StreamObserver<R> responseObserver, Function<Flux<T>, Mono<R>> func) {
         ServerTripleReactorPublisher<T> serverPublisher =
-                new ServerTripleReactorPublisher<T>((CallStreamObserver<R>) responseObserver);
+                new ServerTripleReactorPublisher<>((CallStreamObserver<R>) responseObserver);
         try {
             Mono<R> responseMono = func.apply(Flux.from(serverPublisher));
             responseMono.subscribe(
@@ -118,7 +118,7 @@ public final class ReactorServerCalls {
             StreamObserver<R> responseObserver, Function<Flux<T>, Flux<R>> func) {
         // responseObserver is also a subscription of publisher, we can use it to request more data
         ServerTripleReactorPublisher<T> serverPublisher =
-                new ServerTripleReactorPublisher<T>((CallStreamObserver<R>) responseObserver);
+                new ServerTripleReactorPublisher<>((CallStreamObserver<R>) responseObserver);
         try {
             Flux<R> responseFlux = func.apply(Flux.from(serverPublisher));
             ServerTripleReactorSubscriber<R> serverSubscriber =

--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/integration/InterfaceCompatibleRegistryProtocol.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/integration/InterfaceCompatibleRegistryProtocol.java
@@ -75,6 +75,6 @@ public class InterfaceCompatibleRegistryProtocol extends RegistryProtocol {
             URL url,
             URL consumerUrl) {
         //        ClusterInvoker<T> invoker = getInvoker(cluster, registry, type, url);
-        return new MigrationInvoker<T>(registryProtocol, cluster, registry, type, url, consumerUrl);
+        return new MigrationInvoker<>(registryProtocol, cluster, registry, type, url, consumerUrl);
     }
 }

--- a/dubbo-registry/dubbo-registry-multicast/src/main/java/org/apache/dubbo/registry/multicast/MulticastRegistry.java
+++ b/dubbo-registry/dubbo-registry-multicast/src/main/java/org/apache/dubbo/registry/multicast/MulticastRegistry.java
@@ -82,7 +82,7 @@ public class MulticastRegistry extends FailbackRegistry {
 
     private final int multicastPort;
 
-    private final ConcurrentMap<URL, Set<URL>> received = new ConcurrentHashMap<URL, Set<URL>>();
+    private final ConcurrentMap<URL, Set<URL>> received = new ConcurrentHashMap<>();
 
     private final ScheduledExecutorService cleanExecutor =
             Executors.newScheduledThreadPool(1, new NamedThreadFactory("DubboMulticastRegistryCleanTimer", true));
@@ -361,7 +361,7 @@ public class MulticastRegistry extends FailbackRegistry {
                 }
                 if (urls == null || urls.isEmpty()) {
                     if (urls == null) {
-                        urls = new ConcurrentHashSet<URL>();
+                        urls = new ConcurrentHashSet<>();
                     }
                     URL empty = url.setProtocol(EMPTY_PROTOCOL);
                     urls.add(empty);
@@ -380,7 +380,7 @@ public class MulticastRegistry extends FailbackRegistry {
     }
 
     private List<URL> toList(Set<URL> urls) {
-        List<URL> list = new ArrayList<URL>();
+        List<URL> list = new ArrayList<>();
         if (CollectionUtils.isNotEmpty(urls)) {
             list.addAll(urls);
         }

--- a/dubbo-registry/dubbo-registry-multiple/src/main/java/org/apache/dubbo/registry/multiple/MultipleRegistry.java
+++ b/dubbo-registry/dubbo-registry-multiple/src/main/java/org/apache/dubbo/registry/multiple/MultipleRegistry.java
@@ -268,7 +268,7 @@ public class MultipleRegistry extends AbstractRegistry {
 
     protected static class MultipleNotifyListenerWrapper implements NotifyListener {
 
-        Map<URL, SingleNotifyListener> registryMap = new ConcurrentHashMap<URL, SingleNotifyListener>(4);
+        Map<URL, SingleNotifyListener> registryMap = new ConcurrentHashMap<>(4);
         NotifyListener sourceNotifyListener;
 
         public MultipleNotifyListenerWrapper(NotifyListener sourceNotifyListener) {

--- a/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/exchange/support/ReplierDispatcher.java
+++ b/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/exchange/support/ReplierDispatcher.java
@@ -30,7 +30,7 @@ public class ReplierDispatcher implements Replier<Object> {
 
     private final Replier<?> defaultReplier;
 
-    private final Map<Class<?>, Replier<?>> repliers = new ConcurrentHashMap<Class<?>, Replier<?>>();
+    private final Map<Class<?>, Replier<?>> repliers = new ConcurrentHashMap<>();
 
     public ReplierDispatcher() {
         this(null, null);

--- a/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/exchange/support/header/HeaderExchangeServer.java
+++ b/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/exchange/support/header/HeaderExchangeServer.java
@@ -161,7 +161,7 @@ public class HeaderExchangeServer implements ExchangeServer {
 
     @Override
     public Collection<ExchangeChannel> getExchangeChannels() {
-        Collection<ExchangeChannel> exchangeChannels = new ArrayList<ExchangeChannel>();
+        Collection<ExchangeChannel> exchangeChannels = new ArrayList<>();
         Collection<Channel> channels = server.getChannels();
         if (CollectionUtils.isNotEmpty(channels)) {
             for (Channel channel : channels) {

--- a/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/telnet/codec/TelnetCodec.java
+++ b/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/telnet/codec/TelnetCodec.java
@@ -283,7 +283,7 @@ public class TelnetCodec extends TransportCodec {
         String result = toString(message, getCharset(channel));
         if (result.trim().length() > 0) {
             if (history == null) {
-                history = new LinkedList<String>();
+                history = new LinkedList<>();
                 channel.setAttribute(HISTORY_LIST_KEY, history);
             }
             if (history.isEmpty()) {

--- a/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/telnet/support/command/HelpTelnetHandler.java
+++ b/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/telnet/support/command/HelpTelnetHandler.java
@@ -73,12 +73,12 @@ public class HelpTelnetHandler implements TelnetHandler {
     }
 
     private String generateForAllCommand(Channel channel) {
-        List<List<String>> table = new ArrayList<List<String>>();
+        List<List<String>> table = new ArrayList<>();
         List<TelnetHandler> handlers = extensionLoader.getActivateExtension(channel.getUrl(), "telnet");
         if (CollectionUtils.isNotEmpty(handlers)) {
             for (TelnetHandler handler : handlers) {
                 Help help = handler.getClass().getAnnotation(Help.class);
-                List<String> row = new ArrayList<String>();
+                List<String> row = new ArrayList<>();
                 String parameter = " " + extensionLoader.getExtensionName(handler) + " "
                         + (help != null ? help.parameter().replace("\r\n", " ").replace("\n", " ") : "");
                 row.add(parameter.length() > 55 ? parameter.substring(0, 55) + "..." : parameter);

--- a/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/telnet/support/command/StatusTelnetHandler.java
+++ b/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/telnet/support/command/StatusTelnetHandler.java
@@ -53,8 +53,8 @@ public class StatusTelnetHandler implements TelnetHandler {
         if ("-l".equals(message)) {
             List<StatusChecker> checkers = extensionLoader.getActivateExtension(channel.getUrl(), STATUS_KEY);
             String[] header = new String[] {"resource", "status", "message"};
-            List<List<String>> table = new ArrayList<List<String>>();
-            Map<String, Status> statuses = new HashMap<String, Status>();
+            List<List<String>> table = new ArrayList<>();
+            Map<String, Status> statuses = new HashMap<>();
             if (CollectionUtils.isNotEmpty(checkers)) {
                 for (StatusChecker checker : checkers) {
                     String name = extensionLoader.getExtensionName(checker);
@@ -66,7 +66,7 @@ public class StatusTelnetHandler implements TelnetHandler {
                     }
                     statuses.put(name, stat);
                     if (stat.getLevel() != null && stat.getLevel() != Status.Level.UNKNOWN) {
-                        List<String> row = new ArrayList<String>();
+                        List<String> row = new ArrayList<>();
                         row.add(name);
                         row.add(String.valueOf(stat.getLevel()));
                         row.add(stat.getMessage() == null ? "" : stat.getMessage());
@@ -75,7 +75,7 @@ public class StatusTelnetHandler implements TelnetHandler {
                 }
             }
             Status stat = StatusUtils.getSummaryStatus(statuses);
-            List<String> row = new ArrayList<String>();
+            List<String> row = new ArrayList<>();
             row.add("summary");
             row.add(String.valueOf(stat.getLevel()));
             row.add(stat.getMessage());
@@ -85,7 +85,7 @@ public class StatusTelnetHandler implements TelnetHandler {
             return "Unsupported parameter " + message + " for status.";
         }
         String status = channel.getUrl().getParameter("status");
-        Map<String, Status> statuses = new HashMap<String, Status>();
+        Map<String, Status> statuses = new HashMap<>();
         if (StringUtils.isNotEmpty(status)) {
             String[] ss = COMMA_SPLIT_PATTERN.split(status);
             for (String s : ss) {

--- a/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/transport/CodecSupport.java
+++ b/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/transport/CodecSupport.java
@@ -42,9 +42,9 @@ import static org.apache.dubbo.common.constants.LoggerCodeConstants.TRANSPORT_FA
 
 public class CodecSupport {
     private static final ErrorTypeAwareLogger logger = LoggerFactory.getErrorTypeAwareLogger(CodecSupport.class);
-    private static Map<Byte, Serialization> ID_SERIALIZATION_MAP = new HashMap<Byte, Serialization>();
-    private static Map<Byte, String> ID_SERIALIZATIONNAME_MAP = new HashMap<Byte, String>();
-    private static Map<String, Byte> SERIALIZATIONNAME_ID_MAP = new HashMap<String, Byte>();
+    private static Map<Byte, Serialization> ID_SERIALIZATION_MAP = new HashMap<>();
+    private static Map<Byte, String> ID_SERIALIZATIONNAME_MAP = new HashMap<>();
+    private static Map<String, Byte> SERIALIZATIONNAME_ID_MAP = new HashMap<>();
     // Cache null object serialize results, for heartbeat request/response serialize use.
     private static ConcurrentMap<Byte, byte[]> ID_NULLBYTES_MAP = new ConcurrentHashMap<>();
 

--- a/dubbo-remoting/dubbo-remoting-http/src/main/java/org/apache/dubbo/remoting/http/RequestTemplate.java
+++ b/dubbo-remoting/dubbo-remoting-http/src/main/java/org/apache/dubbo/remoting/http/RequestTemplate.java
@@ -35,8 +35,8 @@ public class RequestTemplate implements Serializable {
     public static final String ENCODING_DEFLATE = "deflate";
     private static final List<String> EMPTY_ARRAYLIST = new ArrayList<>();
 
-    private final Map<String, Collection<String>> queries = new LinkedHashMap<String, Collection<String>>();
-    private final Map<String, Collection<String>> headers = new LinkedHashMap<String, Collection<String>>();
+    private final Map<String, Collection<String>> queries = new LinkedHashMap<>();
+    private final Map<String, Collection<String>> headers = new LinkedHashMap<>();
     private String httpMethod;
     private String path;
     private String address;

--- a/dubbo-remoting/dubbo-remoting-http/src/main/java/org/apache/dubbo/remoting/http/servlet/DispatcherServlet.java
+++ b/dubbo-remoting/dubbo-remoting-http/src/main/java/org/apache/dubbo/remoting/http/servlet/DispatcherServlet.java
@@ -33,7 +33,7 @@ import java.util.concurrent.ConcurrentHashMap;
 public class DispatcherServlet extends HttpServlet {
 
     private static final long serialVersionUID = 5766349180380479888L;
-    private static final Map<Integer, HttpHandler> HANDLERS = new ConcurrentHashMap<Integer, HttpHandler>();
+    private static final Map<Integer, HttpHandler> HANDLERS = new ConcurrentHashMap<>();
     private static DispatcherServlet INSTANCE;
 
     public DispatcherServlet() {

--- a/dubbo-remoting/dubbo-remoting-http/src/main/java/org/apache/dubbo/remoting/http/servlet/ServletManager.java
+++ b/dubbo-remoting/dubbo-remoting-http/src/main/java/org/apache/dubbo/remoting/http/servlet/ServletManager.java
@@ -30,7 +30,7 @@ public class ServletManager {
 
     private static final ServletManager INSTANCE = new ServletManager();
 
-    private final Map<Integer, ServletContext> contextMap = new ConcurrentHashMap<Integer, ServletContext>();
+    private final Map<Integer, ServletContext> contextMap = new ConcurrentHashMap<>();
 
     public static ServletManager getInstance() {
         return INSTANCE;

--- a/dubbo-remoting/dubbo-remoting-netty/src/main/java/org/apache/dubbo/remoting/transport/netty/NettyChannel.java
+++ b/dubbo-remoting/dubbo-remoting-netty/src/main/java/org/apache/dubbo/remoting/transport/netty/NettyChannel.java
@@ -43,11 +43,11 @@ final class NettyChannel extends AbstractChannel {
     private static final ErrorTypeAwareLogger logger = LoggerFactory.getErrorTypeAwareLogger(NettyChannel.class);
 
     private static final ConcurrentMap<org.jboss.netty.channel.Channel, NettyChannel> CHANNEL_MAP =
-            new ConcurrentHashMap<org.jboss.netty.channel.Channel, NettyChannel>();
+            new ConcurrentHashMap<>();
 
     private final org.jboss.netty.channel.Channel channel;
 
-    private final Map<String, Object> attributes = new ConcurrentHashMap<String, Object>();
+    private final Map<String, Object> attributes = new ConcurrentHashMap<>();
 
     private NettyChannel(org.jboss.netty.channel.Channel channel, URL url, ChannelHandler handler) {
         super(url, handler);

--- a/dubbo-remoting/dubbo-remoting-netty/src/main/java/org/apache/dubbo/remoting/transport/netty/NettyChannel.java
+++ b/dubbo-remoting/dubbo-remoting-netty/src/main/java/org/apache/dubbo/remoting/transport/netty/NettyChannel.java
@@ -42,8 +42,7 @@ final class NettyChannel extends AbstractChannel {
 
     private static final ErrorTypeAwareLogger logger = LoggerFactory.getErrorTypeAwareLogger(NettyChannel.class);
 
-    private static final ConcurrentMap<org.jboss.netty.channel.Channel, NettyChannel> CHANNEL_MAP =
-            new ConcurrentHashMap<>();
+    private static final ConcurrentMap<org.jboss.netty.channel.Channel, NettyChannel> CHANNEL_MAP = new ConcurrentHashMap<>();
 
     private final org.jboss.netty.channel.Channel channel;
 

--- a/dubbo-remoting/dubbo-remoting-netty/src/main/java/org/apache/dubbo/remoting/transport/netty/NettyChannel.java
+++ b/dubbo-remoting/dubbo-remoting-netty/src/main/java/org/apache/dubbo/remoting/transport/netty/NettyChannel.java
@@ -42,7 +42,8 @@ final class NettyChannel extends AbstractChannel {
 
     private static final ErrorTypeAwareLogger logger = LoggerFactory.getErrorTypeAwareLogger(NettyChannel.class);
 
-    private static final ConcurrentMap<org.jboss.netty.channel.Channel, NettyChannel> CHANNEL_MAP = new ConcurrentHashMap<>();
+    private static final ConcurrentMap<org.jboss.netty.channel.Channel, NettyChannel> CHANNEL_MAP =
+            new ConcurrentHashMap<>();
 
     private final org.jboss.netty.channel.Channel channel;
 

--- a/dubbo-remoting/dubbo-remoting-netty/src/main/java/org/apache/dubbo/remoting/transport/netty/NettyHandler.java
+++ b/dubbo-remoting/dubbo-remoting-netty/src/main/java/org/apache/dubbo/remoting/transport/netty/NettyHandler.java
@@ -42,7 +42,7 @@ public class NettyHandler extends SimpleChannelHandler {
 
     private static final Logger logger = LoggerFactory.getLogger(NettyHandler.class);
 
-    private final Map<String, Channel> channels = new ConcurrentHashMap<String, Channel>(); // <ip:port, channel>
+    private final Map<String, Channel> channels = new ConcurrentHashMap<>(); // <ip:port, channel>
 
     private final URL url;
 

--- a/dubbo-remoting/dubbo-remoting-netty4/src/main/java/org/apache/dubbo/remoting/transport/netty4/NettyChannel.java
+++ b/dubbo-remoting/dubbo-remoting-netty4/src/main/java/org/apache/dubbo/remoting/transport/netty4/NettyChannel.java
@@ -62,13 +62,13 @@ final class NettyChannel extends AbstractChannel {
      * the cache for netty channel and dubbo channel
      */
     private static final ConcurrentMap<Channel, NettyChannel> CHANNEL_MAP =
-            new ConcurrentHashMap<Channel, NettyChannel>();
+            new ConcurrentHashMap<>();
     /**
      * netty channel
      */
     private final Channel channel;
 
-    private final Map<String, Object> attributes = new ConcurrentHashMap<String, Object>();
+    private final Map<String, Object> attributes = new ConcurrentHashMap<>();
 
     private final AtomicBoolean active = new AtomicBoolean(false);
 

--- a/dubbo-remoting/dubbo-remoting-netty4/src/main/java/org/apache/dubbo/remoting/transport/netty4/NettyChannel.java
+++ b/dubbo-remoting/dubbo-remoting-netty4/src/main/java/org/apache/dubbo/remoting/transport/netty4/NettyChannel.java
@@ -61,8 +61,7 @@ final class NettyChannel extends AbstractChannel {
     /**
      * the cache for netty channel and dubbo channel
      */
-    private static final ConcurrentMap<Channel, NettyChannel> CHANNEL_MAP =
-            new ConcurrentHashMap<>();
+    private static final ConcurrentMap<Channel, NettyChannel> CHANNEL_MAP = new ConcurrentHashMap<>();
     /**
      * netty channel
      */

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/RpcServiceContext.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/RpcServiceContext.java
@@ -459,7 +459,7 @@ public class RpcServiceContext extends RpcContext {
     public RpcServiceContext setInvokers(List<Invoker<?>> invokers) {
         this.invokers = invokers;
         if (CollectionUtils.isNotEmpty(invokers)) {
-            List<URL> urls = new ArrayList<URL>(invokers.size());
+            List<URL> urls = new ArrayList<>(invokers.size());
             for (Invoker<?> invoker : invokers) {
                 urls.add(invoker.getUrl());
             }

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/RpcStatus.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/RpcStatus.java
@@ -34,12 +34,12 @@ import java.util.concurrent.atomic.AtomicLong;
 public class RpcStatus {
 
     private static final ConcurrentMap<String, RpcStatus> SERVICE_STATISTICS =
-            new ConcurrentHashMap<String, RpcStatus>();
+            new ConcurrentHashMap<>();
 
     private static final ConcurrentMap<String, ConcurrentMap<String, RpcStatus>> METHOD_STATISTICS =
-            new ConcurrentHashMap<String, ConcurrentMap<String, RpcStatus>>();
+            new ConcurrentHashMap<>();
 
-    private final ConcurrentMap<String, Object> values = new ConcurrentHashMap<String, Object>();
+    private final ConcurrentMap<String, Object> values = new ConcurrentHashMap<>();
 
     private final AtomicInteger active = new AtomicInteger();
     private final AtomicLong total = new AtomicLong();

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/RpcStatus.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/RpcStatus.java
@@ -35,7 +35,8 @@ public class RpcStatus {
 
     private static final ConcurrentMap<String, RpcStatus> SERVICE_STATISTICS = new ConcurrentHashMap<>();
 
-    private static final ConcurrentMap<String, ConcurrentMap<String, RpcStatus>> METHOD_STATISTICS = new ConcurrentHashMap<>();
+    private static final ConcurrentMap<String, ConcurrentMap<String, RpcStatus>> METHOD_STATISTICS =
+            new ConcurrentHashMap<>();
 
     private final ConcurrentMap<String, Object> values = new ConcurrentHashMap<>();
 

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/RpcStatus.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/RpcStatus.java
@@ -36,8 +36,7 @@ public class RpcStatus {
     private static final ConcurrentMap<String, RpcStatus> SERVICE_STATISTICS =
             new ConcurrentHashMap<>();
 
-    private static final ConcurrentMap<String, ConcurrentMap<String, RpcStatus>> METHOD_STATISTICS =
-            new ConcurrentHashMap<>();
+    private static final ConcurrentMap<String, ConcurrentMap<String, RpcStatus>> METHOD_STATISTICS = new ConcurrentHashMap<>();
 
     private final ConcurrentMap<String, Object> values = new ConcurrentHashMap<>();
 

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/RpcStatus.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/RpcStatus.java
@@ -33,8 +33,7 @@ import java.util.concurrent.atomic.AtomicLong;
  */
 public class RpcStatus {
 
-    private static final ConcurrentMap<String, RpcStatus> SERVICE_STATISTICS =
-            new ConcurrentHashMap<>();
+    private static final ConcurrentMap<String, RpcStatus> SERVICE_STATISTICS = new ConcurrentHashMap<>();
 
     private static final ConcurrentMap<String, ConcurrentMap<String, RpcStatus>> METHOD_STATISTICS = new ConcurrentHashMap<>();
 

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/filter/DeprecatedFilter.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/filter/DeprecatedFilter.java
@@ -44,7 +44,7 @@ public class DeprecatedFilter implements Filter {
 
     private static final ErrorTypeAwareLogger LOGGER = LoggerFactory.getErrorTypeAwareLogger(DeprecatedFilter.class);
 
-    private static final Set<String> LOGGED = new ConcurrentHashSet<String>();
+    private static final Set<String> LOGGED = new ConcurrentHashSet<>();
 
     @Override
     public Result invoke(Invoker<?> invoker, Invocation invocation) throws RpcException {

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/filter/tps/DefaultTPSLimiter.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/filter/tps/DefaultTPSLimiter.java
@@ -35,7 +35,7 @@ import static org.apache.dubbo.rpc.Constants.TPS_LIMIT_RATE_KEY;
  */
 public class DefaultTPSLimiter implements TPSLimiter {
 
-    private final ConcurrentMap<String, StatItem> stats = new ConcurrentHashMap<String, StatItem>();
+    private final ConcurrentMap<String, StatItem> stats = new ConcurrentHashMap<>();
 
     @Override
     public boolean isAllowable(URL url, Invocation invocation) {

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/protocol/AbstractProxyProtocol.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/protocol/AbstractProxyProtocol.java
@@ -50,7 +50,7 @@ import static org.apache.dubbo.common.constants.LoggerCodeConstants.PROTOCOL_UNS
  */
 public abstract class AbstractProxyProtocol extends AbstractProtocol {
 
-    private final List<Class<?>> rpcExceptions = new CopyOnWriteArrayList<Class<?>>();
+    private final List<Class<?>> rpcExceptions = new CopyOnWriteArrayList<>();
 
     protected ProxyFactory proxyFactory;
 

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/protocol/ProtocolListenerWrapper.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/protocol/ProtocolListenerWrapper.java
@@ -74,8 +74,7 @@ public class ProtocolListenerWrapper implements Protocol {
                     .getBeanFactory()
                     .getBean(InjvmExporterListener.class));
         }
-        return new ListenerExporterWrapper<>(
-                protocol.export(invoker), Collections.unmodifiableList(exporterListeners));
+        return new ListenerExporterWrapper<>(protocol.export(invoker), Collections.unmodifiableList(exporterListeners));
     }
 
     @Override

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/protocol/ProtocolListenerWrapper.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/protocol/ProtocolListenerWrapper.java
@@ -74,7 +74,7 @@ public class ProtocolListenerWrapper implements Protocol {
                     .getBeanFactory()
                     .getBean(InjvmExporterListener.class));
         }
-        return new ListenerExporterWrapper<T>(
+        return new ListenerExporterWrapper<>(
                 protocol.export(invoker), Collections.unmodifiableList(exporterListeners));
     }
 

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/support/MockInvoker.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/support/MockInvoker.java
@@ -47,8 +47,8 @@ import static org.apache.dubbo.rpc.Constants.THROW_PREFIX;
 
 public final class MockInvoker<T> implements Invoker<T> {
     private final ProxyFactory proxyFactory;
-    private static final Map<String, Invoker<?>> MOCK_MAP = new ConcurrentHashMap<String, Invoker<?>>();
-    private static final Map<String, Throwable> THROWABLE_MAP = new ConcurrentHashMap<String, Throwable>();
+    private static final Map<String, Invoker<?>> MOCK_MAP = new ConcurrentHashMap<>();
+    private static final Map<String, Throwable> THROWABLE_MAP = new ConcurrentHashMap<>();
 
     private final URL url;
     private final Class<T> type;

--- a/dubbo-rpc/dubbo-rpc-dubbo/src/main/java/org/apache/dubbo/rpc/protocol/dubbo/DubboProtocol.java
+++ b/dubbo-rpc/dubbo-rpc-dubbo/src/main/java/org/apache/dubbo/rpc/protocol/dubbo/DubboProtocol.java
@@ -339,7 +339,7 @@ public class DubboProtocol extends AbstractProtocol {
 
         // export service.
         String key = serviceKey(url);
-        DubboExporter<T> exporter = new DubboExporter<T>(invoker, key, exporterMap);
+        DubboExporter<T> exporter = new DubboExporter<>(invoker, key, exporterMap);
 
         // export a stub service for dispatching event
         boolean isStubSupportEvent = url.getParameter(STUB_EVENT_KEY, DEFAULT_STUB_EVENT);
@@ -443,7 +443,7 @@ public class DubboProtocol extends AbstractProtocol {
         optimizeSerialization(url);
 
         // create rpc invoker.
-        DubboInvoker<T> invoker = new DubboInvoker<T>(serviceType, url, getClients(url), invokers);
+        DubboInvoker<T> invoker = new DubboInvoker<>(serviceType, url, getClients(url), invokers);
         invokers.add(invoker);
 
         return invoker;

--- a/dubbo-rpc/dubbo-rpc-injvm/src/main/java/org/apache/dubbo/rpc/protocol/injvm/InjvmProtocol.java
+++ b/dubbo-rpc/dubbo-rpc-injvm/src/main/java/org/apache/dubbo/rpc/protocol/injvm/InjvmProtocol.java
@@ -75,12 +75,12 @@ public class InjvmProtocol extends AbstractProtocol {
 
     @Override
     public <T> Exporter<T> export(Invoker<T> invoker) throws RpcException {
-        return new InjvmExporter<T>(invoker, invoker.getUrl().getServiceKey(), exporterMap);
+        return new InjvmExporter<>(invoker, invoker.getUrl().getServiceKey(), exporterMap);
     }
 
     @Override
     public <T> Invoker<T> protocolBindingRefer(Class<T> serviceType, URL url) throws RpcException {
-        return new InjvmInvoker<T>(serviceType, url, url.getServiceKey(), exporterMap);
+        return new InjvmInvoker<>(serviceType, url, url.getServiceKey(), exporterMap);
     }
 
     public boolean isInjvmRefer(URL url) {

--- a/dubbo-rpc/dubbo-rpc-rest/src/main/java/org/apache/dubbo/rpc/protocol/rest/RestProtocol.java
+++ b/dubbo-rpc/dubbo-rpc-rest/src/main/java/org/apache/dubbo/rpc/protocol/rest/RestProtocol.java
@@ -134,7 +134,7 @@ public class RestProtocol extends AbstractProtocol {
                 MetadataResolver.resolveConsumerServiceMetadata(type, url, contextPathFromUrl);
 
         Invoker<T> invoker =
-                new RestInvoker<T>(type, url, refClient, httpConnectionPreBuildIntercepts, serviceRestMetadata);
+                new RestInvoker<>(type, url, refClient, httpConnectionPreBuildIntercepts, serviceRestMetadata);
 
         invokers.add(invoker);
         return invoker;

--- a/dubbo-rpc/dubbo-rpc-rest/src/main/java/org/apache/dubbo/rpc/protocol/rest/ViolationReport.java
+++ b/dubbo-rpc/dubbo-rpc-rest/src/main/java/org/apache/dubbo/rpc/protocol/rest/ViolationReport.java
@@ -42,7 +42,7 @@ public class ViolationReport implements Serializable {
 
     public void addConstraintViolation(RestConstraintViolation constraintViolation) {
         if (constraintViolations == null) {
-            constraintViolations = new LinkedList<RestConstraintViolation>();
+            constraintViolations = new LinkedList<>();
         }
         constraintViolations.add(constraintViolation);
     }

--- a/dubbo-rpc/dubbo-rpc-rest/src/main/java/org/apache/dubbo/rpc/protocol/rest/extension/resteasy/filter/DubboPreMatchContainerRequestContext.java
+++ b/dubbo-rpc/dubbo-rpc-rest/src/main/java/org/apache/dubbo/rpc/protocol/rest/extension/resteasy/filter/DubboPreMatchContainerRequestContext.java
@@ -82,7 +82,7 @@ public class DubboPreMatchContainerRequestContext implements SuspendableContaine
 
     @Override
     public Collection<String> getPropertyNames() {
-        ArrayList<String> names = new ArrayList<String>();
+        ArrayList<String> names = new ArrayList<>();
         Enumeration<String> enames = httpRequest.getAttributeNames();
         while (enames.hasMoreElements()) {
             names.add(enames.nextElement());

--- a/dubbo-rpc/dubbo-rpc-rest/src/main/java/org/apache/dubbo/rpc/protocol/rest/util/ReflectUtils.java
+++ b/dubbo-rpc/dubbo-rpc-rest/src/main/java/org/apache/dubbo/rpc/protocol/rest/util/ReflectUtils.java
@@ -115,7 +115,7 @@ public class ReflectUtils {
         } catch (Exception e) {
 
         }
-        return new ArrayList<Constructor<?>>(methods);
+        return new ArrayList<>(methods);
     }
 
     private static void filterConstructMethod(Set<Constructor<?>> methods, Constructor<?>[] declaredMethods) {

--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/TriHttp2RemoteFlowController.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/TriHttp2RemoteFlowController.java
@@ -306,7 +306,7 @@ public class TriHttp2RemoteFlowController implements Http2RemoteFlowController {
 
         FlowState(Http2Stream stream) {
             this.stream = stream;
-            pendingWriteQueue = new ArrayDeque<FlowControlled>(2);
+            pendingWriteQueue = new ArrayDeque<>(2);
         }
 
         /**

--- a/dubbo-test/dubbo-test-common/src/main/java/org/apache/dubbo/test/common/SysProps.java
+++ b/dubbo-test/dubbo-test-common/src/main/java/org/apache/dubbo/test/common/SysProps.java
@@ -24,7 +24,7 @@ import java.util.Map;
  */
 public class SysProps {
 
-    private static Map<String, String> map = new LinkedHashMap<String, String>();
+    private static Map<String, String> map = new LinkedHashMap<>();
 
     public static void reset() {
         map.clear();


### PR DESCRIPTION
We propose the fix to violation s2293 "The diamond operator ('<>') should be used" identified by SonarQube.

Java uses angular brackets (< and >) to provide a specific type (the "type argument") to a generic type. For instance, List is a generic type, so a list containing strings can be declared with List.
Prior to Java 7, the type argument had to be provided explicitly for every occurrence where generics were used. This often caused redundancy, as the type argument would have to be provided both when a field is declared and initialized.
Java 7 introduced the diamond operator (<>) to reduce the code’s verbosity of generics code. The type argument between the angular brackets should be omitted if the compiler can infer it. For instance, instead of having to declare a List's type in both its declaration and its constructor, you can now simplify the constructor declaration with <>, and the compiler will infer the type.

This patch has been automatically produced by our java code remediation solution, available free of charge for all open source projects (https://www.indepth.fr/).

We believe that this PR can improve the quality of the Guava project code to a certain extent. Your feedback will also be very useful for us to know if our solution produces quality code or if we need to improve the way it works.

Thank you for your feedback.