### PR TITLE
optimize: support http1 automatic keepalive setting

### DIFF
--- a/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/HttpHeaderNames.java
+++ b/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/HttpHeaderNames.java
@@ -50,6 +50,8 @@ public enum HttpHeaderNames {
 
     TE(io.netty.handler.codec.http.HttpHeaderNames.TE),
 
+    CONNECTION(io.netty.handler.codec.http.HttpHeaderNames.CONNECTION),
+
     ALT_SVC("alt-svc");
 
     private final String name;

--- a/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/netty4/h1/NettyHttp1Codec.java
+++ b/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/netty4/h1/NettyHttp1Codec.java
@@ -44,7 +44,7 @@ import io.netty.handler.codec.http.LastHttpContent;
 
 public class NettyHttp1Codec extends ChannelDuplexHandler {
 
-    boolean keepAlive;
+    private boolean keepAlive;
 
     @Override
     public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
@@ -97,10 +97,10 @@ public class NettyHttp1Codec extends ChannelDuplexHandler {
 
     private void doWriteMessage(ChannelHandlerContext ctx, HttpOutputMessage msg, ChannelPromise promise) {
         if (HttpOutputMessage.EMPTY_MESSAGE == msg) {
-            if (!keepAlive) {
-                ctx.writeAndFlush(LastHttpContent.EMPTY_LAST_CONTENT, promise).addListener(ChannelFutureListener.CLOSE);
-            } else {
+            if (keepAlive) {
                 ctx.writeAndFlush(LastHttpContent.EMPTY_LAST_CONTENT, promise);
+            } else {
+                ctx.writeAndFlush(LastHttpContent.EMPTY_LAST_CONTENT, promise).addListener(ChannelFutureListener.CLOSE);
             }
             return;
         }

--- a/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/netty4/h1/NettyHttp1Codec.java
+++ b/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/netty4/h1/NettyHttp1Codec.java
@@ -16,9 +16,6 @@
  */
 package org.apache.dubbo.remoting.http12.netty4.h1;
 
-import io.netty.channel.ChannelFutureListener;
-import io.netty.handler.codec.http.HttpHeaderValues;
-import io.netty.handler.codec.http.HttpUtil;
 import org.apache.dubbo.common.utils.CollectionUtils;
 import org.apache.dubbo.remoting.http12.HttpHeaderNames;
 import org.apache.dubbo.remoting.http12.HttpMetadata;
@@ -34,11 +31,14 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufInputStream;
 import io.netty.buffer.ByteBufOutputStream;
 import io.netty.channel.ChannelDuplexHandler;
+import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
 import io.netty.handler.codec.http.DefaultHttpResponse;
 import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.HttpHeaderValues;
 import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.HttpUtil;
 import io.netty.handler.codec.http.HttpVersion;
 import io.netty.handler.codec.http.LastHttpContent;
 

--- a/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/netty4/h1/NettyHttp1Codec.java
+++ b/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/netty4/h1/NettyHttp1Codec.java
@@ -92,7 +92,7 @@ public class NettyHttp1Codec extends ChannelDuplexHandler {
             headers.add(HttpHeaderNames.CONNECTION.getKey(), String.valueOf(HttpHeaderValues.CLOSE));
         }
         // process normal headers
-        ctx.write(new DefaultHttpResponse(HttpVersion.HTTP_1_1, status, headers.getHeaders()), promise);
+        ctx.writeAndFlush(new DefaultHttpResponse(HttpVersion.HTTP_1_1, status, headers.getHeaders()), promise);
     }
 
     private void doWriteMessage(ChannelHandlerContext ctx, HttpOutputMessage msg, ChannelPromise promise) {
@@ -107,7 +107,7 @@ public class NettyHttp1Codec extends ChannelDuplexHandler {
         OutputStream body = msg.getBody();
         if (body instanceof ByteBufOutputStream) {
             ByteBuf buffer = ((ByteBufOutputStream) body).buffer();
-            ctx.write(buffer, promise);
+            ctx.writeAndFlush(buffer, promise);
             return;
         }
         throw new IllegalArgumentException("HttpOutputMessage body must be 'io.netty.buffer.ByteBufOutputStream'");


### PR DESCRIPTION
## What is the purpose of the change?

由于ab压测工具默认是短连接，当使用该工具压测时，针对短连接请求，没有将对应的channel设置该ChannelFutureListener.CLOSE listener时，将使ab压测工具进程hang住，故增加自动识别请求是否需要保持长连接来解决该问题。

Since the ab benchmarking tool uses short connections by default, when using this tool for benchmarking, if the corresponding channel is not set with the ChannelFutureListener.CLOSE listener for short connection requests, it will cause the ab benchmarking tool process to hang. Therefore, adding automatic recognition of whether the request needs to keep the connection alive can solve this problem.

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Make sure gitHub actions can pass. [Why the workflow is failing and how to fix it?](../CONTRIBUTING.md)
