### PR TITLE
Fix the dependency missing of dubbo-spring-boot.(#14947)

### DIFF
--- a/dubbo-spring-boot-project/dubbo-spring-boot/pom.xml
+++ b/dubbo-spring-boot-project/dubbo-spring-boot/pom.xml
@@ -52,6 +52,12 @@
       <version>${project.version}</version>
       <optional>true</optional>
     </dependency>
+    <dependency>
+      <groupId>org.apache.dubbo</groupId>
+      <artifactId>dubbo-config-spring</artifactId>
+      <version>${project.version}</version>
+      <optional>true</optional>
+    </dependency>
 
     <!-- Test Dependencies -->
     <dependency>


### PR DESCRIPTION
Fix the dependency missing of dubbo-spring-boot.(#14947)

## What is the purpose of the change?
ServiceServiceIdConflictProcessor imported ServiceConfig and other classes, But it doesn't rely on dubbo-config-spring.and when running dubbo-demo-spring-boot, An error indicating that the Class not found.
Fixed the issue of missing dependencies



## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Make sure gitHub actions can pass. [Why the workflow is failing and how to fix it?](./CONTRIBUTING.md)
