### PR TITLE
Bugfix: An instance of the subclass of RegistryConfig should be added to configsCache as the RegistryConfig class type #15016

### DIFF
--- a/dubbo-common/src/test/java/org/apache/dubbo/config/context/ConfigManagerTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/config/context/ConfigManagerTest.java
@@ -252,6 +252,21 @@ class ConfigManagerTest {
     }
 
     @Test
+    void testAddCustomConfig() {
+        configManager.addConfig(new CustomRegistryConfig("CustomConfigManagerTest"));
+
+        assertTrue(configManager.getRegistry("CustomConfigManagerTest").isPresent());
+    }
+
+    static class CustomRegistryConfig extends RegistryConfig {
+
+        CustomRegistryConfig(String id) {
+            super();
+            this.setId(id);
+        }
+    }
+
+    @Test
     void testRefreshAll() {
         configManager.refreshAll();
         moduleConfigManager.refreshAll();


### PR DESCRIPTION


## What is the purpose of the change?
Fix #15016  
An instance of the subclass of RegistryConfig should be added to configsCache as the RegistryConfig class type
## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Make sure gitHub actions can pass. [Why the workflow is failing and how to fix it?](../CONTRIBUTING.md)
