### PR TITLE
3.3

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/url/component/URLParam.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/url/component/URLParam.java
@@ -483,7 +483,7 @@ public class URLParam {
      * @return A new URLParam
      */
     public URLParam addParameter(String key, String value) {
-        if (StringUtils.isEmpty(key) || StringUtils.isEmpty(value)) {
+        if (StringUtils.isEmpty(key)) {
             return this;
         }
         return addParameters(Collections.singletonMap(key, value));
@@ -497,7 +497,7 @@ public class URLParam {
      * @return A new URLParam
      */
     public URLParam addParameterIfAbsent(String key, String value) {
-        if (StringUtils.isEmpty(key) || StringUtils.isEmpty(value)) {
+        if (StringUtils.isEmpty(key)) {
             return this;
         }
         if (hasParameter(key)) {
@@ -567,7 +567,7 @@ public class URLParam {
             if (skipIfPresent && hasParameter(entry.getKey())) {
                 continue;
             }
-            if (entry.getKey() == null || entry.getValue() == null) {
+            if (entry.getKey() == null) {
                 continue;
             }
             int keyIndex = DynamicParamTable.getKeyIndex(enableCompressed, entry.getKey());

--- a/dubbo-configcenter/dubbo-configcenter-nacos/src/main/java/org/apache/dubbo/configcenter/support/nacos/NacosConfigServiceWrapper.java
+++ b/dubbo-configcenter/dubbo-configcenter-nacos/src/main/java/org/apache/dubbo/configcenter/support/nacos/NacosConfigServiceWrapper.java
@@ -25,6 +25,8 @@ import static org.apache.dubbo.common.utils.StringUtils.SLASH_CHAR;
 
 public class NacosConfigServiceWrapper {
 
+    private static final char ASTERISK_SYMBOL = '*';
+
     private static final String INNERCLASS_SYMBOL = "$";
 
     private static final String INNERCLASS_COMPATIBLE_SYMBOL = "___";
@@ -76,6 +78,8 @@ public class NacosConfigServiceWrapper {
         if (data == null) {
             return null;
         }
-        return data.replace(INNERCLASS_SYMBOL, INNERCLASS_COMPATIBLE_SYMBOL).replace(SLASH_CHAR, HYPHEN_CHAR);
+        return data.replace(INNERCLASS_SYMBOL, INNERCLASS_COMPATIBLE_SYMBOL)
+                .replace(SLASH_CHAR, HYPHEN_CHAR)
+                .replace(ASTERISK_SYMBOL, HYPHEN_CHAR);
     }
 }

--- a/dubbo-metadata/dubbo-metadata-report-nacos/src/main/java/org/apache/dubbo/metadata/store/nacos/NacosConfigServiceWrapper.java
+++ b/dubbo-metadata/dubbo-metadata-report-nacos/src/main/java/org/apache/dubbo/metadata/store/nacos/NacosConfigServiceWrapper.java
@@ -25,6 +25,8 @@ import static org.apache.dubbo.common.utils.StringUtils.SLASH_CHAR;
 
 public class NacosConfigServiceWrapper {
 
+    private static final char ASTERISK_SYMBOL = '*';
+
     private static final String INNERCLASS_SYMBOL = "$";
 
     private static final String INNERCLASS_COMPATIBLE_SYMBOL = "___";
@@ -76,6 +78,8 @@ public class NacosConfigServiceWrapper {
         if (data == null) {
             return null;
         }
-        return data.replace(INNERCLASS_SYMBOL, INNERCLASS_COMPATIBLE_SYMBOL).replace(SLASH_CHAR, HYPHEN_CHAR);
+        return data.replace(INNERCLASS_SYMBOL, INNERCLASS_COMPATIBLE_SYMBOL)
+                .replace(SLASH_CHAR, HYPHEN_CHAR)
+                .replace(ASTERISK_SYMBOL, HYPHEN_CHAR);
     }
 }


### PR DESCRIPTION
I want consumer with * version to router diffrent version provider which dubbo 2.7 supported
there is two problem

1.nacos dataId not support * SYMBOL
2.consumer with * version invoke Null version provider will block by PermittedSerializationKeeper.checkSerializationPermitted
Because the provider urlParam of version built by consumer has *
Because the null value will not replace the exist urlParam