### PR TITLE
[3.3] Revert "feat:dubbo-remoting-zookeeper-curator5 remove dubbo-test module (#15082)"

### DIFF
--- a/dubbo-remoting/dubbo-remoting-api/pom.xml
+++ b/dubbo-remoting/dubbo-remoting-api/pom.xml
@@ -58,11 +58,5 @@
       <artifactId>log4j-slf4j-impl</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.apache.dubbo</groupId>
-      <artifactId>dubbo-test-check</artifactId>
-      <version>${project.parent.version}</version>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 </project>

--- a/dubbo-remoting/dubbo-remoting-http12/pom.xml
+++ b/dubbo-remoting/dubbo-remoting-http12/pom.xml
@@ -85,11 +85,5 @@
       <artifactId>log4j-slf4j-impl</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.apache.dubbo</groupId>
-      <artifactId>dubbo-test-check</artifactId>
-      <version>${project.parent.version}</version>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 </project>

--- a/dubbo-remoting/dubbo-remoting-http3/pom.xml
+++ b/dubbo-remoting/dubbo-remoting-http3/pom.xml
@@ -52,11 +52,5 @@
       <artifactId>log4j-slf4j-impl</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.apache.dubbo</groupId>
-      <artifactId>dubbo-test-check</artifactId>
-      <version>${project.parent.version}</version>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 </project>

--- a/dubbo-remoting/dubbo-remoting-netty/pom.xml
+++ b/dubbo-remoting/dubbo-remoting-netty/pom.xml
@@ -57,11 +57,5 @@
       <version>${project.parent.version}</version>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.apache.dubbo</groupId>
-      <artifactId>dubbo-test-check</artifactId>
-      <version>${project.parent.version}</version>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 </project>

