### PR TITLE
catch the warning and ignore when childUrl is not json.

### DIFF
--- a/dubbo-registry/dubbo-registry-zookeeper/src/main/java/org/apache/dubbo/registry/zookeeper/ZookeeperRegistry.java
+++ b/dubbo-registry/dubbo-registry-zookeeper/src/main/java/org/apache/dubbo/registry/zookeeper/ZookeeperRegistry.java
@@ -46,7 +46,7 @@ import static org.apache.dubbo.common.constants.CommonConstants.ANY_VALUE;
 import static org.apache.dubbo.common.constants.CommonConstants.CHECK_KEY;
 import static org.apache.dubbo.common.constants.CommonConstants.INTERFACE_KEY;
 import static org.apache.dubbo.common.constants.CommonConstants.PATH_SEPARATOR;
-import static org.apache.dubbo.common.constants.LoggerCodeConstants.REGISTRY_ZOOKEEPER_EXCEPTION;
+import static org.apache.dubbo.common.constants.LoggerCodeConstants.*;
 import static org.apache.dubbo.common.constants.RegistryConstants.CONFIGURATORS_CATEGORY;
 import static org.apache.dubbo.common.constants.RegistryConstants.CONSUMERS_CATEGORY;
 import static org.apache.dubbo.common.constants.RegistryConstants.DEFAULT_CATEGORY;
@@ -202,7 +202,10 @@ public class ZookeeperRegistry extends CacheableFailbackRegistry {
                         listeners, listener, k -> (parentPath, currentChildren) -> {
                             for (String child : currentChildren) {
                                 if(!child.startsWith("{") || !child.endsWith("}")){
-                                    logger.warn(child + "is not json");
+                                    logger.warn(PROTOCOL_ERROR_DESERIALIZE,
+                                        "",
+                                        "",
+                                        child + "is not json,can't be deserialize");
                                     continue;
                                 }
                                 child = URL.decode(child);

--- a/dubbo-registry/dubbo-registry-zookeeper/src/main/java/org/apache/dubbo/registry/zookeeper/ZookeeperRegistry.java
+++ b/dubbo-registry/dubbo-registry-zookeeper/src/main/java/org/apache/dubbo/registry/zookeeper/ZookeeperRegistry.java
@@ -201,6 +201,10 @@ public class ZookeeperRegistry extends CacheableFailbackRegistry {
                 ChildListener zkListener = ConcurrentHashMapUtils.computeIfAbsent(
                         listeners, listener, k -> (parentPath, currentChildren) -> {
                             for (String child : currentChildren) {
+                                if(!child.startsWith("{") || !child.endsWith("}")){
+                                    logger.warn(child + "is not json");
+                                    continue;
+                                }
                                 child = URL.decode(child);
                                 if (!anyServices.contains(child)) {
                                     anyServices.add(child);


### PR DESCRIPTION
## What is the purpose of the change
catch the exception when the url can't be deserialization.[issue12941](https://github.com/apache/dubbo/issues/12941)


## Brief changelog
add the json check when ANY_VALUE.equals(url.getServiceInterface()) at ZookeeperRegistry#doSubscribe.

## Verifying this change
the child will work normal if the child is json.

<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [x] Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [x] GitHub Actions works fine on your own branch.
- [x] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
