### PR TITLE
[3.3] Optimized Wrapper#getWrapper and some unit tests

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/bytecode/Wrapper.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/bytecode/Wrapper.java
@@ -112,16 +112,17 @@ public abstract class Wrapper {
      * @return Wrapper instance(not null).
      */
     public static Wrapper getWrapper(Class<?> c) {
-        while (ClassGenerator.isDynamicClass(c)) // can not wrapper on dynamic class.
-        {
-            c = c.getSuperclass();
-        }
+        return ConcurrentHashMapUtils.computeIfAbsent(WRAPPER_MAP, c, (clazz) -> {
+            while (ClassGenerator.isDynamicClass(clazz)) // can not wrapper on dynamic class.
+            {
+                clazz = clazz.getSuperclass();
+            }
 
-        if (c == Object.class) {
-            return OBJECT_WRAPPER;
-        }
-
-        return ConcurrentHashMapUtils.computeIfAbsent(WRAPPER_MAP, c, Wrapper::makeWrapper);
+            if (clazz == Object.class) {
+                return OBJECT_WRAPPER;
+            }
+            return makeWrapper(clazz);
+        });
     }
 
     private static Wrapper makeWrapper(Class<?> c) {

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/threadpool/support/AbortPolicyWithReportTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/threadpool/support/AbortPolicyWithReportTest.java
@@ -73,6 +73,7 @@ class AbortPolicyWithReportTest {
 
         await().until(() -> AbortPolicyWithReport.guard.availablePermits() == 1);
         Assertions.assertNotNull(fileOutputStream.get());
+        executorService.shutdown();
     }
 
     @Test
@@ -128,6 +129,7 @@ class AbortPolicyWithReportTest {
         Assertions.assertEquals(
                 runTimes, finishedCount.get() + failureCount.get(), "all the test thread should be run completely");
         Assertions.assertEquals(1, jStackCount.get(), "'jstack' should be called only once in 10 minutes");
+        threadPoolExecutor.shutdown();
     }
 
     @Test

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/threadpool/support/eager/EagerThreadPoolExecutorTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/threadpool/support/eager/EagerThreadPoolExecutorTest.java
@@ -101,6 +101,8 @@ class EagerThreadPoolExecutorTest {
         Thread.sleep(5000);
         // cores theads are all alive.
         Assertions.assertEquals(executor.getPoolSize(), cores, "more than cores threads alive!");
+
+        executor.shutdown();
     }
 
     @Test
@@ -163,6 +165,8 @@ class EagerThreadPoolExecutorTest {
         await().until(() -> executor.getActiveCount() == 0);
 
         await().until(() -> executor.getPoolSize() == cores);
+
+        executor.shutdown();
     }
 
     @Test
@@ -218,6 +222,8 @@ class EagerThreadPoolExecutorTest {
         await().until(() -> executor.getActiveCount() == 0);
 
         executor.execute(runnable);
+
+        executor.shutdown();
     }
 
     @Test
@@ -273,5 +279,7 @@ class EagerThreadPoolExecutorTest {
         executor.execute(runnable);
         semaphore.release(5);
         await().until(() -> executor.getActiveCount() == 0);
+
+        executor.shutdown();
     }
 }

--- a/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/ServiceConfigTest.java
+++ b/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/ServiceConfigTest.java
@@ -171,24 +171,28 @@ class ServiceConfigTest {
     void testExport() throws Exception {
         service.export();
 
-        assertThat(service.getExportedUrls(), hasSize(1));
-        URL url = service.toUrl();
-        assertThat(url.getProtocol(), equalTo("mockprotocol2"));
-        assertThat(url.getPath(), equalTo(DemoService.class.getName()));
-        assertThat(url.getParameters(), hasEntry(ANYHOST_KEY, "true"));
-        assertThat(url.getParameters(), hasEntry(APPLICATION_KEY, "app"));
-        assertThat(url.getParameters(), hasKey(BIND_IP_KEY));
-        assertThat(url.getParameters(), hasKey(BIND_PORT_KEY));
-        assertThat(url.getParameters(), hasEntry(EXPORT_KEY, "true"));
-        assertThat(url.getParameters(), hasEntry("echo.0.callback", "false"));
-        assertThat(url.getParameters(), hasEntry(GENERIC_KEY, "false"));
-        assertThat(url.getParameters(), hasEntry(INTERFACE_KEY, DemoService.class.getName()));
-        assertThat(url.getParameters(), hasKey(METHODS_KEY));
-        assertThat(url.getParameters().get(METHODS_KEY), containsString("echo"));
-        assertThat(url.getParameters(), hasEntry(SIDE_KEY, PROVIDER));
-        // export DemoService in "mockprotocol2" protocol.
-        Mockito.verify(protocolDelegate, times(1)).export(Mockito.any(Invoker.class));
-        // MetadataService will be exported on either dubbo or triple (the only two default acceptable protocol)
+        try {
+            assertThat(service.getExportedUrls(), hasSize(1));
+            URL url = service.toUrl();
+            assertThat(url.getProtocol(), equalTo("mockprotocol2"));
+            assertThat(url.getPath(), equalTo(DemoService.class.getName()));
+            assertThat(url.getParameters(), hasEntry(ANYHOST_KEY, "true"));
+            assertThat(url.getParameters(), hasEntry(APPLICATION_KEY, "app"));
+            assertThat(url.getParameters(), hasKey(BIND_IP_KEY));
+            assertThat(url.getParameters(), hasKey(BIND_PORT_KEY));
+            assertThat(url.getParameters(), hasEntry(EXPORT_KEY, "true"));
+            assertThat(url.getParameters(), hasEntry("echo.0.callback", "false"));
+            assertThat(url.getParameters(), hasEntry(GENERIC_KEY, "false"));
+            assertThat(url.getParameters(), hasEntry(INTERFACE_KEY, DemoService.class.getName()));
+            assertThat(url.getParameters(), hasKey(METHODS_KEY));
+            assertThat(url.getParameters().get(METHODS_KEY), containsString("echo"));
+            assertThat(url.getParameters(), hasEntry(SIDE_KEY, PROVIDER));
+            // export DemoService in "mockprotocol2" protocol.
+            Mockito.verify(protocolDelegate, times(1)).export(Mockito.any(Invoker.class));
+            // MetadataService will be exported on either dubbo or triple (the only two default acceptable protocol)
+        } finally {
+            service.unexport();
+        }
     }
 
     @Test
@@ -198,23 +202,31 @@ class ServiceConfigTest {
         service.getProvider().setGroup("groupA");
         service.export();
 
-        String serviceVersion = service.getVersion();
-        String serviceVersion2 = service.toUrl().getVersion();
+        try {
+            String serviceVersion = service.getVersion();
+            String serviceVersion2 = service.toUrl().getVersion();
 
-        String group = service.getGroup();
-        String group2 = service.toUrl().getGroup();
+            String group = service.getGroup();
+            String group2 = service.toUrl().getGroup();
 
-        assertEquals(serviceVersion2, serviceVersion);
-        assertEquals(group, group2);
+            assertEquals(serviceVersion2, serviceVersion);
+            assertEquals(group, group2);
+        } finally {
+            service.unexport();
+        }
     }
 
     @Test
     void testProxy() throws Exception {
         service2.export();
 
-        assertThat(service2.getExportedUrls(), hasSize(1));
-        assertEquals(2, TestProxyFactory.count); // local injvm and registry protocol, so expected is 2
-        TestProxyFactory.count = 0;
+        try {
+            assertThat(service2.getExportedUrls(), hasSize(1));
+            assertEquals(2, TestProxyFactory.count); // local injvm and registry protocol, so expected is 2
+            TestProxyFactory.count = 0;
+        } finally {
+            service2.unexport();
+        }
     }
 
     @Test
@@ -232,8 +244,12 @@ class ServiceConfigTest {
             public void unexported(ServiceConfig sc) {}
         });
         delayService.export();
-        assertTrue(delayService.getExportedUrls().isEmpty());
-        latch.await();
+        try {
+            assertTrue(delayService.getExportedUrls().isEmpty());
+            latch.await();
+        } finally {
+            delayService.unexport();
+        }
     }
 
     @Test
