### PR TITLE
fix: tcp connection window size split from stream connection window size for 3.3

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/config/nested/TripleConfig.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/config/nested/TripleConfig.java
@@ -38,6 +38,7 @@ public class TripleConfig implements Serializable {
     public static final boolean DEFAULT_ENABLE_PUSH = false;
     public static final int DEFAULT_MAX_CONCURRENT_STREAMS = Integer.MAX_VALUE;
     public static final int DEFAULT_INITIAL_WINDOW_SIZE = 8_388_608;
+    public static final int DEFAULT_CONNECTION_INITIAL_WINDOW_SIZE_KEY = 65_535;
     public static final int DEFAULT_MAX_FRAME_SIZE = 8_388_608;
     public static final int DEFAULT_MAX_HEADER_LIST_SIZE = 32_768;
 
@@ -276,7 +277,7 @@ public class TripleConfig implements Serializable {
 
     @Parameter(excluded = true)
     public int getInitialWindowSizeOrDefault() {
-        return initialWindowSize == null ? DEFAULT_INITIAL_WINDOW_SIZE : initialWindowSize;
+        return initialWindowSize == null ? DEFAULT_CONNECTION_INITIAL_WINDOW_SIZE_KEY : initialWindowSize;
     }
 
     public void setInitialWindowSize(Integer initialWindowSize) {


### PR DESCRIPTION
## What is the purpose of the change
see issue #14635


## Brief changelog


## Verifying this change


<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [ ] GitHub Actions works fine on your own branch.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
