### PR TITLE
fix AbortPolicyWithReport may repeatedly jstack when threadPool is exhausted

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/threadpool/support/AbortPolicyWithReport.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/threadpool/support/AbortPolicyWithReport.java
@@ -184,10 +184,9 @@ public class AbortPolicyWithReport extends ThreadPoolExecutor.AbortPolicy {
                     jstack(jStackStream);
                 } catch (Exception t) {
                     logger.error(COMMON_UNEXPECTED_CREATE_DUMP, "", "", "dump jStack error", t);
-                } finally {
-                    lastPrintTime = System.currentTimeMillis();
                 }
             });
+            lastPrintTime = System.currentTimeMillis();
         } finally {
             guard.release();
             // must shut down thread pool ,if not will lead to OOM

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/threadpool/support/AbortPolicyWithReportTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/threadpool/support/AbortPolicyWithReportTest.java
@@ -75,13 +75,13 @@ class AbortPolicyWithReportTest {
 
     @Test
     void jStack_ConcurrencyDump_Silence_10Min() {
-        URL spyUrl = URL.valueOf(
+        URL url = URL.valueOf(
                 "dubbo://admin:hello1234@10.20.130.230:20880/context/path?dump.directory=/tmp&version=1.0.0&application=morgan&noValue=");
         AtomicInteger jStackCount = new AtomicInteger(0);
         AtomicInteger failureCount = new AtomicInteger(0);
         AtomicInteger finishedCount = new AtomicInteger(0);
         AtomicInteger timeoutCount = new AtomicInteger(0);
-        AbortPolicyWithReport abortPolicyWithReport = new AbortPolicyWithReport("Test", spyUrl) {
+        AbortPolicyWithReport abortPolicyWithReport = new AbortPolicyWithReport("Test", url) {
             @Override
             protected void jstack(FileOutputStream jStackStream) {
                 jStackCount.incrementAndGet();
@@ -123,7 +123,6 @@ class AbortPolicyWithReportTest {
         System.out.printf(
                 "jStackCount: %d, finishedCount: %d, failureCount: %d, timeoutCount: %d %n",
                 jStackCount.get(), finishedCount.get(), failureCount.get(), timeoutCount.get());
-        // Mockito.verify(spyUrl, Mockito.times(1)).getParameter(DUMP_DIRECTORY);
         Assertions.assertEquals(
                 runTimes, finishedCount.get() + failureCount.get(), "all the test thread should be run completely");
         Assertions.assertEquals(1, jStackCount.get(), "'jstack' should be called only once in 10 minutes");

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/threadpool/support/AbortPolicyWithReportTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/threadpool/support/AbortPolicyWithReportTest.java
@@ -16,24 +16,24 @@
  */
 package org.apache.dubbo.common.threadpool.support;
 
-import java.util.LinkedList;
-import java.util.List;
-import java.util.concurrent.Future;
-import java.util.concurrent.SynchronousQueue;
-import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.dubbo.common.URL;
 import org.apache.dubbo.common.threadlocal.NamedInternalThreadFactory;
 import org.apache.dubbo.common.threadpool.event.ThreadPoolExhaustedEvent;
 import org.apache.dubbo.common.threadpool.event.ThreadPoolExhaustedListener;
 
 import java.io.FileOutputStream;
+import java.util.LinkedList;
+import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.ThreadPoolExecutor;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -44,6 +44,7 @@ import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class AbortPolicyWithReportTest {
+
     @Test
     void jStackDumpTest() {
         URL url = URL.valueOf(
@@ -69,7 +70,8 @@ class AbortPolicyWithReportTest {
 
     @Test
     void jStack_ConcurrencyDump_Active_10MinSilence() {
-        URL url = URL.valueOf("dubbo://admin:hello1234@10.20.130.230:20880/context/path?dump.directory=/tmp&version=1.0.0&application=morgan&noValue=");
+        URL url = URL.valueOf(
+                "dubbo://admin:hello1234@10.20.130.230:20880/context/path?dump.directory=/tmp&version=1.0.0&application=morgan&noValue=");
         AtomicInteger jStackCount = new AtomicInteger(0);
         AtomicInteger finishedCount = new AtomicInteger(0);
         AbortPolicyWithReport abortPolicyWithReport = new AbortPolicyWithReport("Test", url) {
@@ -83,18 +85,18 @@ class AbortPolicyWithReportTest {
             }
         };
         ThreadPoolExecutor threadPoolExecutor = new ThreadPoolExecutor(
-            4,
-            4,
-            0,
-            TimeUnit.MILLISECONDS,
-            new SynchronousQueue<>(),
-            new NamedInternalThreadFactory("jStackRepeatFixedTest", false),
-            abortPolicyWithReport);
+                4,
+                4,
+                0,
+                TimeUnit.MILLISECONDS,
+                new SynchronousQueue<>(),
+                new NamedInternalThreadFactory("jStackRepeatFixedTest", false),
+                abortPolicyWithReport);
         List<Future<?>> futureList = new LinkedList<>();
         for (int pos = 0; pos < 100; pos++) {
             try {
                 futureList.add(threadPoolExecutor.submit(() -> {
-                   finishedCount.incrementAndGet();
+                    finishedCount.incrementAndGet();
                 }));
             } catch (Exception ignored) {
             }


### PR DESCRIPTION


## What is the purpose of the change
#14467 AbortPolicyWithReport may repeatedly jstack when threadPool is exhausted


## Brief changelog


## Verifying this change


<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [ ] GitHub Actions works fine on your own branch.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
