### PR TITLE
fix flaky tests under DubboAppenderTest

### DIFF
--- a/dubbo-common/src/test/java/org/apache/dubbo/common/utils/DubboAppenderTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/utils/DubboAppenderTest.java
@@ -42,6 +42,9 @@ class DubboAppenderTest {
         when(event.getLevel()).thenReturn(Level.INFO);
         when(event.getThreadName()).thenReturn("thread-name");
         when(event.getMessage()).thenReturn(new SimpleMessage("message"));
+
+        DubboAppender.clear();
+        DubboAppender.doStop();
     }
 
     @AfterEach
@@ -52,7 +55,7 @@ class DubboAppenderTest {
 
     @Test
     void testAvailable() {
-        assumeFalse(DubboAppender.available);
+        assertThat(DubboAppender.available, is(false))
         DubboAppender.doStart();
         assertThat(DubboAppender.available, is(true));
         DubboAppender.doStop();
@@ -62,8 +65,9 @@ class DubboAppenderTest {
     @Test
     void testAppend() {
         DubboAppender appender = new DubboAppender();
+        assertThat(DubboAppender.logList, hasSize(0));
         appender.append(event);
-        assumeTrue(DubboAppender.logList.isEmpty());
+        assertThat(DubboAppender.logList, hasSize(0));
         DubboAppender.doStart();
         appender.append(event);
         assertThat(DubboAppender.logList, hasSize(1));
@@ -75,7 +79,7 @@ class DubboAppenderTest {
         DubboAppender.doStart();
         DubboAppender appender = new DubboAppender();
         appender.append(event);
-        assumeTrue(1 == DubboAppender.logList.size());
+        assertThat(DubboAppender.logList, hasSize(1));
         DubboAppender.clear();
         assertThat(DubboAppender.logList, hasSize(0));
     }

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/utils/DubboAppenderTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/utils/DubboAppenderTest.java
@@ -55,7 +55,7 @@ class DubboAppenderTest {
 
     @Test
     void testAvailable() {
-        assertThat(DubboAppender.available, is(false))
+        assertThat(DubboAppender.available, is(false));
         DubboAppender.doStart();
         assertThat(DubboAppender.available, is(true));
         DubboAppender.doStop();

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/utils/DubboAppenderTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/utils/DubboAppenderTest.java
@@ -27,8 +27,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
-import static org.junit.jupiter.api.Assumptions.assumeFalse;
-import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 


### PR DESCRIPTION
## What is the purpose of the change?
Two tests under module dubbo-common are detected as Order-Dependent flaky tests:
`org.apache.dubbo.common.utils.DubboAppenderTest.testAvailable`
`org.apache.dubbo.common.utils.DubboAppenderTest.testAppend`

In this PR, I modified the test setup to ensure that each unit test starts with an independent state by resetting the DubboAppender in the @BeforeEach method. Currently, all tests rely on the tearDown() method annotated with @AfterEach to clear the state. However, in unit testing, it is essential for each test to be independent and not depend on the state left by previous tests. If a test fails in a way that prevents tearDown() from running (e.g., due to an unexpected exception or forced termination), it can result in residual state in logList, causing dependencies between tests and breaking test isolation.

Additionally, I replaced assumeTrue() and assumeFalse() with assertThat() to ensure that tests fail with clear feedback when conditions are not met, rather than being skipped. Using assertions is better to report failures directly, rather than directly skipping a test when a condition is not met.

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Make sure gitHub actions can pass. [Why the workflow is failing and how to fix it?](./CONTRIBUTING.md)
