### PR TITLE
Try register Service Instance after export

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/deploy/ApplicationDeployer.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/deploy/ApplicationDeployer.java
@@ -52,6 +52,8 @@ public interface ApplicationDeployer extends Deployer<ApplicationModel> {
 
     void exportMetadataService();
 
+    void registerServiceInstance();
+
     /**
      * Register application instance and start internal services
      */

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/deploy/ModuleDeployer.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/deploy/ModuleDeployer.java
@@ -42,6 +42,8 @@ public interface ModuleDeployer extends Deployer<ModuleModel> {
 
     ReferenceCache getReferenceCache();
 
+    void registerServiceInstance();
+
     void prepare();
 
     void setPending();

--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/ServiceConfig.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/ServiceConfig.java
@@ -344,6 +344,8 @@ public class ServiceConfig<T> extends ServiceConfigBase<T> {
                 }
             }
         }
+
+        getScopeModel().getDeployer().registerServiceInstance();
     }
 
     @Override

--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/deploy/DefaultApplicationDeployer.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/deploy/DefaultApplicationDeployer.java
@@ -980,7 +980,7 @@ public class DefaultApplicationDeployer extends AbstractDeployer<ApplicationMode
         return factory.getDynamicConfiguration(connectionURL);
     }
 
-    private volatile boolean registered;
+    private volatile boolean registered = false;
 
     private final AtomicInteger instanceRefreshScheduleTimes = new AtomicInteger(0);
 
@@ -989,21 +989,21 @@ public class DefaultApplicationDeployer extends AbstractDeployer<ApplicationMode
      */
     private final AtomicInteger serviceRefreshState = new AtomicInteger(0);
 
-    private void registerServiceInstance() {
-        try {
-            registered = true;
+    public synchronized void registerServiceInstance() {
+        if (!registered) {
+            try {
+                registered = true;
 
-            ServiceInstanceMetadataUtils.registerMetadataAndInstance(applicationModel);
+                ServiceInstanceMetadataUtils.registerMetadataAndInstance(applicationModel);
 
-        } catch (Exception e) {
-            logger.error(
-                    CONFIG_REGISTER_INSTANCE_ERROR,
-                    "configuration server disconnected",
-                    "",
-                    "Register instance error.",
-                    e);
-        }
-        if (registered) {
+            } catch (Exception e) {
+                logger.error(
+                        CONFIG_REGISTER_INSTANCE_ERROR,
+                        "configuration server disconnected",
+                        "",
+                        "Register instance error.",
+                        e);
+            }
             // scheduled task for updating Metadata and ServiceInstance
             asyncMetadataFuture = frameworkExecutorRepository
                     .getSharedScheduledExecutor()

--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/deploy/DefaultModuleDeployer.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/deploy/DefaultModuleDeployer.java
@@ -652,6 +652,11 @@ public class DefaultModuleDeployer extends AbstractDeployer<ModuleModel> impleme
         return referenceCache;
     }
 
+    @Override
+    public void registerServiceInstance() {
+        applicationDeployer.registerServiceInstance();
+    }
+
     /**
      * Prepare for export/refer service, trigger initializing application and module
      */


### PR DESCRIPTION
## What is the purpose of the change?

When `DubboBootstrap` starts without any `ServiceConfig`, `ServiceInstance` will be no longer registered even though `ServiceConfig` exports later.

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Make sure gitHub actions can pass. [Why the workflow is failing and how to fix it?](../CONTRIBUTING.md)
