### PR TITLE
Add preferred protocol support for application service discovery

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/ProtocolServiceKey.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/ProtocolServiceKey.java
@@ -90,7 +90,7 @@ public class ProtocolServiceKey extends ServiceKey {
             }
 
             // 4.match protocol
-            // 4.1. if rule group is *, match all
+            // 4.1. if rule protocol is *, match all
             if (!CommonConstants.ANY_VALUE.equals(rule.getProtocol())) {
                 // 4.2. if rule protocol is null, match all
                 if (StringUtils.isNotEmpty(rule.getProtocol())) {

--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/ServiceDiscoveryRegistryDirectory.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/ServiceDiscoveryRegistryDirectory.java
@@ -525,7 +525,7 @@ public class ServiceDiscoveryRegistryDirectory<T> extends DynamicDirectory<T> {
                                 return true;
                             } else { // if consumer side protocol is not specified, remove all extra protocols
                                 if (needPreferred) {
-                                    return StringUtils.isNotEmpty(serviceInfo.getParameter(PREFERRED_PROTOCOL));
+                                    return serviceInfo.getProtocol().equals(serviceInfo.getParameter(PREFERRED_PROTOCOL));
                                 } else {
                                     return StringUtils.isEmpty(serviceInfo.getParameter(IS_EXTRA));
                                 }

--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/ServiceDiscoveryRegistryDirectory.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/ServiceDiscoveryRegistryDirectory.java
@@ -448,8 +448,10 @@ public class ServiceDiscoveryRegistryDirectory<T> extends DynamicDirectory<T> {
             }
 
             // filter all the service available (version wildcard, group wildcard, protocol wildcard)
-            List<ProtocolServiceKey> matchedProtocolServiceKeys = getMatchedProtocolServiceKeys(instanceAddressURL, true);
+            List<ProtocolServiceKey> matchedProtocolServiceKeys =
+                    getMatchedProtocolServiceKeys(instanceAddressURL, true);
             if (CollectionUtils.isEmpty(matchedProtocolServiceKeys)) {
+                // if preferred protocol is not specified, use the default main protocol
                 matchedProtocolServiceKeys = getMatchedProtocolServiceKeys(instanceAddressURL, false);
             }
 
@@ -512,27 +514,28 @@ public class ServiceDiscoveryRegistryDirectory<T> extends DynamicDirectory<T> {
         return newUrlInvokerMap;
     }
 
-    private List<ProtocolServiceKey> getMatchedProtocolServiceKeys(InstanceAddressURL instanceAddressURL, boolean needPreferred) {
+    private List<ProtocolServiceKey> getMatchedProtocolServiceKeys(
+            InstanceAddressURL instanceAddressURL, boolean needPreferred) {
         int port = instanceAddressURL.getPort();
         return instanceAddressURL.getMetadataInfo().getMatchedServiceInfos(consumerProtocolServiceKey).stream()
-                        .filter(serviceInfo -> serviceInfo.getPort() <= 0 || serviceInfo.getPort() == port)
-                        // special filter for extra protocols.
-                        .filter(serviceInfo -> {
-                            if (StringUtils.isNotEmpty(
-                                    consumerProtocolServiceKey
-                                            .getProtocol())) { // if consumer side protocol is specified, use all
-                                // the protocols we got in hand now directly
-                                return true;
-                            } else { // if consumer side protocol is not specified, remove all extra protocols
-                                if (needPreferred) {
-                                    return serviceInfo.getProtocol().equals(serviceInfo.getParameter(PREFERRED_PROTOCOL));
-                                } else {
-                                    return StringUtils.isEmpty(serviceInfo.getParameter(IS_EXTRA));
-                                }
-                            }
-                        })
-                        .map(MetadataInfo.ServiceInfo::getProtocolServiceKey)
-                        .collect(Collectors.toList());
+                .filter(serviceInfo -> serviceInfo.getPort() <= 0 || serviceInfo.getPort() == port)
+                // special filter for extra protocols.
+                .filter(serviceInfo -> {
+                    if (StringUtils.isNotEmpty(
+                            consumerProtocolServiceKey
+                                    .getProtocol())) { // if consumer side protocol is specified, use all
+                        // the protocols we got in hand now directly
+                        return true;
+                    } else { // if consumer side protocol is not specified, choose the preferred or default main protocol
+                        if (needPreferred) {
+                            return serviceInfo.getProtocol().equals(serviceInfo.getParameter(PREFERRED_PROTOCOL));
+                        } else {
+                            return StringUtils.isEmpty(serviceInfo.getParameter(IS_EXTRA));
+                        }
+                    }
+                })
+                .map(MetadataInfo.ServiceInfo::getProtocolServiceKey)
+                .collect(Collectors.toList());
     }
 
     private boolean urlChanged(Invoker<T> invoker, InstanceAddressURL newURL, ProtocolServiceKey protocolServiceKey) {

--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/ServiceDiscoveryRegistryDirectory.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/ServiceDiscoveryRegistryDirectory.java
@@ -526,7 +526,8 @@ public class ServiceDiscoveryRegistryDirectory<T> extends DynamicDirectory<T> {
                                     .getProtocol())) { // if consumer side protocol is specified, use all
                         // the protocols we got in hand now directly
                         return true;
-                    } else { // if consumer side protocol is not specified, choose the preferred or default main protocol
+                    } else {
+                        // if consumer side protocol is not specified, choose the preferred or default main protocol
                         if (needPreferred) {
                             return serviceInfo.getProtocol().equals(serviceInfo.getParameter(PREFERRED_PROTOCOL));
                         } else {

--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/ServiceDiscoveryRegistryDirectory.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/ServiceDiscoveryRegistryDirectory.java
@@ -72,6 +72,7 @@ import static org.apache.dubbo.common.constants.CommonConstants.DISABLED_KEY;
 import static org.apache.dubbo.common.constants.CommonConstants.ENABLED_KEY;
 import static org.apache.dubbo.common.constants.CommonConstants.INSTANCE_REGISTER_MODE;
 import static org.apache.dubbo.common.constants.CommonConstants.IS_EXTRA;
+import static org.apache.dubbo.common.constants.CommonConstants.PREFERRED_PROTOCOL;
 import static org.apache.dubbo.common.constants.CommonConstants.PROTOCOL_KEY;
 import static org.apache.dubbo.common.constants.CommonConstants.SIDE_KEY;
 import static org.apache.dubbo.common.constants.LoggerCodeConstants.PROTOCOL_FAILED_DESTROY_INVOKER;
@@ -447,23 +448,10 @@ public class ServiceDiscoveryRegistryDirectory<T> extends DynamicDirectory<T> {
             }
 
             // filter all the service available (version wildcard, group wildcard, protocol wildcard)
-            int port = instanceAddressURL.getPort();
-            List<ProtocolServiceKey> matchedProtocolServiceKeys =
-                    instanceAddressURL.getMetadataInfo().getMatchedServiceInfos(consumerProtocolServiceKey).stream()
-                            .filter(serviceInfo -> serviceInfo.getPort() <= 0 || serviceInfo.getPort() == port)
-                            // special filter for extra protocols.
-                            .filter(serviceInfo -> {
-                                if (StringUtils.isNotEmpty(
-                                        consumerProtocolServiceKey
-                                                .getProtocol())) { // if consumer side protocol is specified, use all
-                                    // the protocols we got in hand now directly
-                                    return true;
-                                } else { // if consumer side protocol is not specified, remove all extra protocols
-                                    return StringUtils.isEmpty(serviceInfo.getParameter(IS_EXTRA));
-                                }
-                            })
-                            .map(MetadataInfo.ServiceInfo::getProtocolServiceKey)
-                            .collect(Collectors.toList());
+            List<ProtocolServiceKey> matchedProtocolServiceKeys = getMatchedProtocolServiceKeys(instanceAddressURL, true);
+            if (CollectionUtils.isEmpty(matchedProtocolServiceKeys)) {
+                matchedProtocolServiceKeys = getMatchedProtocolServiceKeys(instanceAddressURL, false);
+            }
 
             // see org.apache.dubbo.common.ProtocolServiceKey.isSameWith
             // check if needed to override the consumer url
@@ -522,6 +510,29 @@ public class ServiceDiscoveryRegistryDirectory<T> extends DynamicDirectory<T> {
             }
         }
         return newUrlInvokerMap;
+    }
+
+    private List<ProtocolServiceKey> getMatchedProtocolServiceKeys(InstanceAddressURL instanceAddressURL, boolean needPreferred) {
+        int port = instanceAddressURL.getPort();
+        return instanceAddressURL.getMetadataInfo().getMatchedServiceInfos(consumerProtocolServiceKey).stream()
+                        .filter(serviceInfo -> serviceInfo.getPort() <= 0 || serviceInfo.getPort() == port)
+                        // special filter for extra protocols.
+                        .filter(serviceInfo -> {
+                            if (StringUtils.isNotEmpty(
+                                    consumerProtocolServiceKey
+                                            .getProtocol())) { // if consumer side protocol is specified, use all
+                                // the protocols we got in hand now directly
+                                return true;
+                            } else { // if consumer side protocol is not specified, remove all extra protocols
+                                if (needPreferred) {
+                                    return StringUtils.isNotEmpty(serviceInfo.getParameter(PREFERRED_PROTOCOL));
+                                } else {
+                                    return StringUtils.isEmpty(serviceInfo.getParameter(IS_EXTRA));
+                                }
+                            }
+                        })
+                        .map(MetadataInfo.ServiceInfo::getProtocolServiceKey)
+                        .collect(Collectors.toList());
     }
 
     private boolean urlChanged(Invoker<T> invoker, InstanceAddressURL newURL, ProtocolServiceKey protocolServiceKey) {


### PR DESCRIPTION
https://cn.dubbo.apache.org/zh-cn/overview/mannual/java-sdk/reference-manual/upgrades-and-compatibility/migration-triple/

Only interface service discovery has supported `preferred-protocol` in 3.3.0 and 3.3.1 with https://github.com/apache/dubbo/pull/14188. Now add support for application service discovery.

