### PR TITLE
Sync spring init actions to prevent parallel init

### DIFF
--- a/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/ReferenceBean.java
+++ b/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/ReferenceBean.java
@@ -148,7 +148,7 @@ public class ReferenceBean<T>
     private MutablePropertyValues propertyValues;
 
     // actual reference config
-    private ReferenceConfig referenceConfig;
+    private volatile ReferenceConfig referenceConfig;
 
     // ReferenceBeanManager
     private ReferenceBeanManager referenceBeanManager;

--- a/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/ReferenceBean.java
+++ b/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/ReferenceBean.java
@@ -82,14 +82,14 @@ import static org.apache.dubbo.common.constants.LoggerCodeConstants.PROXY_FAILED
  *     }
  * }
  * </pre>
- * <p>
+ *
  * Or register ReferenceBean in xml:
  * <pre class="code">
  * &lt;dubbo:reference id="helloService" interface="org.apache.dubbo.config.spring.api.HelloService"/&gt;
  * &lt;!-- As GenericService --&gt;
  * &lt;dubbo:reference id="genericHelloService" interface="org.apache.dubbo.config.spring.api.HelloService" generic="true"/&gt;
  * </pre>
- * <p>
+ *
  * Step 2: Inject ReferenceBean by @Autowired
  * <pre class="code">
  * public class FooController {
@@ -100,6 +100,7 @@ import static org.apache.dubbo.common.constants.LoggerCodeConstants.PROXY_FAILED
  *     private GenericService genericHelloService;
  * }
  * </pre>
+ *
  *
  * @see org.apache.dubbo.config.annotation.DubboReference
  * @see org.apache.dubbo.config.spring.reference.ReferenceBeanBuilder
@@ -147,7 +148,7 @@ public class ReferenceBean<T>
     private MutablePropertyValues propertyValues;
 
     // actual reference config
-    private volatile ReferenceConfig referenceConfig;
+    private ReferenceConfig referenceConfig;
 
     // ReferenceBeanManager
     private ReferenceBeanManager referenceBeanManager;
@@ -183,20 +184,23 @@ public class ReferenceBean<T>
      *
      * <p></p>
      * Why we need a lazy proxy?
-     * <p>
+     *
      * <p/>
