### PR TITLE
Clean up netty residual memory when the stream is closed

### DIFF
--- a/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/h2/Http2ServerChannelObserver.java
+++ b/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/h2/Http2ServerChannelObserver.java
@@ -119,4 +119,9 @@ public class Http2ServerChannelObserver extends AbstractServerHttpChannelObserve
     public boolean isAutoRequestN() {
         return autoRequestN;
     }
+
+    public void onStreamClosed() {
+        closed = true;
+        streamingDecoder.onStreamClosed();
+    }
 }

--- a/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/message/LengthFieldStreamingDecoder.java
+++ b/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/message/LengthFieldStreamingDecoder.java
@@ -85,6 +85,19 @@ public class LengthFieldStreamingDecoder implements StreamingDecoder {
     }
 
     @Override
+    public final void onStreamClosed() {
+        if (closed) {
+            return;
+        }
+        closed = true;
+        try {
+            accumulate.close();
+        } catch (IOException e) {
+            throw new DecodeException(e);
+        }
+    }
+
+    @Override
     public final void setFragmentListener(FragmentListener listener) {
         this.listener = listener;
     }

--- a/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/message/NoOpStreamingDecoder.java
+++ b/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/message/NoOpStreamingDecoder.java
@@ -40,6 +40,11 @@ public class NoOpStreamingDecoder implements StreamingDecoder {
     }
 
     @Override
+    public void onStreamClosed() {
+        // do nothing
+    }
+
+    @Override
     public void setFragmentListener(FragmentListener listener) {
         this.listener = listener;
     }

--- a/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/message/StreamingDecoder.java
+++ b/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/message/StreamingDecoder.java
@@ -28,6 +28,8 @@ public interface StreamingDecoder {
 
     void close();
 
+    void onStreamClosed();
+
     void setFragmentListener(FragmentListener listener);
 
     interface FragmentListener {

--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/h12/http2/GenericHttp2ServerTransportListener.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/h12/http2/GenericHttp2ServerTransportListener.java
@@ -191,7 +191,7 @@ public class GenericHttp2ServerTransportListener extends AbstractServerTransport
     @Override
     public void onStreamClosed() {
         // doing on event loop thread
-        getStreamingDecoder().close();
+        getServerChannelObserver().onStreamClosed();
     }
 
     private static class Http2StreamingDecodeListener implements ListeningDecoder.Listener {


### PR DESCRIPTION
## What is the purpose of the change
When the stream is closed, only need to clean up the netty memory and do not need to execute the invoke method, otherwise it will cause a memory leak.
![image](https://github.com/apache/dubbo/assets/18413695/d272b376-1852-49c7-b3d3-a9c18a674c03)


## Brief changelog


## Verifying this change


<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [ ] GitHub Actions works fine on your own branch.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
