### PR TITLE
Fix the issue of errors when running out of HTTP2 stream IDs

### DIFF
--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/TripleHttp2Protocol.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/TripleHttp2Protocol.java
@@ -166,6 +166,7 @@ public class TripleHttp2Protocol extends AbstractWireProtocol implements ScopeMo
         codec.connection().local().flowController().frameWriter(codec.encoder().frameWriter());
         List<ChannelHandler> handlers = new ArrayList<>();
         handlers.add(new ChannelHandlerPretender(codec));
+        handlers.add(new ChannelHandlerPretender(new FlushConsolidationHandler(64, true)));
         handlers.add(new ChannelHandlerPretender(new Http2MultiplexHandler(new ChannelDuplexHandler())));
         handlers.add(new ChannelHandlerPretender(new TriplePingPongHandler(UrlUtils.getCloseTimeout(url))));
         handlers.add(new ChannelHandlerPretender(new TripleGoAwayHandler()));

--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/call/TripleClientCall.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/call/TripleClientCall.java
@@ -320,8 +320,7 @@ public class TripleClientCall implements ClientCall, ClientStream.Listener {
     public StreamObserver<Object> start(RequestMetadata metadata, ClientCall.Listener responseListener) {
         this.requestMetadata = metadata;
         this.listener = responseListener;
-        this.stream =
-                new TripleClientStream(frameworkModel, executor, (Channel) connectionClient.getChannel(true), this);
+        this.stream = new TripleClientStream(frameworkModel, executor, (Channel) connectionClient.getChannel(true), this);
         this.sendHeader();
         return new ClientCallToObserverAdapter<>(this);
     }

--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/call/TripleClientCall.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/call/TripleClientCall.java
@@ -320,8 +320,8 @@ public class TripleClientCall implements ClientCall, ClientStream.Listener {
     public StreamObserver<Object> start(RequestMetadata metadata, ClientCall.Listener responseListener) {
         this.requestMetadata = metadata;
         this.listener = responseListener;
-        this.stream = new TripleClientStream(
-                frameworkModel, executor, (Channel) connectionClient.getChannel(true), this);
+        this.stream =
+                new TripleClientStream(frameworkModel, executor, (Channel) connectionClient.getChannel(true), this);
         this.sendHeader();
         return new ClientCallToObserverAdapter<>(this);
     }

--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/call/TripleClientCall.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/call/TripleClientCall.java
@@ -16,9 +16,6 @@
  */
 package org.apache.dubbo.rpc.protocol.tri.call;
 
-import io.netty.handler.codec.http2.Http2NoMoreStreamIdsException;
-import io.netty.util.concurrent.Future;
-
 import org.apache.dubbo.common.logger.ErrorTypeAwareLogger;
 import org.apache.dubbo.common.logger.LoggerFactory;
 import org.apache.dubbo.common.stream.StreamObserver;
@@ -44,6 +41,8 @@ import java.util.concurrent.Executor;
 
 import io.netty.channel.Channel;
 import io.netty.handler.codec.http2.Http2Exception;
+import io.netty.handler.codec.http2.Http2NoMoreStreamIdsException;
+import io.netty.util.concurrent.Future;
 
 import static io.netty.handler.codec.http2.Http2Error.FLOW_CONTROL_ERROR;
 import static org.apache.dubbo.common.constants.LoggerCodeConstants.PROTOCOL_FAILED_RESPONSE;

--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/call/TripleClientCall.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/call/TripleClientCall.java
@@ -320,7 +320,8 @@ public class TripleClientCall implements ClientCall, ClientStream.Listener {
     public StreamObserver<Object> start(RequestMetadata metadata, ClientCall.Listener responseListener) {
         this.requestMetadata = metadata;
         this.listener = responseListener;
-        this.stream = new TripleClientStream(frameworkModel, executor, (Channel) connectionClient.getChannel(true), this);
+        this.stream =
+                new TripleClientStream(frameworkModel, executor, (Channel) connectionClient.getChannel(true), this);
         this.sendHeader();
         return new ClientCallToObserverAdapter<>(this);
     }

--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/command/DataQueueCommand.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/command/DataQueueCommand.java
@@ -47,13 +47,13 @@ public class DataQueueCommand extends StreamQueueCommand {
     @Override
     public void doSend(ChannelHandlerContext ctx, ChannelPromise promise) {
         if (data == null) {
-            ctx.write(new DefaultHttp2DataFrame(endStream), promise);
+            ctx.writeAndFlush(new DefaultHttp2DataFrame(endStream), promise);
         } else {
             ByteBuf buf = ctx.alloc().buffer();
             buf.writeByte(compressFlag);
             buf.writeInt(data.length);
             buf.writeBytes(data);
-            ctx.write(new DefaultHttp2DataFrame(buf, endStream), promise);
+            ctx.writeAndFlush(new DefaultHttp2DataFrame(buf, endStream), promise);
         }
     }
 

--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/command/EndStreamQueueCommand.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/command/EndStreamQueueCommand.java
@@ -34,6 +34,6 @@ public class EndStreamQueueCommand extends StreamQueueCommand {
 
     @Override
     public void doSend(ChannelHandlerContext ctx, ChannelPromise promise) {
-        ctx.write(new DefaultHttp2DataFrame(true), promise);
+        ctx.writeAndFlush(new DefaultHttp2DataFrame(true), promise);
     }
 }

--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/command/HeaderQueueCommand.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/command/HeaderQueueCommand.java
@@ -55,6 +55,6 @@ public class HeaderQueueCommand extends StreamQueueCommand {
 
     @Override
     public void doSend(ChannelHandlerContext ctx, ChannelPromise promise) {
-        ctx.write(new DefaultHttp2HeadersFrame(headers, endStream), promise);
+        ctx.writeAndFlush(new DefaultHttp2HeadersFrame(headers, endStream), promise);
     }
 }

--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/command/QueuedCommand.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/command/QueuedCommand.java
@@ -40,7 +40,7 @@ public abstract class QueuedCommand {
 
     public void run(Channel channel) {
         if (channel.isActive()) {
-            channel.write(this).addListener(future -> {
+            channel.writeAndFlush(this).addListener(future -> {
                 if (future.isSuccess()) {
                     promise.setSuccess();
                 } else {

--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/command/TextDataQueueCommand.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/command/TextDataQueueCommand.java
@@ -44,6 +44,6 @@ public class TextDataQueueCommand extends StreamQueueCommand {
     @Override
     public void doSend(ChannelHandlerContext ctx, ChannelPromise promise) {
         ByteBuf buf = ByteBufUtil.writeUtf8(ctx.alloc(), data);
-        ctx.write(new DefaultHttp2DataFrame(buf, endStream), promise);
+        ctx.writeAndFlush(new DefaultHttp2DataFrame(buf, endStream), promise);
     }
 }

--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/stream/TripleClientStream.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/stream/TripleClientStream.java
@@ -16,8 +16,6 @@
  */
 package org.apache.dubbo.rpc.protocol.tri.stream;
 
-import io.netty.handler.codec.http2.Http2NoMoreStreamIdsException;
-
 import org.apache.dubbo.common.constants.CommonConstants;
 import org.apache.dubbo.common.logger.ErrorTypeAwareLogger;
 import org.apache.dubbo.common.logger.LoggerFactory;
@@ -61,6 +59,7 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.handler.codec.http2.Http2Error;
 import io.netty.handler.codec.http2.Http2Headers;
+import io.netty.handler.codec.http2.Http2NoMoreStreamIdsException;
 import io.netty.handler.codec.http2.Http2StreamChannel;
 import io.netty.handler.codec.http2.Http2StreamChannelBootstrap;
 import io.netty.util.ReferenceCountUtil;
@@ -100,11 +99,7 @@ public class TripleClientStream extends AbstractStream implements ClientStream {
         this.streamChannelFuture = initHttp2StreamChannel(http2StreamChannel);
     }
 
-    public TripleClientStream(
-            FrameworkModel frameworkModel,
-            Executor executor,
-            Channel parent,
-            ClientStream.Listener listener) {
+    public TripleClientStream(FrameworkModel frameworkModel, Executor executor, Channel parent, ClientStream.Listener listener) {
         super(executor, frameworkModel);
         this.parent = parent;
         this.listener = listener;

--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/stream/TripleClientStream.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/stream/TripleClientStream.java
@@ -99,7 +99,8 @@ public class TripleClientStream extends AbstractStream implements ClientStream {
         this.streamChannelFuture = initHttp2StreamChannel(http2StreamChannel);
     }
 
-    public TripleClientStream(FrameworkModel frameworkModel, Executor executor, Channel parent, ClientStream.Listener listener) {
+    public TripleClientStream(
+            FrameworkModel frameworkModel, Executor executor, Channel parent, ClientStream.Listener listener) {
         super(executor, frameworkModel);
         this.parent = parent;
         this.listener = listener;


### PR DESCRIPTION
## What is the purpose of the change
fix #14098 

Fix the issue of errors when running out of HTTP2 stream IDs


## Brief changelog
1. reconnect when throw `Http2NoMoreStreamIdsException `
2. remove WriteQueue in triple

## Verifying this change


<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [ ] GitHub Actions works fine on your own branch.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
