### PR TITLE
Fix `DefaultSerializeClassChecker` verification, when the mode is `WARN`

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/utils/DefaultSerializeClassChecker.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/utils/DefaultSerializeClassChecker.java
@@ -164,8 +164,6 @@ public class DefaultSerializeClassChecker implements AllowClassNotifyListener {
                 if (serializeSecurityManager.getWarnedClasses().add(className)) {
                     logger.warn(PROTOCOL_UNTRUSTED_SERIALIZE_CLASS, "", "", msg);
                 }
-
-                throw new IllegalArgumentException(msg);
             }
         }
 
@@ -185,8 +183,6 @@ public class DefaultSerializeClassChecker implements AllowClassNotifyListener {
                 if (serializeSecurityManager.getWarnedClasses().add(className)) {
                     logger.warn(PROTOCOL_UNTRUSTED_SERIALIZE_CLASS, "", "", msg);
                 }
-
-                throw new IllegalArgumentException(msg);
             }
         }
 

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/utils/DefaultSerializeClassCheckerTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/utils/DefaultSerializeClassCheckerTest.java
@@ -22,6 +22,7 @@ import org.apache.dubbo.rpc.model.FrameworkModel;
 import java.net.Socket;
 import java.util.LinkedList;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.logging.Level;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
@@ -169,6 +170,11 @@ class DefaultSerializeClassCheckerTest {
                 ReentrantReadWriteLock.class,
                 defaultSerializeClassChecker.loadClass(
                         Thread.currentThread().getContextClassLoader(), ReentrantReadWriteLock.class.getName()));
+
+        Assertions.assertEquals(
+                Level.class,
+                defaultSerializeClassChecker.loadClass(
+                        Thread.currentThread().getContextClassLoader(), Level.class.getName()));
 
         ssm.setCheckStatus(SerializeCheckStatus.DISABLE);
         Assertions.assertEquals(


### PR DESCRIPTION

## What is the purpose of the change?

Fix #15179 

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Make sure gitHub actions can pass. [Why the workflow is failing and how to fix it?](../CONTRIBUTING.md)
