### PR TITLE
Resolving the Thread-Safety Problem in registerReferenceKeyAndBeanName Using an Overloaded computeIfAbsent

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/utils/ConcurrentHashMapUtils.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/utils/ConcurrentHashMapUtils.java
@@ -34,6 +34,8 @@ public class ConcurrentHashMapUtils {
     public static <K, V> V computeIfAbsent(ConcurrentMap<K, V> map, K key, Function<? super K, ? extends V> func) {
         return computeIfAbsent(map, key, func, null);
     }
+
+
     public static <K, V> V computeIfAbsent
             (ConcurrentMap<K, V> map, K key, Function<? super K, ? extends V> func, Consumer<V> threadSafeOperation) {
         Objects.requireNonNull(func);

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/utils/ConcurrentHashMapUtils.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/utils/ConcurrentHashMapUtils.java
@@ -35,9 +35,8 @@ public class ConcurrentHashMapUtils {
         return computeIfAbsent(map, key, func, null);
     }
 
-
-    public static <K, V> V computeIfAbsent
-            (ConcurrentMap<K, V> map, K key, Function<? super K, ? extends V> func, Consumer<V> threadSafeOperation) {
+    public static <K, V> V computeIfAbsent(
+            ConcurrentMap<K, V> map, K key, Function<? super K, ? extends V> func, Consumer<V> threadSafeOperation) {
         Objects.requireNonNull(func);
         V value;
         if (JRE.JAVA_8.isCurrentVersion()) {

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/utils/ConcurrentHashMapUtils.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/utils/ConcurrentHashMapUtils.java
@@ -34,12 +34,10 @@ public class ConcurrentHashMapUtils {
     public static <K, V> V computeIfAbsent(ConcurrentMap<K, V> map, K key, Function<? super K, ? extends V> func) {
         return computeIfAbsent(map, key, func, null);
     }
-
-
     public static <K, V> V computeIfAbsent
             (ConcurrentMap<K, V> map, K key, Function<? super K, ? extends V> func, Consumer<V> threadSafeOperation) {
         Objects.requireNonNull(func);
-        V value = null;
+        V value;
         if (JRE.JAVA_8.isCurrentVersion()) {
             V v = map.get(key);
             if (null == v) {

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/utils/ConcurrentHashMapUtils.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/utils/ConcurrentHashMapUtils.java
@@ -18,6 +18,7 @@ package org.apache.dubbo.common.utils;
 
 import java.util.Objects;
 import java.util.concurrent.ConcurrentMap;
+import java.util.function.Consumer;
 import java.util.function.Function;
 
 /**
@@ -27,11 +28,18 @@ public class ConcurrentHashMapUtils {
 
     /**
      * A temporary workaround for Java 8 ConcurrentHashMap#computeIfAbsent specific performance issue: JDK-8161372.</br>
-     * @see <a href="https://bugs.openjdk.java.net/browse/JDK-8161372">https://bugs.openjdk.java.net/browse/JDK-8161372</a>
      *
+     * @see <a href="https://bugs.openjdk.java.net/browse/JDK-8161372">https://bugs.openjdk.java.net/browse/JDK-8161372</a>
      */
     public static <K, V> V computeIfAbsent(ConcurrentMap<K, V> map, K key, Function<? super K, ? extends V> func) {
+        return computeIfAbsent(map, key, func, null);
+    }
+
+
+    public static <K, V> V computeIfAbsent
+            (ConcurrentMap<K, V> map, K key, Function<? super K, ? extends V> func, Consumer<V> threadSafeOperation) {
         Objects.requireNonNull(func);
+        V value = null;
         if (JRE.JAVA_8.isCurrentVersion()) {
             V v = map.get(key);
             if (null == v) {
@@ -47,13 +55,23 @@ public class ConcurrentHashMapUtils {
                 if (null != res) {
                     // if pre value present, means other thread put value already, and putIfAbsent not effect
                     // return exist value
-                    return res;
+                    value = res;
+                }else {
+                    value = v;
                 }
                 // if pre value is null, means putIfAbsent effected, return current value
+            } else {
+                value = v;
             }
-            return v;
         } else {
-            return map.computeIfAbsent(key, func);
+            value = map.computeIfAbsent(key, func);
         }
+        if (value != null && threadSafeOperation != null) {
+            // make sure value operations are thread - safe.
+            synchronized (value){
+                threadSafeOperation.accept(value);
+            }
+        }
+        return value;
     }
 }

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/utils/ConcurrentHashMapUtils.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/utils/ConcurrentHashMapUtils.java
@@ -56,7 +56,7 @@ public class ConcurrentHashMapUtils {
                     // if pre value present, means other thread put value already, and putIfAbsent not effect
                     // return exist value
                     value = res;
-                }else {
+                } else {
                     value = v;
                 }
                 // if pre value is null, means putIfAbsent effected, return current value
@@ -68,7 +68,7 @@ public class ConcurrentHashMapUtils {
         }
         if (value != null && threadSafeOperation != null) {
             // make sure value operations are thread - safe.
-            synchronized (value){
+            synchronized (value) {
                 threadSafeOperation.accept(value);
             }
         }

--- a/dubbo-common/src/main/java/org/apache/dubbo/config/annotation/ProvidedBy.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/config/annotation/ProvidedBy.java
@@ -25,7 +25,9 @@ import java.lang.annotation.Target;
 
 /**
  * Class-level annotation used for declaring Dubbo interface.
- * Example:
+ * Example: <br/>
+ * <pre>
+ * {@code
  * @ProvidedBy("dubbo-samples-xds-provider")
  * public interface GreetingService {
  *     String sayHello(String name);
@@ -36,6 +38,7 @@ import java.lang.annotation.Target;
  *     @DubboReference(version = "1.0.0")
  *     private GreetingService greetingService;
  * }
+ * </pre>
  */
 @Documented
 @Retention(RetentionPolicy.RUNTIME)

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/utils/ConcurrentHashMapUtilsTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/utils/ConcurrentHashMapUtilsTest.java
@@ -16,13 +16,20 @@
  */
 package org.apache.dubbo.common.utils;
 
-import java.util.concurrent.ConcurrentHashMap;
-
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.condition.EnabledForJreRange;
+import org.junit.jupiter.api.condition.JRE;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+
 
 class ConcurrentHashMapUtilsTest {
 
@@ -64,4 +71,51 @@ class ConcurrentHashMapUtilsTest {
             ConcurrentHashMapUtils.computeIfAbsent(map, "AaAa", key -> map.computeIfAbsent("BBBB", key2 -> 42));
         });
     }
+
+
+    private static ConcurrentMap<String, List<Long>> SHARED_MAP;
+
+    private static final String TEST_KEY = "testKey";
+    /**
+     * number of executions
+     */
+    private static final int REPEATED_TEST_NUM = 10_0000;
+
+    @BeforeAll
+    public static void initSharedMap() {
+        SHARED_MAP = new ConcurrentHashMap<>();
+    }
+
+
+    @EnabledForJreRange(max = org.junit.jupiter.api.condition.JRE.JAVA_8)
+    @RepeatedTest(value = REPEATED_TEST_NUM)
+    @Execution(ExecutionMode.CONCURRENT)
+    @DisplayName("ConcurrentHashMapUtils#computeIfAbsent for java8 thread safety test")
+    public void threadSafetyOperatorForJava8Test() {
+        // 创建一个 ConcurrentMap
+        System.out.println(Thread.currentThread().getName());
+        ConcurrentHashMapUtils.computeIfAbsent(SHARED_MAP, TEST_KEY, key -> new ArrayList<>(), list -> {
+            list.add(System.currentTimeMillis());
+        });
+    }
+
+    @EnabledForJreRange(max = JRE.JAVA_17)
+    @Execution(ExecutionMode.CONCURRENT)
+    @DisplayName("ConcurrentHashMapUtils#computeIfAbsent  for java17 thread safety test")
+    @RepeatedTest(value = REPEATED_TEST_NUM)
+    public void threadSafetyOperatorForJava17Test() {
+        // 创建一个 ConcurrentMap
+        String testKey = "testKey";
+        ConcurrentHashMapUtils.computeIfAbsent(SHARED_MAP, testKey, key -> new ArrayList<>(), list -> {
+            list.add(System.currentTimeMillis());
+        });
+    }
+
+    @AfterAll
+    public static void verifyTestResults() {
+        if (SHARED_MAP.isEmpty()) return;
+        assertEquals(REPEATED_TEST_NUM, SHARED_MAP.get(TEST_KEY).size());
+    }
+
+
 }

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/utils/ConcurrentHashMapUtilsTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/utils/ConcurrentHashMapUtilsTest.java
@@ -77,17 +77,21 @@ class ConcurrentHashMapUtilsTest {
     }
 
 
-    private static ConcurrentMap<String, List<Long>> SHARED_MAP;
+    private static ConcurrentMap<String, List<Long>> SHARED_MAP_JDK8;
+
+    private static ConcurrentMap<String, List<Long>> SHARED_MAP_JDK17;
 
     private static final String TEST_KEY = "testKey";
     /**
      * number of executions
+     * 100 K
      */
-    private static final int REPEATED_TEST_NUM = 10_0000;
+    private static final int REPEATED_TEST_NUM = 100_000;
 
     @BeforeAll
     public static void initSharedMap() {
-        SHARED_MAP = new ConcurrentHashMap<>();
+        SHARED_MAP_JDK8 = new ConcurrentHashMap<>();
+        SHARED_MAP_JDK17 = new ConcurrentHashMap<>();
     }
 
 
@@ -96,9 +100,7 @@ class ConcurrentHashMapUtilsTest {
     @Execution(ExecutionMode.CONCURRENT)
     @DisplayName("ConcurrentHashMapUtils#computeIfAbsent for java8 thread safety test")
     public void threadSafetyOperatorForJava8Test() {
-        // 创建一个 ConcurrentMap
-        System.out.println(Thread.currentThread().getName());
-        ConcurrentHashMapUtils.computeIfAbsent(SHARED_MAP, TEST_KEY, key -> new ArrayList<>(), list -> {
+        ConcurrentHashMapUtils.computeIfAbsent(SHARED_MAP_JDK8, TEST_KEY, key -> new ArrayList<>(), list -> {
             list.add(System.currentTimeMillis());
         });
     }
@@ -108,17 +110,21 @@ class ConcurrentHashMapUtilsTest {
     @DisplayName("ConcurrentHashMapUtils#computeIfAbsent  for java17 thread safety test")
     @RepeatedTest(value = REPEATED_TEST_NUM)
     public void threadSafetyOperatorForJava17Test() {
-        // 创建一个 ConcurrentMap
-        ConcurrentHashMapUtils.computeIfAbsent(SHARED_MAP, TEST_KEY, key -> new ArrayList<>(), list -> {
+        ConcurrentHashMapUtils.computeIfAbsent(SHARED_MAP_JDK17, TEST_KEY, key -> new ArrayList<>(), list -> {
             list.add(System.currentTimeMillis());
         });
     }
 
     @AfterAll
     public static void verifyTestResults() {
-        if (SHARED_MAP.isEmpty()) return;
-        assertEquals(REPEATED_TEST_NUM, SHARED_MAP.get(TEST_KEY).size());
-    }
+        if (!SHARED_MAP_JDK8.isEmpty())
+            assertEquals(REPEATED_TEST_NUM, SHARED_MAP_JDK8.get(TEST_KEY).size());
 
+        if (!SHARED_MAP_JDK17.isEmpty())
+            assertEquals(REPEATED_TEST_NUM, SHARED_MAP_JDK8.get(TEST_KEY).size());
+
+        SHARED_MAP_JDK8 = null;
+        SHARED_MAP_JDK17 = null;
+    }
 
 }

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/utils/ConcurrentHashMapUtilsTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/utils/ConcurrentHashMapUtilsTest.java
@@ -16,7 +16,11 @@
  */
 package org.apache.dubbo.common.utils;
 
-import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledForJreRange;
 import org.junit.jupiter.api.condition.JRE;
 import org.junit.jupiter.api.parallel.Execution;
@@ -105,8 +109,7 @@ class ConcurrentHashMapUtilsTest {
     @RepeatedTest(value = REPEATED_TEST_NUM)
     public void threadSafetyOperatorForJava17Test() {
         // 创建一个 ConcurrentMap
-        String testKey = "testKey";
-        ConcurrentHashMapUtils.computeIfAbsent(SHARED_MAP, testKey, key -> new ArrayList<>(), list -> {
+        ConcurrentHashMapUtils.computeIfAbsent(SHARED_MAP, TEST_KEY, key -> new ArrayList<>(), list -> {
             list.add(System.currentTimeMillis());
         });
     }

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/utils/ConcurrentHashMapUtilsTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/utils/ConcurrentHashMapUtilsTest.java
@@ -16,6 +16,11 @@
  */
 package org.apache.dubbo.common.utils;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.RepeatedTest;
@@ -25,28 +30,43 @@ import org.junit.jupiter.api.condition.JRE;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-
 class ConcurrentHashMapUtilsTest {
+
+    private static final String TEST_KEY = "testKey";
+
+    /**
+     * number of executions
+     * 10 K
+     */
+    private static final int REPEATED_TEST_NUM = 10_000;
 
     private static ConcurrentMap<String, List<Long>> SHARED_MAP_JDK8;
 
     private static ConcurrentMap<String, List<Long>> SHARED_MAP_JDK17;
 
-    private static final String TEST_KEY = "testKey";
-    /**
-     * number of executions
-     * 100 K
-     */
-    private static final int REPEATED_TEST_NUM = 100_000;
+    @BeforeAll
+    public static void initSharedMap() {
+        SHARED_MAP_JDK8 = new ConcurrentHashMap<>();
+        SHARED_MAP_JDK17 = new ConcurrentHashMap<>();
+    }
 
+    @AfterAll
+    public static void verifyTestResults() {
+        if (!SHARED_MAP_JDK8.isEmpty()) {
+            assertEquals(REPEATED_TEST_NUM, SHARED_MAP_JDK8.get(TEST_KEY).size());
+        }
+
+        if (!SHARED_MAP_JDK17.isEmpty()) {
+            assertEquals(REPEATED_TEST_NUM, SHARED_MAP_JDK17.get(TEST_KEY).size());
+        }
+
+        SHARED_MAP_JDK8 = null;
+        SHARED_MAP_JDK17 = null;
+    }
 
     @Test
     public void testComputeIfAbsent() {
@@ -82,54 +102,24 @@ class ConcurrentHashMapUtilsTest {
         final ConcurrentHashMap<String, Integer> map = new ConcurrentHashMap<>();
 
         // JDK9+ has been resolved JDK-8161372 bug, when cause dead then throw IllegalStateException
-        assertThrows(IllegalStateException.class,
-                () ->
-                        ConcurrentHashMapUtils.computeIfAbsent(
-                                map,
-                                "AaAa",
-                                key -> map.computeIfAbsent("BBBB", key2 -> 42)));
+        assertThrows(IllegalStateException.class, () -> ConcurrentHashMapUtils.computeIfAbsent(map, "AaAa", key -> map.computeIfAbsent("BBBB", key2 -> 42)));
     }
-
-
-    @BeforeAll
-    public static void initSharedMap() {
-        SHARED_MAP_JDK8 = new ConcurrentHashMap<>();
-        SHARED_MAP_JDK17 = new ConcurrentHashMap<>();
-    }
-
 
     @EnabledForJreRange(max = org.junit.jupiter.api.condition.JRE.JAVA_8)
     @RepeatedTest(value = REPEATED_TEST_NUM)
     @Execution(ExecutionMode.CONCURRENT)
     public void threadSafetyOperatorForJava8Test() {
-        ConcurrentHashMapUtils.computeIfAbsent(
-                SHARED_MAP_JDK8,
-                TEST_KEY,
-                key -> new ArrayList<>(),
-                list -> list.add(System.currentTimeMillis()));
+        List<Long> value = ConcurrentHashMapUtils.computeIfAbsent(SHARED_MAP_JDK8, TEST_KEY, key -> new ArrayList<>(), list -> list.add(System.currentTimeMillis()));
+        assertNotNull(value);
     }
 
     @EnabledForJreRange(max = JRE.JAVA_17)
     @Execution(ExecutionMode.CONCURRENT)
     @RepeatedTest(value = REPEATED_TEST_NUM)
     public void threadSafetyOperatorForJava17Test() {
-        ConcurrentHashMapUtils.computeIfAbsent(
-                SHARED_MAP_JDK17,
-                TEST_KEY,
-                key -> new ArrayList<>(),
-                list -> list.add(System.currentTimeMillis()));
+        List<Long> value = ConcurrentHashMapUtils.computeIfAbsent(SHARED_MAP_JDK17, TEST_KEY, key -> new ArrayList<>(), list -> list.add(System.currentTimeMillis()));
+        assertNotNull(value);
     }
 
-    @AfterAll
-    public static void verifyTestResults() {
-        if (!SHARED_MAP_JDK8.isEmpty())
-            assertEquals(REPEATED_TEST_NUM, SHARED_MAP_JDK8.get(TEST_KEY).size());
-
-        if (!SHARED_MAP_JDK17.isEmpty())
-            assertEquals(REPEATED_TEST_NUM, SHARED_MAP_JDK17.get(TEST_KEY).size());
-
-        SHARED_MAP_JDK8 = null;
-        SHARED_MAP_JDK17 = null;
-    }
 
 }

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/utils/ConcurrentHashMapUtilsTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/utils/ConcurrentHashMapUtilsTest.java
@@ -102,14 +102,18 @@ class ConcurrentHashMapUtilsTest {
         final ConcurrentHashMap<String, Integer> map = new ConcurrentHashMap<>();
 
         // JDK9+ has been resolved JDK-8161372 bug, when cause dead then throw IllegalStateException
-        assertThrows(IllegalStateException.class, () -> ConcurrentHashMapUtils.computeIfAbsent(map, "AaAa", key -> map.computeIfAbsent("BBBB", key2 -> 42)));
+        assertThrows(
+                IllegalStateException.class,
+                () -> ConcurrentHashMapUtils.computeIfAbsent(
+                        map, "AaAa", key -> map.computeIfAbsent("BBBB", key2 -> 42)));
     }
 
     @EnabledForJreRange(max = org.junit.jupiter.api.condition.JRE.JAVA_8)
     @RepeatedTest(value = REPEATED_TEST_NUM)
     @Execution(ExecutionMode.CONCURRENT)
     public void threadSafetyOperatorForJava8Test() {
-        List<Long> value = ConcurrentHashMapUtils.computeIfAbsent(SHARED_MAP_JDK8, TEST_KEY, key -> new ArrayList<>(), list -> list.add(System.currentTimeMillis()));
+        List<Long> value = ConcurrentHashMapUtils.computeIfAbsent(
+                SHARED_MAP_JDK8, TEST_KEY, key -> new ArrayList<>(), list -> list.add(System.currentTimeMillis()));
         assertNotNull(value);
     }
 
@@ -117,9 +121,8 @@ class ConcurrentHashMapUtilsTest {
     @Execution(ExecutionMode.CONCURRENT)
     @RepeatedTest(value = REPEATED_TEST_NUM)
     public void threadSafetyOperatorForJava17Test() {
-        List<Long> value = ConcurrentHashMapUtils.computeIfAbsent(SHARED_MAP_JDK17, TEST_KEY, key -> new ArrayList<>(), list -> list.add(System.currentTimeMillis()));
+        List<Long> value = ConcurrentHashMapUtils.computeIfAbsent(
+                SHARED_MAP_JDK17, TEST_KEY, key -> new ArrayList<>(), list -> list.add(System.currentTimeMillis()));
         assertNotNull(value);
     }
-
-
 }

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/utils/ConcurrentHashMapUtilsTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/utils/ConcurrentHashMapUtilsTest.java
@@ -82,9 +82,12 @@ class ConcurrentHashMapUtilsTest {
         final ConcurrentHashMap<String, Integer> map = new ConcurrentHashMap<>();
 
         // JDK9+ has been resolved JDK-8161372 bug, when cause dead then throw IllegalStateException
-        assertThrows(IllegalStateException.class, () -> {
-            ConcurrentHashMapUtils.computeIfAbsent(map, "AaAa", key -> map.computeIfAbsent("BBBB", key2 -> 42));
-        });
+        assertThrows(IllegalStateException.class,
+                () ->
+                        ConcurrentHashMapUtils.computeIfAbsent(
+                                map,
+                                "AaAa",
+                                key -> map.computeIfAbsent("BBBB", key2 -> 42)));
     }
 
 
@@ -99,18 +102,22 @@ class ConcurrentHashMapUtilsTest {
     @RepeatedTest(value = REPEATED_TEST_NUM)
     @Execution(ExecutionMode.CONCURRENT)
     public void threadSafetyOperatorForJava8Test() {
-        ConcurrentHashMapUtils.computeIfAbsent(SHARED_MAP_JDK8, TEST_KEY, key -> new ArrayList<>(), list -> {
-            list.add(System.currentTimeMillis());
-        });
+        ConcurrentHashMapUtils.computeIfAbsent(
+                SHARED_MAP_JDK8,
+                TEST_KEY,
+                key -> new ArrayList<>(),
+                list -> list.add(System.currentTimeMillis()));
     }
 
     @EnabledForJreRange(max = JRE.JAVA_17)
     @Execution(ExecutionMode.CONCURRENT)
     @RepeatedTest(value = REPEATED_TEST_NUM)
     public void threadSafetyOperatorForJava17Test() {
-        ConcurrentHashMapUtils.computeIfAbsent(SHARED_MAP_JDK17, TEST_KEY, key -> new ArrayList<>(), list -> {
-            list.add(System.currentTimeMillis());
-        });
+        ConcurrentHashMapUtils.computeIfAbsent(
+                SHARED_MAP_JDK17,
+                TEST_KEY,
+                key -> new ArrayList<>(),
+                list -> list.add(System.currentTimeMillis()));
     }
 
     @AfterAll
@@ -119,7 +126,7 @@ class ConcurrentHashMapUtilsTest {
             assertEquals(REPEATED_TEST_NUM, SHARED_MAP_JDK8.get(TEST_KEY).size());
 
         if (!SHARED_MAP_JDK17.isEmpty())
-            assertEquals(REPEATED_TEST_NUM, SHARED_MAP_JDK8.get(TEST_KEY).size());
+            assertEquals(REPEATED_TEST_NUM, SHARED_MAP_JDK17.get(TEST_KEY).size());
 
         SHARED_MAP_JDK8 = null;
         SHARED_MAP_JDK17 = null;

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/utils/ConcurrentHashMapUtilsTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/utils/ConcurrentHashMapUtilsTest.java
@@ -18,7 +18,6 @@ package org.apache.dubbo.common.utils;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledForJreRange;
@@ -36,6 +35,18 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 
 class ConcurrentHashMapUtilsTest {
+
+    private static ConcurrentMap<String, List<Long>> SHARED_MAP_JDK8;
+
+    private static ConcurrentMap<String, List<Long>> SHARED_MAP_JDK17;
+
+    private static final String TEST_KEY = "testKey";
+    /**
+     * number of executions
+     * 100 K
+     */
+    private static final int REPEATED_TEST_NUM = 100_000;
+
 
     @Test
     public void testComputeIfAbsent() {
@@ -77,17 +88,6 @@ class ConcurrentHashMapUtilsTest {
     }
 
 
-    private static ConcurrentMap<String, List<Long>> SHARED_MAP_JDK8;
-
-    private static ConcurrentMap<String, List<Long>> SHARED_MAP_JDK17;
-
-    private static final String TEST_KEY = "testKey";
-    /**
-     * number of executions
-     * 100 K
-     */
-    private static final int REPEATED_TEST_NUM = 100_000;
-
     @BeforeAll
     public static void initSharedMap() {
         SHARED_MAP_JDK8 = new ConcurrentHashMap<>();
@@ -98,7 +98,6 @@ class ConcurrentHashMapUtilsTest {
     @EnabledForJreRange(max = org.junit.jupiter.api.condition.JRE.JAVA_8)
     @RepeatedTest(value = REPEATED_TEST_NUM)
     @Execution(ExecutionMode.CONCURRENT)
-    @DisplayName("ConcurrentHashMapUtils#computeIfAbsent for java8 thread safety test")
     public void threadSafetyOperatorForJava8Test() {
         ConcurrentHashMapUtils.computeIfAbsent(SHARED_MAP_JDK8, TEST_KEY, key -> new ArrayList<>(), list -> {
             list.add(System.currentTimeMillis());
@@ -107,7 +106,6 @@ class ConcurrentHashMapUtilsTest {
 
     @EnabledForJreRange(max = JRE.JAVA_17)
     @Execution(ExecutionMode.CONCURRENT)
-    @DisplayName("ConcurrentHashMapUtils#computeIfAbsent  for java17 thread safety test")
     @RepeatedTest(value = REPEATED_TEST_NUM)
     public void threadSafetyOperatorForJava17Test() {
         ConcurrentHashMapUtils.computeIfAbsent(SHARED_MAP_JDK17, TEST_KEY, key -> new ArrayList<>(), list -> {

--- a/dubbo-common/src/test/resources/junit-platform.properties
+++ b/dubbo-common/src/test/resources/junit-platform.properties
@@ -1,0 +1,6 @@
+junit.jupiter.execution.parallel.enabled = true
+junit.jupiter.execution.parallel.mode.default = concurrent
+
+# the maximum pool size can be configured using a ParallelExecutionConfigurationStrategy
+junit.jupiter.execution.parallel.config.strategy=fixed
+junit.jupiter.execution.parallel.config.fixed.parallelism=10

--- a/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/reference/ReferenceBeanManager.java
+++ b/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/reference/ReferenceBeanManager.java
@@ -69,7 +69,10 @@ public class ReferenceBeanManager implements ApplicationContextAware {
 
         if (!initialized) {
             // TODO add issue url to describe early initialization
-            logger.warn(CONFIG_DUBBO_BEAN_INITIALIZER, "", "",
+            logger.warn(
+                    CONFIG_DUBBO_BEAN_INITIALIZER,
+                    "",
+                    "",
                     "Early initialize reference bean before DubboConfigBeanInitializer,"
                             + " the BeanPostProcessor has not been loaded at this time, which may cause abnormalities in some components (such as seata): "
                             + referenceBeanName + " = "
@@ -82,10 +85,10 @@ public class ReferenceBeanManager implements ApplicationContextAware {
         ReferenceBean oldReferenceBean = referenceBeanMap.get(referenceBeanName);
         if (oldReferenceBean != null) {
             if (referenceBean != oldReferenceBean) {
-                String oldReferenceKey = ReferenceBeanSupport.generateReferenceKey(oldReferenceBean, applicationContext);
-                throw new IllegalStateException(
-                        "Found duplicated ReferenceBean with id: " + referenceBeanName + ", old: " + oldReferenceKey
-                                + ", new: " + referenceKey);
+                String oldReferenceKey =
+                        ReferenceBeanSupport.generateReferenceKey(oldReferenceBean, applicationContext);
+                throw new IllegalStateException("Found duplicated ReferenceBean with id: " + referenceBeanName
+                        + ", old: " + oldReferenceKey + ", new: " + referenceKey);
             }
             return;
         }

--- a/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/reference/ReferenceBeanManager.java
+++ b/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/reference/ReferenceBeanManager.java
@@ -25,20 +25,13 @@ import org.apache.dubbo.config.ReferenceConfig;
 import org.apache.dubbo.config.spring.ReferenceBean;
 import org.apache.dubbo.config.spring.util.DubboBeanUtils;
 import org.apache.dubbo.rpc.model.ModuleModel;
-
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
-
 import org.springframework.beans.BeansException;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
+
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 
 import static org.apache.dubbo.common.constants.LoggerCodeConstants.CONFIG_DUBBO_BEAN_INITIALIZER;
 
@@ -112,13 +105,13 @@ public class ReferenceBeanManager implements ApplicationContextAware {
     }
 
     public void registerReferenceKeyAndBeanName(String referenceKey, String referenceBeanNameOrAlias) {
-        List<String> list =
-                ConcurrentHashMapUtils.computeIfAbsent(referenceKeyMap, referenceKey, (key) -> new ArrayList<>());
-        if (!list.contains(referenceBeanNameOrAlias)) {
-            list.add(referenceBeanNameOrAlias);
-            // register bean name as alias
-            referenceAliasMap.put(referenceBeanNameOrAlias, list.get(0));
-        }
+        ConcurrentHashMapUtils.computeIfAbsent(referenceKeyMap, referenceKey, (key) -> new ArrayList<>(), list -> {
+            if (!list.contains(referenceBeanNameOrAlias)) {
+                list.add(referenceBeanNameOrAlias);
+                // register bean name as alias
+                referenceAliasMap.put(referenceBeanNameOrAlias, list.get(0));
+            }
+        });
     }
 
     public ReferenceBean getById(String referenceBeanNameOrAlias) {

--- a/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/reference/ReferenceBeanManager.java
+++ b/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/reference/ReferenceBeanManager.java
@@ -112,13 +112,17 @@ public class ReferenceBeanManager implements ApplicationContextAware {
     }
 
     public void registerReferenceKeyAndBeanName(String referenceKey, String referenceBeanNameOrAlias) {
-        ConcurrentHashMapUtils.computeIfAbsent(referenceKeyMap, referenceKey, (key) -> new ArrayList<>(), list -> {
-            if (!list.contains(referenceBeanNameOrAlias)) {
-                list.add(referenceBeanNameOrAlias);
-                // register bean name as alias
-                referenceAliasMap.put(referenceBeanNameOrAlias, list.get(0));
-            }
-        });
+        ConcurrentHashMapUtils.computeIfAbsent(
+                referenceKeyMap,
+                referenceKey,
+                (key) -> new ArrayList<>(),
+                list -> {
+                    if (!list.contains(referenceBeanNameOrAlias)) {
+                        list.add(referenceBeanNameOrAlias);
+                        // register bean name as alias
+                        referenceAliasMap.put(referenceBeanNameOrAlias, list.get(0));
+                    }
+                });
     }
 
     public ReferenceBean getById(String referenceBeanNameOrAlias) {

--- a/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/reference/ReferenceBeanManager.java
+++ b/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/reference/ReferenceBeanManager.java
@@ -26,10 +26,6 @@ import org.apache.dubbo.config.spring.ReferenceBean;
 import org.apache.dubbo.config.spring.util.DubboBeanUtils;
 import org.apache.dubbo.rpc.model.ModuleModel;
 
-import org.springframework.beans.BeansException;
-import org.springframework.context.ApplicationContext;
-import org.springframework.context.ApplicationContextAware;
-
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -40,9 +36,14 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
+import org.springframework.beans.BeansException;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+
 import static org.apache.dubbo.common.constants.LoggerCodeConstants.CONFIG_DUBBO_BEAN_INITIALIZER;
 
 public class ReferenceBeanManager implements ApplicationContextAware {
+
     public static final String BEAN_NAME = "dubboReferenceBeanManager";
     private final ErrorTypeAwareLogger logger = LoggerFactory.getErrorTypeAwareLogger(getClass());
 
@@ -68,14 +69,11 @@ public class ReferenceBeanManager implements ApplicationContextAware {
 
         if (!initialized) {
             // TODO add issue url to describe early initialization
-            logger.warn(
-                    CONFIG_DUBBO_BEAN_INITIALIZER,
-                    "",
-                    "",
+            logger.warn(CONFIG_DUBBO_BEAN_INITIALIZER, "", "",
                     "Early initialize reference bean before DubboConfigBeanInitializer,"
                             + " the BeanPostProcessor has not been loaded at this time, which may cause abnormalities in some components (such as seata): "
-                            + referenceBeanName
-                            + " = " + ReferenceBeanSupport.generateReferenceKey(referenceBean, applicationContext));
+                            + referenceBeanName + " = "
+                            + ReferenceBeanSupport.generateReferenceKey(referenceBean, applicationContext));
         }
         String referenceKey = getReferenceKeyByBeanName(referenceBeanName);
         if (StringUtils.isEmpty(referenceKey)) {
@@ -84,10 +82,10 @@ public class ReferenceBeanManager implements ApplicationContextAware {
         ReferenceBean oldReferenceBean = referenceBeanMap.get(referenceBeanName);
         if (oldReferenceBean != null) {
             if (referenceBean != oldReferenceBean) {
-                String oldReferenceKey =
-                        ReferenceBeanSupport.generateReferenceKey(oldReferenceBean, applicationContext);
-                throw new IllegalStateException("Found duplicated ReferenceBean with id: " + referenceBeanName
-                        + ", old: " + oldReferenceKey + ", new: " + referenceKey);
+                String oldReferenceKey = ReferenceBeanSupport.generateReferenceKey(oldReferenceBean, applicationContext);
+                throw new IllegalStateException(
+                        "Found duplicated ReferenceBean with id: " + referenceBeanName + ", old: " + oldReferenceKey
+                                + ", new: " + referenceKey);
             }
             return;
         }
@@ -112,17 +110,13 @@ public class ReferenceBeanManager implements ApplicationContextAware {
     }
 
     public void registerReferenceKeyAndBeanName(String referenceKey, String referenceBeanNameOrAlias) {
-        ConcurrentHashMapUtils.computeIfAbsent(
-                referenceKeyMap,
-                referenceKey,
-                (key) -> new ArrayList<>(),
-                list -> {
-                    if (!list.contains(referenceBeanNameOrAlias)) {
-                        list.add(referenceBeanNameOrAlias);
-                        // register bean name as alias
-                        referenceAliasMap.put(referenceBeanNameOrAlias, list.get(0));
-                    }
-                });
+        ConcurrentHashMapUtils.computeIfAbsent(referenceKeyMap, referenceKey, (key) -> new ArrayList<>(), list -> {
+            if (!list.contains(referenceBeanNameOrAlias)) {
+                list.add(referenceBeanNameOrAlias);
+                // register bean name as alias
+                referenceAliasMap.put(referenceBeanNameOrAlias, list.get(0));
+            }
+        });
     }
 
     public ReferenceBean getById(String referenceBeanNameOrAlias) {

--- a/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/reference/ReferenceBeanManager.java
+++ b/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/reference/ReferenceBeanManager.java
@@ -25,11 +25,18 @@ import org.apache.dubbo.config.ReferenceConfig;
 import org.apache.dubbo.config.spring.ReferenceBean;
 import org.apache.dubbo.config.spring.util.DubboBeanUtils;
 import org.apache.dubbo.rpc.model.ModuleModel;
+
 import org.springframework.beans.BeansException;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
@@ -40,16 +47,16 @@ public class ReferenceBeanManager implements ApplicationContextAware {
     private final ErrorTypeAwareLogger logger = LoggerFactory.getErrorTypeAwareLogger(getClass());
 
     // reference key -> reference bean names
-    private ConcurrentMap<String, List<String>> referenceKeyMap = new ConcurrentHashMap<>();
+    private final ConcurrentMap<String, List<String>> referenceKeyMap = new ConcurrentHashMap<>();
 
     // reference alias -> reference bean name
-    private ConcurrentMap<String, String> referenceAliasMap = new ConcurrentHashMap<>();
+    private final ConcurrentMap<String, String> referenceAliasMap = new ConcurrentHashMap<>();
 
     // reference bean name -> ReferenceBean
-    private ConcurrentMap<String, ReferenceBean> referenceBeanMap = new ConcurrentHashMap<>();
+    private final ConcurrentMap<String, ReferenceBean> referenceBeanMap = new ConcurrentHashMap<>();
 
     // reference key -> ReferenceConfig instance
-    private ConcurrentMap<String, ReferenceConfig> referenceConfigMap = new ConcurrentHashMap<>();
+    private final ConcurrentMap<String, ReferenceConfig> referenceConfigMap = new ConcurrentHashMap<>();
 
     private ApplicationContext applicationContext;
     private volatile boolean initialized = false;

--- a/pom.xml
+++ b/pom.xml
@@ -170,6 +170,10 @@
     <protobuf-protoc_version>3.22.3</protobuf-protoc_version>
     <grpc_version>1.54.0</grpc_version>
     <spotless-maven-plugin.version>2.44.3</spotless-maven-plugin.version>
+    <!-- use a lower version of this dependency to override the version
+     defined by spotless-maven-plugin.version to support JDK
+     versions ranging from 1.8 to 11. -->
+    <spotless-maven-plugin.lower.version>2.22.0</spotless-maven-plugin.lower.version>
     <dubbo-shared-resources.version>1.0.0</dubbo-shared-resources.version>
     <palantirJavaFormat.version>2.38.0</palantirJavaFormat.version>
     <revision>3.3.4-SNAPSHOT</revision>
@@ -813,12 +817,13 @@
     </profile>
 
     <profile>
-      <id>jdk9-jdk11-spotless</id>
+      <id>jdk8-jdk11-spotless</id>
       <activation>
         <jdk>[1.8, 11)</jdk>
       </activation>
       <properties>
         <palantirJavaFormat.version>1.1.0</palantirJavaFormat.version>
+        <spotless-maven-plugin.version>${spotless-maven-plugin.lower.version}</spotless-maven-plugin.version>
       </properties>
     </profile>
 


### PR DESCRIPTION
org.apache.dubbo.config.spring.reference.ReferenceBeanManager.java
```java   
    public void registerReferenceKeyAndBeanName(String referenceKey, String referenceBeanNameOrAlias) {
        List<String> list =
                ConcurrentHashMapUtils.computeIfAbsent(referenceKeyMap, referenceKey, (key) -> new ArrayList<>());
        if (!list.contains(referenceBeanNameOrAlias)) {
            list.add(referenceBeanNameOrAlias);
            // register bean name as alias
            referenceAliasMap.put(referenceBeanNameOrAlias, list.get(0));
        }
    }
```
The ConcurrentHashMapUtils.computeIfAbsent method ensures the creation of a new list in a thread-safe manner when no list exists for the given referenceKey. However, the subsequent operations if (!list.contains(referenceBeanNameOrAlias)) and list.add(referenceBeanNameOrAlias) are not atomic. This situation can lead to thread-safety issues where multiple threads might simultaneously pass the contains check and then all perform the add operation, resulting in duplicate referenceBeanNameOrAlias entries within the list.

To resolve this issue, I added an overloaded version of the computeIfAbsent method that allows for thread-safe operations on the value through the use of a Consumer<T> functional interface. Additionally, I provided concurrent unit tests:

* ConcurrentHashMapUtilsTest#threadSafetyOperatorForJava8Test
* ConcurrentHashMapUtilsTest#threadSafetyOperatorForJava17Test
These tests confirm the correctness of the implementation.

The profile defined here cannot run the `spotless plugin` in JDK 8 because the version of the Spotless plugin is too high. Therefore, I've overridden the version of the Spotless plugin in the jdk8 - jdk11 profile to make it compatible with the lower - version environment.  `spotless plugin` version 2.22.0 can work properly in JDK versions ranging from 8 to 11.
```xml
    <profile>
      <id>jdk9-jdk11-spotless</id>
      <activation>
        <jdk>[1.8, 11)</jdk>
      </activation>
      <properties>
        <palantirJavaFormat.version>1.1.0</palantirJavaFormat.version>
      </properties>
    </profile>
```

```xml

    <properties>
      <spotless-maven-plugin.lower.version>2.22.0</spotless-maven-plugin.lower.version>
    </properties>
    <profile>
      <id>jdk8-jdk11-spotless</id>
      <activation>
        <jdk>[1.8, 11)</jdk>
      </activation>
      <properties>
        <palantirJavaFormat.version>1.1.0</palantirJavaFormat.version>
        <spotless-maven-plugin.version>${spotless-maven-plugin.lower.version}</spotless-maven-plugin.version>
      </properties>
    </profile>
```
Use a lower version of the spotless-maven-plugin dependency to override the version defined by spotless-maven-plugin.version so as to support JDK 1.8.
