### PR TITLE
trim application name of old mapping content

### DIFF
--- a/dubbo-metadata/dubbo-metadata-api/src/main/java/org/apache/dubbo/metadata/ServiceNameMapping.java
+++ b/dubbo-metadata/dubbo-metadata-api/src/main/java/org/apache/dubbo/metadata/ServiceNameMapping.java
@@ -25,7 +25,6 @@ import org.apache.dubbo.rpc.model.ScopeModel;
 import org.apache.dubbo.rpc.model.ScopeModelUtil;
 import org.apache.dubbo.rpc.service.Destroyable;
 
-import java.util.Arrays;
 import java.util.Set;
 import java.util.TreeSet;
 

--- a/dubbo-metadata/dubbo-metadata-api/src/main/java/org/apache/dubbo/metadata/ServiceNameMapping.java
+++ b/dubbo-metadata/dubbo-metadata-api/src/main/java/org/apache/dubbo/metadata/ServiceNameMapping.java
@@ -30,6 +30,8 @@ import java.util.Set;
 import java.util.TreeSet;
 
 import static java.util.Collections.emptySet;
+import static java.util.stream.Collectors.toSet;
+import static java.util.stream.Stream.of;
 import static org.apache.dubbo.common.constants.CommonConstants.COMMA_SEPARATOR;
 import static org.apache.dubbo.common.extension.ExtensionScope.APPLICATION;
 
@@ -88,7 +90,10 @@ public interface ServiceNameMapping extends Destroyable {
         if (StringUtils.isBlank(content)) {
             return emptySet();
         }
-        return new TreeSet<>(Arrays.asList(content.split(COMMA_SEPARATOR)));
+        return new TreeSet<>(of(content.split(COMMA_SEPARATOR))
+                .map(String::trim)
+                .filter(StringUtils::isNotEmpty)
+                .collect(toSet()));
     }
 
     static Set<String> getMappingByUrl(URL consumerURL) {

--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/metadata/MetadataServiceNameMapping.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/metadata/MetadataServiceNameMapping.java
@@ -109,7 +109,7 @@ public class MetadataServiceNameMapping extends AbstractServiceNameMapping {
                         String[] oldAppNames = oldConfigContent.split(",");
                         if (oldAppNames.length > 0) {
                             for (String oldAppName : oldAppNames) {
-                                if (oldAppName.equals(appName)) {
+                                if (StringUtils.trim(oldAppName).equals(appName)) {
                                     succeeded = true;
                                     break;
                                 }


### PR DESCRIPTION
## What is the purpose of the change
Since config service is unreliable, it's getConfig method might return a string that is ended by a space character,
so this PR want to
1. enhance ServiceNameMapping to avoid using untrimmed app names as mappedServices.
2. enhance MetadataServiceNameMapping to avoid registering duplicated service name mapping metadata.
see #14132 

## Brief changelog
1. trim and filter out empty app name at ServiceNameMapping#getAppNames, just like AbstractServiceNameMapping#parseServices.
2. trim old app name before comparison at MetadataServiceNameMapping#map.

## Verifying this change


<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [x] Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [x] GitHub Actions works fine on your own branch.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
