### PR TITLE
dubbo-compiler: pom.xml: set manifest main class to Dubbo3TripleGenerator

### DIFF
--- a/dubbo-plugin/dubbo-compiler/pom.xml
+++ b/dubbo-plugin/dubbo-compiler/pom.xml
@@ -78,7 +78,7 @@
           <archive>
             <manifest>
               <addClasspath>true</addClasspath>
-              <mainClass>org.apache.dubbo.gen.grpc.DubboGrpcGenerator</mainClass>
+              <mainClass>org.apache.dubbo.gen.tri.Dubbo3TripleGenerator</mainClass>
             </manifest>
           </archive>
         </configuration>


### PR DESCRIPTION
The DubboGrpcGenerator class was removed with commit af0f45f7cd71a923d924a7137d998a576180badf "feat:dubbo-compiler remove grpc and grpc/reactive package"

fixes #14818 

