### PR TITLE
Early decode x509 certificate when connection established

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/ssl/DubboX509Certificate.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/ssl/DubboX509Certificate.java
@@ -1,0 +1,230 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.common.ssl;
+
+import javax.security.auth.x500.X500Principal;
+
+import java.io.ByteArrayInputStream;
+import java.math.BigInteger;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.security.NoSuchProviderException;
+import java.security.Principal;
+import java.security.Provider;
+import java.security.PublicKey;
+import java.security.SignatureException;
+import java.security.cert.CertificateEncodingException;
+import java.security.cert.CertificateException;
+import java.security.cert.CertificateExpiredException;
+import java.security.cert.CertificateFactory;
+import java.security.cert.CertificateNotYetValidException;
+import java.security.cert.CertificateParsingException;
+import java.security.cert.X509Certificate;
+import java.util.Collection;
+import java.util.Date;
+import java.util.List;
+import java.util.Set;
+
+public class DubboX509Certificate extends X509Certificate {
+
+    static final CertificateFactory X509_CERT_FACTORY;
+
+    static {
+        CertificateFactory certificateFactory = null;
+        try {
+            certificateFactory = CertificateFactory.getInstance("X.509");
+        } catch (CertificateException e) {
+            //            throw new ExceptionInInitializerError(e);
+        }
+        X509_CERT_FACTORY = certificateFactory;
+    }
+
+    private final X509Certificate wrapped;
+
+    public DubboX509Certificate(byte[] bytes) {
+        try {
+            this.wrapped = (X509Certificate) X509_CERT_FACTORY.generateCertificate(new ByteArrayInputStream(bytes));
+        } catch (CertificateException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    @Override
+    public void checkValidity() throws CertificateExpiredException, CertificateNotYetValidException {
+        wrapped.checkValidity();
+    }
+
+    @Override
+    public void checkValidity(Date date) throws CertificateExpiredException, CertificateNotYetValidException {
+        wrapped.checkValidity(date);
+    }
+
+    @Override
+    public X500Principal getIssuerX500Principal() {
+        return wrapped.getIssuerX500Principal();
+    }
+
+    @Override
+    public X500Principal getSubjectX500Principal() {
+        return wrapped.getSubjectX500Principal();
+    }
+
+    @Override
+    public List<String> getExtendedKeyUsage() throws CertificateParsingException {
+        return wrapped.getExtendedKeyUsage();
+    }
+
+    @Override
+    public Collection<List<?>> getSubjectAlternativeNames() throws CertificateParsingException {
+        return wrapped.getSubjectAlternativeNames();
+    }
+
+    @Override
+    public Collection<List<?>> getIssuerAlternativeNames() throws CertificateParsingException {
+        return wrapped.getIssuerAlternativeNames();
+    }
+
+    @Override
+    public void verify(PublicKey key, Provider sigProvider)
+            throws CertificateException, NoSuchAlgorithmException, InvalidKeyException, SignatureException {
+        wrapped.verify(key, sigProvider);
+    }
+
+    @Override
+    public int getVersion() {
+        return wrapped.getVersion();
+    }
+
+    @Override
+    public BigInteger getSerialNumber() {
+        return wrapped.getSerialNumber();
+    }
+
+    @Override
+    public Principal getIssuerDN() {
+        return wrapped.getIssuerDN();
+    }
+
+    @Override
+    public Principal getSubjectDN() {
+        return wrapped.getSubjectDN();
+    }
+
+    @Override
+    public Date getNotBefore() {
+        return wrapped.getNotBefore();
+    }
+
+    @Override
+    public Date getNotAfter() {
+        return wrapped.getNotAfter();
+    }
+
+    @Override
+    public byte[] getTBSCertificate() throws CertificateEncodingException {
+        return wrapped.getTBSCertificate();
+    }
+
+    @Override
+    public byte[] getSignature() {
+        return wrapped.getSignature();
+    }
+
+    @Override
+    public String getSigAlgName() {
+        return wrapped.getSigAlgName();
+    }
+
+    @Override
+    public String getSigAlgOID() {
+        return wrapped.getSigAlgOID();
+    }
+
+    @Override
+    public byte[] getSigAlgParams() {
+        return wrapped.getSigAlgParams();
+    }
+
+    @Override
+    public boolean[] getIssuerUniqueID() {
+        return wrapped.getIssuerUniqueID();
+    }
+
+    @Override
+    public boolean[] getSubjectUniqueID() {
+        return wrapped.getSubjectUniqueID();
+    }
+
+    @Override
+    public boolean[] getKeyUsage() {
+        return wrapped.getKeyUsage();
+    }
+
+    @Override
+    public int getBasicConstraints() {
+        return wrapped.getBasicConstraints();
+    }
+
+    @Override
+    public byte[] getEncoded() throws CertificateEncodingException {
+        return wrapped.getEncoded();
+    }
+
+    @Override
+    public void verify(PublicKey key)
+            throws CertificateException, NoSuchAlgorithmException, InvalidKeyException, NoSuchProviderException,
+                    SignatureException {
+        wrapped.verify(key);
+    }
+
+    @Override
+    public void verify(PublicKey key, String sigProvider)
+            throws CertificateException, NoSuchAlgorithmException, InvalidKeyException, NoSuchProviderException,
+                    SignatureException {
+        wrapped.verify(key, sigProvider);
+    }
+
+    @Override
+    public String toString() {
+        return wrapped.toString();
+    }
+
+    @Override
+    public PublicKey getPublicKey() {
+        return wrapped.getPublicKey();
+    }
+
+    @Override
+    public boolean hasUnsupportedCriticalExtension() {
+        return wrapped.hasUnsupportedCriticalExtension();
+    }
+
+    @Override
+    public Set<String> getCriticalExtensionOIDs() {
+        return wrapped.getCriticalExtensionOIDs();
+    }
+
+    @Override
+    public Set<String> getNonCriticalExtensionOIDs() {
+        return wrapped.getNonCriticalExtensionOIDs();
+    }
+
+    @Override
+    public byte[] getExtensionValue(String oid) {
+        return wrapped.getExtensionValue(oid);
+    }
+}

--- a/dubbo-remoting/dubbo-remoting-netty4/src/main/java/org/apache/dubbo/remoting/transport/netty4/NettyPortUnificationServerHandler.java
+++ b/dubbo-remoting/dubbo-remoting-netty4/src/main/java/org/apache/dubbo/remoting/transport/netty4/NettyPortUnificationServerHandler.java
@@ -21,6 +21,7 @@ import org.apache.dubbo.common.io.Bytes;
 import org.apache.dubbo.common.logger.ErrorTypeAwareLogger;
 import org.apache.dubbo.common.logger.LoggerFactory;
 import org.apache.dubbo.common.ssl.CertManager;
+import org.apache.dubbo.common.ssl.DubboX509Certificate;
 import org.apache.dubbo.common.ssl.ProviderCert;
 import org.apache.dubbo.remoting.ChannelHandler;
 import org.apache.dubbo.remoting.Constants;
@@ -31,6 +32,8 @@ import org.apache.dubbo.remoting.transport.netty4.ssl.SslContexts;
 
 import javax.net.ssl.SSLSession;
 
+import java.security.cert.Certificate;
+import java.security.cert.X509Certificate;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -92,6 +95,7 @@ public class NettyPortUnificationServerHandler extends ByteToMessageDecoder {
                 SSLSession session =
                         ctx.pipeline().get(SslHandler.class).engine().getSession();
                 LOGGER.info("TLS negotiation succeed with session: " + session);
+                tryExactCerts(session);
                 ctx.channel().attr(SSL_SESSION_KEY).set(session);
             } else {
                 LOGGER.error(
@@ -104,6 +108,18 @@ public class NettyPortUnificationServerHandler extends ByteToMessageDecoder {
             }
         }
         super.userEventTriggered(ctx, evt);
+    }
+
+    private static void tryExactCerts(SSLSession session) {
+        try {
+            Certificate[] originCerts = session.getPeerCertificates();
+            X509Certificate[] decodedCerts = new X509Certificate[originCerts.length];
+            for (int i = 0; i < originCerts.length; i++) {
+                decodedCerts[i] = new DubboX509Certificate(originCerts[i].getEncoded());
+            }
+            session.putValue("decodedCerts", decodedCerts);
+        } catch (Throwable ignore) {
+        }
     }
 
     @Override

--- a/dubbo-remoting/dubbo-remoting-netty4/src/main/java/org/apache/dubbo/remoting/transport/netty4/ssl/SslClientTlsHandler.java
+++ b/dubbo-remoting/dubbo-remoting-netty4/src/main/java/org/apache/dubbo/remoting/transport/netty4/ssl/SslClientTlsHandler.java
@@ -19,10 +19,14 @@ package org.apache.dubbo.remoting.transport.netty4.ssl;
 import org.apache.dubbo.common.URL;
 import org.apache.dubbo.common.logger.ErrorTypeAwareLogger;
 import org.apache.dubbo.common.logger.LoggerFactory;
+import org.apache.dubbo.common.ssl.DubboX509Certificate;
 import org.apache.dubbo.remoting.Constants;
 
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLSession;
+
+import java.security.cert.Certificate;
+import java.security.cert.X509Certificate;
 
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
@@ -61,6 +65,7 @@ public class SslClientTlsHandler extends ChannelInboundHandlerAdapter {
                 SSLSession session =
                         ctx.pipeline().get(SslHandler.class).engine().getSession();
                 logger.info("TLS negotiation succeed with: " + session.getPeerHost());
+                tryExactCerts(session);
                 ctx.pipeline().remove(this);
                 ctx.channel().attr(SSL_SESSION_KEY).set(session);
             } else {
@@ -72,6 +77,18 @@ public class SslClientTlsHandler extends ChannelInboundHandlerAdapter {
                         handshakeEvent.cause());
                 ctx.fireExceptionCaught(handshakeEvent.cause());
             }
+        }
+    }
+
+    private static void tryExactCerts(SSLSession session) {
+        try {
+            Certificate[] originCerts = session.getPeerCertificates();
+            X509Certificate[] decodedCerts = new X509Certificate[originCerts.length];
+            for (int i = 0; i < originCerts.length; i++) {
+                decodedCerts[i] = new DubboX509Certificate(originCerts[i].getEncoded());
+            }
+            session.putValue("decodedCerts", decodedCerts);
+        } catch (Throwable ignore) {
         }
     }
 }

