### PR TITLE
Add ErrorResponse class into security/serialize.allowlist

### DIFF
--- a/dubbo-common/src/main/resources/security/serialize.allowlist
+++ b/dubbo-common/src/main/resources/security/serialize.allowlist
@@ -131,6 +131,7 @@ com.alibaba.com.caucho.hessian.io
 com.alibaba.dubbo.rpc.service.GenericException
 org.apache.dubbo.rpc.service.GenericException
 org.apache.dubbo.rpc.RpcException
+org.apache.dubbo.remoting.http12.ErrorResponse
 org.apache.dubbo.common.url.component.ServiceConfigURL
 org.apache.dubbo.common.URL
 org.apache.dubbo.common.url.component.URLAddress


### PR DESCRIPTION
## What is the purpose of the change

ErrorResponse is the default response type sent to the client when the server exception occurs, so it needs to be added to security/serialize.allowlist.
![image](https://github.com/apache/dubbo/assets/18413695/4ac55bfe-0841-49c9-a6bd-bf19ca9ed228)


## Brief changelog


## Verifying this change


<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [ ] GitHub Actions works fine on your own branch.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
