### PR TITLE
[3.3] optimized testExporterThreadpoolName by starting dispatcher thread directly

### DIFF
--- a/dubbo-metrics/dubbo-metrics-prometheus/src/test/java/org/apache/dubbo/metrics/prometheus/PrometheusMetricsThreadPoolTest.java
+++ b/dubbo-metrics/dubbo-metrics-prometheus/src/test/java/org/apache/dubbo/metrics/prometheus/PrometheusMetricsThreadPoolTest.java
@@ -100,11 +100,6 @@ public class PrometheusMetricsThreadPoolTest {
         PrometheusMetricsReporter reporter = new PrometheusMetricsReporter(metricsConfig.toUrl(), applicationModel);
         reporter.init();
         exportHttpServer(reporter, port);
-        try {
-            Thread.sleep(5000);
-        } catch (InterruptedException e) {
-            throw new RuntimeException(e);
-        }
         if (metricsConfig.getEnableThreadpool()) {
             metricsCollector.registryDefaultSample();
         }
@@ -135,8 +130,8 @@ public class PrometheusMetricsThreadPoolTest {
                     os.write(response.getBytes());
                 }
             });
-            Thread httpServerThread = new Thread(prometheusExporterHttpServer::start);
-            httpServerThread.start();
+            // start ServerImpl dispatcher thread.
+            prometheusExporterHttpServer.start();
         } catch (IOException e) {
             throw new RuntimeException(e);
         }


### PR DESCRIPTION
## What is the purpose of the change?
remove redundant thread creating and time waiting. 
see details at https://github.com/apache/dubbo/actions/runs/13841589593/job/38730837928
![image](https://github.com/user-attachments/assets/f899bf63-3564-4444-bc30-6570382dbf68)

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Make sure gitHub actions can pass. [Why the workflow is failing and how to fix it?](../CONTRIBUTING.md)
