### PR TITLE
3.2 fix executor destroy issue 13615

### DIFF
--- a/dubbo-metadata/dubbo-metadata-api/src/main/java/org/apache/dubbo/metadata/AbstractCacheManager.java
+++ b/dubbo-metadata/dubbo-metadata-api/src/main/java/org/apache/dubbo/metadata/AbstractCacheManager.java
@@ -42,6 +42,7 @@ public abstract class AbstractCacheManager<V> implements Disposable {
     protected final ErrorTypeAwareLogger logger = LoggerFactory.getErrorTypeAwareLogger(getClass());
 
     private ScheduledExecutorService executorService;
+    // Indicator of executor service ownership.
     private boolean isExternalExecutorService=false;
     private ScheduledFuture<?> scheduledFutureTask = null;
     protected FileCacheStore cacheStore;


### PR DESCRIPTION
## What is the purpose of the change
Fix: AbstractCacheManager destroy Framework's executorService when shutdown [#13615](https://github.com/apache/dubbo/issues/13615)
If the ExecutorService is passed from outer caller, then cancel/remove the new-scheduled-task is enough.

## Brief changelog
adds an indicator "isExternalExecutorService" to mark executorService ownership.
If the ExecutorService is passed from outer caller, then cancel/remove the new-scheduled-task is enough.


## Verifying this change


<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [ ] GitHub Actions works fine on your own branch.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
