### PR TITLE
fix(3.2): triple AbstractServerCallListener NPE

### DIFF
--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/call/AbstractServerCallListener.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/call/AbstractServerCallListener.java
@@ -68,6 +68,10 @@ public abstract class AbstractServerCallListener implements AbstractServerCall.L
                     responseObserver.onError(t);
                     return;
                 }
+                if (r.hasException()) {
+                    doOnResponseHasException(r.getException());
+                    return;
+                }
                 if (response.hasException()) {
                     doOnResponseHasException(response.getException());
                     return;

--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/call/AbstractServerCallListener.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/call/AbstractServerCallListener.java
@@ -62,6 +62,10 @@ public abstract class AbstractServerCallListener implements AbstractServerCall.L
         final long stInMillis = System.currentTimeMillis();
         try {
             final Result response = invoker.invoke(invocation);
+            if (response.hasException()) {
+                doOnResponseHasException(response.getException());
+                return;
+            }
             response.whenCompleteWithContext((r, t) -> {
                 responseObserver.setResponseAttachments(response.getObjectAttachments());
                 if (t != null) {
@@ -70,10 +74,6 @@ public abstract class AbstractServerCallListener implements AbstractServerCall.L
                 }
                 if (r.hasException()) {
                     doOnResponseHasException(r.getException());
-                    return;
-                }
-                if (response.hasException()) {
-                    doOnResponseHasException(response.getException());
                     return;
                 }
                 final long cost = System.currentTimeMillis() - stInMillis;


### PR DESCRIPTION
## What is the purpose of the change

NPE bug fix

## Brief changelog

![image](https://github.com/apache/dubbo/assets/55247691/27a61d61-2d9d-4da5-9931-eb259daa196f)
response.getValue is null， onReturn(null) will throw Serialize triple response failed NPE

## Verifying this change


<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [ ] GitHub Actions works fine on your own branch.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
