### PR TITLE
Fix channel leakage in NettyConnectionClient.onConnected and onGoaway methods

### DIFF
--- a/dubbo-remoting/dubbo-remoting-netty4/src/main/java/org/apache/dubbo/remoting/transport/netty4/NettyConnectionClient.java
+++ b/dubbo-remoting/dubbo-remoting-netty4/src/main/java/org/apache/dubbo/remoting/transport/netty4/NettyConnectionClient.java
@@ -236,6 +236,13 @@ public class NettyConnectionClient extends AbstractConnectionClient {
             }
             return;
         }
+
+        // Close the existing channel before setting a new channel
+        final io.netty.channel.Channel current = getNettyChannel();
+        if (current != null) {
+            current.close();
+        }
+
         this.channel.set(nettyChannel);
         // This indicates that the connection is available.
         if (this.connectingPromise.get() != null) {
@@ -254,6 +261,10 @@ public class NettyConnectionClient extends AbstractConnectionClient {
         }
         io.netty.channel.Channel nettyChannel = (io.netty.channel.Channel) channel;
         if (this.channel.compareAndSet(nettyChannel, null)) {
+            // Ensure the channel is closed
+            if (nettyChannel.isOpen()) {
+                nettyChannel.close();
+            }
             NettyChannel.removeChannelIfDisconnected(nettyChannel);
             if (LOGGER.isDebugEnabled()) {
                 LOGGER.debug(String.format("%s goaway", this));


### PR DESCRIPTION
## What is the purpose of the change
fixe #14097
This commit addresses the issue of channel leakage in the onConnected and onGoaway methods of NettyConnectionClient. 

Previously, channels were not properly closed when new channels were set or when the channels were marked as go away, leading to potential resource leaks.

## Brief changelog
### onConnected Method
- Added a check to close the existing channel before setting a new one. 
### onGoaway Method
- Modified to close the channel if it is still open before setting it to null.

## Verifying this change


<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [ ] GitHub Actions works fine on your own branch.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
