### PR TITLE
fix: `path` not set in xdsCluster invoker creation

### DIFF
--- a/dubbo-xds/src/main/java/org/apache/dubbo/xds/directory/XdsDirectory.java
+++ b/dubbo-xds/src/main/java/org/apache/dubbo/xds/directory/XdsDirectory.java
@@ -165,12 +165,11 @@ public class XdsDirectory<T> extends AbstractDirectory<T> {
         xdsEndpoints.forEach(e -> {
             String ip = e.getAddress();
             int port = e.getPortValue();
-            URL url = new URL(this.protocolName, ip, port, this.url.getParameters());
+            URL url = new URL(this.protocolName, ip, port, this.serviceType.getName(), this.url.getParameters());
             // set cluster name
             url = url.addParameter("clusterID", clusterName);
             // set load balance policy
             url = url.addParameter("loadbalance", lbPolicy);
-            url.setPath(this.serviceType.getName());
             //  cluster to invoker
             Invoker<T> invoker = this.protocol.refer(this.serviceType, url);
             invokers.add(invoker);


### PR DESCRIPTION
## What is the purpose of the change

`url.setPath()` does not update the URL object. Set `path` in the constructor method instead.

## Brief changelog


## Verifying this change


<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [ ] GitHub Actions works fine on your own branch.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
