### PR TITLE
fix:tcp connection window size split from stream connection window size for 3.3

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/config/nested/TripleConfig.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/config/nested/TripleConfig.java
@@ -38,6 +38,7 @@ public class TripleConfig implements Serializable {
     public static final boolean DEFAULT_ENABLE_PUSH = false;
     public static final int DEFAULT_MAX_CONCURRENT_STREAMS = Integer.MAX_VALUE;
     public static final int DEFAULT_INITIAL_WINDOW_SIZE = 8_388_608;
+    public static final int DEFAULT_CONNECTION_INITIAL_WINDOW_SIZE_KEY = 65_535;
     public static final int DEFAULT_MAX_FRAME_SIZE = 8_388_608;
     public static final int DEFAULT_MAX_HEADER_LIST_SIZE = 32_768;
 
@@ -276,7 +277,7 @@ public class TripleConfig implements Serializable {
 
     @Parameter(excluded = true)
     public int getInitialWindowSizeOrDefault() {
-        return initialWindowSize == null ? DEFAULT_INITIAL_WINDOW_SIZE : initialWindowSize;
+        return initialWindowSize == null ? DEFAULT_CONNECTION_INITIAL_WINDOW_SIZE_KEY : initialWindowSize;
     }
 
     public void setInitialWindowSize(Integer initialWindowSize) {

--- a/dubbo-common/src/main/java/org/apache/dubbo/config/nested/TripleConfig.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/config/nested/TripleConfig.java
@@ -38,7 +38,7 @@ public class TripleConfig implements Serializable {
     public static final boolean DEFAULT_ENABLE_PUSH = false;
     public static final int DEFAULT_MAX_CONCURRENT_STREAMS = Integer.MAX_VALUE;
     public static final int DEFAULT_INITIAL_WINDOW_SIZE = 8_388_608;
-    public static final int DEFAULT_CONNECTION_INITIAL_WINDOW_SIZE_KEY = 65_535;
+    public static final int DEFAULT_CONNECTION_INITIAL_WINDOW_SIZE_KEY = 65_536;
     public static final int DEFAULT_MAX_FRAME_SIZE = 8_388_608;
     public static final int DEFAULT_MAX_HEADER_LIST_SIZE = 32_768;
 
@@ -124,6 +124,12 @@ public class TripleConfig implements Serializable {
      * <p>For HTTP/2
      */
     private Integer initialWindowSize;
+
+    /**
+     * Initial connection window size.
+     * <p>For HTTP/2
+     */
+    private Integer connectionInitialWindowSize;
 
     /**
      * Maximum frame size.
@@ -277,11 +283,24 @@ public class TripleConfig implements Serializable {
 
     @Parameter(excluded = true)
     public int getInitialWindowSizeOrDefault() {
-        return initialWindowSize == null ? DEFAULT_CONNECTION_INITIAL_WINDOW_SIZE_KEY : initialWindowSize;
+        return initialWindowSize == null ? DEFAULT_INITIAL_WINDOW_SIZE : initialWindowSize;
     }
 
     public void setInitialWindowSize(Integer initialWindowSize) {
         this.initialWindowSize = initialWindowSize;
+    }
+
+    public Integer getConnectionInitialWindowSize() {
+        return connectionInitialWindowSize;
+    }
+
+    @Parameter(excluded = true)
+    public Integer getConnectionInitialWindowSizeOrDefault() {
+        return connectionInitialWindowSize == null ? DEFAULT_CONNECTION_INITIAL_WINDOW_SIZE_KEY : connectionInitialWindowSize;
+    }
+
+    public void setConnectionInitialWindowSize(Integer connectionInitialWindowSize) {
+        this.connectionInitialWindowSize = connectionInitialWindowSize;
     }
 
     public Integer getMaxFrameSize() {

--- a/dubbo-common/src/main/java/org/apache/dubbo/config/nested/TripleConfig.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/config/nested/TripleConfig.java
@@ -126,7 +126,7 @@ public class TripleConfig implements Serializable {
     private Integer initialWindowSize;
 
     /**
-     * Initial connection window size.
+     * Connection initial window size.
      * <p>For HTTP/2
      */
     private Integer connectionInitialWindowSize;
@@ -296,7 +296,9 @@ public class TripleConfig implements Serializable {
 
     @Parameter(excluded = true)
     public Integer getConnectionInitialWindowSizeOrDefault() {
-        return connectionInitialWindowSize == null ? DEFAULT_CONNECTION_INITIAL_WINDOW_SIZE_KEY : connectionInitialWindowSize;
+        return connectionInitialWindowSize == null
+                ? DEFAULT_CONNECTION_INITIAL_WINDOW_SIZE_KEY
+                : connectionInitialWindowSize;
     }
 
     public void setConnectionInitialWindowSize(Integer connectionInitialWindowSize) {

--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/bootstrap/builders/TripleBuilder.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/bootstrap/builders/TripleBuilder.java
@@ -91,6 +91,11 @@ public class TripleBuilder {
     private Integer initialWindowSize;
 
     /**
+     * Connection initial window size.
+     */
+    private Integer connectionInitialWindowSize;
+
+    /**
      * Maximum frame size.
      */
     private Integer maxFrameSize;
@@ -154,6 +159,11 @@ public class TripleBuilder {
         return getThis();
     }
 
+    public TripleBuilder connectionInitialWindowSize(Integer connectionInitialWindowSize) {
+        this.connectionInitialWindowSize = connectionInitialWindowSize;
+        return getThis();
+    }
+
     public TripleBuilder maxFrameSize(Integer maxFrameSize) {
         this.maxFrameSize = maxFrameSize;
         return getThis();
@@ -200,6 +210,9 @@ public class TripleBuilder {
         }
         if (initialWindowSize != null) {
             triple.setInitialWindowSize(initialWindowSize);
+        }
+        if (connectionInitialWindowSize != null) {
+            triple.setConnectionInitialWindowSize(connectionInitialWindowSize);
         }
         if (maxFrameSize != null) {
             triple.setMaxFrameSize(maxFrameSize);

--- a/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/bootstrap/DubboBootstrapTest.java
+++ b/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/bootstrap/DubboBootstrapTest.java
@@ -514,6 +514,7 @@ class DubboBootstrapTest {
         Assertions.assertFalse(tripleConfig.getEnablePushOrDefault());
         Assertions.assertEquals(Integer.MAX_VALUE, tripleConfig.getMaxConcurrentStreamsOrDefault());
         Assertions.assertEquals(1 << 23, tripleConfig.getInitialWindowSizeOrDefault());
+        Assertions.assertEquals(1 << 16, tripleConfig.getConnectionInitialWindowSizeOrDefault());
         Assertions.assertEquals(1 << 23, tripleConfig.getMaxFrameSizeOrDefault());
         Assertions.assertEquals(1 << 15, tripleConfig.getMaxHeaderListSizeOrDefault());
     }

--- a/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/bootstrap/builders/TripleBuilderTest.java
+++ b/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/bootstrap/builders/TripleBuilderTest.java
@@ -94,6 +94,13 @@ class TripleBuilderTest {
     }
 
     @Test
+    void connectionInitialWindowSize() {
+        TripleBuilder builder = TripleBuilder.newBuilder();
+        builder.connectionInitialWindowSize(8192);
+        Assertions.assertEquals(8192, builder.build().getConnectionInitialWindowSize());
+    }
+
+    @Test
     void maxFrameSize() {
         TripleBuilder builder = TripleBuilder.newBuilder();
         builder.maxFrameSize(4096);
@@ -120,6 +127,7 @@ class TripleBuilderTest {
                 .enablePush(true)
                 .maxConcurrentStreams(Integer.MAX_VALUE)
                 .initialWindowSize(4096)
+                .connectionInitialWindowSize(8192)
                 .maxFrameSize(1024)
                 .maxHeaderListSize(500);
 

--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/TriHttp2RemoteFlowController.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/TriHttp2RemoteFlowController.java
@@ -18,6 +18,9 @@ package org.apache.dubbo.rpc.protocol.tri;
 
 import org.apache.dubbo.config.nested.TripleConfig;
 
+import java.util.ArrayDeque;
+import java.util.Deque;
+
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.http2.Http2Connection;
 import io.netty.handler.codec.http2.Http2ConnectionAdapter;
@@ -31,9 +34,6 @@ import io.netty.handler.codec.http2.WeightedFairQueueByteDistributor;
 import io.netty.util.internal.UnstableApi;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
-
-import java.util.ArrayDeque;
-import java.util.Deque;
 
 import static io.netty.handler.codec.http2.Http2CodecUtil.MAX_WEIGHT;
 import static io.netty.handler.codec.http2.Http2CodecUtil.MIN_WEIGHT;
@@ -82,7 +82,7 @@ public class TriHttp2RemoteFlowController implements Http2RemoteFlowController {
             TripleConfig config) {
         this.connection = checkNotNull(connection, "connection");
         this.streamByteDistributor = checkNotNull(streamByteDistributor, "streamWriteDistributor");
-        this.initialWindowSize = config.getInitialWindowSizeOrDefault();
+        this.initialWindowSize = config.getConnectionInitialWindowSizeOrDefault();
 
         // Add a flow state for the connection.
         stateKey = connection.newKey();


### PR DESCRIPTION
## What is the purpose of the change

see issue #14635

## Brief changelog


## Verifying this change


<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [ ] GitHub Actions works fine on your own branch.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
