### PR TITLE
remove unnecessary protocolRevisionsToUrls and build newServiceUrls d…

### DIFF
--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/event/listener/ServiceInstancesChangedListener.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/event/listener/ServiceInstancesChangedListener.java
@@ -201,20 +201,13 @@ public class ServiceInstancesChangedListener {
             hasEmptyMetadata = false;
         }
 
-        Map<String, Map<Integer, Map<Set<String>, Object>>> protocolRevisionsToUrls = new HashMap<>();
         Map<String, List<ProtocolServiceKeyWithUrls>> newServiceUrls = new HashMap<>();
         for (Map.Entry<ServiceInfo, Set<String>> entry : localServiceToRevisions.entrySet()) {
             ServiceInfo serviceInfo = entry.getKey();
             Set<String> revisions = entry.getValue();
 
-            Map<Integer, Map<Set<String>, Object>> portToRevisions =
-                    protocolRevisionsToUrls.computeIfAbsent(serviceInfo.getProtocol(), k -> new HashMap<>());
-            Map<Set<String>, Object> revisionsToUrls =
-                    portToRevisions.computeIfAbsent(serviceInfo.getPort(), k -> new HashMap<>());
-            Object urls = revisionsToUrls.computeIfAbsent(
-                    revisions,
-                    k -> getServiceUrlsCache(
-                            revisionToInstances, revisions, serviceInfo.getProtocol(), serviceInfo.getPort()));
+            Object urls = getServiceUrlsCache(
+                    revisionToInstances, revisions, serviceInfo.getProtocol(), serviceInfo.getPort());
 
             List<ProtocolServiceKeyWithUrls> list =
                     newServiceUrls.computeIfAbsent(serviceInfo.getPath(), k -> new LinkedList<>());


### PR DESCRIPTION
…irectly

## What is the purpose of the change?
The primary role of **protocolRevisionsToUrls** in the overall code logic is to act as an intermediate cache, mapping **(protocol, port, revisions)** to **urls**. However, the ultimate goal is to construct **newServiceUrls**, and **protocolRevisionsToUrls** is not directly used elsewhere. This layer can be completely removed, and the results can be directly stored in **newServiceUrls**.

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Make sure gitHub actions can pass. [Why the workflow is failing and how to fix it?](../CONTRIBUTING.md)
