### PR TITLE
Optimize scheduled register

### DIFF
--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/AbstractServiceDiscovery.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/AbstractServiceDiscovery.java
@@ -196,6 +196,7 @@ public abstract class AbstractServiceDiscovery implements ServiceDiscovery {
         ServiceInstance oldServiceInstance = this.serviceInstance;
         DefaultServiceInstance newServiceInstance =
                 new DefaultServiceInstance((DefaultServiceInstance) oldServiceInstance);
+        newServiceInstance.setServiceMetadata(oldServiceInstance.getServiceMetadata().clone());
         boolean revisionUpdated = calOrUpdateInstanceRevision(newServiceInstance);
         if (revisionUpdated) {
             logger.info(String.format(
@@ -348,8 +349,6 @@ public abstract class AbstractServiceDiscovery implements ServiceDiscovery {
      */
     protected void doUpdate(ServiceInstance oldServiceInstance, ServiceInstance newServiceInstance) {
         this.doUnregister(oldServiceInstance);
-
-        this.serviceInstance = newServiceInstance;
 
         if (!EMPTY_REVISION.equals(getExportedServicesRevision(newServiceInstance))) {
             reportMetadata(newServiceInstance.getServiceMetadata());

--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/AbstractServiceDiscovery.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/AbstractServiceDiscovery.java
@@ -196,7 +196,8 @@ public abstract class AbstractServiceDiscovery implements ServiceDiscovery {
         ServiceInstance oldServiceInstance = this.serviceInstance;
         DefaultServiceInstance newServiceInstance =
                 new DefaultServiceInstance((DefaultServiceInstance) oldServiceInstance);
-        newServiceInstance.setServiceMetadata(oldServiceInstance.getServiceMetadata().clone());
+        newServiceInstance.setServiceMetadata(
+                oldServiceInstance.getServiceMetadata().clone());
         boolean revisionUpdated = calOrUpdateInstanceRevision(newServiceInstance);
         if (revisionUpdated) {
             logger.info(String.format(

--- a/dubbo-registry/dubbo-registry-api/src/test/java/org/apache/dubbo/registry/client/ServiceDiscoveryCacheTest.java
+++ b/dubbo-registry/dubbo-registry-api/src/test/java/org/apache/dubbo/registry/client/ServiceDiscoveryCacheTest.java
@@ -29,6 +29,7 @@ import java.util.Objects;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
 import org.mockito.Mockito;
 
 import static org.apache.dubbo.common.constants.CommonConstants.METADATA_INFO_CACHE_EXPIRE_KEY;
@@ -119,6 +120,41 @@ class ServiceDiscoveryCacheTest {
 
         Thread.sleep(100);
         Assertions.assertDoesNotThrow(mockServiceDiscovery::update);
+
+        applicationModel.destroy();
+    }
+
+    @Test
+    void testRetryWhenUpdateFailed() {
+        ApplicationModel applicationModel = FrameworkModel.defaultModel().newApplication();
+        applicationModel.getApplicationConfigManager().setApplication(new ApplicationConfig("Test"));
+
+        URL registryUrl = URL.valueOf("mock://127.0.0.1:12345").addParameter(METADATA_INFO_CACHE_EXPIRE_KEY, 10);
+        MockServiceDiscovery mockServiceDiscovery =
+                Mockito.spy(new MockServiceDiscovery(applicationModel, registryUrl));
+
+        mockServiceDiscovery.register(URL.valueOf("mock://127.0.0.1:12345")
+                .setServiceInterface("org.apache.dubbo.registry.service.DemoService"));
+
+        Mockito.doNothing().when(mockServiceDiscovery).doRegister(Mockito.any(ServiceInstance.class));
+        // first time
+        Assertions.assertDoesNotThrow(() -> mockServiceDiscovery.register());
+
+        mockServiceDiscovery.register(URL.valueOf("mock://127.0.0.1:12345")
+                .setServiceInterface("org.apache.dubbo.registry.service.TestService"));
+
+        Mockito.doThrow(new RuntimeException())
+                .when(mockServiceDiscovery)
+                .reportMetadata(Mockito.any(MetadataInfo.class));
+        Assertions.assertThrows(RuntimeException.class, mockServiceDiscovery::update);
+
+        Mockito.verify(mockServiceDiscovery, Mockito.times(1)).doUpdate(Mockito.any(ServiceInstance.class), Mockito.any(ServiceInstance.class));
+
+        Mockito.doNothing().when(mockServiceDiscovery).reportMetadata(Mockito.any(MetadataInfo.class));
+        // second time
+        Assertions.assertDoesNotThrow(mockServiceDiscovery::update);
+
+        Mockito.verify(mockServiceDiscovery, Mockito.times(2)).doUpdate(Mockito.any(ServiceInstance.class), Mockito.any(ServiceInstance.class));
 
         applicationModel.destroy();
     }

--- a/dubbo-registry/dubbo-registry-api/src/test/java/org/apache/dubbo/registry/client/ServiceDiscoveryCacheTest.java
+++ b/dubbo-registry/dubbo-registry-api/src/test/java/org/apache/dubbo/registry/client/ServiceDiscoveryCacheTest.java
@@ -29,7 +29,6 @@ import java.util.Objects;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.function.Executable;
 import org.mockito.Mockito;
 
 import static org.apache.dubbo.common.constants.CommonConstants.METADATA_INFO_CACHE_EXPIRE_KEY;

--- a/dubbo-registry/dubbo-registry-api/src/test/java/org/apache/dubbo/registry/client/ServiceDiscoveryCacheTest.java
+++ b/dubbo-registry/dubbo-registry-api/src/test/java/org/apache/dubbo/registry/client/ServiceDiscoveryCacheTest.java
@@ -156,6 +156,10 @@ class ServiceDiscoveryCacheTest {
 
         Mockito.verify(mockServiceDiscovery, Mockito.times(2)).doUpdate(Mockito.any(ServiceInstance.class), Mockito.any(ServiceInstance.class));
 
+        Assertions.assertDoesNotThrow(mockServiceDiscovery::update);
+        // if update success, revision won't changed when next scheduled time, so doUpdate will not be called
+        Mockito.verify(mockServiceDiscovery, Mockito.times(2)).doUpdate(Mockito.any(ServiceInstance.class), Mockito.any(ServiceInstance.class));
+
         applicationModel.destroy();
     }
 }

--- a/dubbo-registry/dubbo-registry-api/src/test/java/org/apache/dubbo/registry/client/ServiceDiscoveryCacheTest.java
+++ b/dubbo-registry/dubbo-registry-api/src/test/java/org/apache/dubbo/registry/client/ServiceDiscoveryCacheTest.java
@@ -147,17 +147,20 @@ class ServiceDiscoveryCacheTest {
                 .reportMetadata(Mockito.any(MetadataInfo.class));
         Assertions.assertThrows(RuntimeException.class, mockServiceDiscovery::update);
 
-        Mockito.verify(mockServiceDiscovery, Mockito.times(1)).doUpdate(Mockito.any(ServiceInstance.class), Mockito.any(ServiceInstance.class));
+        Mockito.verify(mockServiceDiscovery, Mockito.times(1))
+                .doUpdate(Mockito.any(ServiceInstance.class), Mockito.any(ServiceInstance.class));
 
         Mockito.doNothing().when(mockServiceDiscovery).reportMetadata(Mockito.any(MetadataInfo.class));
         // second time
         Assertions.assertDoesNotThrow(mockServiceDiscovery::update);
 
-        Mockito.verify(mockServiceDiscovery, Mockito.times(2)).doUpdate(Mockito.any(ServiceInstance.class), Mockito.any(ServiceInstance.class));
+        Mockito.verify(mockServiceDiscovery, Mockito.times(2))
+                .doUpdate(Mockito.any(ServiceInstance.class), Mockito.any(ServiceInstance.class));
 
         Assertions.assertDoesNotThrow(mockServiceDiscovery::update);
         // if update success, revision won't changed when next scheduled time, so doUpdate will not be called
-        Mockito.verify(mockServiceDiscovery, Mockito.times(2)).doUpdate(Mockito.any(ServiceInstance.class), Mockito.any(ServiceInstance.class));
+        Mockito.verify(mockServiceDiscovery, Mockito.times(2))
+                .doUpdate(Mockito.any(ServiceInstance.class), Mockito.any(ServiceInstance.class));
 
         applicationModel.destroy();
     }


### PR DESCRIPTION
## What is the purpose of the change?
Due to the early update of the revision, scheduled tasks will no longer call doUpdate retry after reporting metadata or registration failure.

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Make sure gitHub actions can pass. [Why the workflow is failing and how to fix it?](../CONTRIBUTING.md)
