### PR TITLE
feat: Support disable Curator EnsembleTracker

### DIFF
--- a/dubbo-registry/dubbo-registry-zookeeper/src/main/java/org/apache/dubbo/registry/zookeeper/util/CuratorFrameworkUtils.java
+++ b/dubbo-registry/dubbo-registry-zookeeper/src/main/java/org/apache/dubbo/registry/zookeeper/util/CuratorFrameworkUtils.java
@@ -24,6 +24,7 @@ import org.apache.dubbo.registry.zookeeper.ZookeeperInstance;
 import org.apache.dubbo.registry.zookeeper.ZookeeperServiceDiscovery;
 import org.apache.dubbo.rpc.model.ScopeModelUtil;
 
+import java.lang.reflect.Method;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -32,6 +33,7 @@ import java.util.stream.Collectors;
 import org.apache.curator.RetryPolicy;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
+import org.apache.curator.framework.CuratorFrameworkFactory.Builder;
 import org.apache.curator.framework.api.ACLProvider;
 import org.apache.curator.framework.imps.CuratorFrameworkState;
 import org.apache.curator.retry.ExponentialBackoffRetry;
@@ -43,6 +45,7 @@ import org.apache.zookeeper.data.ACL;
 
 import static org.apache.curator.x.discovery.ServiceInstance.builder;
 import static org.apache.dubbo.common.constants.CommonConstants.PATH_SEPARATOR;
+import static org.apache.dubbo.common.constants.CommonConstants.ZOOKEEPER_ENSEMBLE_TRACKER_KEY;
 import static org.apache.dubbo.registry.zookeeper.ZookeeperServiceDiscovery.DEFAULT_GROUP;
 import static org.apache.dubbo.registry.zookeeper.util.CuratorFrameworkParams.BASE_SLEEP_TIME;
 import static org.apache.dubbo.registry.zookeeper.util.CuratorFrameworkParams.BLOCK_UNTIL_CONNECTED_UNIT;
@@ -72,6 +75,16 @@ public abstract class CuratorFrameworkUtils {
         CuratorFrameworkFactory.Builder builder = CuratorFrameworkFactory.builder()
                 .connectString(connectionURL.getBackupAddress())
                 .retryPolicy(buildRetryPolicy(connectionURL));
+        try {
+            // use reflect to check method exist to compatibility with curator4, can remove in dubbo3.3 and direct call
+            // the method because 3.3 only supported curator5
+            Class<? extends Builder> builderClass = builder.getClass();
+            Method ignore = builderClass.getMethod("ensembleTracker", boolean.class);
+            boolean ensembleTrackerFlag = connectionURL.getParameter(ZOOKEEPER_ENSEMBLE_TRACKER_KEY, true);
+            builder.ensembleTracker(ensembleTrackerFlag);
+        } catch (NoSuchMethodException | SecurityException ignore) {
+        }
+
         String userInformation = connectionURL.getUserInformation();
         if (StringUtils.isNotEmpty(userInformation)) {
             builder = builder.authorization("digest", userInformation.getBytes());

--- a/dubbo-registry/dubbo-registry-zookeeper/src/main/java/org/apache/dubbo/registry/zookeeper/util/CuratorFrameworkUtils.java
+++ b/dubbo-registry/dubbo-registry-zookeeper/src/main/java/org/apache/dubbo/registry/zookeeper/util/CuratorFrameworkUtils.java
@@ -82,7 +82,7 @@ public abstract class CuratorFrameworkUtils {
             Method ignore = builderClass.getMethod("ensembleTracker", boolean.class);
             boolean ensembleTrackerFlag = connectionURL.getParameter(ZOOKEEPER_ENSEMBLE_TRACKER_KEY, true);
             builder.ensembleTracker(ensembleTrackerFlag);
-        } catch (NoSuchMethodException | SecurityException ignore) {
+        } catch (Throwable ignore) {
         }
 
         String userInformation = connectionURL.getUserInformation();


### PR DESCRIPTION
## What is the purpose of the change

fix #14559 

Curator5 has a new feature about `EnsembleTracker`,  the `dubbo-registry-zookeeper` module introduces curator5 dependency default, but it still compatible with Curator4 because all the classes and  method are also exist in curator4 exclude the `ensembleTracker()` method so it works fine.

If we want to support the new feature about Curator5 and compatible with Curator4 together, it need to check the method exist to avoid occur the `NoSuchMethodError`.

## Brief changelog

Support disable Curator EnsembleTracker and compatible with curator4

## Verifying this change


<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [ ] GitHub Actions works fine on your own branch.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