@@ -317,8 +333,12 @@ class ServiceConfigTest {
     @Test
     void testApplicationInUrl() {
         service.export();
-        assertNotNull(service.toUrl().getApplication());
-        Assertions.assertEquals("app", service.toUrl().getApplication());
+        try {
+            assertNotNull(service.toUrl().getApplication());
+            Assertions.assertEquals("app", service.toUrl().getApplication());
+        } finally {
+            service.unexport();
+        }
     }
 
     @Test
@@ -345,24 +365,28 @@ class ServiceConfigTest {
     void testExportWithoutRegistryConfig() {
         serviceWithoutRegistryConfig.export();
 
-        assertThat(serviceWithoutRegistryConfig.getExportedUrls(), hasSize(1));
-        URL url = serviceWithoutRegistryConfig.toUrl();
-        assertThat(url.getProtocol(), equalTo("mockprotocol2"));
-        assertThat(url.getPath(), equalTo(DemoService.class.getName()));
-        assertThat(url.getParameters(), hasEntry(ANYHOST_KEY, "true"));
-        assertThat(url.getParameters(), hasEntry(APPLICATION_KEY, "app"));
-        assertThat(url.getParameters(), hasKey(BIND_IP_KEY));
-        assertThat(url.getParameters(), hasKey(BIND_PORT_KEY));
-        assertThat(url.getParameters(), hasEntry(EXPORT_KEY, "true"));
-        assertThat(url.getParameters(), hasEntry("echo.0.callback", "false"));
-        assertThat(url.getParameters(), hasEntry(GENERIC_KEY, "false"));
-        assertThat(url.getParameters(), hasEntry(INTERFACE_KEY, DemoService.class.getName()));
-        assertThat(url.getParameters(), hasKey(METHODS_KEY));
-        assertThat(url.getParameters().get(METHODS_KEY), containsString("echo"));
-        assertThat(url.getParameters(), hasEntry(SIDE_KEY, PROVIDER));
-        // export DemoService in "mockprotocol2" protocol (MetadataService will be not exported if no registry
-        // specified)
-        Mockito.verify(protocolDelegate, times(1)).export(Mockito.any(Invoker.class));
+        try {
+            assertThat(serviceWithoutRegistryConfig.getExportedUrls(), hasSize(1));
+            URL url = serviceWithoutRegistryConfig.toUrl();
+            assertThat(url.getProtocol(), equalTo("mockprotocol2"));
+            assertThat(url.getPath(), equalTo(DemoService.class.getName()));
+            assertThat(url.getParameters(), hasEntry(ANYHOST_KEY, "true"));
+            assertThat(url.getParameters(), hasEntry(APPLICATION_KEY, "app"));
+            assertThat(url.getParameters(), hasKey(BIND_IP_KEY));
+            assertThat(url.getParameters(), hasKey(BIND_PORT_KEY));
+            assertThat(url.getParameters(), hasEntry(EXPORT_KEY, "true"));
+            assertThat(url.getParameters(), hasEntry("echo.0.callback", "false"));
+            assertThat(url.getParameters(), hasEntry(GENERIC_KEY, "false"));
+            assertThat(url.getParameters(), hasEntry(INTERFACE_KEY, DemoService.class.getName()));
+            assertThat(url.getParameters(), hasKey(METHODS_KEY));
+            assertThat(url.getParameters().get(METHODS_KEY), containsString("echo"));
+            assertThat(url.getParameters(), hasEntry(SIDE_KEY, PROVIDER));
+            // export DemoService in "mockprotocol2" protocol (MetadataService will be not exported if no registry
+            // specified)
+            Mockito.verify(protocolDelegate, times(1)).export(Mockito.any(Invoker.class));
+        } finally {
+            serviceWithoutRegistryConfig.unexport();
+        }
     }
 
     @Test
@@ -374,10 +398,14 @@ class ServiceConfigTest {
 
         service.export();
 
-        Map<String, ServiceConfig> exportedServices = mockServiceListener.getExportedServices();
-        assertEquals(1, exportedServices.size());
-        ServiceConfig serviceConfig = exportedServices.get(service.getUniqueServiceName());
-        assertSame(service, serviceConfig);
+        try {
+            Map<String, ServiceConfig> exportedServices = mockServiceListener.getExportedServices();
+            assertEquals(1, exportedServices.size());
+            ServiceConfig serviceConfig = exportedServices.get(service.getUniqueServiceName());
+            assertSame(service, serviceConfig);
+        } finally {
+            service.unexport();
+        }
     }
 
     @Test
@@ -404,6 +432,7 @@ class ServiceConfigTest {
             service.setMethods(Lists.newArrayList(methodConfig));
 
             service.export();
+            service.unexport();
         });
     }
 
