### PR TITLE
Compatible nacos service discovery, export noting suffix servicename

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/URL.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/URL.java
@@ -1295,6 +1295,19 @@ public /*final**/ class URL implements Serializable {
         return serviceNameBuilder.toString();
     }
 
+    /**
+     * The format is "{interface}:[version]"
+     *
+     * @return
+     */
+    public String getCompatibleColonSeparatedKey() {
+        StringBuilder serviceNameBuilder = new StringBuilder();
+        serviceNameBuilder.append(this.getServiceInterface());
+        compatibleAppend(serviceNameBuilder, VERSION_KEY);
+        compatibleAppend(serviceNameBuilder, GROUP_KEY);
+        return serviceNameBuilder.toString();
+    }
+
     private void append(StringBuilder target, String parameterName, boolean first) {
         String parameterValue = this.getParameter(parameterName);
         if (!isBlank(parameterValue)) {
@@ -1304,6 +1317,14 @@ public /*final**/ class URL implements Serializable {
             target.append(parameterValue);
         } else {
             target.append(':');
+        }
+    }
+
+    private void compatibleAppend(StringBuilder target, String parameterName) {
+        String parameterValue = this.getParameter(parameterName);
+        if (!isBlank(parameterValue)) {
+            target.append(':');
+            target.append(parameterValue);
         }
     }
 

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/constants/RegistryConstants.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/constants/RegistryConstants.java
@@ -141,4 +141,11 @@ public interface RegistryConstants {
     String ENABLE_EMPTY_PROTECTION_KEY = "enable-empty-protection";
     boolean DEFAULT_ENABLE_EMPTY_PROTECTION = false;
     String REGISTER_CONSUMER_URL_KEY = "register-consumer-url";
+
+    /**
+     * export noting suffix servicename
+     * by default, dubbo export servicename is "${interface}:${version}:", this servicename with ':' suffix
+     * for compatible, we should export noting suffix servicename, eg: ${interface}:${version}
+     */
+    String NACOE_REGISTER_COMPATIBLE = "nacos.register-compatible";
 }


### PR DESCRIPTION
by default, dubbo export servicename is "${interface}:${version}:", this servicename with ':' suffix
for compatible nacos service discovery, export noting suffix servicename, eg: {interface}:${version}