### PR TITLE
Fix metrics unable to retrieve lazy inited executor status

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/store/DataStore.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/store/DataStore.java
@@ -36,5 +36,4 @@ public interface DataStore {
     void remove(String componentName, String key);
 
     default void addListener(DataStoreUpdateListener dataStoreUpdateListener) {}
-    ;
 }

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/store/DataStoreUpdateListener.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/store/DataStoreUpdateListener.java
@@ -16,25 +16,6 @@
  */
 package org.apache.dubbo.common.store;
 
-import org.apache.dubbo.common.extension.ExtensionScope;
-import org.apache.dubbo.common.extension.SPI;
-
-import java.util.Map;
-
-@SPI(value = "simple", scope = ExtensionScope.APPLICATION)
-public interface DataStore {
-
-    /**
-     * return a snapshot value of componentName
-     */
-    Map<String, Object> get(String componentName);
-
-    Object get(String componentName, String key);
-
-    void put(String componentName, String key, Object value);
-
-    void remove(String componentName, String key);
-
-    default void addListener(DataStoreUpdateListener dataStoreUpdateListener) {}
-    ;
+public interface DataStoreUpdateListener {
+    void onUpdate(String componentName, String key, Object value);
 }

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/store/support/SimpleDataStore.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/store/support/SimpleDataStore.java
@@ -82,7 +82,12 @@ public class SimpleDataStore implements DataStore {
                 listener.onUpdate(componentName, key, value);
             } catch (Throwable t) {
                 logger.warn(
-                        LoggerCodeConstants.INTERNAL_ERROR, "", "", "Failed to notify data store update listener", t);
+                        LoggerCodeConstants.INTERNAL_ERROR,
+                        "",
+                        "",
+                        "Failed to notify data store update listener. " + "ComponentName: " + componentName + " Key: "
+                                + key,
+                        t);
             }
         }
     }

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/store/support/SimpleDataStore.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/store/support/SimpleDataStore.java
@@ -16,8 +16,13 @@
  */
 package org.apache.dubbo.common.store.support;
 
+import org.apache.dubbo.common.constants.LoggerCodeConstants;
+import org.apache.dubbo.common.logger.ErrorTypeAwareLogger;
+import org.apache.dubbo.common.logger.LoggerFactory;
 import org.apache.dubbo.common.store.DataStore;
+import org.apache.dubbo.common.store.DataStoreUpdateListener;
 import org.apache.dubbo.common.utils.ConcurrentHashMapUtils;
+import org.apache.dubbo.common.utils.ConcurrentHashSet;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -25,9 +30,11 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
 public class SimpleDataStore implements DataStore {
+    private static final ErrorTypeAwareLogger logger = LoggerFactory.getErrorTypeAwareLogger(SimpleDataStore.class);
 
     // <component name or id, <data-name, data-value>>
     private final ConcurrentMap<String, ConcurrentMap<String, Object>> data = new ConcurrentHashMap<>();
+    private final ConcurrentHashSet<DataStoreUpdateListener> listeners = new ConcurrentHashSet<>();
 
     @Override
     public Map<String, Object> get(String componentName) {
@@ -52,6 +59,7 @@ public class SimpleDataStore implements DataStore {
         Map<String, Object> componentData =
                 ConcurrentHashMapUtils.computeIfAbsent(data, componentName, k -> new ConcurrentHashMap<>());
         componentData.put(key, value);
+        notifyListeners(componentName, key, value);
     }
 
     @Override
@@ -60,5 +68,22 @@ public class SimpleDataStore implements DataStore {
             return;
         }
         data.get(componentName).remove(key);
+        notifyListeners(componentName, key, null);
+    }
+
+    @Override
+    public void addListener(DataStoreUpdateListener dataStoreUpdateListener) {
+        listeners.add(dataStoreUpdateListener);
+    }
+
+    private void notifyListeners(String componentName, String key, Object value) {
+        for (DataStoreUpdateListener listener : listeners) {
+            try {
+                listener.onUpdate(componentName, key, value);
+            } catch (Throwable t) {
+                logger.warn(
+                        LoggerCodeConstants.INTERNAL_ERROR, "", "", "Failed to notify data store update listener", t);
+            }
+        }
     }
 }