--- a/dubbo-remoting/dubbo-remoting-netty4/src/main/java/org/apache/dubbo/remoting/transport/netty4/ssl/SslServerTlsHandler.java
+++ b/dubbo-remoting/dubbo-remoting-netty4/src/main/java/org/apache/dubbo/remoting/transport/netty4/ssl/SslServerTlsHandler.java
@@ -21,11 +21,14 @@ import org.apache.dubbo.common.logger.ErrorTypeAwareLogger;
 import org.apache.dubbo.common.logger.LoggerFactory;
 import org.apache.dubbo.common.ssl.AuthPolicy;
 import org.apache.dubbo.common.ssl.CertManager;
+import org.apache.dubbo.common.ssl.DubboX509Certificate;
 import org.apache.dubbo.common.ssl.ProviderCert;
 import org.apache.dubbo.remoting.Constants;
 
 import javax.net.ssl.SSLSession;
 
+import java.security.cert.Certificate;
+import java.security.cert.X509Certificate;
 import java.util.List;
 
 import io.netty.buffer.ByteBuf;
@@ -75,6 +78,7 @@ public class SslServerTlsHandler extends ByteToMessageDecoder {
                 SSLSession session =
                         ctx.pipeline().get(SslHandler.class).engine().getSession();
                 logger.info("TLS negotiation succeed with: " + session.getPeerHost());
+                tryExactCerts(session);
                 // Remove after handshake success.
                 ctx.pipeline().remove(this);
                 ctx.channel().attr(SSL_SESSION_KEY).set(session);
@@ -89,6 +93,18 @@ public class SslServerTlsHandler extends ByteToMessageDecoder {
             }
         }
         super.userEventTriggered(ctx, evt);
+    }
+
+    private static void tryExactCerts(SSLSession session) {
+        try {
+            Certificate[] originCerts = session.getPeerCertificates();
+            X509Certificate[] decodedCerts = new X509Certificate[originCerts.length];
+            for (int i = 0; i < originCerts.length; i++) {
+                decodedCerts[i] = new DubboX509Certificate(originCerts[i].getEncoded());
+            }
+            session.putValue("decodedCerts", decodedCerts);
+        } catch (Throwable ignore) {
+        }
     }
 
     @Override


### PR DESCRIPTION
## What is the purpose of the change?

- Certificate in SSLSession is `javax.security.cert.X509Certificate` and cannot load properties like SANs
- Only `java.security.cert.X509Certificate` support get custom properties
- Try load `org.apache.dubbo.common.ssl.DubboX509Certificate` when connection established

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Make sure gitHub actions can pass. [Why the workflow is failing and how to fix it?](../CONTRIBUTING.md)
