### PR TITLE
fix(3.2): The oneToOne method of the ReactorServerCalls class will cause the request to hang when the result is Mono Empty

### DIFF
--- a/dubbo-plugin/dubbo-reactive/src/main/java/org/apache/dubbo/reactive/calls/ReactorServerCalls.java
+++ b/dubbo-plugin/dubbo-reactive/src/main/java/org/apache/dubbo/reactive/calls/ReactorServerCalls.java
@@ -19,6 +19,8 @@ package org.apache.dubbo.reactive.calls;
 import org.apache.dubbo.common.stream.StreamObserver;
 import org.apache.dubbo.reactive.ServerTripleReactorPublisher;
 import org.apache.dubbo.reactive.ServerTripleReactorSubscriber;
+import org.apache.dubbo.rpc.StatusRpcException;
+import org.apache.dubbo.rpc.TriRpcStatus;
 import org.apache.dubbo.rpc.protocol.tri.observer.CallStreamObserver;
 import org.apache.dubbo.rpc.protocol.tri.observer.ServerCallToObserverAdapter;
 

--- a/dubbo-plugin/dubbo-reactive/src/main/java/org/apache/dubbo/reactive/calls/ReactorServerCalls.java
+++ b/dubbo-plugin/dubbo-reactive/src/main/java/org/apache/dubbo/reactive/calls/ReactorServerCalls.java
@@ -22,7 +22,6 @@ import org.apache.dubbo.reactive.ServerTripleReactorSubscriber;
 import org.apache.dubbo.rpc.protocol.tri.observer.CallStreamObserver;
 import org.apache.dubbo.rpc.protocol.tri.observer.ServerCallToObserverAdapter;
 
-import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 
 import reactor.core.publisher.Flux;
@@ -44,17 +43,17 @@ public final class ReactorServerCalls {
      */
     public static <T, R> void oneToOne(T request, StreamObserver<R> responseObserver, Function<Mono<T>, Mono<R>> func) {
         try {
-            func.apply(Mono.just(request)).subscribe(
-				res -> {
-					responseObserver.onNext(res);
-					responseObserver.onCompleted();
-				},
-				throwable -> doOnResponseHasException(throwable, responseObserver),
-				() -> doOnResponseHasException(TriRpcStatus.NOT_FOUND.asException(), responseObserver)
-			);
+            func.apply(Mono.just(request))
+                    .subscribe(
+                            res -> {
+                                responseObserver.onNext(res);
+                                responseObserver.onCompleted();
+                            },
+                            throwable -> doOnResponseHasException(throwable, responseObserver),
+                            () -> doOnResponseHasException(TriRpcStatus.NOT_FOUND.asException(), responseObserver));
         } catch (Throwable throwable) {
-			doOnResponseHasException(throwable, responseObserver);
-		}
+            doOnResponseHasException(throwable, responseObserver);
+        }
     }
 
     /**
@@ -135,7 +134,8 @@ public final class ReactorServerCalls {
     }
 
     private static void doOnResponseHasException(Throwable throwable, StreamObserver<?> responseObserver) {
-		StatusRpcException statusRpcException = TriRpcStatus.getStatus(throwable).asException();
-		responseObserver.onError(statusRpcException);
-	}
+        StatusRpcException statusRpcException =
+                TriRpcStatus.getStatus(throwable).asException();
+        responseObserver.onError(statusRpcException);
+    }
 }


### PR DESCRIPTION
## What is the purpose of the change

When the return value is Mono Empty, it will cause the request to hang.

## Brief changelog


## Verifying this change


<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [ ] GitHub Actions works fine on your own branch.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
