### PR TITLE
Optimize GitHub Action to Retrieve target/logs/ Files

### DIFF
--- a/.github/workflows/build-and-test-pr.yml
+++ b/.github/workflows/build-and-test-pr.yml
@@ -350,6 +350,12 @@ jobs:
         with:
           name: samples-test-result-${{matrix.job_id}}
           path: test/jobs/*-result*
+      - name: "Upload test logs"
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: samples-test-logs-${{matrix.job_id}}
+          path: test/logs/*
   samples-test-result:
     needs: [check-format, samples-test-job]
     if: always()
@@ -453,6 +459,12 @@ jobs:
         with:
           name: test-result-${{matrix.job_id}}
           path: test/jobs/*-result*
+      - name: "Upload test logs"
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: integration-test-logs-${{matrix.job_id}}
+          path: test/logs/*
   integration-test-result:
     needs: [check-format, integration-test-job]
     if: always()

--- a/.github/workflows/build-and-test-scheduled-3.1.yml
+++ b/.github/workflows/build-and-test-scheduled-3.1.yml
@@ -293,6 +293,12 @@ jobs:
           cd test && bash ./build-test-image.sh
       - name: "Run tests"
         run: cd test && bash ./run-tests.sh
+      - name: "Upload test logs"
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: samples-test-logs-${{matrix.jdk}}-${{matrix.job_id}}
+          path: test/logs/*
       - name: "Upload test result"
         if: always()
         uses: actions/upload-artifact@v4
@@ -392,6 +398,12 @@ jobs:
           cd test && bash ./build-test-image.sh
       - name: "Run tests"
         run: cd test && bash ./run-tests.sh
+      - name: "Upload test logs"
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: integration-test-logs-${{matrix.jdk}}-${{matrix.job_id}}
+          path: test/logs/*
       - name: "Upload test result"
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build-and-test-scheduled-3.2.yml
+++ b/.github/workflows/build-and-test-scheduled-3.2.yml
@@ -293,6 +293,12 @@ jobs:
           cd test && bash ./build-test-image.sh
       - name: "Run tests"
         run: cd test && bash ./run-tests.sh
+      - name: "Upload test logs"
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: samples-test-logs-${{matrix.jdk}}-${{matrix.job_id}}
+          path: test/logs/*
       - name: "Upload test result"
         if: always()
         uses: actions/upload-artifact@v4
@@ -392,6 +398,12 @@ jobs:
           cd test && bash ./build-test-image.sh
       - name: "Run tests"
         run: cd test && bash ./run-tests.sh
+      - name: "Upload test logs"
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: integration-test-logs-${{matrix.jdk}}-${{matrix.job_id}}
+          path: test/logs/*
       - name: "Upload test result"
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build-and-test-scheduled-3.3.yml
+++ b/.github/workflows/build-and-test-scheduled-3.3.yml
@@ -293,6 +293,12 @@ jobs:
           cd test && bash ./build-test-image.sh
       - name: "Run tests"
         run: cd test && bash ./run-tests.sh
+      - name: "Upload test logs"
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: samples-test-logs-${{matrix.jdk}}-${{matrix.job_id}}
+          path: test/logs/*
       - name: "Upload test result"
         if: always()
         uses: actions/upload-artifact@v4
@@ -392,6 +398,12 @@ jobs:
           cd test && bash ./build-test-image.sh
       - name: "Run tests"
         run: cd test && bash ./run-tests.sh
+      - name: "Upload test logs"
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: integration-test-logs-${{matrix.jdk}}-${{matrix.job_id}}
+          path: test/logs/*
       - name: "Upload test result"
         if: always()
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## What is the purpose of the change?

upload artifacts for logs
This is a solution for issue #15234 
After this PR, we can download runtime logs at step `Upload test logs`
## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Make sure gitHub actions can pass. [Why the workflow is failing and how to fix it?](../CONTRIBUTING.md)
