### PR TITLE
[Feature] Integration testing and Example for HTTP/3

### DIFF
--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/h3/GenericHttp3ServerTransportListener.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/h3/GenericHttp3ServerTransportListener.java
@@ -23,7 +23,7 @@ import org.apache.dubbo.remoting.http3.Http3TransportListener;
 import org.apache.dubbo.rpc.model.FrameworkModel;
 import org.apache.dubbo.rpc.protocol.tri.h12.http2.GenericHttp2ServerTransportListener;
 
-public final class GenericHttp3ServerTransportListener extends GenericHttp2ServerTransportListener
+public class GenericHttp3ServerTransportListener extends GenericHttp2ServerTransportListener
         implements Http3TransportListener {
 
     public GenericHttp3ServerTransportListener(

--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/h3/GenericHttp3ServerTransportListener.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/h3/GenericHttp3ServerTransportListener.java
@@ -42,4 +42,5 @@ public class GenericHttp3ServerTransportListener extends GenericHttp2ServerTrans
 
     @Override
     protected void initializeAltSvc(URL url) {}
+
 }

--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/h3/GenericHttp3ServerTransportListener.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/h3/GenericHttp3ServerTransportListener.java
@@ -42,5 +42,4 @@ public class GenericHttp3ServerTransportListener extends GenericHttp2ServerTrans
 
     @Override
     protected void initializeAltSvc(URL url) {}
-
 }

--- a/dubbo-rpc/dubbo-rpc-triple/src/test/java/org/apache/dubbo/rpc/protocol/tri/stream/TripleClientStreamTest.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/test/java/org/apache/dubbo/rpc/protocol/tri/stream/TripleClientStreamTest.java
@@ -26,10 +26,10 @@ import org.apache.dubbo.rpc.protocol.tri.RequestMetadata;
 import org.apache.dubbo.rpc.protocol.tri.TripleConstant;
 import org.apache.dubbo.rpc.protocol.tri.TripleHeaderEnum;
 import org.apache.dubbo.rpc.protocol.tri.command.CancelQueueCommand;
-import org.apache.dubbo.rpc.protocol.tri.command.CreateStreamQueueCommand;
 import org.apache.dubbo.rpc.protocol.tri.command.DataQueueCommand;
 import org.apache.dubbo.rpc.protocol.tri.command.EndStreamQueueCommand;
 import org.apache.dubbo.rpc.protocol.tri.command.HeaderQueueCommand;
+import org.apache.dubbo.rpc.protocol.tri.command.Http3CreateStreamQueueCommand;
 import org.apache.dubbo.rpc.protocol.tri.command.QueuedCommand;
 import org.apache.dubbo.rpc.protocol.tri.compressor.Compressor;
 import org.apache.dubbo.rpc.protocol.tri.h3.Http3TripleClientStream;
@@ -85,7 +85,7 @@ class TripleClientStreamTest {
                 writeQueue,
                 listener,
                 http2StreamChannel);
-        verify(writeQueue).enqueue(any(CreateStreamQueueCommand.class));
+        verify(writeQueue).enqueue(any(Http3CreateStreamQueueCommand.class));
 
         final RequestMetadata requestMetadata = new RequestMetadata();
         requestMetadata.method = methodDescriptor;

--- a/dubbo-rpc/dubbo-rpc-triple/src/test/java/org/apache/dubbo/rpc/protocol/tri/stream/TripleClientStreamTest.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/test/java/org/apache/dubbo/rpc/protocol/tri/stream/TripleClientStreamTest.java
@@ -32,7 +32,7 @@ import org.apache.dubbo.rpc.protocol.tri.command.EndStreamQueueCommand;
 import org.apache.dubbo.rpc.protocol.tri.command.HeaderQueueCommand;
 import org.apache.dubbo.rpc.protocol.tri.command.QueuedCommand;
 import org.apache.dubbo.rpc.protocol.tri.compressor.Compressor;
-import org.apache.dubbo.rpc.protocol.tri.h12.http2.Http2TripleClientStream;
+import org.apache.dubbo.rpc.protocol.tri.h3.Http3TripleClientStream;
 import org.apache.dubbo.rpc.protocol.tri.support.IGreeter;
 import org.apache.dubbo.rpc.protocol.tri.transport.H2TransportListener;
 import org.apache.dubbo.rpc.protocol.tri.transport.TripleWriteQueue;
@@ -79,7 +79,7 @@ class TripleClientStreamTest {
         when(http2StreamChannel.eventLoop()).thenReturn(new NioEventLoopGroup().next());
         when(http2StreamChannel.newPromise()).thenReturn(channel.newPromise());
         when(http2StreamChannel.parent()).thenReturn(channel);
-        AbstractTripleClientStream stream = new Http2TripleClientStream(
+        AbstractTripleClientStream stream = new Http3TripleClientStream(
                 url.getOrDefaultFrameworkModel(),
                 ImmediateEventExecutor.INSTANCE,
                 writeQueue,

--- a/dubbo-rpc/dubbo-rpc-triple/src/test/java/org/apache/dubbo/rpc/protocol/tri/test/TestServerTransportListener.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/test/java/org/apache/dubbo/rpc/protocol/tri/test/TestServerTransportListener.java
@@ -20,11 +20,11 @@ import org.apache.dubbo.common.URL;
 import org.apache.dubbo.remoting.http12.h2.H2StreamChannel;
 import org.apache.dubbo.remoting.http12.h2.Http2Header;
 import org.apache.dubbo.rpc.model.FrameworkModel;
-import org.apache.dubbo.rpc.protocol.tri.h12.http2.GenericHttp2ServerTransportListener;
+import org.apache.dubbo.rpc.protocol.tri.h3.GenericHttp3ServerTransportListener;
 
 import java.util.concurrent.Executor;
 
-public class TestServerTransportListener extends GenericHttp2ServerTransportListener {
+public class TestServerTransportListener extends GenericHttp3ServerTransportListener {
 
     public TestServerTransportListener(H2StreamChannel h2StreamChannel, URL url, FrameworkModel frameworkModel) {
         super(h2StreamChannel, url, frameworkModel);


### PR DESCRIPTION
## What is the purpose of the change
[Feature] Integration testing and Example for HTTP/3 #14354 


## Brief changelog
升级通用监听器以支持HTTP/3并启用测试 

将通用HTTP/2服务器传输监听器扩展为HTTP/3版本，并相应地更新测试监听器及客户端流测试，以支持新的HTTP/3功能。此更改允许Dubbo在HTTP/3上运行，从而提高传输层的性能和效率。

## Verifying this change
No

<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [ ] GitHub Actions works fine on your own branch.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
