### PR TITLE
Initialize executor after route for rest

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/rpc/executor/AbstractIsolationExecutorSupport.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/rpc/executor/AbstractIsolationExecutorSupport.java
@@ -16,7 +16,6 @@
  */
 package org.apache.dubbo.rpc.executor;
 
-import org.apache.dubbo.common.ServiceKey;
 import org.apache.dubbo.common.URL;
 import org.apache.dubbo.common.threadpool.manager.ExecutorRepository;
 import org.apache.dubbo.rpc.model.FrameworkServiceRepository;
@@ -57,15 +56,12 @@ public abstract class AbstractIsolationExecutorSupport implements ExecutorSuppor
         return executorRepository.getExecutor(providerModel, serviceUrls.get(0));
     }
 
-    protected ServiceKey getServiceKey(Object data) {
+    protected String getServiceKey(Object data) {
         return null;
     }
 
     protected ProviderModel getProviderModel(Object data) {
-        ServiceKey serviceKey = getServiceKey(data);
-        if (serviceKey == null) {
-            return null;
-        }
-        return frameworkServiceRepository.lookupExportedService(serviceKey.toString());
+        String serviceKey = getServiceKey(data);
+        return serviceKey == null ? null : frameworkServiceRepository.lookupExportedService(serviceKey);
     }
 }

--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/h12/http1/DefaultHttp11ServerTransportListener.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/h12/http1/DefaultHttp11ServerTransportListener.java
@@ -18,7 +18,6 @@ package org.apache.dubbo.rpc.protocol.tri.h12.http1;
 
 import org.apache.dubbo.common.URL;
 import org.apache.dubbo.common.stream.StreamObserver;
-import org.apache.dubbo.common.threadpool.serial.SerializingExecutor;
 import org.apache.dubbo.remoting.Constants;
 import org.apache.dubbo.remoting.http12.HttpChannel;
 import org.apache.dubbo.remoting.http12.HttpHeaderNames;
@@ -32,7 +31,6 @@ import org.apache.dubbo.remoting.http12.message.MediaType;
 import org.apache.dubbo.remoting.http12.message.codec.JsonCodec;
 import org.apache.dubbo.rpc.Invoker;
 import org.apache.dubbo.rpc.RpcInvocation;
-import org.apache.dubbo.rpc.executor.ExecutorSupport;
 import org.apache.dubbo.rpc.model.FrameworkModel;
 import org.apache.dubbo.rpc.model.MethodDescriptor;
 import org.apache.dubbo.rpc.protocol.tri.Http3Exchanger;
@@ -44,19 +42,15 @@ import org.apache.dubbo.rpc.protocol.tri.h12.ServerCallListener;
 import org.apache.dubbo.rpc.protocol.tri.h12.ServerStreamServerCallListener;
 import org.apache.dubbo.rpc.protocol.tri.h12.UnaryServerCallListener;
 
-import java.util.concurrent.Executor;
-
 public class DefaultHttp11ServerTransportListener
         extends AbstractServerTransportListener<RequestMetadata, HttpInputMessage>
         implements Http1ServerTransportListener {
 
-    private final ExecutorSupport executorSupport;
     private final HttpChannel httpChannel;
     private Http1ServerChannelObserver responseObserver;
 
     public DefaultHttp11ServerTransportListener(HttpChannel httpChannel, URL url, FrameworkModel frameworkModel) {
         super(frameworkModel, url, httpChannel);
-        executorSupport = getExecutorSupport(url);
         this.httpChannel = httpChannel;
         responseObserver = prepareResponseObserver(new Http1UnaryServerChannelObserver(httpChannel));
     }
@@ -66,11 +60,6 @@ public class DefaultHttp11ServerTransportListener
         RpcInvocationBuildContext context = getContext();
         responseObserver.setResponseEncoder(context == null ? JsonCodec.INSTANCE : context.getHttpMessageEncoder());
         return responseObserver;
-    }
-
-    @Override
-    protected Executor initializeExecutor(RequestMetadata metadata) {
-        return new SerializingExecutor(executorSupport.getExecutor(metadata));
     }
 
     @Override

--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/h12/http2/GenericHttp2ServerTransportListener.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/h12/http2/GenericHttp2ServerTransportListener.java
@@ -17,7 +17,6 @@
 package org.apache.dubbo.rpc.protocol.tri.h12.http2;
 
 import org.apache.dubbo.common.URL;
-import org.apache.dubbo.common.threadpool.serial.SerializingExecutor;
 import org.apache.dubbo.remoting.Constants;
 import org.apache.dubbo.remoting.http12.HttpHeaderNames;
 import org.apache.dubbo.remoting.http12.h2.CancelStreamException;
@@ -34,7 +33,6 @@ import org.apache.dubbo.remoting.http12.message.codec.JsonCodec;
 import org.apache.dubbo.rpc.Invoker;
 import org.apache.dubbo.rpc.RpcContext;
 import org.apache.dubbo.rpc.RpcInvocation;
-import org.apache.dubbo.rpc.executor.ExecutorSupport;
 import org.apache.dubbo.rpc.model.FrameworkModel;
 import org.apache.dubbo.rpc.model.MethodDescriptor;
 import org.apache.dubbo.rpc.protocol.tri.Http3Exchanger;
