### PR TITLE
correctly validate service-name-mapping parameter

### DIFF
--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/ServiceConfig.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/ServiceConfig.java
@@ -395,7 +395,7 @@ public class ServiceConfig<T> extends ServiceConfigBase<T> {
         exported = true;
         List<URL> exportedURLs = this.getExportedUrls();
         exportedURLs.forEach(url -> {
-            if (url.getParameters().containsKey(SERVICE_NAME_MAPPING_KEY)) {
+            if (url.getParameter(SERVICE_NAME_MAPPING_KEY, false)) {
                 ServiceNameMapping serviceNameMapping = ServiceNameMapping.getDefaultExtension(getScopeModel());
                 ScheduledExecutorService scheduledExecutor = getScopeModel()
                         .getBeanFactory()


### PR DESCRIPTION
## What is the purpose of the change?
The service-name-mapping is set as follows:

if (SERVICE_REGISTRY_PROTOCOL.equals(registryURL.getProtocol())) {
    url = url.addParameterIfAbsent(SERVICE_NAME_MAPPING_KEY, "true");
}

The validation logic should be consistent with the setting logic.

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Make sure gitHub actions can pass. [Why the workflow is failing and how to fix it?](./CONTRIBUTING.md)
