### PR TITLE
Configure releaseOnClose to release ByteBuf

### DIFF
--- a/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/h1/Http1OutputMessage.java
+++ b/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/h1/Http1OutputMessage.java
@@ -18,10 +18,7 @@ package org.apache.dubbo.remoting.http12.h1;
 
 import org.apache.dubbo.remoting.http12.HttpOutputMessage;
 
-import java.io.IOException;
 import java.io.OutputStream;
-
-import io.netty.buffer.ByteBufOutputStream;
 
 public class Http1OutputMessage implements HttpOutputMessage {
 
@@ -34,13 +31,5 @@ public class Http1OutputMessage implements HttpOutputMessage {
     @Override
     public OutputStream getBody() {
         return outputStream;
-    }
-
-    @Override
-    public void close() throws IOException {
-        if (outputStream instanceof ByteBufOutputStream) {
-            ((ByteBufOutputStream) outputStream).buffer().release();
-        }
-        outputStream.close();
     }
 }

--- a/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/h2/Http2OutputMessageFrame.java
+++ b/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/h2/Http2OutputMessageFrame.java
@@ -16,10 +16,7 @@
  */
 package org.apache.dubbo.remoting.http12.h2;
 
-import java.io.IOException;
 import java.io.OutputStream;
-
-import io.netty.buffer.ByteBufOutputStream;
 
 public class Http2OutputMessageFrame implements Http2OutputMessage {
 
@@ -43,14 +40,6 @@ public class Http2OutputMessageFrame implements Http2OutputMessage {
     @Override
     public OutputStream getBody() {
         return body;
-    }
-
-    @Override
-    public void close() throws IOException {
-        if (body instanceof ByteBufOutputStream) {
-            ((ByteBufOutputStream) body).buffer().release();
-        }
-        body.close();
     }
 
     @Override

--- a/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/netty4/h1/NettyHttp1Channel.java
+++ b/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/netty4/h1/NettyHttp1Channel.java
@@ -52,7 +52,7 @@ public class NettyHttp1Channel implements HttpChannel {
 
     @Override
     public HttpOutputMessage newOutputMessage() {
-        return new Http1OutputMessage(new ByteBufOutputStream(channel.alloc().buffer()));
+        return new Http1OutputMessage(new ByteBufOutputStream(channel.alloc().buffer(), true));
     }
 
     @Override

--- a/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/netty4/h2/NettyH2StreamChannel.java
+++ b/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/netty4/h2/NettyH2StreamChannel.java
@@ -57,7 +57,7 @@ public class NettyH2StreamChannel implements H2StreamChannel {
     @Override
     public Http2OutputMessage newOutputMessage(boolean endStream) {
         ByteBuf buffer = http2StreamChannel.alloc().buffer();
-        ByteBufOutputStream outputStream = new ByteBufOutputStream(buffer);
+        ByteBufOutputStream outputStream = new ByteBufOutputStream(buffer, true);
         return new Http2OutputMessageFrame(outputStream, endStream);
     }
 


### PR DESCRIPTION
## What is the purpose of the change

Configure releaseOnClose to release ByteBuf when output stream is closed.
Related pr: https://github.com/netty/netty/pull/13986

## Brief changelog


## Verifying this change


<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [ ] GitHub Actions works fine on your own branch.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
