### PR TITLE
Triple http limiting the size of the HTTP request and response

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/config/TripleConfig.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/config/TripleConfig.java
@@ -21,14 +21,59 @@ import java.io.Serializable;
 /**
  * Configuration for triple protocol.
  */
-public class TripleConfig implements Serializable {
+public class TripleConfig extends AbstractConfig implements Serializable {
 
     private static final long serialVersionUID = -3682252713701362155L;
 
     /**
+     * Maximum allowed size for HTTP1 request bodies.
+     * Limits the size of request to prevent excessively large request.
+     * <p>The default value is 8MiB.
+     */
+    private Integer maxBodySize;
+
+    /**
+     * Maximum allowed size for HTTP1 response bodies.
+     * Limits the size of responses to prevent excessively large response.
+     * <p>The default value is 8MiB.
+     */
+    private Integer maxResponseBodySize;
+
+    /**
+     * Set the maximum chunk size.
+     * HTTP requests and responses can be quite large, in which case it's better to process the data as a stream of
+     * chunks.
+     * This sets the limit, in bytes, at which Netty will send a chunk down the pipeline.
+     * <p>The default value is 1MiB.
+     */
+    private Integer maxChunkSize;
+
+    /**
+     * Set the maximum line length of header lines.
+     * This limits how much memory Netty will use when parsing HTTP header key-value pairs.
+     * You would typically set this to the same value as {@link #setMaxInitialLineLength(Integer)}.
+     * <p>The default value is 8KiB.
+     */
+    private Integer maxHeaderSize;
+
+    /**
+     * Set the maximum length of the first line of the HTTP header.
+     * This limits how much memory Netty will use when parsed the initial HTTP header line.
+     * You would typically set this to the same value as {@link #setMaxHeaderSize(Integer)}.
+     * <p>The default value is 4096.
+     */
+    private Integer maxInitialLineLength;
+
+    /**
+     * Set the initial size of the temporary buffer used when parsing the lines of the HTTP headers.
+     * <p>The default value is 128 octets.
+     */
+    private Integer initialBufferSize;
+
+    /**
      * The header table size.
      */
-    private String headerTableSize;
+    private Integer headerTableSize;
 
     /**
      * Whether to enable push, default is false.
@@ -38,33 +83,81 @@ public class TripleConfig implements Serializable {
     /**
      * Maximum concurrent streams.
      */
-    private String maxConcurrentStreams;
+    private Integer maxConcurrentStreams;
 
     /**
      * Initial window size.
      */
-    private String initialWindowSize;
+    private Integer initialWindowSize;
 
     /**
      * Maximum frame size.
      */
-    private String maxFrameSize;
+    private Integer maxFrameSize;
 
     /**
      * Maximum header list size.
      */
-    private String maxHeaderListSize;
+    private Integer maxHeaderListSize;
 
     /**
      * Whether to pass through standard HTTP headers, default is false.
      */
     private Boolean passThroughStandardHttpHeaders;
 
-    public String getHeaderTableSize() {
+    public Integer getMaxBodySize() {
+        return maxBodySize;
+    }
+
+    public void setMaxBodySize(Integer maxBodySize) {
+        this.maxBodySize = maxBodySize;
+    }
+
+    public Integer getMaxResponseBodySize() {
+        return maxResponseBodySize;
+    }
+
+    public void setMaxResponseBodySize(Integer maxResponseBodySize) {
+        this.maxResponseBodySize = maxResponseBodySize;
+    }
+
+    public Integer getMaxChunkSize() {
+        return maxChunkSize;
+    }
+
+    public void setMaxChunkSize(Integer maxChunkSize) {
+        this.maxChunkSize = maxChunkSize;
+    }
+
+    public Integer getMaxHeaderSize() {
+        return maxHeaderSize;
+    }
+
+    public void setMaxHeaderSize(Integer maxHeaderSize) {
+        this.maxHeaderSize = maxHeaderSize;
+    }
+
+    public Integer getMaxInitialLineLength() {
+        return maxInitialLineLength;
+    }
+
+    public void setMaxInitialLineLength(Integer maxInitialLineLength) {
+        this.maxInitialLineLength = maxInitialLineLength;
+    }
+
+    public Integer getInitialBufferSize() {
+        return initialBufferSize;
+    }
+
+    public void setInitialBufferSize(Integer initialBufferSize) {
+        this.initialBufferSize = initialBufferSize;
+    }
+
+    public Integer getHeaderTableSize() {
         return headerTableSize;
     }
 
-    public void setHeaderTableSize(String headerTableSize) {
+    public void setHeaderTableSize(Integer headerTableSize) {
         this.headerTableSize = headerTableSize;
     }
 
@@ -76,35 +169,35 @@ public class TripleConfig implements Serializable {
         this.enablePush = enablePush;
     }
 
-    public String getMaxConcurrentStreams() {
+    public Integer getMaxConcurrentStreams() {
         return maxConcurrentStreams;
     }
 
-    public void setMaxConcurrentStreams(String maxConcurrentStreams) {
+    public void setMaxConcurrentStreams(Integer maxConcurrentStreams) {
         this.maxConcurrentStreams = maxConcurrentStreams;
     }
 
-    public String getInitialWindowSize() {
+    public Integer getInitialWindowSize() {
         return initialWindowSize;
     }
 
-    public void setInitialWindowSize(String initialWindowSize) {
+    public void setInitialWindowSize(Integer initialWindowSize) {
         this.initialWindowSize = initialWindowSize;
     }
 
-    public String getMaxFrameSize() {
+    public Integer getMaxFrameSize() {
         return maxFrameSize;
     }
 
-    public void setMaxFrameSize(String maxFrameSize) {
+    public void setMaxFrameSize(Integer maxFrameSize) {
         this.maxFrameSize = maxFrameSize;
     }
 
-    public String getMaxHeaderListSize() {
+    public Integer getMaxHeaderListSize() {
         return maxHeaderListSize;
     }
 
-    public void setMaxHeaderListSize(String maxHeaderListSize) {
+    public void setMaxHeaderListSize(Integer maxHeaderListSize) {
         this.maxHeaderListSize = maxHeaderListSize;
     }
 
@@ -114,5 +207,47 @@ public class TripleConfig implements Serializable {
 
     public void setPassThroughStandardHttpHeaders(Boolean passThroughStandardHttpHeaders) {
         this.passThroughStandardHttpHeaders = passThroughStandardHttpHeaders;
+    }
+
+    @Override
+    protected void checkDefault() {
+        super.checkDefault();
+
+        if (maxBodySize == null) {
+            maxBodySize = 1 << 23; // 8MiB
+        }
+        if (maxResponseBodySize == null) {
+            maxResponseBodySize = 1 << 23; // 8MiB
+        }
+        if (maxChunkSize == null) {
+            maxChunkSize = 1 << 20; // 1MiB
+        }
+        if (maxHeaderSize == null) {
+            maxHeaderSize = 8192;
+        }
+        if (maxInitialLineLength == null) {
+            maxInitialLineLength = 4096;
+        }
+        if (initialBufferSize == null) {
+            initialBufferSize = 128;
+        }
+        if (headerTableSize == null) {
+            headerTableSize = 4096;
+        }
+        if (enablePush == null) {
+            enablePush = false;
+        }
+        if (maxConcurrentStreams == null) {
+            maxConcurrentStreams = Integer.MAX_VALUE;
+        }
+        if (initialWindowSize == null) {
+            initialWindowSize = 1 << 23; // 8MiB
+        }
+        if (maxFrameSize == null) {
+            maxFrameSize = 1 << 23; // 8MiB
+        }
+        if (maxHeaderListSize == null) {
+            maxHeaderListSize = 1 << 15; // 32KiB
+        }
     }
 }

--- a/dubbo-common/src/main/java/org/apache/dubbo/config/TripleConfig.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/config/TripleConfig.java
@@ -66,7 +66,7 @@ public class TripleConfig extends AbstractConfig implements Serializable {
 
     /**
      * Set the initial size of the temporary buffer used when parsing the lines of the HTTP headers.
-     * <p>The default value is 128 octets.
+     * <p>The default value is 16384 octets.
      */
     private Integer initialBufferSize;
 
@@ -229,7 +229,7 @@ public class TripleConfig extends AbstractConfig implements Serializable {
             maxInitialLineLength = 4096;
         }
         if (initialBufferSize == null) {
-            initialBufferSize = 128;
+            initialBufferSize = 16384;
         }
         if (headerTableSize == null) {
             headerTableSize = 4096;

--- a/dubbo-common/src/main/java/org/apache/dubbo/config/TripleConfig.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/config/TripleConfig.java
@@ -44,7 +44,7 @@ public class TripleConfig extends AbstractConfig implements Serializable {
      * HTTP requests and responses can be quite large, in which case it's better to process the data as a stream of
      * chunks.
      * This sets the limit, in bytes, at which Netty will send a chunk down the pipeline.
-     * <p>The default value is 1MiB.
+     * <p>The default value is 8MiB.
      */
     private Integer maxChunkSize;
 
@@ -220,7 +220,7 @@ public class TripleConfig extends AbstractConfig implements Serializable {
             maxResponseBodySize = 1 << 23; // 8MiB
         }
         if (maxChunkSize == null) {
-            maxChunkSize = 1 << 20; // 1MiB
+            maxChunkSize = 1 << 23; // 8MiB
         }
         if (maxHeaderSize == null) {
             maxHeaderSize = 8192;

--- a/dubbo-common/src/main/java/org/apache/dubbo/config/context/AbstractConfigManager.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/config/context/AbstractConfigManager.java
@@ -40,6 +40,7 @@ import org.apache.dubbo.config.RegistryConfig;
 import org.apache.dubbo.config.ServiceConfigBase;
 import org.apache.dubbo.config.SslConfig;
 import org.apache.dubbo.config.TracingConfig;
+import org.apache.dubbo.config.TripleConfig;
 import org.apache.dubbo.rpc.model.ApplicationModel;
 import org.apache.dubbo.rpc.model.ScopeModel;
 import org.apache.dubbo.rpc.model.ScopeModelUtil;
@@ -96,6 +97,7 @@ public abstract class AbstractConfigManager extends LifecycleAdapter {
         uniqueConfigTypes.add(MetricsConfig.class);
         uniqueConfigTypes.add(TracingConfig.class);
         uniqueConfigTypes.add(SslConfig.class);
+        uniqueConfigTypes.add(TripleConfig.class);
 
         // unique config in each module
         uniqueConfigTypes.add(ModuleConfig.class);

--- a/dubbo-common/src/main/java/org/apache/dubbo/config/context/ConfigManager.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/config/context/ConfigManager.java
@@ -33,6 +33,7 @@ import org.apache.dubbo.config.ProtocolConfig;
 import org.apache.dubbo.config.RegistryConfig;
 import org.apache.dubbo.config.SslConfig;
 import org.apache.dubbo.config.TracingConfig;
+import org.apache.dubbo.config.TripleConfig;
 import org.apache.dubbo.rpc.model.ApplicationModel;
 
 import java.util.Arrays;
@@ -69,7 +70,8 @@ public class ConfigManager extends AbstractConfigManager implements ApplicationE
                         RegistryConfig.class,
                         ConfigCenterConfig.class,
                         MetadataReportConfig.class,
-                        TracingConfig.class));
+                        TracingConfig.class,
+                        TripleConfig.class));
     }
 
     // ApplicationConfig correlative methods
@@ -129,6 +131,19 @@ public class ConfigManager extends AbstractConfigManager implements ApplicationE
 
     public Optional<SslConfig> getSsl() {
         return ofNullable(getSingleConfig(getTagName(SslConfig.class)));
+    }
+
+    @DisableInject
+    public void setTriple(TripleConfig tripleConfig) {
+        addConfig(tripleConfig);
+    }
+
+    public Optional<TripleConfig> getTriple() {
+        return ofNullable(getSingleConfig(getTagName(TripleConfig.class)));
+    }
+
+    public TripleConfig getTripleOrElseThrow() {
+        return getTriple().orElseThrow(() -> new IllegalStateException("There's no ApplicationConfig specified."));
     }
 
     // ConfigCenterConfig correlative methods
@@ -242,6 +257,7 @@ public class ConfigManager extends AbstractConfigManager implements ApplicationE
         getMetrics().ifPresent(MetricsConfig::refresh);
         getTracing().ifPresent(TracingConfig::refresh);
         getSsl().ifPresent(SslConfig::refresh);
+        getTriple().ifPresent(TripleConfig::refresh);
 
         getProtocols().forEach(ProtocolConfig::refresh);
         getRegistries().forEach(RegistryConfig::refresh);
@@ -277,6 +293,9 @@ public class ConfigManager extends AbstractConfigManager implements ApplicationE
         // config centers has bean loaded before starting config center
         // loadConfigsOfTypeFromProps(ConfigCenterConfig.class);
 
+        // load dubbo.triples.xxx
+        loadConfigsOfTypeFromProps(TripleConfig.class);
+
         refreshAll();
 
         checkConfigs();
@@ -296,7 +315,8 @@ public class ConfigManager extends AbstractConfigManager implements ApplicationE
                 MonitorConfig.class,
                 MetricsConfig.class,
                 TracingConfig.class,
-                SslConfig.class);
+                SslConfig.class,
+                TripleConfig.class);
 
         for (Class<? extends AbstractConfig> configType : multipleConfigTypes) {
             checkDefaultAndValidateConfigs(configType);

--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/bootstrap/DubboBootstrap.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/bootstrap/DubboBootstrap.java
@@ -40,6 +40,7 @@ import org.apache.dubbo.config.RegistryConfig;
 import org.apache.dubbo.config.ServiceConfig;
 import org.apache.dubbo.config.SslConfig;
 import org.apache.dubbo.config.TracingConfig;
+import org.apache.dubbo.config.TripleConfig;
 import org.apache.dubbo.config.bootstrap.builders.ApplicationBuilder;
 import org.apache.dubbo.config.bootstrap.builders.ConfigCenterBuilder;
 import org.apache.dubbo.config.bootstrap.builders.ConsumerBuilder;
@@ -713,6 +714,12 @@ public final class DubboBootstrap {
     public DubboBootstrap ssl(SslConfig sslConfig) {
         sslConfig.setScopeModel(applicationModel);
         configManager.setSsl(sslConfig);
+        return this;
+    }
+
+    public DubboBootstrap triple(TripleConfig triple) {
+        triple.setScopeModel(applicationModel);
+        configManager.setTriple(triple);
         return this;
     }
 

--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/bootstrap/builders/TripleBuilder.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/bootstrap/builders/TripleBuilder.java
@@ -1,0 +1,202 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.config.bootstrap.builders;
+
+import org.apache.dubbo.config.TripleConfig;
+
+/**
+ * This is a builder for build {@link TripleConfig}.
+ *
+ * @since 3.3
+ */
+public class TripleBuilder extends AbstractBuilder<TripleConfig, TripleBuilder> {
+
+    /**
+     * Maximum allowed size for HTTP1 request bodies.
+     * Limits the size of request to prevent excessively large request.
+     * <p>The default value is 8MiB.
+     */
+    private Integer maxBodySize;
+
+    /**
+     * Maximum allowed size for HTTP1 response bodies.
+     * Limits the size of responses to prevent excessively large response.
+     * <p>The default value is 8MiB.
+     */
+    private Integer maxResponseBodySize;
+
+    /**
+     * Set the maximum chunk size.
+     * HTTP requests and responses can be quite large, in which case it's better to process the data as a stream of
+     * chunks.
+     * This sets the limit, in bytes, at which Netty will send a chunk down the pipeline.
+     * <p>The default value is 8KiB.
+     */
+    private Integer maxChunkSize;
+
+    /**
+     * Set the maximum line length of header lines.
+     * This limits how much memory Netty will use when parsing HTTP header key-value pairs.
+     * You would typically set this to the same value as {@link #maxInitialLineLength(Integer)}.
+     * <p>The default value is 8KiB.
+     */
+    private Integer maxHeaderSize;
+
+    /**
+     * Set the maximum length of the first line of the HTTP header.
+     * This limits how much memory Netty will use when parsed the initial HTTP header line.
+     * You would typically set this to the same value as {@link #maxHeaderSize(Integer)}.
+     * <p>The default value is 4096.
+     */
+    private Integer maxInitialLineLength;
+
+    /**
+     * Set the initial size of the temporary buffer used when parsing the lines of the HTTP headers.
+     * <p>The default value is 128 octets.
+     */
+    private Integer initialBufferSize;
+
+    /**
+     * The header table size.
+     */
+    private Integer headerTableSize;
+
+    /**
+     * Whether to enable push, default is false.
+     */
+    private Boolean enablePush;
+
+    /**
+     * Maximum concurrent streams.
+     */
+    private Integer maxConcurrentStreams;
+
+    /**
+     * Initial window size.
+     */
+    private Integer initialWindowSize;
+
+    /**
+     * Maximum frame size.
+     */
+    private Integer maxFrameSize;
+
+    /**
+     * Maximum header list size.
+     */
+    private Integer maxHeaderListSize;
+
+    /**
+     * Whether to pass through standard HTTP headers, default is false.
+     */
+    private Boolean passThroughStandardHttpHeaders;
+
+    public static TripleBuilder newBuilder() {
+        return new TripleBuilder();
+    }
+
+    public TripleBuilder maxBodySize(Integer maxBodySize) {
+        this.maxBodySize = maxBodySize;
+        return getThis();
+    }
+
+    public TripleBuilder maxResponseBodySize(Integer maxResponseBodySize) {
+        this.maxResponseBodySize = maxResponseBodySize;
+        return getThis();
+    }
+
+    public TripleBuilder maxChunkSize(Integer maxChunkSize) {
+        this.maxChunkSize = maxChunkSize;
+        return getThis();
+    }
+
+    public TripleBuilder maxHeaderSize(Integer maxHeaderSize) {
+        this.maxHeaderSize = maxHeaderSize;
+        return getThis();
+    }
+
+    public TripleBuilder maxInitialLineLength(Integer maxInitialLineLength) {
+        this.maxInitialLineLength = maxInitialLineLength;
+        return getThis();
+    }
+
+    public TripleBuilder initialBufferSize(Integer initialBufferSize) {
+        this.initialBufferSize = initialBufferSize;
+        return getThis();
+    }
+
+    public TripleBuilder headerTableSize(Integer headerTableSize) {
+        this.headerTableSize = headerTableSize;
+        return getThis();
+    }
+
+    public TripleBuilder enablePush(Boolean enablePush) {
+        this.enablePush = enablePush;
+        return getThis();
+    }
+
+    public TripleBuilder maxConcurrentStreams(Integer maxConcurrentStreams) {
+        this.maxConcurrentStreams = maxConcurrentStreams;
+        return getThis();
+    }
+
+    public TripleBuilder initialWindowSize(Integer initialWindowSize) {
+        this.initialWindowSize = initialWindowSize;
+        return getThis();
+    }
+
+    public TripleBuilder maxFrameSize(Integer maxFrameSize) {
+        this.maxFrameSize = maxFrameSize;
+        return getThis();
+    }
+
+    public TripleBuilder maxHeaderListSize(Integer maxHeaderListSize) {
+        this.maxHeaderListSize = maxHeaderListSize;
+        return getThis();
+    }
+
+    public TripleBuilder passThroughStandardHttpHeaders(Boolean passThroughStandardHttpHeaders) {
+        this.passThroughStandardHttpHeaders = passThroughStandardHttpHeaders;
+        return getThis();
+    }
+
+    @Override
+    protected TripleBuilder getThis() {
+        return this;
+    }
+
+    @Override
+    public TripleConfig build() {
+        TripleConfig triple = new TripleConfig();
+        super.build(triple);
+
+        triple.setMaxBodySize(maxBodySize);
+        triple.setMaxResponseBodySize(maxResponseBodySize);
+        triple.setMaxChunkSize(maxChunkSize);
+        triple.setMaxHeaderSize(maxHeaderSize);
+        triple.setMaxInitialLineLength(maxInitialLineLength);
+        triple.setInitialBufferSize(initialBufferSize);
+        triple.setHeaderTableSize(headerTableSize);
+        triple.setEnablePush(enablePush);
+        triple.setMaxConcurrentStreams(maxConcurrentStreams);
+        triple.setInitialWindowSize(initialWindowSize);
+        triple.setMaxFrameSize(maxFrameSize);
+        triple.setMaxHeaderListSize(maxHeaderListSize);
+        triple.setPassThroughStandardHttpHeaders(passThroughStandardHttpHeaders);
+        return triple;
+    }
+}

--- a/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/bootstrap/builders/TripleBuilderTest.java
+++ b/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/bootstrap/builders/TripleBuilderTest.java
@@ -1,0 +1,152 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.config.bootstrap.builders;
+
+import org.apache.dubbo.config.TripleConfig;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class TripleBuilderTest {
+
+    @Test
+    void maxBodySize() {
+        TripleBuilder builder = TripleBuilder.newBuilder();
+        builder.maxBodySize(10240);
+        Assertions.assertEquals(10240, builder.build().getMaxBodySize());
+    }
+
+    @Test
+    void maxResponseBodySize() {
+        TripleBuilder builder = TripleBuilder.newBuilder();
+        builder.maxResponseBodySize(8192);
+        Assertions.assertEquals(8192, builder.build().getMaxResponseBodySize());
+    }
+
+    @Test
+    void maxChunkSize() {
+        TripleBuilder builder = TripleBuilder.newBuilder();
+        builder.maxChunkSize(2048);
+        Assertions.assertEquals(2048, builder.build().getMaxChunkSize());
+    }
+
+    @Test
+    void maxHeaderSize() {
+        TripleBuilder builder = TripleBuilder.newBuilder();
+        builder.maxHeaderSize(40960);
+        Assertions.assertEquals(40960, builder.build().getMaxHeaderSize());
+    }
+
+    @Test
+    void maxInitialLineLength() {
+        TripleBuilder builder = TripleBuilder.newBuilder();
+        builder.maxInitialLineLength(Integer.MAX_VALUE);
+        Assertions.assertEquals(Integer.MAX_VALUE, builder.build().getMaxInitialLineLength());
+    }
+
+    @Test
+    void initialBufferSize() {
+        TripleBuilder builder = TripleBuilder.newBuilder();
+        builder.initialBufferSize(3000);
+        Assertions.assertEquals(3000, builder.build().getInitialBufferSize());
+    }
+
+    @Test
+    void headerTableSize() {
+        TripleBuilder builder = TripleBuilder.newBuilder();
+        builder.headerTableSize(1000);
+        Assertions.assertEquals(1000, builder.build().getHeaderTableSize());
+    }
+
+    @Test
+    void enablePush() {
+        TripleBuilder builder = TripleBuilder.newBuilder();
+        builder.enablePush(false);
+        Assertions.assertFalse(builder.build().getEnablePush());
+    }
+
+    @Test
+    void maxConcurrentStreams() {
+        TripleBuilder builder = TripleBuilder.newBuilder();
+        builder.maxConcurrentStreams(3000);
+        Assertions.assertEquals(3000, builder.build().getMaxConcurrentStreams());
+    }
+
+    @Test
+    void initialWindowSize() {
+        TripleBuilder builder = TripleBuilder.newBuilder();
+        builder.initialWindowSize(10240);
+        Assertions.assertEquals(10240, builder.build().getInitialWindowSize());
+    }
+
+    @Test
+    void maxFrameSize() {
+        TripleBuilder builder = TripleBuilder.newBuilder();
+        builder.maxFrameSize(4096);
+        Assertions.assertEquals(4096, builder.build().getMaxFrameSize());
+    }
+
+    @Test
+    void maxHeaderListSize() {
+        TripleBuilder builder = TripleBuilder.newBuilder();
+        builder.maxHeaderListSize(2000);
+        Assertions.assertEquals(2000, builder.build().getMaxHeaderListSize());
+    }
+
+    @Test
+    void passThroughStandardHttpHeaders() {
+        TripleBuilder builder = TripleBuilder.newBuilder();
+        builder.passThroughStandardHttpHeaders(true);
+        Assertions.assertTrue(builder.build().getPassThroughStandardHttpHeaders());
+    }
+
+    @Test
+    void build() {
+        TripleBuilder builder = TripleBuilder.newBuilder();
+        builder.maxBodySize(2048)
+                .maxResponseBodySize(3072)
+                .maxChunkSize(10240)
+                .maxHeaderSize(400)
+                .maxInitialLineLength(100)
+                .initialBufferSize(8192)
+                .headerTableSize(300)
+                .enablePush(true)
+                .maxConcurrentStreams(Integer.MAX_VALUE)
+                .initialWindowSize(4096)
+                .maxFrameSize(1024)
+                .maxHeaderListSize(500)
+                .passThroughStandardHttpHeaders(false);
+
+        TripleConfig config = builder.build();
+        TripleConfig config2 = builder.build();
+
+        Assertions.assertEquals(2048, config.getMaxBodySize());
+        Assertions.assertEquals(3072, config.getMaxResponseBodySize());
+        Assertions.assertEquals(10240, config.getMaxChunkSize());
+        Assertions.assertEquals(400, config.getMaxHeaderSize());
+        Assertions.assertEquals(100, config.getMaxInitialLineLength());
+        Assertions.assertEquals(8192, config.getInitialBufferSize());
+        Assertions.assertEquals(300, config.getHeaderTableSize());
+        Assertions.assertTrue(config.getEnablePush());
+        Assertions.assertEquals(Integer.MAX_VALUE, config.getMaxConcurrentStreams());
+        Assertions.assertEquals(4096, config.getInitialWindowSize());
+        Assertions.assertEquals(1024, config.getMaxFrameSize());
+        Assertions.assertEquals(500, config.getMaxHeaderListSize());
+        Assertions.assertFalse(config.getPassThroughStandardHttpHeaders());
+        Assertions.assertNotSame(config, config2);
+    }
+}

--- a/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/exception/HttpOverPayloadException.java
+++ b/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/exception/HttpOverPayloadException.java
@@ -14,13 +14,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.dubbo.remoting.http12.h1;
+package org.apache.dubbo.remoting.http12.exception;
 
-import io.netty.buffer.ByteBufOutputStream;
+public class HttpOverPayloadException extends HttpStatusException {
 
-public class Http1OutputMessage extends LimitedHttpOutputMessage {
+    private static final String OVER_PAYLOAD_MESSAGE = "Response Entity Too Large: %s, max response body size: %s";
 
-    public Http1OutputMessage(ByteBufOutputStream outputStream, int capacity) {
-        super(outputStream, capacity);
+    public HttpOverPayloadException(String message) {
+        super(500, message);
+    }
+
+    public HttpOverPayloadException(int writerIndex, int capacity) {
+        super(500, String.format(OVER_PAYLOAD_MESSAGE, writerIndex, capacity));
     }
 }

--- a/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/h1/Http1Channel.java
+++ b/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/h1/Http1Channel.java
@@ -16,11 +16,13 @@
  */
 package org.apache.dubbo.remoting.http12.h1;
 
-import io.netty.buffer.ByteBufOutputStream;
+import org.apache.dubbo.remoting.http12.HttpChannel;
 
-public class Http1OutputMessage extends LimitedHttpOutputMessage {
+import java.util.concurrent.CompletableFuture;
 
-    public Http1OutputMessage(ByteBufOutputStream outputStream, int capacity) {
-        super(outputStream, capacity);
-    }
+import io.netty.handler.codec.http.FullHttpMessage;
+
+public interface Http1Channel extends HttpChannel {
+
+    CompletableFuture<Void> writeFullHttpMessage(FullHttpMessage fullHttpMessage);
 }

--- a/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/h1/Http1ServerChannelObserver.java
+++ b/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/h1/Http1ServerChannelObserver.java
@@ -31,6 +31,11 @@ public class Http1ServerChannelObserver extends AbstractServerHttpChannelObserve
     }
 
     @Override
+    public Http1Channel getHttpChannel() {
+        return (Http1Channel) super.getHttpChannel();
+    }
+
+    @Override
     protected HttpMetadata encodeHttpMetadata() {
         HttpHeaders httpHeaders = new HttpHeaders();
         return new Http1Metadata(httpHeaders);

--- a/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/h1/Http1ServerUnaryChannelObserver.java
+++ b/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/h1/Http1ServerUnaryChannelObserver.java
@@ -16,16 +16,36 @@
  */
 package org.apache.dubbo.remoting.http12.h1;
 
+import org.apache.dubbo.common.logger.ErrorTypeAwareLogger;
+import org.apache.dubbo.common.logger.LoggerFactory;
 import org.apache.dubbo.remoting.http12.HttpChannel;
 import org.apache.dubbo.remoting.http12.HttpHeaderNames;
 import org.apache.dubbo.remoting.http12.HttpMetadata;
 import org.apache.dubbo.remoting.http12.HttpOutputMessage;
+import org.apache.dubbo.remoting.http12.exception.HttpOverPayloadException;
 
 import java.io.OutputStream;
 
 import io.netty.buffer.ByteBufOutputStream;
+import io.netty.buffer.Unpooled;
+import io.netty.handler.codec.http.DefaultFullHttpResponse;
+import io.netty.handler.codec.http.FullHttpResponse;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.HttpVersion;
+
+import static io.netty.handler.codec.http.HttpHeaderNames.CONTENT_LENGTH;
 
 public class Http1ServerUnaryChannelObserver extends Http1ServerChannelObserver {
+
+    private static final ErrorTypeAwareLogger log =
+            LoggerFactory.getErrorTypeAwareLogger(Http1ServerUnaryChannelObserver.class);
+
+    private static final FullHttpResponse RESPONSE_TOO_LARGE = new DefaultFullHttpResponse(
+            HttpVersion.HTTP_1_1, new HttpResponseStatus(500, "Response Entity Too Large"), Unpooled.EMPTY_BUFFER);
+
+    static {
+        RESPONSE_TOO_LARGE.headers().set(CONTENT_LENGTH, 0);
+    }
 
     public Http1ServerUnaryChannelObserver(HttpChannel httpChannel) {
         super(httpChannel);
@@ -40,6 +60,10 @@ public class Http1ServerUnaryChannelObserver extends Http1ServerChannelObserver 
 
     @Override
     protected void doOnError(Throwable throwable) throws Throwable {
+        if (throwable instanceof HttpOverPayloadException) {
+            handleOverPayloadMessage((HttpOverPayloadException) throwable);
+            return;
+        }
         String statusCode = resolveStatusCode(throwable);
         Object data = buildErrorResponse(statusCode, throwable);
         HttpOutputMessage httpOutputMessage = buildMessage(data);
@@ -54,5 +78,13 @@ public class Http1ServerUnaryChannelObserver extends Http1ServerChannelObserver 
             int contentLength = ((ByteBufOutputStream) body).writtenBytes();
             httpMetadata.headers().set(HttpHeaderNames.CONTENT_LENGTH.getName(), String.valueOf(contentLength));
         }
+    }
+
+    protected void handleOverPayloadMessage(HttpOverPayloadException exception) {
+        getHttpChannel().writeFullHttpMessage(RESPONSE_TOO_LARGE).whenComplete((unused, throwable) -> {
+            if (throwable != null && log.isDebugEnabled()) {
+                log.debug("Failed to send a 500 Response Entity Too Large.", throwable);
+            }
+        });
     }
 }

--- a/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/h1/LimitedByteBufOutputStreamDelegate.java
+++ b/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/h1/LimitedByteBufOutputStreamDelegate.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.remoting.http12.h1;
+
+import org.apache.dubbo.remoting.http12.exception.HttpOverPayloadException;
+
+import java.io.IOException;
+
+import io.netty.buffer.ByteBufOutputStream;
+
+public class LimitedByteBufOutputStreamDelegate extends ByteBufOutputStream {
+
+    private final ByteBufOutputStream outputStream;
+
+    private final int capacity;
+
+    private int writerIndex;
+
+    public LimitedByteBufOutputStreamDelegate(ByteBufOutputStream outputStream, int capacity) {
+        super(outputStream.buffer());
+        this.outputStream = outputStream;
+        this.capacity = capacity == 0 ? Integer.MAX_VALUE : capacity;
+        this.writerIndex = 0;
+    }
+
+    @Override
+    public void write(int b) throws IOException {
+        writerIndex++;
+        if (writerIndex > capacity) {
+            throw new HttpOverPayloadException(writerIndex, capacity);
+        }
+        outputStream.write(b);
+    }
+
+    @Override
+    public void write(byte[] b) throws IOException {
+        writerIndex += b.length;
+        if (writerIndex > capacity) {
+            throw new HttpOverPayloadException(writerIndex, capacity);
+        }
+        outputStream.write(b);
+    }
+
+    @Override
+    public void write(byte[] b, int off, int len) throws IOException {
+        writerIndex += len;
+        if (writerIndex > capacity) {
+            throw new HttpOverPayloadException(writerIndex, capacity);
+        }
+        outputStream.write(b, off, len);
+    }
+}

--- a/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/h1/LimitedHttpOutputMessage.java
+++ b/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/h1/LimitedHttpOutputMessage.java
@@ -16,11 +16,22 @@
  */
 package org.apache.dubbo.remoting.http12.h1;
 
+import org.apache.dubbo.remoting.http12.HttpOutputMessage;
+
+import java.io.OutputStream;
+
 import io.netty.buffer.ByteBufOutputStream;
 
-public class Http1OutputMessage extends LimitedHttpOutputMessage {
+public class LimitedHttpOutputMessage implements HttpOutputMessage {
 
-    public Http1OutputMessage(ByteBufOutputStream outputStream, int capacity) {
-        super(outputStream, capacity);
+    private final OutputStream delegate;
+
+    protected LimitedHttpOutputMessage(ByteBufOutputStream outputStream, int capacity) {
+        this.delegate = new LimitedByteBufOutputStreamDelegate(outputStream, capacity);
+    }
+
+    @Override
+    public OutputStream getBody() {
+        return delegate;
     }
 }

--- a/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/message/codec/BinaryCodec.java
+++ b/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/message/codec/BinaryCodec.java
@@ -19,6 +19,7 @@ package org.apache.dubbo.remoting.http12.message.codec;
 import org.apache.dubbo.common.io.StreamUtils;
 import org.apache.dubbo.remoting.http12.exception.DecodeException;
 import org.apache.dubbo.remoting.http12.exception.EncodeException;
+import org.apache.dubbo.remoting.http12.exception.HttpStatusException;
 import org.apache.dubbo.remoting.http12.message.HttpMessageCodec;
 import org.apache.dubbo.remoting.http12.message.MediaType;
 
@@ -49,6 +50,8 @@ public class BinaryCodec implements HttpMessageCodec {
     public Object decode(InputStream is, Class<?> targetType, Charset charset) throws DecodeException {
         try {
             return StreamUtils.readBytes(is);
+        } catch (HttpStatusException e) {
+            throw e;
         } catch (Exception e) {
             throw new DecodeException(e);
         }

--- a/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/message/codec/HtmlCodec.java
+++ b/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/message/codec/HtmlCodec.java
@@ -19,6 +19,7 @@ package org.apache.dubbo.remoting.http12.message.codec;
 import org.apache.dubbo.common.io.StreamUtils;
 import org.apache.dubbo.remoting.http12.exception.DecodeException;
 import org.apache.dubbo.remoting.http12.exception.EncodeException;
+import org.apache.dubbo.remoting.http12.exception.HttpStatusException;
 import org.apache.dubbo.remoting.http12.message.HttpMessageCodec;
 import org.apache.dubbo.remoting.http12.message.MediaType;
 
@@ -48,6 +49,8 @@ public class HtmlCodec implements HttpMessageCodec {
             if (targetType == String.class) {
                 return StreamUtils.toString(is, charset);
             }
+        } catch (HttpStatusException e) {
+            throw e;
         } catch (Exception e) {
             throw new DecodeException(e);
         }

--- a/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/message/codec/JsonCodec.java
+++ b/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/message/codec/JsonCodec.java
@@ -20,6 +20,7 @@ import org.apache.dubbo.common.io.StreamUtils;
 import org.apache.dubbo.common.utils.JsonUtils;
 import org.apache.dubbo.remoting.http12.exception.DecodeException;
 import org.apache.dubbo.remoting.http12.exception.EncodeException;
+import org.apache.dubbo.remoting.http12.exception.HttpStatusException;
 import org.apache.dubbo.remoting.http12.message.HttpMessageCodec;
 import org.apache.dubbo.remoting.http12.message.MediaType;
 
@@ -35,14 +36,19 @@ public class JsonCodec implements HttpMessageCodec {
     public void encode(OutputStream os, Object data, Charset charset) throws EncodeException {
         try {
             os.write(JsonUtils.toJson(data).getBytes(charset));
+        } catch (HttpStatusException e) {
+            throw e;
         } catch (Throwable t) {
             throw new EncodeException("Error encoding json", t);
         }
     }
 
+    @Override
     public void encode(OutputStream os, Object[] data, Charset charset) throws EncodeException {
         try {
             os.write(JsonUtils.toJson(data).getBytes(charset));
+        } catch (HttpStatusException e) {
+            throw e;
         } catch (Throwable t) {
             throw new EncodeException("Error encoding json", t);
         }
@@ -52,6 +58,8 @@ public class JsonCodec implements HttpMessageCodec {
     public Object decode(InputStream is, Class<?> targetType, Charset charset) throws DecodeException {
         try {
             return JsonUtils.toJavaObject(StreamUtils.toString(is, charset), targetType);
+        } catch (HttpStatusException e) {
+            throw e;
         } catch (Throwable t) {
             throw new DecodeException("Error decoding json", t);
         }
@@ -78,7 +86,7 @@ public class JsonCodec implements HttpMessageCodec {
                 return new Object[] {JsonUtils.convertObject(obj, targetTypes[0])};
             }
             throw new DecodeException("Json must be array");
-        } catch (DecodeException e) {
+        }  catch (HttpStatusException e) {
             throw e;
         } catch (Throwable t) {
             throw new DecodeException("Error decoding json", t);

--- a/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/message/codec/JsonCodec.java
+++ b/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/message/codec/JsonCodec.java
@@ -86,7 +86,7 @@ public class JsonCodec implements HttpMessageCodec {
                 return new Object[] {JsonUtils.convertObject(obj, targetTypes[0])};
             }
             throw new DecodeException("Json must be array");
-        }  catch (HttpStatusException e) {
+        } catch (HttpStatusException e) {
             throw e;
         } catch (Throwable t) {
             throw new DecodeException("Error decoding json", t);

--- a/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/message/codec/JsonPbCodec.java
+++ b/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/message/codec/JsonPbCodec.java
@@ -29,6 +29,8 @@ import java.nio.charset.Charset;
 import com.google.protobuf.Message;
 import com.google.protobuf.util.JsonFormat;
 
+import org.apache.dubbo.remoting.http12.exception.HttpStatusException;
+
 public final class JsonPbCodec extends JsonCodec {
 
     @Override
@@ -54,7 +56,9 @@ public final class JsonPbCodec extends JsonCodec {
                 JsonFormat.parser().ignoringUnknownFields().merge(StreamUtils.toString(is, charset), newBuilder);
                 return newBuilder.build();
             }
-        } catch (Throwable e) {
+        } catch (HttpStatusException e) {
+            throw e;
+        }  catch (Throwable e) {
             throw new DecodeException("Error decoding jsonPb", e);
         }
         return super.decode(is, targetType, charset);
@@ -67,7 +71,9 @@ public final class JsonPbCodec extends JsonCodec {
                 // protobuf only support one parameter
                 return new Object[] {decode(is, targetTypes[0], charset)};
             }
-        } catch (Throwable e) {
+        } catch (HttpStatusException e) {
+            throw e;
+        }  catch (Throwable e) {
             throw new DecodeException("Error decoding jsonPb", e);
         }
         return super.decode(is, targetTypes, charset);

--- a/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/message/codec/JsonPbCodec.java
+++ b/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/message/codec/JsonPbCodec.java
@@ -58,7 +58,7 @@ public final class JsonPbCodec extends JsonCodec {
             }
         } catch (HttpStatusException e) {
             throw e;
-        }  catch (Throwable e) {
+        } catch (Throwable e) {
             throw new DecodeException("Error decoding jsonPb", e);
         }
         return super.decode(is, targetType, charset);
@@ -73,7 +73,7 @@ public final class JsonPbCodec extends JsonCodec {
             }
         } catch (HttpStatusException e) {
             throw e;
-        }  catch (Throwable e) {
+        } catch (Throwable e) {
             throw new DecodeException("Error decoding jsonPb", e);
         }
         return super.decode(is, targetTypes, charset);

--- a/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/message/codec/JsonPbCodec.java
+++ b/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/message/codec/JsonPbCodec.java
@@ -20,6 +20,7 @@ import org.apache.dubbo.common.io.StreamUtils;
 import org.apache.dubbo.common.utils.MethodUtils;
 import org.apache.dubbo.remoting.http12.exception.DecodeException;
 import org.apache.dubbo.remoting.http12.exception.EncodeException;
+import org.apache.dubbo.remoting.http12.exception.HttpStatusException;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -28,8 +29,6 @@ import java.nio.charset.Charset;
 
 import com.google.protobuf.Message;
 import com.google.protobuf.util.JsonFormat;
-
-import org.apache.dubbo.remoting.http12.exception.HttpStatusException;
 
 public final class JsonPbCodec extends JsonCodec {
 

--- a/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/message/codec/PlainTextCodec.java
+++ b/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/message/codec/PlainTextCodec.java
@@ -54,7 +54,7 @@ public final class PlainTextCodec implements HttpMessageCodec {
             }
         } catch (HttpStatusException e) {
             throw e;
-        }  catch (Exception e) {
+        } catch (Exception e) {
             throw new DecodeException(e);
         }
         throw new DecodeException("'text/plain' media-type only supports String as method param.");

--- a/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/message/codec/PlainTextCodec.java
+++ b/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/message/codec/PlainTextCodec.java
@@ -19,6 +19,7 @@ package org.apache.dubbo.remoting.http12.message.codec;
 import org.apache.dubbo.common.io.StreamUtils;
 import org.apache.dubbo.remoting.http12.exception.DecodeException;
 import org.apache.dubbo.remoting.http12.exception.EncodeException;
+import org.apache.dubbo.remoting.http12.exception.HttpStatusException;
 import org.apache.dubbo.remoting.http12.message.HttpMessageCodec;
 import org.apache.dubbo.remoting.http12.message.MediaType;
 
@@ -51,7 +52,9 @@ public final class PlainTextCodec implements HttpMessageCodec {
             if (targetType == String.class) {
                 return StreamUtils.toString(is, charset);
             }
-        } catch (Exception e) {
+        } catch (HttpStatusException e) {
+            throw e;
+        }  catch (Exception e) {
             throw new DecodeException(e);
         }
         throw new DecodeException("'text/plain' media-type only supports String as method param.");

--- a/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/message/codec/UrlEncodeFormCodec.java
+++ b/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/message/codec/UrlEncodeFormCodec.java
@@ -66,7 +66,7 @@ public class UrlEncodeFormCodec implements HttpMessageCodec {
             }
         } catch (HttpStatusException e) {
             throw e;
-        }  catch (Exception e) {
+        } catch (Exception e) {
             throw new EncodeException(e);
         }
     }
@@ -104,7 +104,7 @@ public class UrlEncodeFormCodec implements HttpMessageCodec {
             }
         } catch (HttpStatusException e) {
             throw e;
-        }  catch (Exception e) {
+        } catch (Exception e) {
             throw new DecodeException(e);
         }
     }

--- a/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/message/codec/UrlEncodeFormCodec.java
+++ b/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/message/codec/UrlEncodeFormCodec.java
@@ -20,6 +20,7 @@ import org.apache.dubbo.common.convert.ConverterUtil;
 import org.apache.dubbo.common.io.StreamUtils;
 import org.apache.dubbo.remoting.http12.exception.DecodeException;
 import org.apache.dubbo.remoting.http12.exception.EncodeException;
+import org.apache.dubbo.remoting.http12.exception.HttpStatusException;
 import org.apache.dubbo.remoting.http12.message.HttpMessageCodec;
 import org.apache.dubbo.remoting.http12.message.MediaType;
 
@@ -63,7 +64,9 @@ public class UrlEncodeFormCodec implements HttpMessageCodec {
             } else {
                 throw new EncodeException("UrlEncodeFrom media-type only supports String or Map as return type.");
             }
-        } catch (Exception e) {
+        } catch (HttpStatusException e) {
+            throw e;
+        }  catch (Exception e) {
             throw new EncodeException(e);
         }
     }
@@ -99,7 +102,9 @@ public class UrlEncodeFormCodec implements HttpMessageCodec {
             } else {
                 return res.values().toArray();
             }
-        } catch (Exception e) {
+        } catch (HttpStatusException e) {
+            throw e;
+        }  catch (Exception e) {
             throw new DecodeException(e);
         }
     }

--- a/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/message/codec/XmlCodec.java
+++ b/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/message/codec/XmlCodec.java
@@ -50,7 +50,7 @@ public class XmlCodec implements HttpMessageCodec {
             }
         } catch (HttpStatusException e) {
             throw e;
-        }  catch (Exception e) {
+        } catch (Exception e) {
             throw new EncodeException("Error encoding xml", e);
         }
     }
@@ -68,7 +68,7 @@ public class XmlCodec implements HttpMessageCodec {
             }
         } catch (HttpStatusException e) {
             throw e;
-        }  catch (Exception e) {
+        } catch (Exception e) {
             throw new DecodeException("Error decoding xml", e);
         }
     }

--- a/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/message/codec/XmlCodec.java
+++ b/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/message/codec/XmlCodec.java
@@ -18,6 +18,7 @@ package org.apache.dubbo.remoting.http12.message.codec;
 
 import org.apache.dubbo.remoting.http12.exception.DecodeException;
 import org.apache.dubbo.remoting.http12.exception.EncodeException;
+import org.apache.dubbo.remoting.http12.exception.HttpStatusException;
 import org.apache.dubbo.remoting.http12.message.HttpMessageCodec;
 import org.apache.dubbo.remoting.http12.message.MediaType;
 
@@ -47,7 +48,9 @@ public class XmlCodec implements HttpMessageCodec {
             try (OutputStreamWriter writer = new OutputStreamWriter(os, charset)) {
                 marshaller.marshal(data, writer);
             }
-        } catch (Exception e) {
+        } catch (HttpStatusException e) {
+            throw e;
+        }  catch (Exception e) {
             throw new EncodeException("Error encoding xml", e);
         }
     }
@@ -63,7 +66,9 @@ public class XmlCodec implements HttpMessageCodec {
                 Unmarshaller unmarshaller = context.createUnmarshaller();
                 return unmarshaller.unmarshal(xmlSource);
             }
-        } catch (Exception e) {
+        } catch (HttpStatusException e) {
+            throw e;
+        }  catch (Exception e) {
             throw new DecodeException("Error decoding xml", e);
         }
     }

--- a/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/message/codec/YamlCodec.java
+++ b/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/message/codec/YamlCodec.java
@@ -20,6 +20,7 @@ import org.apache.dubbo.common.utils.ClassUtils;
 import org.apache.dubbo.common.utils.DefaultSerializeClassChecker;
 import org.apache.dubbo.remoting.http12.exception.DecodeException;
 import org.apache.dubbo.remoting.http12.exception.EncodeException;
+import org.apache.dubbo.remoting.http12.exception.HttpStatusException;
 import org.apache.dubbo.remoting.http12.message.HttpMessageCodec;
 import org.apache.dubbo.remoting.http12.message.MediaType;
 
@@ -43,7 +44,9 @@ public class YamlCodec implements HttpMessageCodec {
     public Object decode(InputStream is, Class<?> targetType, Charset charset) throws DecodeException {
         try (InputStreamReader reader = new InputStreamReader(is, charset)) {
             return createYaml().loadAs(reader, (Class) targetType);
-        } catch (Throwable t) {
+        } catch (HttpStatusException e) {
+            throw e;
+        }  catch (Throwable t) {
             throw new DecodeException("Error decoding yaml", t);
         }
     }
@@ -69,7 +72,9 @@ public class YamlCodec implements HttpMessageCodec {
                 }
             }
             return results;
-        } catch (Throwable t) {
+        } catch (HttpStatusException e) {
+            throw e;
+        }  catch (Throwable t) {
             throw new DecodeException("Error decoding yaml", t);
         }
     }
@@ -78,7 +83,9 @@ public class YamlCodec implements HttpMessageCodec {
     public void encode(OutputStream os, Object data, Charset charset) throws EncodeException {
         try (OutputStreamWriter writer = new OutputStreamWriter(os, charset)) {
             createYaml().dump(data, writer);
-        } catch (Throwable t) {
+        } catch (HttpStatusException e) {
+            throw e;
+        }  catch (Throwable t) {
             throw new EncodeException("Error encoding yaml", t);
         }
     }
@@ -87,7 +94,9 @@ public class YamlCodec implements HttpMessageCodec {
     public void encode(OutputStream os, Object[] data, Charset charset) throws EncodeException {
         try (OutputStreamWriter writer = new OutputStreamWriter(os, charset)) {
             createYaml().dump(data, writer);
-        } catch (Throwable t) {
+        } catch (HttpStatusException e) {
+            throw e;
+        }  catch (Throwable t) {
             throw new EncodeException("Error encoding yaml", t);
         }
     }

--- a/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/message/codec/YamlCodec.java
+++ b/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/message/codec/YamlCodec.java
@@ -46,7 +46,7 @@ public class YamlCodec implements HttpMessageCodec {
             return createYaml().loadAs(reader, (Class) targetType);
         } catch (HttpStatusException e) {
             throw e;
-        }  catch (Throwable t) {
+        } catch (Throwable t) {
             throw new DecodeException("Error decoding yaml", t);
         }
     }
@@ -74,7 +74,7 @@ public class YamlCodec implements HttpMessageCodec {
             return results;
         } catch (HttpStatusException e) {
             throw e;
-        }  catch (Throwable t) {
+        } catch (Throwable t) {
             throw new DecodeException("Error decoding yaml", t);
         }
     }
@@ -85,7 +85,7 @@ public class YamlCodec implements HttpMessageCodec {
             createYaml().dump(data, writer);
         } catch (HttpStatusException e) {
             throw e;
-        }  catch (Throwable t) {
+        } catch (Throwable t) {
             throw new EncodeException("Error encoding yaml", t);
         }
     }
@@ -96,7 +96,7 @@ public class YamlCodec implements HttpMessageCodec {
             createYaml().dump(data, writer);
         } catch (HttpStatusException e) {
             throw e;
-        }  catch (Throwable t) {
+        } catch (Throwable t) {
             throw new EncodeException("Error encoding yaml", t);
         }
     }

--- a/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/netty4/h1/NettyHttp1Channel.java
+++ b/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/netty4/h1/NettyHttp1Channel.java
@@ -64,7 +64,8 @@ public class NettyHttp1Channel implements Http1Channel {
 
     @Override
     public HttpOutputMessage newOutputMessage() {
-        return new Http1OutputMessage(new ByteBufOutputStream(channel.alloc().buffer()), triple.getMaxResponseBodySize());
+        return new Http1OutputMessage(
+                new ByteBufOutputStream(channel.alloc().buffer()), triple.getMaxResponseBodySize());
     }
 
     @Override

--- a/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/netty4/h1/NettyHttp1Codec.java
+++ b/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/netty4/h1/NettyHttp1Codec.java
@@ -35,6 +35,7 @@ import io.netty.channel.ChannelDuplexHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
 import io.netty.handler.codec.http.DefaultHttpResponse;
+import io.netty.handler.codec.http.FullHttpMessage;
 import io.netty.handler.codec.http.FullHttpRequest;
 import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.HttpResponseStatus;
@@ -78,6 +79,10 @@ public class NettyHttp1Codec extends ChannelDuplexHandler {
             doWriteMessage(ctx, ((HttpOutputMessage) msg), promise);
             return;
         }
+        if (msg instanceof FullHttpMessage) {
+            doWriteFullHttpMessage(ctx, (FullHttpMessage) msg, promise);
+            return;
+        }
         super.write(ctx, msg, promise);
     }
 
@@ -109,5 +114,10 @@ public class NettyHttp1Codec extends ChannelDuplexHandler {
             return;
         }
         throw new IllegalArgumentException("HttpOutputMessage body must be 'io.netty.buffer.ByteBufOutputStream'");
+    }
+
+    private void doWriteFullHttpMessage(
+            ChannelHandlerContext ctx, FullHttpMessage fullHttpMessage, ChannelPromise promise) {
+        ctx.writeAndFlush(fullHttpMessage, promise);
     }
 }

