### PR TITLE
Fix more non-idempotent unit tests

### DIFF
--- a/dubbo-common/src/test/java/org/apache/dubbo/common/bytecode/ClassGeneratorTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/bytecode/ClassGeneratorTest.java
@@ -57,7 +57,8 @@ class ClassGeneratorTest {
         ClassGenerator cg = ClassGenerator.newInstance();
 
         // add className, interface, superClass
-        String className = BaseClass.class.getPackage().getName() + ".TestClass";
+        String className = BaseClass.class.getPackage().getName() + ".TestClass"
+                + UUID.randomUUID().toString().replace("-", "");
         cg.setClassName(className);
         cg.addInterface(BaseInterface.class);
         cg.setSuperClass(BaseClass.class);
@@ -212,7 +213,7 @@ class ClassGeneratorTest {
         fname.setAccessible(true);
 
         ClassGenerator cg = ClassGenerator.newInstance();
-        cg.setClassName(Bean.class.getName() + "$Builder2");
+        cg.setClassName(Bean.class.getName() + "$Builder2" + UUID.randomUUID().toString());
         cg.addInterface(Builder.class);
 
         cg.addField("FNAME", Modifier.PUBLIC | Modifier.STATIC, java.lang.reflect.Field.class);

--- a/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/integration/multiple/exportmetadata/MultipleRegistryCenterExportMetadataIntegrationTest.java
+++ b/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/integration/multiple/exportmetadata/MultipleRegistryCenterExportMetadataIntegrationTest.java
@@ -172,7 +172,6 @@ class MultipleRegistryCenterExportMetadataIntegrationTest implements Integration
     @AfterEach
     public void tearDown() throws IOException {
         DubboBootstrap.reset();
-        PROVIDER_APPLICATION_NAME = null;
         serviceConfig = null;
         // The exported service has been unexported
         Assertions.assertTrue(serviceListener.getExportedServices().isEmpty());

--- a/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/integration/multiple/exportprovider/MultipleRegistryCenterExportProviderIntegrationTest.java
+++ b/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/integration/multiple/exportprovider/MultipleRegistryCenterExportProviderIntegrationTest.java
@@ -239,7 +239,6 @@ class MultipleRegistryCenterExportProviderIntegrationTest implements Integration
     @AfterEach
     public void tearDown() throws IOException {
         DubboBootstrap.reset();
-        PROVIDER_APPLICATION_NAME = null;
         serviceConfig = null;
         // The exported service has been unexported
         Assertions.assertTrue(serviceListener.getExportedServices().isEmpty());

--- a/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/integration/multiple/injvm/MultipleRegistryCenterInjvmIntegrationTest.java
+++ b/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/integration/multiple/injvm/MultipleRegistryCenterInjvmIntegrationTest.java
@@ -185,7 +185,6 @@ class MultipleRegistryCenterInjvmIntegrationTest implements IntegrationTest {
     @AfterEach
     public void tearDown() throws IOException {
         DubboBootstrap.reset();
-        PROVIDER_APPLICATION_NAME = null;
         serviceConfig = null;
         // The exported service has been unexported
         Assertions.assertTrue(serviceListener.getExportedServices().isEmpty());

--- a/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/integration/multiple/servicediscoveryregistry/MultipleRegistryCenterServiceDiscoveryRegistryIntegrationTest.java
+++ b/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/integration/multiple/servicediscoveryregistry/MultipleRegistryCenterServiceDiscoveryRegistryIntegrationTest.java
@@ -201,7 +201,6 @@ class MultipleRegistryCenterServiceDiscoveryRegistryIntegrationTest implements I
     @AfterEach
     public void tearDown() throws IOException {
         DubboBootstrap.reset();
-        PROVIDER_APPLICATION_NAME = null;
         serviceConfig = null;
         // TODO: we need to check whether this scenario is normal
         // TODO: the Exporter and ServiceDiscoveryRegistry are same in multiple registry center

--- a/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/integration/single/exportmetadata/SingleRegistryCenterExportMetadataIntegrationTest.java
+++ b/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/integration/single/exportmetadata/SingleRegistryCenterExportMetadataIntegrationTest.java
@@ -169,7 +169,6 @@ class SingleRegistryCenterExportMetadataIntegrationTest implements IntegrationTe
     @AfterEach
     public void tearDown() throws IOException {
         DubboBootstrap.reset();
-        PROVIDER_APPLICATION_NAME = null;
         serviceConfig = null;
         // The exported service has been unexported
         Assertions.assertTrue(serviceListener.getExportedServices().isEmpty());

--- a/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/integration/single/exportprovider/SingleRegistryCenterExportProviderIntegrationTest.java
+++ b/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/integration/single/exportprovider/SingleRegistryCenterExportProviderIntegrationTest.java
@@ -240,7 +240,6 @@ class SingleRegistryCenterExportProviderIntegrationTest implements IntegrationTe
     @AfterEach
     public void tearDown() throws IOException {
         DubboBootstrap.reset();
-        PROVIDER_APPLICATION_NAME = null;
         serviceConfig = null;
         // The exported service has been unexported
         Assertions.assertTrue(serviceListener.getExportedServices().isEmpty());

--- a/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/integration/single/injvm/SingleRegistryCenterInjvmIntegrationTest.java
+++ b/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/integration/single/injvm/SingleRegistryCenterInjvmIntegrationTest.java
@@ -185,7 +185,6 @@ class SingleRegistryCenterInjvmIntegrationTest implements IntegrationTest {
     @AfterEach
     public void tearDown() throws IOException {
         DubboBootstrap.reset();
-        PROVIDER_APPLICATION_NAME = null;
         serviceConfig = null;
         // The exported service has been unexported
         Assertions.assertTrue(serviceListener.getExportedServices().isEmpty());

--- a/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/utils/ReferenceCacheTest.java
+++ b/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/utils/ReferenceCacheTest.java
@@ -35,6 +35,7 @@ class ReferenceCacheTest {
     public void setUp() throws Exception {
         DubboBootstrap.reset();
         MockReferenceConfig.setCounter(0);
+        XxxMockReferenceConfig.setCounter(0);
         SimpleReferenceCache.CACHE_HOLDER.clear();
     }
 

--- a/dubbo-metrics/dubbo-metrics-prometheus/src/test/java/org/apache/dubbo/metrics/prometheus/PrometheusMetricsReporterTest.java
+++ b/dubbo-metrics/dubbo-metrics-prometheus/src/test/java/org/apache/dubbo/metrics/prometheus/PrometheusMetricsReporterTest.java
@@ -51,6 +51,7 @@ class PrometheusMetricsReporterTest {
     private MetricsConfig metricsConfig;
     private ApplicationModel applicationModel;
     private FrameworkModel frameworkModel;
+    HttpServer prometheusExporterHttpServer;
 
     @BeforeEach
     public void setup() {
@@ -64,6 +65,9 @@ class PrometheusMetricsReporterTest {
     @AfterEach
     public void teardown() {
         applicationModel.destroy();
+        if (prometheusExporterHttpServer != null) {
+            prometheusExporterHttpServer.stop(0);
+        }
     }
 
     @Test
@@ -146,7 +150,7 @@ class PrometheusMetricsReporterTest {
     private void exportHttpServer(PrometheusMetricsReporter reporter, int port) {
 
         try {
-            HttpServer prometheusExporterHttpServer = HttpServer.create(new InetSocketAddress(port), 0);
+            prometheusExporterHttpServer = HttpServer.create(new InetSocketAddress(port), 0);
             prometheusExporterHttpServer.createContext("/metrics", httpExchange -> {
                 reporter.resetIfSamplesChanged();
                 String response = reporter.getPrometheusRegistry().scrape();

--- a/dubbo-metrics/dubbo-metrics-prometheus/src/test/java/org/apache/dubbo/metrics/prometheus/PrometheusMetricsThreadPoolTest.java
+++ b/dubbo-metrics/dubbo-metrics-prometheus/src/test/java/org/apache/dubbo/metrics/prometheus/PrometheusMetricsThreadPoolTest.java
@@ -62,6 +62,8 @@ public class PrometheusMetricsThreadPoolTest {
 
     DefaultMetricsCollector metricsCollector;
 
+    HttpServer prometheusExporterHttpServer;
+
     @BeforeEach
     public void setup() {
         applicationModel = ApplicationModel.defaultModel();
@@ -77,6 +79,9 @@ public class PrometheusMetricsThreadPoolTest {
     @AfterEach
     public void teardown() {
         applicationModel.destroy();
+        if (prometheusExporterHttpServer != null) {
+            prometheusExporterHttpServer.stop(0);
+        }
     }
 
     @Test
@@ -121,7 +126,7 @@ public class PrometheusMetricsThreadPoolTest {
 
     private void exportHttpServer(PrometheusMetricsReporter reporter, int port) {
         try {
-            HttpServer prometheusExporterHttpServer = HttpServer.create(new InetSocketAddress(port), 0);
+            prometheusExporterHttpServer = HttpServer.create(new InetSocketAddress(port), 0);
             prometheusExporterHttpServer.createContext("/metrics", httpExchange -> {
                 reporter.resetIfSamplesChanged();
                 String response = reporter.getPrometheusRegistry().scrape();

--- a/dubbo-monitor/dubbo-monitor-default/src/test/java/org/apache/dubbo/monitor/dubbo/DubboMonitorTest.java
+++ b/dubbo-monitor/dubbo-monitor-default/src/test/java/org/apache/dubbo/monitor/dubbo/DubboMonitorTest.java
@@ -30,6 +30,8 @@ import org.apache.dubbo.rpc.ProxyFactory;
 import org.apache.dubbo.rpc.Result;
 import org.apache.dubbo.rpc.RpcException;
 
+import java.io.IOException;
+import java.net.ServerSocket;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
@@ -139,7 +141,13 @@ class DubboMonitorTest {
     }
 
     @Test
-    void testMonitorFactory() {
+    void testMonitorFactory() throws IOException {
+        int port;
+        try (ServerSocket socket = new ServerSocket(0)) {
+            port = socket.getLocalPort();
+            socket.close();
+        }
+
         MockMonitorService monitorService = new MockMonitorService();
         URL statistics = new URLBuilder(DUBBO_PROTOCOL, "10.20.153.10", 0)
                 .addParameter(APPLICATION_KEY, "morgan")
@@ -163,12 +171,12 @@ class DubboMonitorTest {
         Exporter<MonitorService> exporter = protocol.export(proxyFactory.getInvoker(
                 monitorService,
                 MonitorService.class,
-                URL.valueOf("dubbo://127.0.0.1:17979/" + MonitorService.class.getName())));
+                URL.valueOf("dubbo://127.0.0.1:" + port + "/" + MonitorService.class.getName())));
         try {
             Monitor monitor = null;
             long start = System.currentTimeMillis();
             while (System.currentTimeMillis() - start < 60000) {
-                monitor = monitorFactory.getMonitor(URL.valueOf("dubbo://127.0.0.1:17979?interval=10"));
+                monitor = monitorFactory.getMonitor(URL.valueOf("dubbo://127.0.0.1:" + port + "?interval=10"));
                 if (monitor == null) {
                     continue;
                 }

--- a/dubbo-plugin/dubbo-qos/src/test/java/org/apache/dubbo/qos/command/impl/LiveTest.java
+++ b/dubbo-plugin/dubbo-qos/src/test/java/org/apache/dubbo/qos/command/impl/LiveTest.java
@@ -35,6 +35,7 @@ class LiveTest {
     @AfterEach
     public void reset() {
         frameworkModel.destroy();
+        MockLivenessProbe.setCheckReturnValue(false);
     }
 
     @Test

--- a/dubbo-remoting/dubbo-remoting-api/src/test/java/org/apache/dubbo/remoting/transport/ChannelHandlerDispatcherTest.java
+++ b/dubbo-remoting/dubbo-remoting-api/src/test/java/org/apache/dubbo/remoting/transport/ChannelHandlerDispatcherTest.java
@@ -24,11 +24,17 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 class ChannelHandlerDispatcherTest {
+
+    @AfterEach
+    public void tearDown() {
+        MockChannelHandler.reset();
+    }
 
     @Test
     void test() {
@@ -137,5 +143,13 @@ class MockChannelHandler extends ChannelHandlerAdapter {
 
     public static int getCaughtCount() {
         return caughtCount;
+    }
+
+    public static void reset() {
+        sentCount = 0;
+        connectedCount = 0;
+        disconnectedCount = 0;
+        receivedCount = 0;
+        caughtCount = 0;
     }
 }

--- a/dubbo-rpc/dubbo-rpc-api/src/test/java/org/apache/dubbo/rpc/RpcStatusTest.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/test/java/org/apache/dubbo/rpc/RpcStatusTest.java
@@ -39,6 +39,10 @@ class RpcStatusTest {
         URL url = new ServiceConfigURL("dubbo", "127.0.0.1", 91031, DemoService.class.getName());
         String methodName = "testBeginCountEndCount";
         int max = 2;
+
+        RpcStatus.removeStatus(url);
+        RpcStatus.removeStatus(url, methodName);
+
         boolean flag = RpcStatus.beginCount(url, methodName, max);
         RpcStatus urlRpcStatus = RpcStatus.getStatus(url);
         RpcStatus methodRpcStatus = RpcStatus.getStatus(url, methodName);
@@ -65,6 +69,10 @@ class RpcStatusTest {
     void testBeginCountEndCountInMultiThread() throws Exception {
         URL url = new ServiceConfigURL("dubbo", "127.0.0.1", 91032, DemoService.class.getName());
         String methodName = "testBeginCountEndCountInMultiThread";
+
+        RpcStatus.removeStatus(url);
+        RpcStatus.removeStatus(url, methodName);
+
         int max = 50;
         int threadNum = 10;
         AtomicInteger successCount = new AtomicInteger();
@@ -99,6 +107,10 @@ class RpcStatusTest {
         URL url = new ServiceConfigURL("dubbo", "127.0.0.1", 91033, DemoService.class.getName());
         String methodName = "testStatistics";
         int max = 0;
+
+        RpcStatus.removeStatus(url);
+        RpcStatus.removeStatus(url, methodName);
+
         RpcStatus.beginCount(url, methodName, max);
         RpcStatus.beginCount(url, methodName, max);
         RpcStatus.beginCount(url, methodName, max);


### PR DESCRIPTION
Fixes #14171.

# The Problem

Followup of #14135 - fixing more non-idempotent unit tests (tests that pass in the first run but fails in repeated runs in the same environment in isolation)

# All Non-Idempotent Tests & Proposed Fix
## ClassGeneratorTest#test and ClassGeneratorTest#testMain0
Reason: Similar as described in https://github.com/apache/dubbo/pull/14135, these tests employs the ClassGenerator to configure a custom class with **hard-coded names**, and then invokes `ClassGenerator.toClass()` to instantiate the desired `Class<?>` object. However, within `ClassGenerator.toClass()`, the invoked method `javassist.ClassPool.makeClass()` is called to create the class. Given that Javassist freezes a class upon its initial loading (ensuring classes cannot be altered or removed at runtime), repeated invocations of the two unit tests fail as the class names remain unchanged, leading to class generation errors.

Error message of one of the tests in the repeated run:
```
java.lang.RuntimeException: org.apache.dubbo.common.bytecode.Bean$Builder: frozen class (cannot edit)
```
Fix: Assign a unique ID to each class to be generated in the same classloader.

## ChannelHandlerDispatcherTest#test
Reason: The `MockChannelHandler` class has stores metrics like `sentCount` and `connectedCount` as static variables. However, there're no reset methods to clear these metrics after a round of test execution. Therefore, in the repeated runs, metrics like `sentCount` will be an accumulative count across multiple test runs. This will make the assertions fail.

Error message in the repeated run:
```
org.opentest4j.AssertionFailedError: expected: <4> but was: <2>
```
Fix: Add a `reset()` methods to clear all metrics, and call this `reset()` method after each test execution.

## RpcStatusTest#testStatistics, RpcStatusTest#testBeginCountEndCount and RpcStatusTest#testBeginCountEndCountInMultiThread
Reason: For each test method, `RpcStatus` records metrics retrieved by methods like `getTotal()`. However, the metrics are not reset before the repeated runs of the same test method, so the values returned by methods like `getTotal()` would be an accumulative count of multiple test runs, causing the assertions fail.

Error message of one of the tests in the repeated run:
```
org.opentest4j.AssertionFailedError: expected: <8> but was: <4>
```
Fix: Call `RpcStatus.removeStatus()` to reset the metrics corresponding to the url and the method name for each test at the start of test execution.

## DubboMonitorTest#testMonitorFactory
Reason: `monitorFactory.getMonitor()` uses the hard-coded port number `17979`. However, the port will be occupied by the first test execution, so repeated run will fail to start the server since the address has already been used.

Error message:
```
org.apache.dubbo.rpc.RpcException: Fail to start server(url: dubbo://127.0.0.1:17979/org.apache.dubbo.monitor.MonitorService?channel.readonly.sent=true&codec=dubbo&heartbeat=60000) Failed to bind NettyServer on /0.0.0.0:17979, cause: Address already in use
```

Fix: Find a free port using `java.net.ServerSocket` and use it.

## PrometheusMetricsThreadPoolTest#testExporterThreadpoolName and PrometheusMetricsReporterTest#testExporter
Reason: The tests attempt to create a `prometheusExporterHttpServer` in each execution. However, in the first execution, the server is created but not shut down after execution. Therefore, repeated test executions will throw a runtime exception since the address corresponding to the server is already in use.

Error Message:
```
java.lang.RuntimeException: java.net.BindException: Address already in use
```

Fix: Extract `prometheusExporterHttpServer` as a field and stop it in the `tearDown()` method to ensure each test execution starts with a fresh state.

## Register Center Integration Tests
- `MultipleRegistryCenterInjvmIntegrationTest#integrate`
- `SingleRegistryCenterInjvmIntegrationTest#integrate`
- `MultipleRegistryCenterExportMetadataIntegrationTest#integrate`
- `SingleRegistryCenterExportMetadataIntegrationTest#integrate`
- `MultipleRegistryCenterServiceDiscoveryRegistryIntegrationTest#integrate`
- `MultipleRegistryCenterExportProviderIntegrationTest#integrate`
- `SingleRegistryCenterExportProviderIntegrationTest#integrate`
Reason: These integration tests set the static string `PROVIDER_APPLICATION_NAME` to `null` in its `tearDown()` method. This causes repeated runs to fail to find the corresponding configuration. There's really no need to clear `PROVIDER_APPLICATION_NAME` in the reset method since each integration test class has its globally unique provide application name and they're not interdependent on each other.

Error Message:
```
java.lang.IllegalStateException: No application config found or it's not a valid config! Please add <dubbo:application name="..." /> to your spring config.
```

Fix: Do not set `PROVIDER_APPLICATION_NAME` to `null` when tearing down.

## ReferenceCacheTest#testGetCacheDiffReference
Reason: Though the `XxxMockReferenceConfig` instance `configCopy` is re-constructed in each test execution, the `configCopy.getCounter()` will return accumulative counts across different runs since `counter` is static (of global scope). Therefore, the assertion `assertEquals(0L, configCopy.getCounter());` will fail in repeated runs.

Error Message:
```
org.opentest4j.AssertionFailedError: expected: <0> but was: <1>
```

Fix: Call `XxxMockReferenceConfig.setCounter(0)` in the `setUp()` method.

## LiveTest#testExecute
Reason: The test sets the check return value of `MockLivenessProbe` to `true` during the test execution, but does not reset it back to `false` when the test finishes. Therefore, `Assertions.assertEquals(result, "false");` will fail in the repeated run.

Error Message:
```
org.opentest4j.AssertionFailedError: expected: <true> but was: <false>
```

Fix: Ensure the return value of `MockLivenessProbe` is set to the default value (`false`) in the `tearDown()` method.

# Verifying this change
After the patch, running the tests repeatedly in the same environment will not lead to failures.


<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [x] Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] GitHub Actions works fine on your own branch.