--- a/dubbo-common/src/main/java/org/apache/dubbo/config/Constants.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/config/Constants.java
@@ -149,7 +149,11 @@ public interface Constants {
 
     String SERVER_THREAD_POOL_NAME = "DubboServerHandler";
 
+    String SERVER_THREAD_POOL_PREFIX = SERVER_THREAD_POOL_NAME + "-";
+
     String CLIENT_THREAD_POOL_NAME = "DubboClientHandler";
+
+    String CLIENT_THREAD_POOL_PREFIX = CLIENT_THREAD_POOL_NAME + "-";
 
     String REST_PROTOCOL = "rest";
 }

--- a/dubbo-metrics/dubbo-metrics-default/src/main/java/org/apache/dubbo/metrics/collector/sample/ThreadPoolMetricsSampler.java
+++ b/dubbo-metrics/dubbo-metrics-default/src/main/java/org/apache/dubbo/metrics/collector/sample/ThreadPoolMetricsSampler.java
@@ -43,8 +43,9 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import static org.apache.dubbo.common.constants.CommonConstants.CONSUMER_SHARED_EXECUTOR_SERVICE_COMPONENT_KEY;
 import static org.apache.dubbo.common.constants.CommonConstants.EXECUTOR_SERVICE_COMPONENT_KEY;
 import static org.apache.dubbo.common.constants.LoggerCodeConstants.COMMON_METRICS_COLLECTOR_EXCEPTION;
-import static org.apache.dubbo.config.Constants.CLIENT_THREAD_POOL_NAME;
+import static org.apache.dubbo.config.Constants.CLIENT_THREAD_POOL_PREFIX;
 import static org.apache.dubbo.config.Constants.SERVER_THREAD_POOL_NAME;
+import static org.apache.dubbo.config.Constants.SERVER_THREAD_POOL_PREFIX;
 import static org.apache.dubbo.metrics.model.MetricsCategory.THREAD_POOL;
 
 public class ThreadPoolMetricsSampler implements MetricsSampler, DataStoreUpdateListener {
@@ -66,11 +67,11 @@ public class ThreadPoolMetricsSampler implements MetricsSampler, DataStoreUpdate
     public void onUpdate(String componentName, String key, Object value) {
         if (EXECUTOR_SERVICE_COMPONENT_KEY.equals(componentName)) {
             if (value instanceof ThreadPoolExecutor) {
-                addExecutors(SERVER_THREAD_POOL_NAME + "-" + key, (ThreadPoolExecutor) value);
+                addExecutors(SERVER_THREAD_POOL_PREFIX + key, (ThreadPoolExecutor) value);
             }
         } else if (CONSUMER_SHARED_EXECUTOR_SERVICE_COMPONENT_KEY.equals(componentName)) {
             if (value instanceof ThreadPoolExecutor) {
-                addExecutors(CLIENT_THREAD_POOL_NAME + "-" + key, (ThreadPoolExecutor) value);
+                addExecutors(CLIENT_THREAD_POOL_PREFIX + key, (ThreadPoolExecutor) value);
             }
         }
     }
@@ -173,14 +174,14 @@ public class ThreadPoolMetricsSampler implements MetricsSampler, DataStoreUpdate
             for (Map.Entry<String, Object> entry : executors.entrySet()) {
                 ExecutorService executor = (ExecutorService) entry.getValue();
                 if (executor instanceof ThreadPoolExecutor) {
-                    this.addExecutors(SERVER_THREAD_POOL_NAME + "-" + entry.getKey(), executor);
+                    this.addExecutors(SERVER_THREAD_POOL_PREFIX + entry.getKey(), executor);
                 }
             }
             executors = dataStore.get(CONSUMER_SHARED_EXECUTOR_SERVICE_COMPONENT_KEY);
             for (Map.Entry<String, Object> entry : executors.entrySet()) {
                 ExecutorService executor = (ExecutorService) entry.getValue();
                 if (executor instanceof ThreadPoolExecutor) {
-                    this.addExecutors(CLIENT_THREAD_POOL_NAME + "-" + entry.getKey(), executor);
+                    this.addExecutors(CLIENT_THREAD_POOL_PREFIX + entry.getKey(), executor);
                 }
             }
 


### PR DESCRIPTION
## What is the purpose of the change



## Brief changelog


## Verifying this change


<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [ ] GitHub Actions works fine on your own branch.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
