### PR TITLE
Fix non-idempotent unit test `ClassGeneratorTest.testMain`

### DIFF
--- a/dubbo-common/src/test/java/org/apache/dubbo/common/bytecode/ClassGeneratorTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/bytecode/ClassGeneratorTest.java
@@ -22,6 +22,7 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
 import javassist.ClassPool;
 
@@ -184,7 +185,7 @@ class ClassGeneratorTest {
         fname.setAccessible(true);
 
         ClassGenerator cg = ClassGenerator.newInstance();
-        cg.setClassName(Bean.class.getName() + "$Builder");
+        cg.setClassName(Bean.class.getName() + "$Builder" + UUID.randomUUID().toString());
         cg.addInterface(Builder.class);
 
         cg.addField("public static java.lang.reflect.Field FNAME;");


### PR DESCRIPTION
Fixes https://github.com/apache/dubbo/issues/14134.

## The Problem
The `ClassGeneratorTest.testMain` test is non-idempotent and fails upon repeated execution within the same JVM instance due to self-induced state pollution. Specifically, the test employs the `ClassGenerator` to configure a custom class with a predetermined name (`Bean.class.getName() + "$Builder"`). Subsequently, the test invokes `ClassGenerator.toClass()` to instantiate the desired `Class<?>` object. However, within `ClassGenerator.toClass()`, the invoked method `javassist.ClassPool.makeClass()` is called to create the class. Given that Javassist freezes a class upon its initial loading (ensuring classes cannot be altered or removed at runtime), repeated invocations of `testMain()` fail as the class name remains unchanged, leading to class generation errors.

## Sample Failure Message (in the 2nd run of the test):
```
java.lang.RuntimeException: org.apache.dubbo.common.bytecode.Bean$Builder: frozen class (cannot edit)
	at javassist.ClassPool.checkNotFrozen(ClassPool.java:595)
	at javassist.ClassPool.makeClass(ClassPool.java:837)
	at javassist.ClassPool.makeClass(ClassPool.java:814)
	at org.apache.dubbo.common.bytecode.ClassGenerator.toClass(ClassGenerator.java:318)
	at org.apache.dubbo.common.bytecode.ClassGenerator.toClass(ClassGenerator.java:302)
	at org.apache.dubbo.common.bytecode.ClassGeneratorTest.testMain(ClassGeneratorTest.java:197)
	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
```

## What is the purpose of the change
Fixing this issue is recommended since unit tests should be idempotent (deterministically passing in repeated runs). 

## Brief changelog
Assign a unique ID to each class to be generated in the same classloader.

## Verifying this change
After the patch, running the test multiple times within the same JVM will not lead to failures.

## Additional Notes
There are some other non-idempotent tests detected in the test suite. I can open a new PR to address the others if you find this fix reasonable.

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [x] Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] GitHub Actions works fine on your own branch.