--- a/dubbo-remoting/dubbo-remoting-netty4/pom.xml
+++ b/dubbo-remoting/dubbo-remoting-netty4/pom.xml
@@ -69,12 +69,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.apache.dubbo</groupId>
-      <artifactId>dubbo-test-check</artifactId>
-      <version>${project.parent.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j-impl</artifactId>
       <scope>test</scope>

--- a/dubbo-remoting/dubbo-remoting-websocket/pom.xml
+++ b/dubbo-remoting/dubbo-remoting-websocket/pom.xml
@@ -37,11 +37,5 @@
       <artifactId>dubbo-remoting-http12</artifactId>
       <version>${project.parent.version}</version>
     </dependency>
-    <dependency>
-      <groupId>org.apache.dubbo</groupId>
-      <artifactId>dubbo-test-check</artifactId>
-      <version>${project.parent.version}</version>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 </project>

--- a/dubbo-remoting/dubbo-remoting-zookeeper-curator5/pom.xml
+++ b/dubbo-remoting/dubbo-remoting-zookeeper-curator5/pom.xml
@@ -40,6 +40,13 @@
     </dependency>
 
     <dependency>
+      <groupId>org.apache.dubbo</groupId>
+      <artifactId>dubbo-test-common</artifactId>
+      <version>${project.parent.version}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.apache.curator</groupId>
       <artifactId>curator-framework</artifactId>
       <version>${curator5_version}</version>

--- a/dubbo-remoting/dubbo-remoting-zookeeper-curator5/src/test/java/org/apache/dubbo/remoting/zookeeper/curator5/Curator5ZookeeperClientManagerTest.java
+++ b/dubbo-remoting/dubbo-remoting-zookeeper-curator5/src/test/java/org/apache/dubbo/remoting/zookeeper/curator5/Curator5ZookeeperClientManagerTest.java
@@ -18,32 +18,22 @@ package org.apache.dubbo.remoting.zookeeper.curator5;
 
 import org.apache.dubbo.common.URL;
 
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.MockedConstruction;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsNot.not;
 import static org.hamcrest.core.IsNull.nullValue;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.mockConstructionWithAnswer;
 
 class Curator5ZookeeperClientManagerTest {
     private ZookeeperClient zookeeperClient;
     private ZookeeperClientManager zookeeperClientManager;
-    private static MockedConstruction<Curator5ZookeeperClient> mockedCurator5ZookeeperClientConstruction;
     private static String zookeeperConnectionAddress1;
 
     @BeforeAll
     public static void beforeAll() {
         zookeeperConnectionAddress1 = System.getProperty("zookeeper.connection.address.1");
-        Curator5ZookeeperClient mockCurator5ZookeeperClient = mock(Curator5ZookeeperClient.class);
-        mockedCurator5ZookeeperClientConstruction =
-                mockConstructionWithAnswer(Curator5ZookeeperClient.class, invocationOnMock -> invocationOnMock
-                        .getMethod()
-                        .invoke(mockCurator5ZookeeperClient, invocationOnMock.getArguments()));
     }
 
     @BeforeEach
@@ -56,10 +46,5 @@ class Curator5ZookeeperClientManagerTest {
     void testZookeeperClient() {
         assertThat(zookeeperClient, not(nullValue()));
         zookeeperClient.close();
-    }
-
-    @AfterAll
-    public static void afterAll() {
-        mockedCurator5ZookeeperClientConstruction.close();
     }
 }

--- a/dubbo-remoting/dubbo-remoting-zookeeper-curator5/src/test/java/org/apache/dubbo/remoting/zookeeper/curator5/Curator5ZookeeperClientTest.java
+++ b/dubbo-remoting/dubbo-remoting-zookeeper-curator5/src/test/java/org/apache/dubbo/remoting/zookeeper/curator5/Curator5ZookeeperClientTest.java
@@ -18,152 +18,48 @@ package org.apache.dubbo.remoting.zookeeper.curator5;
 
 import org.apache.dubbo.common.URL;
 import org.apache.dubbo.common.config.configcenter.ConfigItem;
-import org.apache.dubbo.remoting.zookeeper.curator5.Curator5ZookeeperClient.CuratorWatcherImpl;
 
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
-import com.google.common.collect.Lists;
-import org.apache.curator.CuratorZookeeperClient;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
-import org.apache.curator.framework.WatcherRemoveCuratorFramework;
-import org.apache.curator.framework.api.CreateBuilder;
-import org.apache.curator.framework.api.CuratorWatcher;
-import org.apache.curator.framework.api.DeleteBuilder;
-import org.apache.curator.framework.api.ExistsBuilder;
-import org.apache.curator.framework.api.GetChildrenBuilder;
-import org.apache.curator.framework.api.GetDataBuilder;
-import org.apache.curator.framework.api.Pathable;
-import org.apache.curator.framework.api.SetDataBuilder;
-import org.apache.curator.framework.api.WatchPathable;
-import org.apache.curator.framework.listen.StandardListenerManager;
-import org.apache.curator.framework.recipes.cache.NodeCache;
-import org.apache.zookeeper.KeeperException.NodeExistsException;
+import org.apache.curator.retry.ExponentialBackoffRetry;
 import org.apache.zookeeper.WatchedEvent;
-import org.apache.zookeeper.Watcher;
-import org.apache.zookeeper.Watcher.Event;
-import org.apache.zookeeper.Watcher.Event.KeeperState;
 import org.apache.zookeeper.data.Stat;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
-import org.mockito.MockedConstruction;
-import org.mockito.MockedStatic;
-import org.mockito.stubbing.Answer;
 
 import static org.awaitility.Awaitility.await;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.mockConstructionWithAnswer;
-import static org.mockito.Mockito.mockStatic;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.when;
 
 class Curator5ZookeeperClientTest {
     private static Curator5ZookeeperClient curatorClient;
+    private static CuratorFramework client = null;
 
-    private static int zookeeperServerMockPort1;
+    private static int zookeeperServerPort1;
     private static String zookeeperConnectionAddress1;
-
-    private static MockedStatic<CuratorFrameworkFactory> curatorFrameworkFactoryMockedStatic;
-
-    CuratorFrameworkFactory.Builder spyBuilder = CuratorFrameworkFactory.builder();
-
-    private CuratorFramework mockCuratorFramework;
-    private CreateBuilder mockCreateBuilder;
-    private ExistsBuilder mockExistsBuilder;
-    private GetChildrenBuilder mockGetChildrenBuilder;
-    private DeleteBuilder mockDeleteBuilder;
-    private GetDataBuilder mockGetDataBuilder;
-    private SetDataBuilder mockSetDataBuilder;
-    private CuratorZookeeperClient mockCuratorZookeeperClient;
-    private WatcherRemoveCuratorFramework mockWatcherRemoveCuratorFramework;
-    private Answer<String> createAnswer;
 
     @BeforeAll
     public static void setUp() throws Exception {
-        zookeeperServerMockPort1 = 2181;
-        zookeeperConnectionAddress1 = "zookeeper://localhost:" + zookeeperServerMockPort1;
-
-        // mock begin
-        // create mock bean begin
-        CuratorFrameworkFactory.Builder realBuilder = CuratorFrameworkFactory.builder();
-        CuratorFrameworkFactory.Builder spyBuilder = spy(realBuilder);
-
-        curatorFrameworkFactoryMockedStatic = mockStatic(CuratorFrameworkFactory.class);
-        curatorFrameworkFactoryMockedStatic
-                .when(CuratorFrameworkFactory::builder)
-                .thenReturn(spyBuilder);
-    }
-
-    @BeforeEach
-    public void init() throws Exception {
-        mockCreateBuilder = mock(CreateBuilder.class);
-        mockExistsBuilder = mock(ExistsBuilder.class);
-        mockDeleteBuilder = mock(DeleteBuilder.class);
-        mockCuratorFramework = mock(CuratorFramework.class);
-        mockGetChildrenBuilder = mock(GetChildrenBuilder.class);
-        mockGetDataBuilder = mock(GetDataBuilder.class);
-        mockCuratorZookeeperClient = mock(CuratorZookeeperClient.class);
-        mockWatcherRemoveCuratorFramework = mock(WatcherRemoveCuratorFramework.class);
-        mockSetDataBuilder = mock(SetDataBuilder.class);
-        doReturn(mockCuratorFramework).when(spyBuilder).build();
-        when(mockCuratorFramework.blockUntilConnected(anyInt(), any())).thenReturn(true);
-        when(mockCuratorFramework.getConnectionStateListenable()).thenReturn(StandardListenerManager.standard());
-        when(mockCuratorFramework.create()).thenReturn(mockCreateBuilder);
-        when(mockCuratorFramework.checkExists()).thenReturn(mockExistsBuilder);
-        when(mockCuratorFramework.getChildren()).thenReturn(mockGetChildrenBuilder);
-        when(mockCuratorFramework.getZookeeperClient()).thenReturn(mockCuratorZookeeperClient);
-        when(mockCuratorFramework.newWatcherRemoveCuratorFramework()).thenReturn(mockWatcherRemoveCuratorFramework);
-        when(mockCuratorZookeeperClient.isConnected()).thenReturn(true);
-        when(mockCuratorFramework.delete()).thenReturn(mockDeleteBuilder);
-        when(mockCreateBuilder.withMode(any())).thenReturn(mockCreateBuilder);
-        when(mockDeleteBuilder.deletingChildrenIfNeeded()).thenReturn(mockDeleteBuilder);
-        when(mockDeleteBuilder.forPath(any())).then((Answer<Void>) invocationOnMock -> null);
-        when(mockCuratorFramework.getData()).thenReturn(mockGetDataBuilder);
-        when(mockCuratorFramework.setData()).thenReturn(mockSetDataBuilder);
-        when(mockSetDataBuilder.withVersion(anyInt())).thenReturn(mockSetDataBuilder);
-        List<String> paths = new ArrayList<>();
-        createAnswer = invocationOnMock -> {
-            String param = invocationOnMock.getArgument(0);
-            if (paths.contains(param)) {
-                throw new NodeExistsException("node existed: " + param);
-            }
-            paths.add(invocationOnMock.getArgument(0));
-            return invocationOnMock.getArgument(0);
-        };
-        when(mockCreateBuilder.forPath(anyString())).thenAnswer(createAnswer);
-        when(mockCreateBuilder.forPath(anyString(), any())).thenAnswer(createAnswer);
-        when(mockExistsBuilder.forPath(anyString())).thenAnswer(i -> {
-            if (paths.contains(i.getArgument(0))) {
-                return new Stat();
-            }
-            return null;
-        });
-        when(mockDeleteBuilder.forPath(anyString())).thenAnswer(i -> {
-            if (paths.contains(i.getArgument(0))) {
-                paths.remove(i.getArgument(0));
-            }
-            return null;
-        });
-
+        zookeeperConnectionAddress1 = System.getProperty("zookeeper.connection.address.1");
+        zookeeperServerPort1 = Integer.parseInt(
+                zookeeperConnectionAddress1.substring(zookeeperConnectionAddress1.lastIndexOf(":") + 1));
         curatorClient = new Curator5ZookeeperClient(
                 URL.valueOf(zookeeperConnectionAddress1 + "/org.apache.dubbo.registry.RegistryService"));
+        client = CuratorFrameworkFactory.newClient(
+                "127.0.0.1:" + zookeeperServerPort1, new ExponentialBackoffRetry(1000, 3));
+        client.start();
     }
 
     @Test
@@ -175,8 +71,7 @@ class Curator5ZookeeperClientTest {
     }
 
     @Test
-    void testChildrenPath() throws Exception {
-        when(mockGetChildrenBuilder.forPath(any())).thenReturn(Lists.newArrayList("provider1", "provider2"));
+    void testChildrenPath() {
         String path = "/dubbo/org.apache.dubbo.demo.DemoService/providers";
         curatorClient.create(path, false, true);
         curatorClient.create(path + "/provider1", false, true);
@@ -188,28 +83,23 @@ class Curator5ZookeeperClientTest {
 
     @Test
     @Timeout(value = 2)
-    public void testChildrenListener() throws Exception {
+    public void testChildrenListener() throws InterruptedException {
         String path = "/dubbo/org.apache.dubbo.demo.DemoListenerService/providers";
         curatorClient.create(path, false, true);
         final CountDownLatch countDownLatch = new CountDownLatch(1);
-        when(mockGetChildrenBuilder.usingWatcher(any(CuratorWatcher.class))).thenReturn(mockGetChildrenBuilder);
-        when(mockGetChildrenBuilder.forPath(any())).thenReturn(Lists.newArrayList("providers"));
-        CuratorWatcherImpl watcher = new CuratorWatcherImpl() {
+        curatorClient.addTargetChildListener(path, new Curator5ZookeeperClient.CuratorWatcherImpl() {
 
             @Override
             public void process(WatchedEvent watchedEvent) {
                 countDownLatch.countDown();
             }
-        };
-        curatorClient.addTargetChildListener(path, watcher);
-        watcher.process(new WatchedEvent(Event.EventType.NodeDeleted, KeeperState.Closed, "providers"));
+        });
         curatorClient.createPersistent(path + "/provider1", true);
         countDownLatch.await();
     }
 
     @Test
-    void testWithInvalidServer() throws InterruptedException {
-        when(mockCuratorFramework.blockUntilConnected(anyInt(), any())).thenReturn(false);
+    void testWithInvalidServer() {
         Assertions.assertThrows(IllegalStateException.class, () -> {
             curatorClient = new Curator5ZookeeperClient(URL.valueOf("zookeeper://127.0.0.1:1/service?timeout=1000"));
             curatorClient.create("/testPath", true, true);
@@ -217,10 +107,8 @@ class Curator5ZookeeperClientTest {
     }
 
     @Test
-    void testRemoveChildrenListener() throws Exception {
+    void testRemoveChildrenListener() {
         ChildListener childListener = mock(ChildListener.class);
-        when(mockGetChildrenBuilder.usingWatcher(any(CuratorWatcher.class))).thenReturn(mockGetChildrenBuilder);
-        when(mockGetChildrenBuilder.forPath(any())).thenReturn(Lists.newArrayList("children"));
         curatorClient.addChildListener("/children", childListener);
         curatorClient.removeChildListener("/children", childListener);
     }
@@ -239,28 +127,26 @@ class Curator5ZookeeperClientTest {
     }
 
     @Test
-    void testCreateContent4Persistent() throws Exception {
+    void testCreateContent4Persistent() {
         String path = "/curatorTest4CrContent/content.data";
         String content = "createContentTest";
         curatorClient.delete(path);
         assertThat(curatorClient.checkExists(path), is(false));
         assertNull(curatorClient.getContent(path));
 
-        when(mockGetDataBuilder.forPath(any())).then(invocationOnMock -> content.getBytes());
         curatorClient.createOrUpdate(path, content, false);
         assertThat(curatorClient.checkExists(path), is(true));
         assertEquals(curatorClient.getContent(path), content);
     }
 
     @Test
-    void testCreateContent4Temp() throws Exception {
+    void testCreateContent4Temp() {
         String path = "/curatorTest4CrContent/content.data";
         String content = "createContentTest";
         curatorClient.delete(path);
         assertThat(curatorClient.checkExists(path), is(false));
         assertNull(curatorClient.getContent(path));
 
-        when(mockGetDataBuilder.forPath(any())).then(invocationOnMock -> content.getBytes());
         curatorClient.createOrUpdate(path, content, true);
         assertThat(curatorClient.checkExists(path), is(true));
         assertEquals(curatorClient.getContent(path), content);
@@ -311,49 +197,30 @@ class Curator5ZookeeperClientTest {
         String value = "vav";
 
         curatorClient.createOrUpdate(path + "/d.json", value, true);
-        when(mockGetDataBuilder.forPath(any())).then(invocationOnMock -> value.getBytes());
         String valueFromCache = curatorClient.getContent(path + "/d.json");
         Assertions.assertEquals(value, valueFromCache);
         final AtomicInteger atomicInteger = new AtomicInteger(0);
-        NodeCache mockNodeCache = mock(NodeCache.class);
-        MockedConstruction<NodeCache> mockedConstruction =
-                mockConstructionWithAnswer(NodeCache.class, invocationOnMock -> invocationOnMock
-                        .getMethod()
-                        .invoke(mockNodeCache, invocationOnMock.getArguments()));
-        when(mockNodeCache.getListenable()).thenReturn(StandardListenerManager.standard());
-        Curator5ZookeeperClient.NodeCacheListenerImpl nodeCacheListener =
-                new Curator5ZookeeperClient.NodeCacheListenerImpl() {
-                    @Override
-                    public void nodeChanged() {
-                        atomicInteger.incrementAndGet();
-                    }
-                };
-        curatorClient.addTargetDataListener(path + "/d.json", nodeCacheListener);
+        curatorClient.addTargetDataListener(path + "/d.json", new Curator5ZookeeperClient.NodeCacheListenerImpl() {
+            @Override
+            public void nodeChanged() {
+                atomicInteger.incrementAndGet();
+            }
+        });
 
         valueFromCache = curatorClient.getContent(path + "/d.json");
         Assertions.assertNotNull(valueFromCache);
 
         int currentCount1 = atomicInteger.get();
-        when(mockSetDataBuilder.forPath(any(), any())).then(invocationOnMock -> {
-            nodeCacheListener.nodeChanged();
-            return null;
-        });
         curatorClient.getClient().setData().forPath(path + "/d.json", "foo".getBytes());
         await().until(() -> atomicInteger.get() > currentCount1);
         int currentCount2 = atomicInteger.get();
         curatorClient.getClient().setData().forPath(path + "/d.json", "bar".getBytes());
         await().until(() -> atomicInteger.get() > currentCount2);
         int currentCount3 = atomicInteger.get();
-        when(mockDeleteBuilder.forPath(any())).then(invocationOnMock -> {
-            nodeCacheListener.nodeChanged();
-            return null;
-        });
         curatorClient.delete(path + "/d.json");
-        when(mockGetDataBuilder.forPath(any())).thenReturn(null);
         valueFromCache = curatorClient.getContent(path + "/d.json");
         Assertions.assertNull(valueFromCache);
         await().until(() -> atomicInteger.get() > currentCount3);
-        mockedConstruction.close();
     }
 
     @Test
@@ -384,80 +251,41 @@ class Curator5ZookeeperClientTest {
 
         runnable.set(() -> {
             try {
-                mockCuratorFramework.create().forPath(path, "version x".getBytes(StandardCharsets.UTF_8));
+                client.create().forPath(path, "version x".getBytes(StandardCharsets.UTF_8));
             } catch (Exception e) {
                 throw new RuntimeException(e);
             }
         });
-        when(mockGetDataBuilder.forPath(any())).then(invocationOnMock -> "version x".getBytes());
-        when(mockCreateBuilder.forPath(any())).then(invocationOnMock -> {
-            String value;
-            try {
-                value = createAnswer.answer(invocationOnMock);
-            } catch (Exception e) {
-                throw e;
-            }
-            try {
-                runnable.get().run();
-            } catch (Exception ignored) {
-
-            }
-            return value;
-        });
-
         Assertions.assertThrows(
                 IllegalStateException.class, () -> curatorClient.createOrUpdate(path, "version 1", false, 0));
         Assertions.assertEquals("version x", curatorClient.getContent(path));
-        mockCuratorFramework.setData().forPath(path, "version 1".getBytes(StandardCharsets.UTF_8));
-        when(mockGetDataBuilder.storingStatIn(any())).thenReturn(new WatchPathable<byte[]>() {
-            @Override
-            public byte[] forPath(String s) throws Exception {
-                return mockGetDataBuilder.forPath(s);
-            }
 
-            @Override
-            public Pathable<byte[]> watched() {
-                return null;
-            }
+        client.setData().forPath(path, "version 1".getBytes(StandardCharsets.UTF_8));
 
-            @Override
-            public Pathable<byte[]> usingWatcher(Watcher watcher) {
-                return null;
-            }
-
-            @Override
-            public Pathable<byte[]> usingWatcher(CuratorWatcher curatorWatcher) {
-                return null;
-            }
-        });
         ConfigItem configItem = curatorClient.getConfigItem(path);
         runnable.set(() -> {
             try {
-                mockCuratorFramework.setData().forPath(path, "version x".getBytes(StandardCharsets.UTF_8));
+                client.setData().forPath(path, "version x".getBytes(StandardCharsets.UTF_8));
             } catch (Exception e) {
                 throw new RuntimeException(e);
             }
         });
-        when(mockSetDataBuilder.forPath(any(), any())).thenThrow(new IllegalStateException());
         int version1 = ((Stat) configItem.getTicket()).getVersion();
         Assertions.assertThrows(
                 IllegalStateException.class, () -> curatorClient.createOrUpdate(path, "version 2", false, version1));
-        when(mockGetDataBuilder.forPath(any())).then(invocationOnMock -> "version x".getBytes());
         Assertions.assertEquals("version x", curatorClient.getContent(path));
 
         runnable.set(null);
         configItem = curatorClient.getConfigItem(path);
         int version2 = ((Stat) configItem.getTicket()).getVersion();
-        doReturn(null).when(mockSetDataBuilder).forPath(any(), any());
         curatorClient.createOrUpdate(path, "version 2", false, version2);
-        when(mockGetDataBuilder.forPath(any())).then(invocationOnMock -> "version 2".getBytes());
         Assertions.assertEquals("version 2", curatorClient.getContent(path));
 
         curatorClient.close();
     }
 
     @Test
-    void testPersistentCas2() throws Exception {
+    void testPersistentCas2() {
         // test update failed when others create success
         String path = "/dubbo/mapping/org.apache.dubbo.demo.DemoService";
         Curator5ZookeeperClient curatorClient = new Curator5ZookeeperClient(
@@ -467,14 +295,13 @@ class Curator5ZookeeperClientTest {
         curatorClient.createOrUpdate(path, "version x", false);
         Assertions.assertThrows(
                 IllegalStateException.class, () -> curatorClient.createOrUpdate(path, "version 1", false, null));
-        when(mockGetDataBuilder.forPath(any())).then(invocationOnMock -> "version x".getBytes());
         Assertions.assertEquals("version x", curatorClient.getContent(path));
 
         curatorClient.close();
     }
 
     @Test
-    void testPersistentNonVersion() throws Exception {
+    void testPersistentNonVersion() {
         String path = "/dubbo/metadata/org.apache.dubbo.demo.DemoService";
         AtomicReference<Runnable> runnable = new AtomicReference<>();
         Curator5ZookeeperClient curatorClient =
@@ -498,51 +325,32 @@ class Curator5ZookeeperClientTest {
                 };
         curatorClient.delete(path);
 
-        when(mockGetDataBuilder.forPath(any())).then(invocationOnMock -> "version x".getBytes());
-        when(mockCreateBuilder.forPath(any())).then(invocationOnMock -> {
-            String value;
-            try {
-                value = createAnswer.answer(invocationOnMock);
-            } catch (Exception e) {
-                throw e;
-            }
-            try {
-                runnable.get().run();
-            } catch (Exception ignored) {
-
-            }
-            return value;
-        });
-        when(mockGetDataBuilder.forPath(any())).then(invocationOnMock -> "version 0".getBytes());
         curatorClient.createOrUpdate(path, "version 0", false);
         Assertions.assertEquals("version 0", curatorClient.getContent(path));
         curatorClient.delete(path);
 
         runnable.set(() -> {
             try {
-                mockCuratorFramework.create().forPath(path, "version x".getBytes(StandardCharsets.UTF_8));
+                client.create().forPath(path, "version x".getBytes(StandardCharsets.UTF_8));
             } catch (Exception e) {
                 throw new RuntimeException(e);
             }
         });
-        when(mockGetDataBuilder.forPath(any())).then(invocationOnMock -> "version 1".getBytes());
         curatorClient.createOrUpdate(path, "version 1", false);
         Assertions.assertEquals("version 1", curatorClient.getContent(path));
 
         runnable.set(() -> {
             try {
-                mockCuratorFramework.setData().forPath(path, "version x".getBytes(StandardCharsets.UTF_8));
+                client.setData().forPath(path, "version x".getBytes(StandardCharsets.UTF_8));
             } catch (Exception e) {
                 throw new RuntimeException(e);
             }
         });
         curatorClient.createOrUpdate(path, "version 2", false);
-        when(mockGetDataBuilder.forPath(any())).then(invocationOnMock -> "version 2".getBytes());
         Assertions.assertEquals("version 2", curatorClient.getContent(path));
 
         runnable.set(null);
         curatorClient.createOrUpdate(path, "version 3", false);
-        when(mockGetDataBuilder.forPath(any())).then(invocationOnMock -> "version 3".getBytes());
         Assertions.assertEquals("version 3", curatorClient.getContent(path));
 
         curatorClient.close();
@@ -573,82 +381,44 @@ class Curator5ZookeeperClientTest {
                     }
                 };
         curatorClient.delete(path);
-        when(mockCreateBuilder.forPath(any())).then(invocationOnMock -> {
-            String value;
-            try {
-                value = createAnswer.answer(invocationOnMock);
-            } catch (Exception e) {
-                throw e;
-            }
-            try {
-                runnable.get().run();
-            } catch (Exception ignored) {
 
-            }
-            return value;
-        });
         runnable.set(() -> {
             try {
-                mockCuratorFramework.create().forPath(path, "version x".getBytes(StandardCharsets.UTF_8));
+                client.create().forPath(path, "version x".getBytes(StandardCharsets.UTF_8));
             } catch (Exception e) {
                 throw new RuntimeException(e);
             }
         });
         Assertions.assertThrows(
                 IllegalStateException.class, () -> curatorClient.createOrUpdate(path, "version 1", true, 0));
-        when(mockGetDataBuilder.forPath(any())).then(invocationOnMock -> "version x".getBytes());
         Assertions.assertEquals("version x", curatorClient.getContent(path));
 
-        mockCuratorFramework.setData().forPath(path, "version 1".getBytes(StandardCharsets.UTF_8));
-        when(mockGetDataBuilder.storingStatIn(any())).thenReturn(new WatchPathable<byte[]>() {
-            @Override
-            public byte[] forPath(String s) throws Exception {
-                return mockGetDataBuilder.forPath(s);
-            }
+        client.setData().forPath(path, "version 1".getBytes(StandardCharsets.UTF_8));
 
-            @Override
-            public Pathable<byte[]> watched() {
-                return null;
-            }
-
-            @Override
-            public Pathable<byte[]> usingWatcher(Watcher watcher) {
-                return null;
-            }
-
-            @Override
-            public Pathable<byte[]> usingWatcher(CuratorWatcher curatorWatcher) {
-                return null;
-            }
-        });
         ConfigItem configItem = curatorClient.getConfigItem(path);
         runnable.set(() -> {
             try {
-                mockCuratorFramework.setData().forPath(path, "version x".getBytes(StandardCharsets.UTF_8));
+                client.setData().forPath(path, "version x".getBytes(StandardCharsets.UTF_8));
             } catch (Exception e) {
                 throw new RuntimeException(e);
             }
         });
         int version1 = ((Stat) configItem.getTicket()).getVersion();
-        when(mockSetDataBuilder.forPath(any(), any())).thenThrow(new IllegalStateException());
         Assertions.assertThrows(
                 IllegalStateException.class, () -> curatorClient.createOrUpdate(path, "version 2", true, version1));
-        when(mockGetDataBuilder.forPath(any())).then(invocationOnMock -> "version x".getBytes());
         Assertions.assertEquals("version x", curatorClient.getContent(path));
 
         runnable.set(null);
         configItem = curatorClient.getConfigItem(path);
         int version2 = ((Stat) configItem.getTicket()).getVersion();
-        doReturn(null).when(mockSetDataBuilder).forPath(any(), any());
         curatorClient.createOrUpdate(path, "version 2", true, version2);
-        when(mockGetDataBuilder.forPath(any())).then(invocationOnMock -> "version 2".getBytes());
         Assertions.assertEquals("version 2", curatorClient.getContent(path));
 
         curatorClient.close();
     }
 
     @Test
-    void testEphemeralCas2() throws Exception {
+    void testEphemeralCas2() {
         // test update failed when others create success
         String path = "/dubbo/mapping/org.apache.dubbo.demo.DemoService";
         Curator5ZookeeperClient curatorClient = new Curator5ZookeeperClient(
@@ -658,14 +428,13 @@ class Curator5ZookeeperClientTest {
         curatorClient.createOrUpdate(path, "version x", true);
         Assertions.assertThrows(
                 IllegalStateException.class, () -> curatorClient.createOrUpdate(path, "version 1", true, null));
-        when(mockGetDataBuilder.forPath(any())).then(invocationOnMock -> "version x".getBytes());
         Assertions.assertEquals("version x", curatorClient.getContent(path));
 
         curatorClient.close();
     }
 
     @Test
-    void testEphemeralNonVersion() throws Exception {
+    void testEphemeralNonVersion() {
         String path = "/dubbo/metadata/org.apache.dubbo.demo.DemoService";
         AtomicReference<Runnable> runnable = new AtomicReference<>();
         Curator5ZookeeperClient curatorClient =
@@ -690,35 +459,31 @@ class Curator5ZookeeperClientTest {
         curatorClient.delete(path);
 
         curatorClient.createOrUpdate(path, "version 0", true);
-        when(mockGetDataBuilder.forPath(any())).then(invocationOnMock -> "version 0".getBytes());
         Assertions.assertEquals("version 0", curatorClient.getContent(path));
         curatorClient.delete(path);
 
         runnable.set(() -> {
             try {
-                mockCuratorFramework.create().forPath(path, "version x".getBytes(StandardCharsets.UTF_8));
+                client.create().forPath(path, "version x".getBytes(StandardCharsets.UTF_8));
             } catch (Exception e) {
                 throw new RuntimeException(e);
             }
         });
         curatorClient.createOrUpdate(path, "version 1", true);
-        when(mockGetDataBuilder.forPath(any())).then(invocationOnMock -> "version 1".getBytes());
         Assertions.assertEquals("version 1", curatorClient.getContent(path));
 
         runnable.set(() -> {
             try {
-                mockCuratorFramework.setData().forPath(path, "version x".getBytes(StandardCharsets.UTF_8));
+                client.setData().forPath(path, "version x".getBytes(StandardCharsets.UTF_8));
             } catch (Exception e) {
                 throw new RuntimeException(e);
             }
         });
         curatorClient.createOrUpdate(path, "version 2", true);
-        when(mockGetDataBuilder.forPath(any())).then(invocationOnMock -> "version 2".getBytes());
         Assertions.assertEquals("version 2", curatorClient.getContent(path));
 
         runnable.set(null);
         curatorClient.createOrUpdate(path, "version 3", true);
-        when(mockGetDataBuilder.forPath(any())).then(invocationOnMock -> "version 3".getBytes());
         Assertions.assertEquals("version 3", curatorClient.getContent(path));
 
         curatorClient.close();
@@ -726,7 +491,6 @@ class Curator5ZookeeperClientTest {
 
     @AfterAll
     public static void testWithStoppedServer() {
-        curatorFrameworkFactoryMockedStatic.close();
         curatorClient.close();
     }
 }

--- a/dubbo-remoting/dubbo-remoting-zookeeper-curator5/src/test/java/org/apache/dubbo/remoting/zookeeper/curator5/support/ZookeeperClientManagerTest.java
+++ b/dubbo-remoting/dubbo-remoting-zookeeper-curator5/src/test/java/org/apache/dubbo/remoting/zookeeper/curator5/support/ZookeeperClientManagerTest.java
@@ -17,25 +17,19 @@
 package org.apache.dubbo.remoting.zookeeper.curator5.support;
 
 import org.apache.dubbo.common.URL;
-import org.apache.dubbo.remoting.zookeeper.curator5.Curator5ZookeeperClient;
 import org.apache.dubbo.remoting.zookeeper.curator5.ZookeeperClient;
 import org.apache.dubbo.remoting.zookeeper.curator5.ZookeeperClientManager;
 
 import java.util.List;
 
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.MockedConstruction;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsNot.not;
 import static org.hamcrest.core.IsNull.nullValue;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.mockConstructionWithAnswer;
-import static org.mockito.Mockito.when;
 
 /**
  * ZookeeperManagerTest
@@ -43,20 +37,18 @@ import static org.mockito.Mockito.when;
 class ZookeeperClientManagerTest {
     private ZookeeperClient zookeeperClient;
     private ZookeeperClientManager zookeeperClientManager;
-    private static Curator5ZookeeperClient mockedCurator5ZookeeperClient;
-    private static MockedConstruction<Curator5ZookeeperClient> mockedCurator5ZookeeperClientConstruction;
-    private static int zookeeperServerPort1 = 2181;
-    private static int zookeeperServerPort2 = 2182;
-    private static String zookeeperConnectionAddress1 = "zookeeper://127.0.0.1:2181";
-    private static String zookeeperConnectionAddress2 = "zookeeper://127.0.0.1:2182";
+
+    private static int zookeeperServerPort1, zookeeperServerPort2;
+    private static String zookeeperConnectionAddress1, zookeeperConnectionAddress2;
 
     @BeforeAll
     public static void beforeAll() {
-        mockedCurator5ZookeeperClient = mock(Curator5ZookeeperClient.class);
-        mockedCurator5ZookeeperClientConstruction =
-                mockConstructionWithAnswer(Curator5ZookeeperClient.class, invocationOnMock -> invocationOnMock
-                        .getMethod()
-                        .invoke(mockedCurator5ZookeeperClient, invocationOnMock.getArguments()));
+        zookeeperConnectionAddress1 = System.getProperty("zookeeper.connection.address.1");
+        zookeeperConnectionAddress2 = System.getProperty("zookeeper.connection.address.2");
+        zookeeperServerPort1 = Integer.parseInt(
+                zookeeperConnectionAddress1.substring(zookeeperConnectionAddress1.lastIndexOf(":") + 1));
+        zookeeperServerPort2 = Integer.parseInt(
+                zookeeperConnectionAddress2.substring(zookeeperConnectionAddress2.lastIndexOf(":") + 1));
     }
 
     @BeforeEach
@@ -138,7 +130,6 @@ class ZookeeperClientManagerTest {
         Assertions.assertEquals(
                 zookeeperClientManager.getZookeeperClientMap().get("127.0.0.1:" + zookeeperServerPort1),
                 newZookeeperClient);
-        when(mockedCurator5ZookeeperClient.isConnected()).thenReturn(true);
         Assertions.assertTrue(newZookeeperClient.isConnected());
 
         ZookeeperClient newZookeeperClient2 = zookeeperClientManager.connect(url2);
@@ -188,7 +179,6 @@ class ZookeeperClientManagerTest {
                 zookeeperConnectionAddress1 + "/org.apache.dubbo.metadata.store.MetadataReport?backup=127.0.0.1:"
                         + zookeeperServerPort2
                         + "&address=zookeeper://127.0.0.1:2181&application=metadatareport-local-xml-provider2&cycle-report=false&interface=org.apache.dubbo.metadata.store.MetadataReport&retry-period=4590&retry-times=23&sync-report=true");
-        when(mockedCurator5ZookeeperClient.isConnected()).thenReturn(true);
         ZookeeperClient newZookeeperClient = zookeeperClientManager.connect(url);
         // just for connected
         newZookeeperClient.getContent("/dubbo/test");
@@ -242,10 +232,5 @@ class ZookeeperClientManagerTest {
         ZookeeperClient client1 = zookeeperClientManager.connect(url1);
         ZookeeperClient client2 = zookeeperClientManager.connect(url2);
         assertThat(client1, not(client2));
-    }
-
-    @AfterAll
-    public static void afterAll() {
-        mockedCurator5ZookeeperClientConstruction.close();
     }
 }

--- a/dubbo-remoting/pom.xml
+++ b/dubbo-remoting/pom.xml
@@ -40,4 +40,12 @@
     <skip_maven_deploy>false</skip_maven_deploy>
   </properties>
 
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.dubbo</groupId>
+      <artifactId>dubbo-test-check</artifactId>
+      <version>${project.parent.version}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
 </project>


### PR DESCRIPTION
## What is the purpose of the change?
try to solve dubbo-samples-configcenter-apollo sample test failure issue

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Make sure gitHub actions can pass. [Why the workflow is failing and how to fix it?](../CONTRIBUTING.md)
