### PR TITLE
[3.3] Enable server socket reuseAddress option before binding

### DIFF
--- a/dubbo-common/src/test/java/org/apache/dubbo/common/utils/NetUtilsTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/utils/NetUtilsTest.java
@@ -387,6 +387,14 @@ class NetUtilsTest {
         }
     }
 
+    @Test
+    void testRepeatedStatusChecking() {
+        int port = NetUtils.getAvailablePort();
+        for (int i = 0; i < 10000; i++) {
+            assertFalse(NetUtils.isPortInUsed(port));
+        }
+    }
+
     private String getIgnoredInterfaces() {
         return SystemPropertyConfigUtils.getSystemProperty(
                 CommonConstants.DubboProperty.DUBBO_NETWORK_IGNORED_INTERFACE);

--- a/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/SimpleRegistryExporter.java
+++ b/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/SimpleRegistryExporter.java
@@ -25,6 +25,7 @@ import org.apache.dubbo.rpc.Protocol;
 import org.apache.dubbo.rpc.ProxyFactory;
 
 import java.io.IOException;
+import java.net.InetSocketAddress;
 import java.net.ServerSocket;
 
 import static org.apache.dubbo.common.constants.CommonConstants.CALLBACK_INSTANCES_LIMIT_KEY;
@@ -45,7 +46,13 @@ public class SimpleRegistryExporter {
 
     public static synchronized Exporter<RegistryService> exportIfAbsent(int port) {
         try {
-            new ServerSocket(port).close();
+            ServerSocket serverSocket = new ServerSocket();
+            if (NetUtils.isReuseAddressSupported()) {
+                // SO_REUSEADDR should be enabled before bind.
+                serverSocket.setReuseAddress(true);
+            }
+            serverSocket.bind(new InetSocketAddress(port));
+            serverSocket.close();
             return export(port);
         } catch (IOException e) {
             return null;

--- a/dubbo-remoting/dubbo-remoting-netty/src/main/java/org/apache/dubbo/remoting/transport/netty/NettyPortUnificationServer.java
+++ b/dubbo-remoting/dubbo-remoting-netty/src/main/java/org/apache/dubbo/remoting/transport/netty/NettyPortUnificationServer.java
@@ -101,6 +101,7 @@ public class NettyPortUnificationServer extends AbstractPortUnificationServer {
         // final Timer timer = new HashedWheelTimer(new NamedThreadFactory("NettyIdleTimer", true));
         bootstrap.setOption("child.tcpNoDelay", true);
         bootstrap.setOption("backlog", getUrl().getPositiveParameter(BACKLOG_KEY, Constants.DEFAULT_BACKLOG));
+        bootstrap.setOption("reuseAddress", true);
         bootstrap.setPipelineFactory(new ChannelPipelineFactory() {
             @Override
             public ChannelPipeline getPipeline() {

--- a/dubbo-remoting/dubbo-remoting-netty/src/main/java/org/apache/dubbo/remoting/transport/netty/NettyServer.java
+++ b/dubbo-remoting/dubbo-remoting-netty/src/main/java/org/apache/dubbo/remoting/transport/netty/NettyServer.java
@@ -84,6 +84,7 @@ public class NettyServer extends AbstractServer implements RemotingServer {
         // final Timer timer = new HashedWheelTimer(new NamedThreadFactory("NettyIdleTimer", true));
         bootstrap.setOption("child.tcpNoDelay", true);
         bootstrap.setOption("backlog", getUrl().getPositiveParameter(BACKLOG_KEY, Constants.DEFAULT_BACKLOG));
+        bootstrap.setOption("reuseAddress", true);
         bootstrap.setPipelineFactory(new ChannelPipelineFactory() {
             @Override
             public ChannelPipeline getPipeline() {

--- a/dubbo-remoting/dubbo-remoting-netty4/src/test/java/org/apache/dubbo/remoting/transport/netty4/NettyTransporterTest.java
+++ b/dubbo-remoting/dubbo-remoting-netty4/src/test/java/org/apache/dubbo/remoting/transport/netty4/NettyTransporterTest.java
@@ -32,6 +32,7 @@ import org.apache.dubbo.rpc.model.ModuleModel;
 
 import java.util.concurrent.CountDownLatch;
 
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import static org.apache.dubbo.common.constants.CommonConstants.EXECUTOR_MANAGEMENT_MODE_DEFAULT;
@@ -59,6 +60,7 @@ class NettyTransporterTest {
         RemotingServer server = new NettyTransporter().bind(url, new ChannelHandlerAdapter());
 
         assertThat(server.isBound(), is(true));
+        Assertions.assertNotEquals(port, NetUtils.getAvailablePort(port));
     }
 
     @Test

--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/TriplePathResolver.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/TriplePathResolver.java
@@ -28,7 +28,7 @@ import java.util.Map;
 
 public class TriplePathResolver implements PathResolver {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(TripleProtocol.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(TriplePathResolver.class);
 
     private final Map<String, Invoker<?>> mapping = CollectionUtils.newConcurrentHashMap();
     private final Map<String, Boolean> nativeStubs = CollectionUtils.newConcurrentHashMap();


### PR DESCRIPTION
## What is the purpose of the change?
try to fix #15238 
sometimes the port got from NetUtils#getAvailablePort could not be bound directly because the port status is still TIME-WAIT as getAvailablePort closed it without setting SO_REUSEADDR option.

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Make sure gitHub actions can pass. [Why the workflow is failing and how to fix it?](../CONTRIBUTING.md)