@@ -433,8 +462,13 @@ class ServiceConfigTest {
 
         service.export();
 
-        assertFalse(service.getExportedUrls().isEmpty());
-        assertEquals("false", service.getExportedUrls().get(0).getParameters().get("sayName.0.callback"));
+        try {
+            assertFalse(service.getExportedUrls().isEmpty());
+            assertEquals(
+                    "false", service.getExportedUrls().get(0).getParameters().get("sayName.0.callback"));
+        } finally {
+            service.unexport();
+        }
     }
 
     @Test
@@ -462,8 +496,13 @@ class ServiceConfigTest {
 
         service.export();
 
-        assertFalse(service.getExportedUrls().isEmpty());
-        assertEquals("false", service.getExportedUrls().get(0).getParameters().get("sayName.0.callback"));
+        try {
+            assertFalse(service.getExportedUrls().isEmpty());
+            assertEquals(
+                    "false", service.getExportedUrls().get(0).getParameters().get("sayName.0.callback"));
+        } finally {
+            service.unexport();
+        }
     }
 
     @Test
@@ -491,8 +530,13 @@ class ServiceConfigTest {
 
         service.export();
 
-        assertFalse(service.getExportedUrls().isEmpty());
-        assertEquals("false", service.getExportedUrls().get(0).getParameters().get("sayName.0.callback"));
+        try {
+            assertFalse(service.getExportedUrls().isEmpty());
+            assertEquals(
+                    "false", service.getExportedUrls().get(0).getParameters().get("sayName.0.callback"));
+        } finally {
+            service.unexport();
+        }
     }
 
     @Test