-     * When Spring searches beans by type, if Spring cannot determine the type of a factory bean, it may try to
-     * initialize it. The ReferenceBean is also a FactoryBean. <br/> (This has already been resolved by decorating the
-     * BeanDefinition: {@link DubboBeanDefinitionParser#configReferenceBean})
-     * <p>
+     * When Spring searches beans by type, if Spring cannot determine the type of a factory bean, it may try to initialize it.
+     * The ReferenceBean is also a FactoryBean.
+     * <br/>
+     * (This has already been resolved by decorating the BeanDefinition: {@link DubboBeanDefinitionParser#configReferenceBean})
+     *
      * <p/>
-     * In addition, if some ReferenceBeans are dependent on beans that are initialized very early, and dubbo config
-     * beans are not ready yet, there will be many unexpected problems if initializing the dubbo reference immediately.
-     * <p>
+     * In addition, if some ReferenceBeans are dependent on beans that are initialized very early,
+     * and dubbo config beans are not ready yet, there will be many unexpected problems if initializing the dubbo reference immediately.
+     *
      * <p/>
-     * When it is initialized, only a lazy proxy object will be created, and dubbo reference-related resources will not
-     * be initialized. <br/> In this way, the influence of Spring is eliminated, and the dubbo configuration
-     * initialization is controllable.
+     * When it is initialized, only a lazy proxy object will be created,
+     * and dubbo reference-related resources will not be initialized.
+     * <br/>
+     * In this way, the influence of Spring is eliminated, and the dubbo configuration initialization is controllable.
+     *
      *
      * @see DubboConfigBeanInitializer
      * @see ReferenceBeanManager#initReferenceBean(ReferenceBean)
@@ -280,7 +284,6 @@ public class ReferenceBean<T>
 
     /**
      * The interface of this ReferenceBean, for injection purpose
-     *
      * @return
      */
     public Class<?> getInterfaceClass() {
@@ -411,7 +414,7 @@ public class ReferenceBean<T>
                     PROXY_FAILED,
                     "",
                     "",
-                    "Failed to generate proxy by Javassist failed. Fmvnallback to use JDK proxy is also failed. "
+                    "Failed to generate proxy by Javassist failed. Fallback to use JDK proxy is also failed. "
                             + "Interfaces: " + interfaces + " JDK Error.",
                     fromJdk);
             throw fromJdk;

--- a/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/ReferenceBean.java
+++ b/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/ReferenceBean.java
@@ -82,14 +82,14 @@ import static org.apache.dubbo.common.constants.LoggerCodeConstants.PROXY_FAILED
  *     }
  * }
  * </pre>
- *
+ * <p>
  * Or register ReferenceBean in xml:
  * <pre class="code">
  * &lt;dubbo:reference id="helloService" interface="org.apache.dubbo.config.spring.api.HelloService"/&gt;
  * &lt;!-- As GenericService --&gt;
  * &lt;dubbo:reference id="genericHelloService" interface="org.apache.dubbo.config.spring.api.HelloService" generic="true"/&gt;
  * </pre>
- *
+ * <p>
  * Step 2: Inject ReferenceBean by @Autowired
  * <pre class="code">
  * public class FooController {
@@ -100,7 +100,6 @@ import static org.apache.dubbo.common.constants.LoggerCodeConstants.PROXY_FAILED
  *     private GenericService genericHelloService;
  * }
  * </pre>
- *
  *
  * @see org.apache.dubbo.config.annotation.DubboReference
  * @see org.apache.dubbo.config.spring.reference.ReferenceBeanBuilder
@@ -148,7 +147,7 @@ public class ReferenceBean<T>
     private MutablePropertyValues propertyValues;
 
     // actual reference config
-    private ReferenceConfig referenceConfig;
+    private volatile ReferenceConfig referenceConfig;
 
     // ReferenceBeanManager
     private ReferenceBeanManager referenceBeanManager;
@@ -184,23 +183,20 @@ public class ReferenceBean<T>
      *
      * <p></p>
      * Why we need a lazy proxy?
-     *
+     * <p>
      * <p/>
-     * When Spring searches beans by type, if Spring cannot determine the type of a factory bean, it may try to initialize it.
-     * The ReferenceBean is also a FactoryBean.
-     * <br/>
-     * (This has already been resolved by decorating the BeanDefinition: {@link DubboBeanDefinitionParser#configReferenceBean})
-     *
+     * When Spring searches beans by type, if Spring cannot determine the type of a factory bean, it may try to
+     * initialize it. The ReferenceBean is also a FactoryBean. <br/> (This has already been resolved by decorating the
+     * BeanDefinition: {@link DubboBeanDefinitionParser#configReferenceBean})
+     * <p>
      * <p/>
-     * In addition, if some ReferenceBeans are dependent on beans that are initialized very early,
-     * and dubbo config beans are not ready yet, there will be many unexpected problems if initializing the dubbo reference immediately.
-     *
+     * In addition, if some ReferenceBeans are dependent on beans that are initialized very early, and dubbo config
+     * beans are not ready yet, there will be many unexpected problems if initializing the dubbo reference immediately.
+     * <p>
      * <p/>
-     * When it is initialized, only a lazy proxy object will be created,
-     * and dubbo reference-related resources will not be initialized.
-     * <br/>
-     * In this way, the influence of Spring is eliminated, and the dubbo configuration initialization is controllable.
-     *
+     * When it is initialized, only a lazy proxy object will be created, and dubbo reference-related resources will not
+     * be initialized. <br/> In this way, the influence of Spring is eliminated, and the dubbo configuration
+     * initialization is controllable.
      *
      * @see DubboConfigBeanInitializer
      * @see ReferenceBeanManager#initReferenceBean(ReferenceBean)
@@ -284,6 +280,7 @@ public class ReferenceBean<T>
 
     /**
      * The interface of this ReferenceBean, for injection purpose
+     *
      * @return
      */
     public Class<?> getInterfaceClass() {
@@ -414,7 +411,7 @@ public class ReferenceBean<T>
                     PROXY_FAILED,
                     "",
                     "",
-                    "Failed to generate proxy by Javassist failed. Fallback to use JDK proxy is also failed. "
+                    "Failed to generate proxy by Javassist failed. Fmvnallback to use JDK proxy is also failed. "
                             + "Interfaces: " + interfaces + " JDK Error.",
                     fromJdk);
             throw fromJdk;
@@ -423,15 +420,22 @@ public class ReferenceBean<T>
 
     private Object getCallProxy() throws Exception {
         if (referenceConfig == null) {
-            referenceBeanManager.initReferenceBean(this);
-            applicationContext
-                    .getBean(DubboConfigApplicationListener.class.getName(), DubboConfigApplicationListener.class)
-                    .init();
-            logger.warn(
-                    CONFIG_DUBBO_BEAN_INITIALIZER,
-                    "",
-                    "",
-                    "ReferenceBean is not ready yet, please make sure to call reference interface method after dubbo is started.");
+            synchronized (LockUtils.getSingletonMutex(applicationContext)) {
+                if (referenceConfig == null) {
+                    referenceBeanManager.initReferenceBean(this);
+                    applicationContext
+                            .getBean(
+                                    DubboConfigApplicationListener.class.getName(),
+                                    DubboConfigApplicationListener.class)
+                            .init();
+                    logger.warn(
+                            CONFIG_DUBBO_BEAN_INITIALIZER,
+                            "",
+                            "",
+                            "ReferenceBean is not ready yet, please make sure to "
+                                    + "call reference interface method after dubbo is started.");
+                }
+            }
         }
         // get reference proxy
         // Subclasses should synchronize on the given Object if they perform any sort of extended singleton creation

--- a/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/context/DubboConfigApplicationListener.java
+++ b/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/context/DubboConfigApplicationListener.java
@@ -60,7 +60,7 @@ public class DubboConfigApplicationListener
         }
     }
 
-    public void init() {
+    public synchronized void init() {
         // It's expected to be notified at
         // org.springframework.context.support.AbstractApplicationContext.registerListeners(),
         // before loading non-lazy singleton beans. At this moment, all BeanFactoryPostProcessor have been processed,


### PR DESCRIPTION
## What is the purpose of the change

Status: Dubbo not inited. Early trigger Dubbo invoke during Spring Application Listener init.

```
main thread: invoke Dubbo Reference Bean -> referenceConfig not prepared ->                                  success get not well prepared referenceConfig -> invoke -> throw config not found exception
other thread: invoke Dubbo Reference Bean -> referenceConfig not prepared -> trigger spring config listener config load -> still getting config
```

```
stack=java.lang.IllegalStateException: No application config found or it's not a valid config! Please add <dubbo:application name="..." /> to your spring config.
  at org.apache.dubbo.config.utils.ConfigValidationUtils.validateApplicationConfig(ConfigValidationUtils.java:494)
  at org.apache.dubbo.config.utils.DefaultConfigValidator.validate(DefaultConfigValidator.java:48)
  at org.apache.dubbo.config.context.AbstractConfigManager.checkDefaultAndValidateConfigs(AbstractConfigManager.java:620)
  at org.apache.dubbo.config.context.ConfigManager.checkConfigs(ConfigManager.java:302)
  at org.apache.dubbo.config.context.ConfigManager.loadConfigs(ConfigManager.java:282)
  at org.apache.dubbo.config.deploy.DefaultApplicationDeployer.loadApplicationConfigs(DefaultApplicationDeployer.java:255)
  at org.apache.dubbo.config.deploy.DefaultApplicationDeployer.initialize(DefaultApplicationDeployer.java:222)
  at org.apache.dubbo.config.deploy.DefaultModuleDeployer.prepare(DefaultModuleDeployer.java:638)
  at org.apache.dubbo.config.ReferenceConfig.get(ReferenceConfig.java:232)
  at org.apache.dubbo.config.ReferenceConfigBase.get(ReferenceConfigBase.java:395)
  at org.apache.dubbo.config.spring.ReferenceBean.getCallProxy(ReferenceBean.java:446)
  at org.apache.dubbo.config.spring.ReferenceBean.access$100(ReferenceBean.java:108)
  at org.apache.dubbo.config.spring.ReferenceBean$DubboReferenceLazyInitTargetSource.getTarget(ReferenceBean.java:453)
  at org.apache.dubbo.config.spring.util.LazyTargetInvocationHandler.invoke(LazyTargetInvocationHandler.java:50)
```

## Brief changelog


## Verifying this change


<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [ ] GitHub Actions works fine on your own branch.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
