### PR TITLE
FIX-15184 resolved NettyHttp Header add by set to empty String

### DIFF
--- a/dubbo-plugin/dubbo-triple-servlet/src/main/java/org/apache/dubbo/rpc/protocol/tri/servlet/HttpMetadataAdapter.java
+++ b/dubbo-plugin/dubbo-triple-servlet/src/main/java/org/apache/dubbo/rpc/protocol/tri/servlet/HttpMetadataAdapter.java
@@ -16,6 +16,7 @@
  */
 package org.apache.dubbo.rpc.protocol.tri.servlet;
 
+import org.apache.dubbo.common.utils.StringUtils;
 import org.apache.dubbo.remoting.http12.HttpHeaderNames;
 import org.apache.dubbo.remoting.http12.HttpHeaders;
 import org.apache.dubbo.remoting.http12.h2.Http2Header;
@@ -53,9 +54,10 @@ public final class HttpMetadataAdapter implements Http2Header {
                     headers.add(key, ven.nextElement());
                 }
             }
+            String hostName = request.getHeader(HttpHeaderNames.HOST.getName());
             headers.add(PseudoHeaderName.METHOD.value(), method());
             headers.add(PseudoHeaderName.SCHEME.value(), request.getScheme());
-            headers.add(PseudoHeaderName.AUTHORITY.value(), request.getHeader(HttpHeaderNames.HOST.getName()));
+            headers.add(PseudoHeaderName.AUTHORITY.value(), StringUtils.isBlank(hostName) ? "" : hostName);
             headers.add(PseudoHeaderName.PROTOCOL.value(), request.getProtocol());
             this.headers = headers;
         }

--- a/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/message/DefaultHttpRequest.java
+++ b/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/message/DefaultHttpRequest.java
@@ -306,7 +306,7 @@ public class DefaultHttpRequest implements HttpRequest {
     @Override
     public String serverHost() {
         String host = getHost0();
-        return host == null ? localHost() + ':' + localPort() : host;
+        return StringUtils.isBlank(host) ? localHost() + ':' + localPort() : host;
     }
 
     @Override
@@ -316,7 +316,7 @@ public class DefaultHttpRequest implements HttpRequest {
             return host;
         }
         host = getHost0();
-        if (host != null) {
+        if (StringUtils.isNotBlank(host)) {
             int index = host.lastIndexOf(':');
             return index == -1 ? host : host.substring(0, index);
         }
@@ -330,7 +330,7 @@ public class DefaultHttpRequest implements HttpRequest {
             return Integer.parseInt(port);
         }
         String host = getHost0();
-        if (host != null) {
+        if (StringUtils.isNotBlank(host)) {
             int index = host.lastIndexOf(':');
             return index == -1 ? -1 : Integer.parseInt(host.substring(0, index));
         }


### PR DESCRIPTION
## What is the purpose of the change?
`io.netty.handler.codec.Headers.HttpMetadataAdapter` is adding a null value for `PseudoHeaderName.AUTHORITY` key. I checked the docs for `io.netty.handler.codec.Headers` and it might be linked to this [issue](https://github.com/spring-projects/spring-framework/issues/26274). So, I replaced with a default value of empty string "". All the client methods checking for the key `PseudoHeaderName.AUTHORITY` will do a null or empty value check using `StringUtils.isBlank()` and `StringUtils.isNotBlank`

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Make sure gitHub actions can pass. [Why the workflow is failing and how to fix it?](../CONTRIBUTING.md)