--- a/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/netty4/h1/NettyHttp1ConnectionHandler.java
+++ b/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/netty4/h1/NettyHttp1ConnectionHandler.java
@@ -43,7 +43,8 @@ public class NettyHttp1ConnectionHandler extends SimpleChannelInboundHandler<Htt
         this.url = url;
         this.frameworkModel = frameworkModel;
         this.http1ServerTransportListenerFactory = http1ServerTransportListenerFactory;
-        this.triple = url.getOrDefaultApplicationModel().getApplicationConfigManager().getTripleOrElseThrow();
+        this.triple =
+                url.getOrDefaultApplicationModel().getApplicationConfigManager().getTripleOrElseThrow();
     }
 
     /**

--- a/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/netty4/h1/NettyHttp1ConnectionHandler.java
+++ b/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/netty4/h1/NettyHttp1ConnectionHandler.java
@@ -17,6 +17,7 @@
 package org.apache.dubbo.remoting.http12.netty4.h1;
 
 import org.apache.dubbo.common.URL;
+import org.apache.dubbo.config.TripleConfig;
 import org.apache.dubbo.remoting.http12.h1.Http1Request;
 import org.apache.dubbo.remoting.http12.h1.Http1ServerTransportListener;
 import org.apache.dubbo.remoting.http12.h1.Http1ServerTransportListenerFactory;
@@ -33,6 +34,8 @@ public class NettyHttp1ConnectionHandler extends SimpleChannelInboundHandler<Htt
 
     private final Http1ServerTransportListenerFactory http1ServerTransportListenerFactory;
 
+    private final TripleConfig triple;
+
     public NettyHttp1ConnectionHandler(
             URL url,
             FrameworkModel frameworkModel,
@@ -40,6 +43,7 @@ public class NettyHttp1ConnectionHandler extends SimpleChannelInboundHandler<Htt
         this.url = url;
         this.frameworkModel = frameworkModel;
         this.http1ServerTransportListenerFactory = http1ServerTransportListenerFactory;
+        this.triple = url.getOrDefaultApplicationModel().getApplicationConfigManager().getTripleOrElseThrow();
     }
 
     /**
@@ -47,7 +51,7 @@ public class NettyHttp1ConnectionHandler extends SimpleChannelInboundHandler<Htt
      */
     protected void channelRead0(ChannelHandlerContext ctx, Http1Request http1Request) {
         Http1ServerTransportListener http1TransportListener = http1ServerTransportListenerFactory.newInstance(
-                new NettyHttp1Channel(ctx.channel()), url, frameworkModel);
+                new NettyHttp1Channel(ctx.channel(), triple), url, frameworkModel);
         http1TransportListener.onMetadata(http1Request);
         http1TransportListener.onData(http1Request);
     }

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/Constants.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/Constants.java
@@ -97,12 +97,6 @@ public interface Constants {
     String INVOCATION_KEY = "invocation";
     String SERIALIZATION_ID_KEY = "serialization_id";
 
-    String H2_SETTINGS_HEADER_TABLE_SIZE_KEY = "dubbo.rpc.tri.header-table-size";
-    String H2_SETTINGS_ENABLE_PUSH_KEY = "dubbo.rpc.tri.enable-push";
-    String H2_SETTINGS_MAX_CONCURRENT_STREAMS_KEY = "dubbo.rpc.tri.max-concurrent-streams";
-    String H2_SETTINGS_INITIAL_WINDOW_SIZE_KEY = "dubbo.rpc.tri.initial-window-size";
-    String H2_SETTINGS_MAX_FRAME_SIZE_KEY = "dubbo.rpc.tri.max-frame-size";
-    String H2_SETTINGS_MAX_HEADER_LIST_SIZE_KEY = "dubbo.rpc.tri.max-header-list-size";
     String H2_SETTINGS_SUPPORT_NO_LOWER_HEADER_KEY = "dubbo.rpc.tri.support-no-lower-header";
     String H2_SETTINGS_IGNORE_1_0_0_KEY = "dubbo.rpc.tri.ignore-1.0.0-version";
     String H2_SETTINGS_RESOLVE_FALLBACK_TO_DEFAULT_KEY = "dubbo.rpc.tri.resolve-fallback-to-default";

--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/TriHttp2RemoteFlowController.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/TriHttp2RemoteFlowController.java
@@ -16,8 +16,7 @@
 
 package org.apache.dubbo.rpc.protocol.tri;
 
-import org.apache.dubbo.common.config.Configuration;
-import org.apache.dubbo.common.config.ConfigurationUtils;
+import org.apache.dubbo.config.TripleConfig;
 import org.apache.dubbo.rpc.model.ApplicationModel;
 
 import io.netty.channel.ChannelHandlerContext;
@@ -37,7 +36,6 @@ import io.netty.util.internal.logging.InternalLoggerFactory;
 import java.util.ArrayDeque;
 import java.util.Deque;
 
-import static io.netty.handler.codec.http2.Http2CodecUtil.DEFAULT_WINDOW_SIZE;
 import static io.netty.handler.codec.http2.Http2CodecUtil.MAX_WEIGHT;
 import static io.netty.handler.codec.http2.Http2CodecUtil.MIN_WEIGHT;
 import static io.netty.handler.codec.http2.Http2Error.FLOW_CONTROL_ERROR;
@@ -49,7 +47,6 @@ import static io.netty.util.internal.ObjectUtil.checkNotNull;
 import static io.netty.util.internal.ObjectUtil.checkPositiveOrZero;
 import static java.lang.Math.max;
 import static java.lang.Math.min;
-import static org.apache.dubbo.rpc.Constants.H2_SETTINGS_INITIAL_WINDOW_SIZE_KEY;
 
 /**
  * This design is learning from {@see io.netty.handler.codec.http2.DefaultHttp2RemoteFlowController} which is in Netty.
@@ -63,7 +60,7 @@ public class TriHttp2RemoteFlowController implements Http2RemoteFlowController {
     private final Http2Connection.PropertyKey stateKey;
     private final StreamByteDistributor streamByteDistributor;
     private final FlowState connectionState;
-    private final Configuration config;
+    private final TripleConfig config;
     private int initialWindowSize;
     private WritabilityMonitor monitor;
     private ChannelHandlerContext ctx;
@@ -88,8 +85,8 @@ public class TriHttp2RemoteFlowController implements Http2RemoteFlowController {
                                         ApplicationModel applicationModel) {
         this.connection = checkNotNull(connection, "connection");
         this.streamByteDistributor = checkNotNull(streamByteDistributor, "streamWriteDistributor");
-        this.config = ConfigurationUtils.getGlobalConfiguration(applicationModel);
-        this.initialWindowSize = config.getInt(H2_SETTINGS_INITIAL_WINDOW_SIZE_KEY, DEFAULT_WINDOW_SIZE);
+        this.config = applicationModel.getApplicationConfigManager().getTripleOrElseThrow();
+        this.initialWindowSize = config.getInitialWindowSize();
 
         // Add a flow state for the connection.
         stateKey = connection.newKey();

--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/TripleHttp2Protocol.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/TripleHttp2Protocol.java
@@ -17,9 +17,8 @@
 package org.apache.dubbo.rpc.protocol.tri;
 
 import org.apache.dubbo.common.URL;
-import org.apache.dubbo.common.config.Configuration;
-import org.apache.dubbo.common.config.ConfigurationUtils;
 import org.apache.dubbo.common.extension.Activate;
+import org.apache.dubbo.config.TripleConfig;
 import org.apache.dubbo.remoting.ChannelHandler;
 import org.apache.dubbo.remoting.api.AbstractWireProtocol;
 import org.apache.dubbo.remoting.api.pu.ChannelHandlerPretender;
@@ -46,6 +45,7 @@ import java.util.List;
 import io.netty.channel.ChannelDuplexHandler;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelPipeline;
+import io.netty.handler.codec.http.HttpDecoderConfig;
 import io.netty.handler.codec.http.HttpObjectAggregator;
 import io.netty.handler.codec.http.HttpServerCodec;
 import io.netty.handler.codec.http2.Http2FrameCodec;
@@ -57,24 +57,8 @@ import io.netty.handler.codec.http2.Http2StreamChannel;
 import io.netty.handler.flush.FlushConsolidationHandler;
 import io.netty.handler.logging.LogLevel;
 
-import static org.apache.dubbo.rpc.Constants.H2_SETTINGS_ENABLE_PUSH_KEY;
-import static org.apache.dubbo.rpc.Constants.H2_SETTINGS_HEADER_TABLE_SIZE_KEY;
-import static org.apache.dubbo.rpc.Constants.H2_SETTINGS_INITIAL_WINDOW_SIZE_KEY;
-import static org.apache.dubbo.rpc.Constants.H2_SETTINGS_MAX_CONCURRENT_STREAMS_KEY;
-import static org.apache.dubbo.rpc.Constants.H2_SETTINGS_MAX_FRAME_SIZE_KEY;
-import static org.apache.dubbo.rpc.Constants.H2_SETTINGS_MAX_HEADER_LIST_SIZE_KEY;
-
 @Activate
 public class TripleHttp2Protocol extends AbstractWireProtocol implements ScopeModelAware {
-
-    // 1 MiB
-    private static final int MIB_1 = 1 << 20;
-    private static final int MIB_8 = 1 << 23;
-    private static final int KIB_32 = 1 << 15;
-    private static final int DEFAULT_MAX_HEADER_LIST_SIZE = KIB_32;
-    private static final int DEFAULT_SETTING_HEADER_LIST_SIZE = 4096;
-    private static final int DEFAULT_MAX_FRAME_SIZE = MIB_8;
-    private static final int DEFAULT_WINDOW_INIT_SIZE = MIB_8;
 
     public static final Http2FrameLogger CLIENT_LOGGER = new Http2FrameLogger(LogLevel.DEBUG, "H2_CLIENT");
 
@@ -98,18 +82,17 @@ public class TripleHttp2Protocol extends AbstractWireProtocol implements ScopeMo
 
     @Override
     public void configClientPipeline(URL url, ChannelOperator operator, ContextOperator contextOperator) {
-        Configuration config = ConfigurationUtils.getGlobalConfiguration(url.getOrDefaultApplicationModel());
+        TripleConfig tripleConfig =
+                url.getOrDefaultApplicationModel().getApplicationConfigManager().getTripleOrElseThrow();
         final Http2FrameCodec codec = Http2FrameCodecBuilder.forClient()
                 .gracefulShutdownTimeoutMillis(10000)
                 .initialSettings(new Http2Settings()
-                        .headerTableSize(
-                                config.getInt(H2_SETTINGS_HEADER_TABLE_SIZE_KEY, DEFAULT_SETTING_HEADER_LIST_SIZE))
-                        .pushEnabled(config.getBoolean(H2_SETTINGS_ENABLE_PUSH_KEY, false))
-                        .maxConcurrentStreams(config.getInt(H2_SETTINGS_MAX_CONCURRENT_STREAMS_KEY, Integer.MAX_VALUE))
-                        .initialWindowSize(config.getInt(H2_SETTINGS_INITIAL_WINDOW_SIZE_KEY, DEFAULT_WINDOW_INIT_SIZE))
-                        .maxFrameSize(config.getInt(H2_SETTINGS_MAX_FRAME_SIZE_KEY, DEFAULT_MAX_FRAME_SIZE))
-                        .maxHeaderListSize(
-                                config.getInt(H2_SETTINGS_MAX_HEADER_LIST_SIZE_KEY, DEFAULT_MAX_HEADER_LIST_SIZE)))
+                        .headerTableSize(tripleConfig.getHeaderTableSize())
+                        .pushEnabled(tripleConfig.getEnablePush())
+                        .maxConcurrentStreams(tripleConfig.getMaxConcurrentStreams())
+                        .initialWindowSize(tripleConfig.getInitialWindowSize())
+                        .maxFrameSize(tripleConfig.getMaxFrameSize())
+                        .maxHeaderListSize(tripleConfig.getMaxHeaderListSize()))
                 .frameLogger(CLIENT_LOGGER)
                 .build();
         //        codec.connection().local().flowController().frameWriter(codec.encoder().frameWriter());
@@ -143,15 +126,22 @@ public class TripleHttp2Protocol extends AbstractWireProtocol implements ScopeMo
     }
 
     private void configurerHttp1Handlers(URL url, List<ChannelHandler> handlers) {
-        handlers.add(new ChannelHandlerPretender(new HttpServerCodec()));
-        handlers.add(new ChannelHandlerPretender(new HttpObjectAggregator(Integer.MAX_VALUE)));
+        TripleConfig tripleConfig =
+                url.getOrDefaultApplicationModel().getApplicationConfigManager().getTripleOrElseThrow();
+        handlers.add(new ChannelHandlerPretender(new HttpServerCodec(new HttpDecoderConfig()
+                .setMaxChunkSize(tripleConfig.getMaxChunkSize())
+                .setMaxHeaderSize(tripleConfig.getMaxHeaderSize())
+                .setMaxInitialLineLength(tripleConfig.getMaxInitialLineLength())
+                .setInitialBufferSize(tripleConfig.getInitialBufferSize()))));
+        handlers.add(new ChannelHandlerPretender(new HttpObjectAggregator(tripleConfig.getMaxBodySize())));
         handlers.add(new ChannelHandlerPretender(new NettyHttp1Codec()));
         handlers.add(new ChannelHandlerPretender(new NettyHttp1ConnectionHandler(
                 url, frameworkModel, DefaultHttp11ServerTransportListenerFactory.INSTANCE)));
     }
 
     private void configurerHttp2Handlers(URL url, List<ChannelHandler> handlers) {
-        Configuration config = ConfigurationUtils.getGlobalConfiguration(url.getOrDefaultApplicationModel());
+        TripleConfig tripleConfig =
+                url.getOrDefaultApplicationModel().getApplicationConfigManager().getTripleOrElseThrow();
         final Http2FrameCodec codec = TripleHttp2FrameCodecBuilder.forServer()
                 .customizeConnection((connection) -> connection
                         .remote()
@@ -159,13 +149,11 @@ public class TripleHttp2Protocol extends AbstractWireProtocol implements ScopeMo
                                 new TriHttp2RemoteFlowController(connection, url.getOrDefaultApplicationModel())))
                 .gracefulShutdownTimeoutMillis(10000)
                 .initialSettings(new Http2Settings()
-                        .headerTableSize(
-                                config.getInt(H2_SETTINGS_HEADER_TABLE_SIZE_KEY, DEFAULT_SETTING_HEADER_LIST_SIZE))
-                        .maxConcurrentStreams(config.getInt(H2_SETTINGS_MAX_CONCURRENT_STREAMS_KEY, Integer.MAX_VALUE))
-                        .initialWindowSize(config.getInt(H2_SETTINGS_INITIAL_WINDOW_SIZE_KEY, DEFAULT_WINDOW_INIT_SIZE))
-                        .maxFrameSize(config.getInt(H2_SETTINGS_MAX_FRAME_SIZE_KEY, DEFAULT_MAX_FRAME_SIZE))
-                        .maxHeaderListSize(
-                                config.getInt(H2_SETTINGS_MAX_HEADER_LIST_SIZE_KEY, DEFAULT_MAX_HEADER_LIST_SIZE)))
+                        .headerTableSize(tripleConfig.getHeaderTableSize())
+                        .maxConcurrentStreams(tripleConfig.getMaxConcurrentStreams())
+                        .initialWindowSize(tripleConfig.getInitialWindowSize())
+                        .maxFrameSize(tripleConfig.getMaxFrameSize())
+                        .maxHeaderListSize(tripleConfig.getMaxHeaderListSize()))
                 .frameLogger(SERVER_LOGGER)
                 .build();
         final Http2MultiplexHandler handler = new Http2MultiplexHandler(new ChannelInitializer<Http2StreamChannel>() {

--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/rest/RestHttpMessageCodec.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/rest/RestHttpMessageCodec.java
@@ -21,6 +21,7 @@ import org.apache.dubbo.remoting.http12.HttpRequest;
 import org.apache.dubbo.remoting.http12.HttpResponse;
 import org.apache.dubbo.remoting.http12.exception.DecodeException;
 import org.apache.dubbo.remoting.http12.exception.EncodeException;
+import org.apache.dubbo.remoting.http12.exception.HttpStatusException;
 import org.apache.dubbo.remoting.http12.message.HttpMessageDecoder;
 import org.apache.dubbo.remoting.http12.message.HttpMessageEncoder;
 import org.apache.dubbo.remoting.http12.message.MediaType;
@@ -108,7 +109,9 @@ public final class RestHttpMessageCodec implements HttpMessageDecoder, HttpMessa
                 if (messageEncoder.mediaType().isPureText() && type != String.class) {
                     data = typeConverter.convert(data, String.class);
                 }
-            } catch (Exception e) {
+            } catch (HttpStatusException e) {
+                throw e;
+            }  catch (Exception e) {
                 throw new EncodeException(e);
             }
         }


### PR DESCRIPTION
## What is the purpose of the change

refer: #14068 

1. Add TripleConfig to ConfigManager
2. Limit Http body size

request limit result:
![image](https://github.com/apache/dubbo/assets/18413695/91717a2e-85da-40f9-a968-02c4947665a1)
response limit result:
![image](https://github.com/apache/dubbo/assets/18413695/ef22cb94-6581-48cf-9610-efb44f4c27f5)


## Brief changelog


## Verifying this change


<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [ ] GitHub Actions works fine on your own branch.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
