### PR TITLE
[3.4] Get authority by calling HttpServletRequest#getServerName

### DIFF
--- a/dubbo-plugin/dubbo-triple-servlet/src/main/java/org/apache/dubbo/rpc/protocol/tri/servlet/HttpMetadataAdapter.java
+++ b/dubbo-plugin/dubbo-triple-servlet/src/main/java/org/apache/dubbo/rpc/protocol/tri/servlet/HttpMetadataAdapter.java
@@ -16,7 +16,6 @@
  */
 package org.apache.dubbo.rpc.protocol.tri.servlet;
 
-import org.apache.dubbo.remoting.http12.HttpHeaderNames;
 import org.apache.dubbo.remoting.http12.HttpHeaders;
 import org.apache.dubbo.remoting.http12.h2.Http2Header;
 
@@ -55,7 +54,7 @@ public final class HttpMetadataAdapter implements Http2Header {
             }
             headers.add(PseudoHeaderName.METHOD.value(), method());
             headers.add(PseudoHeaderName.SCHEME.value(), request.getScheme());
-            headers.add(PseudoHeaderName.AUTHORITY.value(), request.getHeader(HttpHeaderNames.HOST.getName()));
+            headers.add(PseudoHeaderName.AUTHORITY.value(), request.getServerName());
             headers.add(PseudoHeaderName.PROTOCOL.value(), request.getProtocol());
             this.headers = headers;
         }


