### PR TITLE
NPE will occur when consumer lazy init and the consumer thread contextClassLoader is null

### DIFF
--- a/dubbo-serialization/dubbo-serialization-hessian2/src/main/java/org/apache/dubbo/common/serialize/hessian2/Hessian2ObjectInput.java
+++ b/dubbo-serialization/dubbo-serialization-hessian2/src/main/java/org/apache/dubbo/common/serialize/hessian2/Hessian2ObjectInput.java
@@ -23,6 +23,7 @@ import org.apache.dubbo.rpc.model.FrameworkModel;
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.Type;
+import java.util.Objects;
 
 import com.alibaba.com.caucho.hessian.io.Hessian2Input;
 
@@ -96,11 +97,10 @@ public class Hessian2ObjectInput implements ObjectInput, Cleanable {
 
     @Override
     public Object readObject() throws IOException {
-        if (!mH2i.getSerializerFactory()
-                .getClassLoader()
-                .equals(Thread.currentThread().getContextClassLoader())) {
-            mH2i.setSerializerFactory(hessian2FactoryManager.getSerializerFactory(
-                    Thread.currentThread().getContextClassLoader()));
+        if (!Objects.equals(mH2i.getSerializerFactory().getClassLoader(),
+                Thread.currentThread().getContextClassLoader())) {
+            mH2i.setSerializerFactory(hessian2FactoryManager.getSerializerFactory(Thread.currentThread()
+                    .getContextClassLoader()));
         }
         return mH2i.readObject();
     }
@@ -108,22 +108,20 @@ public class Hessian2ObjectInput implements ObjectInput, Cleanable {
     @Override
     @SuppressWarnings("unchecked")
     public <T> T readObject(Class<T> cls) throws IOException, ClassNotFoundException {
-        if (!mH2i.getSerializerFactory()
-                .getClassLoader()
-                .equals(Thread.currentThread().getContextClassLoader())) {
-            mH2i.setSerializerFactory(hessian2FactoryManager.getSerializerFactory(
-                    Thread.currentThread().getContextClassLoader()));
+        if (!Objects.equals(mH2i.getSerializerFactory().getClassLoader(),
+                Thread.currentThread().getContextClassLoader())) {
+            mH2i.setSerializerFactory(hessian2FactoryManager.getSerializerFactory(Thread.currentThread()
+                    .getContextClassLoader()));
         }
         return (T) mH2i.readObject(cls);
     }
 
     @Override
     public <T> T readObject(Class<T> cls, Type type) throws IOException, ClassNotFoundException {
-        if (!mH2i.getSerializerFactory()
-                .getClassLoader()
-                .equals(Thread.currentThread().getContextClassLoader())) {
-            mH2i.setSerializerFactory(hessian2FactoryManager.getSerializerFactory(
-                    Thread.currentThread().getContextClassLoader()));
+        if (!Objects.equals(mH2i.getSerializerFactory().getClassLoader(),
+                Thread.currentThread().getContextClassLoader())) {
+            mH2i.setSerializerFactory(hessian2FactoryManager.getSerializerFactory(Thread.currentThread()
+                    .getContextClassLoader()));
         }
         return readObject(cls);
     }

--- a/dubbo-serialization/dubbo-serialization-hessian2/src/main/java/org/apache/dubbo/common/serialize/hessian2/Hessian2ObjectInput.java
+++ b/dubbo-serialization/dubbo-serialization-hessian2/src/main/java/org/apache/dubbo/common/serialize/hessian2/Hessian2ObjectInput.java
@@ -97,10 +97,11 @@ public class Hessian2ObjectInput implements ObjectInput, Cleanable {
 
     @Override
     public Object readObject() throws IOException {
-        if (!Objects.equals(mH2i.getSerializerFactory().getClassLoader(),
+        if (!Objects.equals(
+                mH2i.getSerializerFactory().getClassLoader(),
                 Thread.currentThread().getContextClassLoader())) {
-            mH2i.setSerializerFactory(hessian2FactoryManager.getSerializerFactory(Thread.currentThread()
-                    .getContextClassLoader()));
+            mH2i.setSerializerFactory(hessian2FactoryManager.getSerializerFactory(
+                    Thread.currentThread().getContextClassLoader()));
         }
         return mH2i.readObject();
     }
@@ -108,20 +109,22 @@ public class Hessian2ObjectInput implements ObjectInput, Cleanable {
     @Override
     @SuppressWarnings("unchecked")
     public <T> T readObject(Class<T> cls) throws IOException, ClassNotFoundException {
-        if (!Objects.equals(mH2i.getSerializerFactory().getClassLoader(),
+        if (!Objects.equals(
+                mH2i.getSerializerFactory().getClassLoader(),
                 Thread.currentThread().getContextClassLoader())) {
-            mH2i.setSerializerFactory(hessian2FactoryManager.getSerializerFactory(Thread.currentThread()
-                    .getContextClassLoader()));
+            mH2i.setSerializerFactory(hessian2FactoryManager.getSerializerFactory(
+                    Thread.currentThread().getContextClassLoader()));
         }
         return (T) mH2i.readObject(cls);
     }
 
     @Override
     public <T> T readObject(Class<T> cls, Type type) throws IOException, ClassNotFoundException {
-        if (!Objects.equals(mH2i.getSerializerFactory().getClassLoader(),
+        if (!Objects.equals(
+                mH2i.getSerializerFactory().getClassLoader(),
                 Thread.currentThread().getContextClassLoader())) {
-            mH2i.setSerializerFactory(hessian2FactoryManager.getSerializerFactory(Thread.currentThread()
-                    .getContextClassLoader()));
+            mH2i.setSerializerFactory(hessian2FactoryManager.getSerializerFactory(
+                    Thread.currentThread().getContextClassLoader()));
         }
         return readObject(cls);
     }


### PR DESCRIPTION
## What is the purpose of the change

fix the NPE Exception when Hessian2ObjectInput readObject

## Brief changelog


## Verifying this change


<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [ ] GitHub Actions works fine on your own branch.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
