### PR TITLE
Merge CommonConfigPostProcessor and ConfigPostProcessor

### DIFF
--- a/dubbo-common/pom.xml
+++ b/dubbo-common/pom.xml
@@ -104,5 +104,11 @@
       <artifactId>protobuf-java</artifactId>
       <scope>test</scope>
     </dependency>
+      <dependency>
+          <groupId>org.apache.dubbo</groupId>
+          <artifactId>dubbo-config-api</artifactId>
+          <version>3.2.12-SNAPSHOT</version>
+          <scope>compile</scope>
+      </dependency>
   </dependencies>
 </project>

--- a/dubbo-common/src/main/java/org/apache/dubbo/config/CommonConfigPostProcessor.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/config/CommonConfigPostProcessor.java
@@ -18,13 +18,11 @@ package org.apache.dubbo.config;
 import org.apache.dubbo.common.extension.ExtensionScope;
 import org.apache.dubbo.common.extension.SPI;
 
-
 /**
  * 2024/03/31
  */
 @SPI(scope = ExtensionScope.MODULE)
-public interface CommonConfigPostProcessor  {
-
+public interface CommonConfigPostProcessor{
     default void postProcessReferConfig(ReferenceConfig referenceConfig) {}
 
     default void postProcessServiceConfig(ServiceConfig serviceConfig) {}

--- a/dubbo-common/src/main/java/org/apache/dubbo/config/CommonConfigPostProcessor.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/config/CommonConfigPostProcessor.java
@@ -18,6 +18,7 @@ package org.apache.dubbo.config;
 import org.apache.dubbo.common.extension.ExtensionScope;
 import org.apache.dubbo.common.extension.SPI;
 
+
 /**
  * 2024/03/31
  */

--- a/dubbo-common/src/main/java/org/apache/dubbo/config/CommonConfigPostProcessor.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/config/CommonConfigPostProcessor.java
@@ -18,12 +18,11 @@ package org.apache.dubbo.config;
 
 import org.apache.dubbo.common.extension.ExtensionScope;
 import org.apache.dubbo.common.extension.SPI;
-
 /**
- * 2019/12/30
+ * 2024/03/31
  */
 @SPI(scope = ExtensionScope.MODULE)
-public interface ConfigPostProcessor {
+public interface CommonConfigPostProcessor  {
 
     default void postProcessReferConfig(ReferenceConfig referenceConfig) {}
 

--- a/dubbo-common/src/main/java/org/apache/dubbo/config/CommonConfigPostProcessor.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/config/CommonConfigPostProcessor.java
@@ -15,9 +15,9 @@
  * limitations under the License.
  */
 package org.apache.dubbo.config;
-
 import org.apache.dubbo.common.extension.ExtensionScope;
 import org.apache.dubbo.common.extension.SPI;
+
 /**
  * 2024/03/31
  */

--- a/dubbo-common/src/test/java/org/apache/dubbo/config/CommonConfigPostProcessorTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/config/CommonConfigPostProcessorTest.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.config;
+
+import org.apache.dubbo.common.extension.ExtensionLoader;
+import org.junit.jupiter.api.Test;
+
+import static org.mockito.Mockito.mock;
+
+public class CommonConfigPostProcessorTest {
+    @Test
+    public void testPostProcessReferConfig() {
+        ReferenceConfig referenceConfig = mock(ReferenceConfig.class);
+
+        CommonConfigPostProcessor postProcessor = ExtensionLoader.getExtensionLoader(CommonConfigPostProcessor.class).getDefaultExtension();
+
+        postProcessor.postProcessReferConfig(referenceConfig);
+
+    }
+
+    @Test
+    public void testPostProcessServiceConfig() {
+        ServiceConfig serviceConfig = mock(ServiceConfig.class);
+
+        CommonConfigPostProcessor postProcessor = ExtensionLoader.getExtensionLoader(CommonConfigPostProcessor.class).getDefaultExtension();
+
+        postProcessor.postProcessServiceConfig(serviceConfig);
+
+    }
+}

--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/ReferenceConfig.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/ReferenceConfig.java
@@ -853,7 +853,7 @@ public class ReferenceConfig<T> extends ReferenceConfigBase<T> {
     }
 
     private void postProcessConfig() {
-        List<ConfigPostProcessor> configPostProcessors = this.getExtensionLoader(ConfigPostProcessor.class)
+        List<CommonConfigPostProcessor> configPostProcessors = this.getExtensionLoader(CommonConfigPostProcessor.class)
                 .getActivateExtension(URL.valueOf("configPostProcessor://"), (String[]) null);
         configPostProcessors.forEach(component -> component.postProcessReferConfig(this));
     }

--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/ServiceConfig.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/ServiceConfig.java
@@ -976,7 +976,7 @@ public class ServiceConfig<T> extends ServiceConfigBase<T> {
     }
 
     private void postProcessConfig() {
-        List<ConfigPostProcessor> configPostProcessors = this.getExtensionLoader(ConfigPostProcessor.class)
+        List<CommonConfigPostProcessor> configPostProcessors = this.getExtensionLoader(CommonConfigPostProcessor.class)
                 .getActivateExtension(URL.valueOf("configPostProcessor://", getScopeModel()), (String[]) null);
         configPostProcessors.forEach(component -> component.postProcessServiceConfig(this));
     }


### PR DESCRIPTION
## What is the purpose of the change

Merge CommonConfigPostProcessor and ConfigPostProcessor #13959 

## Brief changelog
* create src/main/java/org/apache/dubbo/config/CommonConfigPostProcessor.java;(because there is no CommonConfigPostProcessor but need to merge)
* move ConfigPostProcessor to src/main/java/org/apache/dubbo/config/CommonConfigPostProcessor.java;
* Modify dependencies
## Verifying this change
it is ok;

