### PR TITLE
fix: getClassLoader() may return null

### DIFF
--- a/dubbo-serialization/dubbo-serialization-hessian2/src/main/java/org/apache/dubbo/common/serialize/hessian2/Hessian2SerializerFactory.java
+++ b/dubbo-serialization/dubbo-serialization-hessian2/src/main/java/org/apache/dubbo/common/serialize/hessian2/Hessian2SerializerFactory.java
@@ -25,7 +25,12 @@ public class Hessian2SerializerFactory extends SerializerFactory {
 
     @Override
     public ClassLoader getClassLoader() {
-        return Thread.currentThread().getContextClassLoader();
+        ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
+        if (contextClassLoader == null) {
+            throw new IllegalStateException("context class loader is null");
+        }
+
+        return contextClassLoader;
     }
 
 }


### PR DESCRIPTION
In the Java 8 + WAR + Tomcat runtime environment, when using CompletableFuture.runAsync() (which runs in ForkJoinPool), Thread.currentThread().getContextClassLoader() may return null.

Meanwhile, SerializerFactory#getClassFactory only creates a ClassFactory instance on its first invocation. If the first Dubbo call happens to be executed in ForkJoinPool, ClassFactory._loader will be initialized as null and will remain null permanently. As a result, all subsequent Dubbo calls will fail during deserialization (objects will be converted to HashMap).

Therefore, if classLoader is null at this point, it is better to throw an exception immediately to prevent ClassFactory from being initialized incorrectly.
