### PR TITLE
check the network,Local site be the preferred one

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/utils/NetUtils.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/utils/NetUtils.java
@@ -552,7 +552,11 @@ public final class NetUtils {
                     if (addressOp.isPresent()) {
                         try {
                             if (addressOp.get().isReachable(100)) {
-                                return networkInterface;
+                                if (addressOp.get().isSiteLocalAddress()) {
+                                    return networkInterface;
+                                } else {
+                                    result = networkInterface;
+                                }
                             }
                         } catch (IOException e) {
                             // ignore


### PR DESCRIPTION
## What is the purpose of the change?
I found an issue: every time I enable the VPN, Dubbo's local address check always picks up the VPN address instead of my machine's actual address. This leads to an incorrect address selection, preventing normal startup.

I found a similar issue reported a long time ago. Here are two ideas I have:

1. When retrieving the address, check if it is a SiteLocalAddress. If it is, return it directly; otherwise, return a reachable alternative address. (After my development and testing, this solution at least resolves the issue on my computer.)
2.Add an IP parameter to specify the preferred local network interface instead of relying on the interface name parameter.

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Make sure gitHub actions can pass. [Why the workflow is failing and how to fix it?](../CONTRIBUTING.md)
