### PR TITLE
fix the signature error when using reflection to access the org.springframework.core.annotation.AnnotatedElementUtils#getMergedAnnotation method

### DIFF
--- a/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/util/AnnotationUtils.java
+++ b/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/util/AnnotationUtils.java
@@ -444,21 +444,11 @@ public abstract class AnnotationUtils {
                 (_k) -> ClassUtils.isPresent(ANNOTATED_ELEMENT_UTILS_CLASS_NAME, classLoader))) {
             Class<?> annotatedElementUtilsClass = resolveClassName(ANNOTATED_ELEMENT_UTILS_CLASS_NAME, classLoader);
             // getMergedAnnotation method appears in the Spring Framework 4.2
-            Method getMergedAnnotationMethod = findMethod(
-                    annotatedElementUtilsClass,
-                    "getMergedAnnotation",
-                    AnnotatedElement.class,
-                    Class.class,
-                    boolean.class,
-                    boolean.class);
+            Method getMergedAnnotationMethod =
+                    findMethod(annotatedElementUtilsClass, "getMergedAnnotation", AnnotatedElement.class, Class.class);
             if (getMergedAnnotationMethod != null) {
-                mergedAnnotation = (Annotation) invokeMethod(
-                        getMergedAnnotationMethod,
-                        null,
-                        annotatedElement,
-                        annotationType,
-                        classValuesAsString,
-                        nestedAnnotationsAsMap);
+                mergedAnnotation =
+                        (Annotation) invokeMethod(getMergedAnnotationMethod, null, annotatedElement, annotationType);
             }
         }
 


### PR DESCRIPTION
Fixes https://github.com/apache/dubbo/issues/14104.

## The Problem
The method `org.apache.dubbo.config.spring.util.AnnotationUtils#tryGetMergedAnnotation` utilizes reflection to access `org.springframework.core.annotation.AnnotatedElementUtils#getMergedAnnotation`. However, there is a signature mismatch in the method's input parameters, which leads to an inability to retrieve the correct method. Consequently, this results in the failure to obtain the mergedAnnotation.

## What is the purpose of the change
It is recommended to fix this issue, as it will cause the passing of the `DubboReference` annotation to become ineffective.


## Brief changelog
fix the signature error when using reflection to access the org.springframework.core.annotation.AnnotatedElementUtils#getMergedAnnotation method

## Verifying this change
After the patch, it is possible to correctly obtain the `org.springframework.core.annotation.AnnotatedElementUtils#getMergedAnnotation` method.

<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [x] Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] GitHub Actions works fine on your own branch.

