### PR TITLE
fix: Fix the issue of HTTP calling 404 when the first letter of RPC

### DIFF
--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/rest/mapping/DefaultRequestMappingRegistry.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/rest/mapping/DefaultRequestMappingRegistry.java
@@ -130,6 +130,12 @@ public final class DefaultRequestMappingRegistry implements RequestMappingRegist
                 consumer.accept((methods) -> {
                     Method method = methods.get(0);
                     MethodDescriptor md = sd.getMethod(method.getName(), method.getParameterTypes());
+                    if (md == null) {
+                        String originMethodName = method.getName();
+                        String upperMethod =
+                                Character.toUpperCase(originMethodName.charAt(0)) + originMethodName.substring(1);
+                        md = sd.getMethod(upperMethod, method.getParameterTypes());
+                    }
                     MethodMeta methodMeta = new MethodMeta(methods, md, serviceMeta);
                     if (!resolver.accept(methodMeta)) {
                         return;


### PR DESCRIPTION
method name in proto is capitalized (#15291)

## What is the purpose of the change?
Fix the issue of HTTP calling 404 when the first letter of RPC method name in proto is capitalized （#15291)

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Make sure gitHub actions can pass. [Why the workflow is failing and how to fix it?](../CONTRIBUTING.md)