@@ -47,13 +45,11 @@ import org.apache.dubbo.rpc.protocol.tri.h12.ServerStreamServerCallListener;
 import org.apache.dubbo.rpc.protocol.tri.h12.UnaryServerCallListener;
 
 import java.io.InputStream;
-import java.util.concurrent.Executor;
 
 public class GenericHttp2ServerTransportListener extends AbstractServerTransportListener<Http2Header, Http2InputMessage>
         implements Http2TransportListener {
 
     private final H2StreamChannel h2StreamChannel;
-    private final ExecutorSupport executorSupport;
     private final StreamingDecoder streamingDecoder;
     private Http2ServerChannelObserver responseObserver;
     private ServerCallListener serverCallListener;
@@ -62,7 +58,6 @@ public class GenericHttp2ServerTransportListener extends AbstractServerTransport
             H2StreamChannel h2StreamChannel, URL url, FrameworkModel frameworkModel) {
         super(frameworkModel, url, h2StreamChannel);
         this.h2StreamChannel = h2StreamChannel;
-        executorSupport = getExecutorSupport(url);
         streamingDecoder = newStreamingDecoder();
         responseObserver = prepareResponseObserver(newResponseObserver(h2StreamChannel));
     }
@@ -86,11 +81,6 @@ public class GenericHttp2ServerTransportListener extends AbstractServerTransport
         responseObserver.setCancellationContext(RpcContext.getCancellationContext());
         responseObserver.setStreamingDecoder(streamingDecoder);
         return responseObserver;
-    }
-
-    @Override
-    protected Executor initializeExecutor(Http2Header metadata) {
-        return new SerializingExecutor(executorSupport.getExecutor(metadata));
     }
 
     @Override

--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/rest/mapping/DefaultRequestMappingRegistry.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/rest/mapping/DefaultRequestMappingRegistry.java
@@ -143,7 +143,7 @@ public final class DefaultRequestMappingRegistry implements RequestMappingRegist
             }
         });
         LOGGER.info(
-                "Registered {} REST mappings for service [{}] at url [{}] in {}ms",
+                "Registered {} rest mappings for service [{}] at url [{}] in {}ms",
                 counter,
                 ClassUtils.toShortString(service),
                 url.toString(""),

--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/transport/TripleIsolationExecutorSupport.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/transport/TripleIsolationExecutorSupport.java
@@ -16,7 +16,6 @@
  */
 package org.apache.dubbo.rpc.protocol.tri.transport;
 
-import org.apache.dubbo.common.ServiceKey;
 import org.apache.dubbo.common.URL;
 import org.apache.dubbo.common.logger.ErrorTypeAwareLogger;
 import org.apache.dubbo.common.logger.LoggerFactory;
@@ -37,22 +36,25 @@ public class TripleIsolationExecutorSupport extends AbstractIsolationExecutorSup
     }
 
     @Override
-    protected ServiceKey getServiceKey(Object data) {
-        if (!(data instanceof RequestMetadata)) {
-            return null;
+    protected String getServiceKey(Object data) {
+        if (data instanceof RequestMetadata) {
+            RequestMetadata httpMetadata = (RequestMetadata) data;
+            RequestPath path = RequestPath.parse(httpMetadata.path());
+            if (path == null) {
+                return null;
+            }
+            HttpHeaders headers = httpMetadata.headers();
+            return URL.buildKey(
+                    path.getServiceInterface(),
+                    getHeader(headers, TripleHeaderEnum.SERVICE_GROUP, RestConstants.HEADER_SERVICE_GROUP),
+                    getHeader(headers, TripleHeaderEnum.SERVICE_VERSION, RestConstants.HEADER_SERVICE_VERSION));
         }
 
-        RequestMetadata httpMetadata = (RequestMetadata) data;
-        RequestPath path = RequestPath.parse(httpMetadata.path());
-        if (path == null) {
-            return null;
+        if (data instanceof URL) {
+            return ((URL) data).getServiceKey();
         }
 
-        HttpHeaders headers = httpMetadata.headers();
-        return new ServiceKey(
-                path.getServiceInterface(),
-                getHeader(headers, TripleHeaderEnum.SERVICE_VERSION, RestConstants.HEADER_SERVICE_VERSION),
-                getHeader(headers, TripleHeaderEnum.SERVICE_GROUP, RestConstants.HEADER_SERVICE_GROUP));
+        return null;
     }
 
     private static String getHeader(HttpHeaders headers, TripleHeaderEnum en, String key) {

--- a/dubbo-rpc/dubbo-rpc-triple/src/test/java/org/apache/dubbo/rpc/protocol/tri/test/TestServerTransportListener.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/test/java/org/apache/dubbo/rpc/protocol/tri/test/TestServerTransportListener.java
@@ -31,7 +31,7 @@ public class TestServerTransportListener extends GenericHttp2ServerTransportList
     }
 
     @Override
-    protected Executor initializeExecutor(Http2Header metadata) {
+    protected Executor initializeExecutor(URL url, Http2Header metadata) {
         return Runnable::run;
     }
 }


### PR DESCRIPTION
## What is the purpose of the change
Triple get thread pool based on the serviceInterface in the url, but after rest support, the url maybe doesn't have a serviceInterface, so rest needs to route first, then get the thread pool, and grpc stays the same.

## Brief changelog


## Verifying this change


<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [ ] GitHub Actions works fine on your own branch.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
