### PR TITLE
[3.3] Optimized testReadByte of FastJson2SerializationTest

### DIFF
--- a/dubbo-serialization/dubbo-serialization-fastjson2/src/test/java/org/apache/dubbo/common/serialize/fastjson2/FastJson2SerializationTest.java
+++ b/dubbo-serialization/dubbo-serialization-fastjson2/src/test/java/org/apache/dubbo/common/serialize/fastjson2/FastJson2SerializationTest.java
@@ -27,7 +27,7 @@ import org.apache.dubbo.rpc.model.FrameworkModel;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.util.Date;
+import java.time.LocalDate;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -227,7 +227,8 @@ public class FastJson2SerializationTest {
         {
             ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
             ObjectOutput objectOutput = serialization.serialize(url, outputStream);
-            objectOutput.writeObject(new Date());
+            // fastjson2 could not read byte from the serialization of LocalDate by now. 2025/04/02
+            objectOutput.writeObject(LocalDate.now());
             objectOutput.flushBuffer();
 
             byte[] bytes = outputStream.toByteArray();


### PR DESCRIPTION
## What is the purpose of the change?
the milliseconds of variable date that used by testReadByte should not be zero, otherwise the output could be read as byte which will cause ```Assertions.assertThrows(IOException.class, objectInput::readByte)``` failure.
```
Error:  Tests run: 8, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 1.454 s <<< FAILURE! -- in org.apache.dubbo.common.serialize.fastjson2.FastJson2SerializationTest
Error:  org.apache.dubbo.common.serialize.fastjson2.FastJson2SerializationTest.testReadByte -- Time elapsed: 0.063 s <<< FAILURE!
org.opentest4j.AssertionFailedError: Expected java.io.IOException to be thrown, but nothing was thrown.
	at org.junit.jupiter.api.AssertionFailureBuilder.build(AssertionFailureBuilder.java:152)
	at org.junit.jupiter.api.AssertThrows.assertThrows(AssertThrows.java:73)
	at org.junit.jupiter.api.AssertThrows.assertThrows(AssertThrows.java:35)
	at org.junit.jupiter.api.Assertions.assertThrows(Assertions.java:3128)
	at org.apache.dubbo.common.serialize.fastjson2.FastJson2SerializationTest.testReadByte(FastJson2SerializationTest.java:236)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at java.util.ArrayList.forEach(ArrayList.java:1259)
	at java.util.ArrayList.forEach(ArrayList.java:1259)
```

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Make sure gitHub actions can pass. [Why the workflow is failing and how to fix it?](../CONTRIBUTING.md)
