### PR TITLE
Fix three flaky tests in TaskQueueTest.java

### DIFF
--- a/dubbo-common/src/test/java/org/apache/dubbo/common/threadpool/support/eager/TaskQueueTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/threadpool/support/eager/TaskQueueTest.java
@@ -20,6 +20,7 @@ import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
@@ -28,6 +29,16 @@ import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.mock;
 
 class TaskQueueTest {
+
+    private TaskQueue<Runnable> queue;
+    private EagerThreadPoolExecutor executor;
+
+    @BeforeEach
+    void setup() {
+        queue = new TaskQueue<Runnable>(1);
+        executor = mock(EagerThreadPoolExecutor.class);
+        queue.setExecutor(executor);
+    }
 
     @Test
     void testOffer1() throws Exception {
@@ -39,53 +50,38 @@ class TaskQueueTest {
 
     @Test
     void testOffer2() throws Exception {
-        TaskQueue<Runnable> queue = new TaskQueue<Runnable>(1);
-        EagerThreadPoolExecutor executor = mock(EagerThreadPoolExecutor.class);
         Mockito.when(executor.getPoolSize()).thenReturn(2);
         Mockito.when(executor.getActiveCount()).thenReturn(1);
-        queue.setExecutor(executor);
         assertThat(queue.offer(mock(Runnable.class)), is(true));
     }
 
     @Test
     void testOffer3() throws Exception {
-        TaskQueue<Runnable> queue = new TaskQueue<Runnable>(1);
-        EagerThreadPoolExecutor executor = mock(EagerThreadPoolExecutor.class);
         Mockito.when(executor.getPoolSize()).thenReturn(2);
         Mockito.when(executor.getActiveCount()).thenReturn(2);
         Mockito.when(executor.getMaximumPoolSize()).thenReturn(4);
-        queue.setExecutor(executor);
         assertThat(queue.offer(mock(Runnable.class)), is(false));
     }
 
     @Test
     void testOffer4() throws Exception {
-        TaskQueue<Runnable> queue = new TaskQueue<Runnable>(1);
-        EagerThreadPoolExecutor executor = mock(EagerThreadPoolExecutor.class);
         Mockito.when(executor.getPoolSize()).thenReturn(4);
         Mockito.when(executor.getActiveCount()).thenReturn(4);
         Mockito.when(executor.getMaximumPoolSize()).thenReturn(4);
-        queue.setExecutor(executor);
         assertThat(queue.offer(mock(Runnable.class)), is(true));
     }
 
     @Test
     void testRetryOffer1() throws Exception {
         Assertions.assertThrows(RejectedExecutionException.class, () -> {
-            TaskQueue<Runnable> queue = new TaskQueue<Runnable>(1);
-            EagerThreadPoolExecutor executor = mock(EagerThreadPoolExecutor.class);
             Mockito.when(executor.isShutdown()).thenReturn(true);
-            queue.setExecutor(executor);
             queue.retryOffer(mock(Runnable.class), 1000, TimeUnit.MILLISECONDS);
         });
     }
 
     @Test
     void testRetryOffer2() throws Exception {
-        TaskQueue<Runnable> queue = new TaskQueue<Runnable>(1);
-        EagerThreadPoolExecutor executor = mock(EagerThreadPoolExecutor.class);
         Mockito.when(executor.isShutdown()).thenReturn(false);
-        queue.setExecutor(executor);
         assertThat(queue.retryOffer(mock(Runnable.class), 1000, TimeUnit.MILLISECONDS), is(true));
     }
 }

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/threadpool/support/eager/TaskQueueTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/threadpool/support/eager/TaskQueueTest.java
@@ -29,7 +29,6 @@ import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.mock;
 
 class TaskQueueTest {
-
     private TaskQueue<Runnable> queue;
     private EagerThreadPoolExecutor executor;
 

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/threadpool/support/eager/TaskQueueTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/threadpool/support/eager/TaskQueueTest.java
@@ -29,6 +29,7 @@ import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.mock;
 
 class TaskQueueTest {
+
     private TaskQueue<Runnable> queue;
     private EagerThreadPoolExecutor executor;
 


### PR DESCRIPTION
## What is the purpose of the change?
Three tests under module `dubbo-common` are detected as Order-Dependent flaky tests:
`dubbo-common\src\test\java\org\apache\dubbo\common\threadpool\support\eager\TaskQueueTest.java#testOffer2`
`dubbo-common\src\test\java\org\apache\dubbo\common\threadpool\support\eager\TaskQueueTest.java#testOffer3`
`dubbo-common\src\test\java\org\apache\dubbo\common\threadpool\support\eager\TaskQueueTest.java#testOffer4`
There exists circumstances which if queue or executor retain modifications from a previous test (e.g., adding elements or changing state), subsequent tests may inherit an altered state. Tests like testOffer3 and testOffer4 manipulate executor properties such as pool size and active count. If they run in an order where a test expecting an empty state follows one that fills or modifies the queue, the test could fail or produce flaky results. 
This approach modify TaskQueueTest class by defining queue and executor as class-level variables and initializing them in the @BeforeEach method to ensure each test starts with a fresh and consistent state. This approach prevents potential state contamination between tests, promoting better test isolation and reliability, also ensures that all tests share a consistent setup foundation.

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Make sure gitHub actions can pass. [Why the workflow is failing and how to fix it?](./CONTRIBUTING.md)