### PR DESCRIPTION
## What is the purpose of the change?
try to fix #15144 for solving NPE issue of testing https://github.com/apache/dubbo-samples/tree/master/2-advanced/dubbo-samples-triple-servlet
```
[DUBBO] Initialize executor failed., dubbo version: 3.3.4-SNAPSHOT, current host: 172.28.0.3, error code: 0-18. This may be caused by , go to https://dubbo.apache.org/faq/0/18 to find instructions. 
2025-02-17T04:07:06.9735242Z java.lang.NullPointerException: value
2025-02-17T04:07:06.9735742Z 	at io.netty.util.internal.ObjectUtil.checkNotNull(ObjectUtil.java:39) ~[netty-common-4.1.107.Final.jar:4.1.107.Final]
2025-02-17T04:07:06.9736459Z 	at io.netty.handler.codec.DefaultHeaders.add(DefaultHeaders.java:331) ~[netty-codec-4.1.107.Final.jar:4.1.107.Final]
2025-02-17T04:07:06.9737289Z 	at org.apache.dubbo.remoting.http12.netty4.NettyHttpHeaders.add(NettyHttpHeaders.java:82) ~[dubbo-remoting-http12-3.3.4-SNAPSHOT.jar:3.3.4-SNAPSHOT]
2025-02-17T04:07:06.9738463Z 	at org.apache.dubbo.rpc.protocol.tri.servlet.jakarta.HttpMetadataAdapter.headers(HttpMetadataAdapter.java:58) ~[dubbo-3.3.4-SNAPSHOT.jar:3.3.4-SNAPSHOT]
2025-02-17T04:07:06.9739624Z 	at org.apache.dubbo.rpc.protocol.tri.transport.TripleIsolationExecutorSupport.getServiceKey(TripleIsolationExecutorSupport.java:46) ~[dubbo-rpc-triple-3.3.4-SNAPSHOT.jar:3.3.4-SNAPSHOT]
2025-02-17T04:07:06.9741116Z 	at org.apache.dubbo.rpc.executor.AbstractIsolationExecutorSupport.getProviderModel(AbstractIsolationExecutorSupport.java:64) ~[dubbo-common-3.3.4-SNAPSHOT.jar:3.3.4-SNAPSHOT]
2025-02-17T04:07:06.9742504Z 	at org.apache.dubbo.rpc.executor.AbstractIsolationExecutorSupport.getExecutor(AbstractIsolationExecutorSupport.java:41) ~[dubbo-common-3.3.4-SNAPSHOT.jar:3.3.4-SNAPSHOT]
2025-02-17T04:07:06.9743703Z 	at org.apache.dubbo.rpc.protocol.tri.h12.AbstractServerTransportListener.getExecutor(AbstractServerTransportListener.java:137) ~[dubbo-rpc-triple-3.3.4-SNAPSHOT.jar:3.3.4-SNAPSHOT]
2025-02-17T04:07:06.9744998Z 	at org.apache.dubbo.rpc.protocol.tri.h12.grpc.GrpcHttp2ServerTransportListener.initializeExecutor(GrpcHttp2ServerTransportListener.java:64) ~[dubbo-rpc-triple-3.3.4-SNAPSHOT.jar:3.3.4-SNAPSHOT]
2025-02-17T04:07:06.9746339Z 	at org.apache.dubbo.rpc.protocol.tri.h12.grpc.GrpcHttp2ServerTransportListener.initializeExecutor(GrpcHttp2ServerTransportListener.java:49) ~[dubbo-rpc-triple-3.3.4-SNAPSHOT.jar:3.3.4-SNAPSHOT]
2025-02-17T04:07:06.9747622Z 	at org.apache.dubbo.rpc.protocol.tri.h12.AbstractServerTransportListener.onMetadata(AbstractServerTransportListener.java:93) ~[dubbo-rpc-triple-3.3.4-SNAPSHOT.jar:3.3.4-SNAPSHOT]
2025-02-17T04:07:06.9748831Z 	at org.apache.dubbo.rpc.protocol.tri.h12.AbstractServerTransportListener.onMetadata(AbstractServerTransportListener.java:54) ~[dubbo-rpc-triple-3.3.4-SNAPSHOT.jar:3.3.4-SNAPSHOT]
2025-02-17T04:07:06.9749904Z 	at org.apache.dubbo.rpc.protocol.tri.servlet.jakarta.TripleFilter.handleHttp2(TripleFilter.java:115) ~[dubbo-3.3.4-SNAPSHOT.jar:3.3.4-SNAPSHOT]
2025-02-17T04:07:06.9750992Z 	at org.apache.dubbo.rpc.protocol.tri.servlet.jakarta.TripleFilter.doFilter(TripleFilter.java:87) ~[dubbo-3.3.4-SNAPSHOT.jar:3.3.4-SNAPSHOT]
2025-02-17T04:07:06.9751998Z 	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:174) ~[tomcat-embed-core-10.1.19.jar:10.1.19]
2025-02-17T04:07:06.9753947Z 	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:149) ~[tomcat-embed-core-10.1.19.jar:10.1.19]
2025-02-17T04:07:06.9755202Z 	at org.springframework.web.filter.CharacterEncodingFilter.doFilterInternal(CharacterEncodingFilter.java:201) ~[spring-web-6.1.4.jar:6.1.4]
2025-02-17T04:07:06.9756109Z 	at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:116) ~[spring-web-6.1.4.jar:6.1.4]
2025-02-17T04:07:06.9757005Z 	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:174) ~[tomcat-embed-core-10.1.19.jar:10.1.19]
2025-02-17T04:07:06.9757929Z 	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:149) ~[tomcat-embed-core-10.1.19.jar:10.1.19]
2025-02-17T04:07:06.9758785Z 	at org.apache.catalina.core.StandardWrapperValve.invoke(StandardWrapperValve.java:167) ~[tomcat-embed-core-10.1.19.jar:10.1.19]
2025-02-17T04:07:06.9759613Z 	at org.apache.catalina.core.StandardContextValve.invoke(StandardContextValve.java:90) ~[tomcat-embed-core-10.1.19.jar:10.1.19]
2025-02-17T04:07:06.9760465Z 	at org.apache.catalina.authenticator.AuthenticatorBase.invoke(AuthenticatorBase.java:482) ~[tomcat-embed-core-10.1.19.jar:10.1.19]
2025-02-17T04:07:06.9761583Z 	at org.apache.catalina.core.StandardHostValve.invoke(StandardHostValve.java:115) ~[tomcat-embed-core-10.1.19.jar:10.1.19]
2025-02-17T04:07:06.9762359Z 	at org.apache.catalina.valves.ErrorReportValve.invoke(ErrorReportValve.java:93) ~[tomcat-embed-core-10.1.19.jar:10.1.19]
2025-02-17T04:07:06.9763332Z 	at org.apache.catalina.core.StandardEngineValve.invoke(StandardEngineValve.java:74) ~[tomcat-embed-core-10.1.19.jar:10.1.19]
2025-02-17T04:07:06.9764109Z 	at org.apache.catalina.connector.CoyoteAdapter.service(CoyoteAdapter.java:344) ~[tomcat-embed-core-10.1.19.jar:10.1.19]
2025-02-17T04:07:06.9764857Z 	at org.apache.coyote.http2.StreamProcessor.service(StreamProcessor.java:432) ~[tomcat-embed-core-10.1.19.jar:10.1.19]
2025-02-17T04:07:06.9765640Z 	at org.apache.coyote.AbstractProcessorLight.process(AbstractProcessorLight.java:63) ~[tomcat-embed-core-10.1.19.jar:10.1.19]
2025-02-17T04:07:06.9766557Z 	at org.apache.coyote.http2.StreamProcessor.process(StreamProcessor.java:90) ~[tomcat-embed-core-10.1.19.jar:10.1.19]
2025-02-17T04:07:06.9767267Z 	at org.apache.coyote.http2.StreamRunnable.run(StreamRunnable.java:35) ~[tomcat-embed-core-10.1.19.jar:10.1.19]
2025-02-17T04:07:06.9768058Z 	at org.apache.tomcat.util.threads.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1191) ~[tomcat-embed-core-10.1.19.jar:10.1.19]
2025-02-17T04:07:06.9768923Z 	at org.apache.tomcat.util.threads.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:659) ~[tomcat-embed-core-10.1.19.jar:10.1.19]
2025-02-17T04:07:06.9769735Z 	at org.apache.tomcat.util.threads.TaskThread$WrappingRunnable.run(TaskThread.java:63) ~[tomcat-embed-core-10.1.19.jar:10.1.19]
2025-02-17T04:07:06.9770306Z 	at java.base/java.lang.Thread.run(Thread.java:1583) [?:?]
```

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Make sure gitHub actions can pass. [Why the workflow is failing and how to fix it?](../CONTRIBUTING.md)