@@ -520,6 +564,7 @@ class ServiceConfigTest {
             service.setMethods(Lists.newArrayList(methodConfig));
 
             service.export();
+            service.unexport();
         });
     }
 
@@ -548,6 +593,7 @@ class ServiceConfigTest {
             service.setMethods(Lists.newArrayList(methodConfig));
 
             service.export();
+            service.unexport();
         });
     }
 
@@ -576,6 +622,7 @@ class ServiceConfigTest {
             service.setMethods(Lists.newArrayList(methodConfig));
 
             service.export();
+            service.unexport();
         });
     }
 

--- a/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/isolation/spring/annotation/AnnotationIsolationTest.java
+++ b/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/isolation/spring/annotation/AnnotationIsolationTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.dubbo.config.spring.isolation.spring.annotation;
 
+import org.apache.dubbo.common.utils.NetUtils;
 import org.apache.dubbo.config.ApplicationConfig;
 import org.apache.dubbo.config.ProtocolConfig;
 import org.apache.dubbo.config.RegistryConfig;
@@ -113,14 +114,14 @@ public class AnnotationIsolationTest extends BaseTest {
         // expose services with dubbo protocol
         @Bean
         public ProtocolConfig dubbo() {
-            ProtocolConfig protocolConfig = new ProtocolConfig("dubbo");
+            ProtocolConfig protocolConfig = new ProtocolConfig("dubbo", NetUtils.getAvailablePort());
             return protocolConfig;
         }
 
         // expose services with tri protocol
         @Bean
         public ProtocolConfig tri() {
-            ProtocolConfig protocolConfig = new ProtocolConfig("tri");
+            ProtocolConfig protocolConfig = new ProtocolConfig("tri", NetUtils.getAvailablePort());
             return protocolConfig;
         }
 

--- a/dubbo-configcenter/dubbo-configcenter-apollo/src/test/java/org/apache/dubbo/configcenter/support/apollo/ApolloDynamicConfigurationTest.java
+++ b/dubbo-configcenter/dubbo-configcenter-apollo/src/test/java/org/apache/dubbo/configcenter/support/apollo/ApolloDynamicConfigurationTest.java
@@ -20,6 +20,7 @@ import org.apache.dubbo.common.URL;
 import org.apache.dubbo.common.config.configcenter.ConfigChangeType;
 import org.apache.dubbo.common.config.configcenter.ConfigurationListener;
 import org.apache.dubbo.rpc.model.ApplicationModel;
+import org.apache.dubbo.rpc.model.FrameworkModel;
 
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -60,6 +61,7 @@ class ApolloDynamicConfigurationTest {
      */
     @BeforeEach
     public void setUp() {
+        FrameworkModel.destroyAll();
         String apolloUrl = System.getProperty("apollo.configService");
         String urlForDubbo = "apollo://" + apolloUrl.substring(apolloUrl.lastIndexOf("/") + 1)
                 + "/org.apache.dubbo.apollo.testService?namespace=dubbo&check=true";

--- a/dubbo-remoting/dubbo-remoting-netty/src/test/java/org/apache/dubbo/remoting/transport/netty/NettyClientTest.java
+++ b/dubbo-remoting/dubbo-remoting-netty/src/test/java/org/apache/dubbo/remoting/transport/netty/NettyClientTest.java
@@ -23,6 +23,7 @@ import org.apache.dubbo.remoting.RemotingServer;
 import org.apache.dubbo.remoting.exchange.ExchangeChannel;
 import org.apache.dubbo.remoting.exchange.Exchangers;
 import org.apache.dubbo.rpc.model.ApplicationModel;
+import org.apache.dubbo.rpc.model.FrameworkModel;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -43,6 +44,7 @@ class NettyClientTest {
 
     @BeforeAll
     public static void setUp() throws Exception {
+        FrameworkModel.destroyAll();
         URL url = URL.valueOf("exchange://localhost:" + port + "?server=netty3&codec=exchange");
         ApplicationModel applicationModel = ApplicationModel.defaultModel();
         ApplicationConfig applicationConfig = new ApplicationConfig("provider-app");

--- a/dubbo-remoting/dubbo-remoting-netty4/src/test/java/org/apache/dubbo/remoting/transport/netty4/ReplierDispatcherTest.java
+++ b/dubbo-remoting/dubbo-remoting-netty4/src/test/java/org/apache/dubbo/remoting/transport/netty4/ReplierDispatcherTest.java
@@ -27,6 +27,7 @@ import org.apache.dubbo.remoting.exchange.ExchangeServer;
 import org.apache.dubbo.remoting.exchange.Exchangers;
 import org.apache.dubbo.remoting.exchange.support.ReplierDispatcher;
 import org.apache.dubbo.rpc.model.ApplicationModel;
+import org.apache.dubbo.rpc.model.FrameworkModel;
 import org.apache.dubbo.rpc.model.ModuleModel;
 
 import java.io.Serializable;
@@ -61,6 +62,7 @@ class ReplierDispatcherTest {
 
     @BeforeEach
     public void startServer() throws RemotingException {
+        FrameworkModel.destroyAll();
         port = NetUtils.getAvailablePort();
         ReplierDispatcher dispatcher = new ReplierDispatcher();
         dispatcher.addReplier(RpcMessage.class, new RpcMessageHandler());


### PR DESCRIPTION
## What is the purpose of the change?
try to fix #15160
1. cached wrapper as soon as possible.
2. fixed exhausted thread pool issue: destroyed all framework model before running some unit tests. dubbo thread pool might be exhausted by some other unit tests which don't destroyed framework models after their running.
3. fixed address already in use issue: un-exported service config of some unit tests.

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Make sure gitHub actions can pass. [Why the workflow is failing and how to fix it?](../CONTRIBUTING.md)
