### PR TITLE
fix: apply dynamic config in routing by merging override and consumer URLs

### DIFF
--- a/.github/workflows/build-and-test-pr.yml
+++ b/.github/workflows/build-and-test-pr.yml
@@ -289,7 +289,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 90
     env:
-      JAVA_VER: 8
+      JAVA_VER: 17
       TEST_CASE_FILE: jobs/testjob_${{matrix.job_id}}.txt
     strategy:
       fail-fast: false
@@ -323,11 +323,11 @@ jobs:
         with:
           name: samples-test-list
           path: test/jobs/
-      - name: "Set up JDK 8"
+      - name: "Set up JDK 17"
         uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
-          java-version: 8
+          java-version: 17
       - name: "Init Candidate Versions"
         run: |
           DUBBO_VERSION="${{needs.build-source.outputs.version}}"
@@ -355,7 +355,7 @@ jobs:
     if: always()
     runs-on: ubuntu-latest
     env:
-      JAVA_VER: 8
+      JAVA_VER: 17
     steps:
       - uses: actions/checkout@v4
         with:
@@ -392,7 +392,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 90
     env:
-      JAVA_VER: 8
+      JAVA_VER: 17
       TEST_CASE_FILE: jobs/testjob_${{matrix.job_id}}.txt
     strategy:
       fail-fast: false
@@ -430,7 +430,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
-          java-version: 8
+          java-version: 17
       - name: "Init Candidate Versions"
         run: |
           DUBBO_VERSION="${{needs.build-source.outputs.version}}"
@@ -458,7 +458,7 @@ jobs:
     if: always()
     runs-on: ubuntu-latest
     env:
-      JAVA_VER: 8
+      JAVA_VER: 17
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/build-and-test-scheduled-3.1.yml
+++ b/.github/workflows/build-and-test-scheduled-3.1.yml
@@ -43,7 +43,7 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
-          java-version: 8
+          java-version: 17
       - uses: actions/cache@v3
         name: "Cache local Maven repository"
         with:
@@ -251,7 +251,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        jdk: [ 8, 11 ]
+        jdk: [ 8, 11, 17, 21 ]
         job_id: [1, 2, 3, 4, 5]
     steps:
       - uses: actions/checkout@v4
@@ -307,7 +307,7 @@ jobs:
       JAVA_VER: ${{matrix.jdk}}
     strategy:
       matrix:
-        jdk: [ 8, 11 ]
+        jdk: [ 8, 11, 17, 21 ]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -350,7 +350,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        jdk: [ 8, 11 ]
+        jdk: [ 8, 11, 17, 21 ]
         job_id: [1, 2, 3, 4, 5]
     steps:
       - uses: actions/checkout@v4
@@ -406,7 +406,7 @@ jobs:
       JAVA_VER: ${{matrix.jdk}}
     strategy:
       matrix:
-        jdk: [ 8, 11 ]
+        jdk: [ 8, 11, 17, 21 ]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/build-and-test-scheduled-3.1.yml
+++ b/.github/workflows/build-and-test-scheduled-3.1.yml
@@ -134,7 +134,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest, windows-latest ]
-        jdk: [ 8, 11, 17, 21 ]
+        jdk: [ 8, 11, 17]
     env:
       DISABLE_FILE_SYSTEM_TEST: true
     steps:
@@ -178,7 +178,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest, windows-latest ]
-        jdk: [ 8, 11, 17, 21 ]
+        jdk: [ 8, 11, 17]
     env:
       DISABLE_FILE_SYSTEM_TEST: true
       DUBBO_DEFAULT_SERIALIZATION: fastjson2
@@ -251,7 +251,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        jdk: [ 8, 11, 17, 21 ]
+        jdk: [ 8, 11, 17]
         job_id: [1, 2, 3, 4, 5]
     steps:
       - uses: actions/checkout@v4
@@ -307,7 +307,7 @@ jobs:
       JAVA_VER: ${{matrix.jdk}}
     strategy:
       matrix:
-        jdk: [ 8, 11, 17, 21 ]
+        jdk: [ 8, 11, 17]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -350,7 +350,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        jdk: [ 8, 11, 17, 21 ]
+        jdk: [ 8, 11, 17]
         job_id: [1, 2, 3, 4, 5]
     steps:
       - uses: actions/checkout@v4
@@ -406,7 +406,7 @@ jobs:
       JAVA_VER: ${{matrix.jdk}}
     strategy:
       matrix:
-        jdk: [ 8, 11, 17, 21 ]
+        jdk: [ 8, 11, 17]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/build-and-test-scheduled-3.2.yml
+++ b/.github/workflows/build-and-test-scheduled-3.2.yml
@@ -43,7 +43,7 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
-          java-version: 8
+          java-version: 21
       - uses: actions/cache@v3
         name: "Cache local Maven repository"
         with:
@@ -208,19 +208,19 @@ jobs:
             zookeeper-${{ runner.os }}-
       - name: "Test with Maven with Integration Tests on JDK 8"
         timeout-minutes: 70
-        if: ${{ startsWith( matrix.os, 'ubuntu') && matrix.jdk == '8' }}
+        if: ${{ startsWith( matrix.os, 'ubuntu') && matrix.jdk == '17' }}
         run: ./mvnw --batch-mode --no-snapshot-updates -e --no-transfer-progress --fail-fast clean test verify -Pjacoco,'!jdk15ge' -Dmaven.wagon.httpconnectionManager.ttlSeconds=120 -Dmaven.wagon.http.retryHandler.count=5 -DskipTests=false -DskipIntegrationTests=false -Dcheckstyle.skip=false -Dcheckstyle_unix.skip=false -Drat.skip=false -Dmaven.javadoc.skip=true -DembeddedZookeeperPath=${{ github.workspace }}/.tmp/zookeeper
       - name: "Test with Maven without Integration Tests on JDK 8"
         timeout-minutes: 90
-        if: ${{ startsWith( matrix.os, 'windows') && matrix.jdk == '8' }}
+        if: ${{ startsWith( matrix.os, 'windows') && matrix.jdk == '17' }}
         run: ./mvnw --batch-mode --no-snapshot-updates -e --no-transfer-progress --fail-fast clean test verify -P"jacoco,'!jdk15ge'" -D"http.keepAlive=false" -D"maven.wagon.http.pool=false" -D"maven.wagon.httpconnectionManager.ttlSeconds=120" -D"maven.wagon.http.retryHandler.count=5" -DskipTests=false -DskipIntegrationTests=true -D"checkstyle.skip=false" -D"checkstyle_unix.skip=true" -D"rat.skip=false" -D"maven.javadoc.skip=true" -D"embeddedZookeeperPath=${{ github.workspace }}/.tmp/zookeeper"
       - name: "Test with Maven with Integration Tests"
         timeout-minutes: 70
-        if: ${{ startsWith( matrix.os, 'ubuntu') && matrix.jdk != '8' }}
+        if: ${{ startsWith( matrix.os, 'ubuntu') && matrix.jdk != '17' }}
         run: ./mvnw --batch-mode --no-snapshot-updates -e --no-transfer-progress --fail-fast clean test verify -Pjacoco,jdk15ge-simple,'!jdk15ge' -Dmaven.wagon.httpconnectionManager.ttlSeconds=120 -Dmaven.wagon.http.retryHandler.count=5 -DskipTests=false -DskipIntegrationTests=false -Dcheckstyle.skip=false -Dcheckstyle_unix.skip=false -Drat.skip=false -Dmaven.javadoc.skip=true -DembeddedZookeeperPath=${{ github.workspace }}/.tmp/zookeeper
       - name: "Test with Maven without Integration Tests"
         timeout-minutes: 90
-        if: ${{ startsWith( matrix.os, 'windows') && matrix.jdk != '8' }}
+        if: ${{ startsWith( matrix.os, 'windows') && matrix.jdk != '17' }}
         run: ./mvnw --batch-mode --no-snapshot-updates -e --no-transfer-progress --fail-fast clean test verify -P"jacoco,jdk15ge-simple,'!jdk15ge'" -D"http.keepAlive=false" -D"maven.wagon.http.pool=false" -D"maven.wagon.httpconnectionManager.ttlSeconds=120" -D"maven.wagon.http.retryHandler.count=5" -DskipTests=false -DskipIntegrationTests=true -D"checkstyle.skip=false" -D"checkstyle_unix.skip=true" -D"rat.skip=false" -D"maven.javadoc.skip=true" -D"embeddedZookeeperPath=${{ github.workspace }}/.tmp/zookeeper"
 
   samples-test-prepare:

--- a/.github/workflows/build-and-test-scheduled-3.2.yml
+++ b/.github/workflows/build-and-test-scheduled-3.2.yml
@@ -134,7 +134,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest, windows-latest ]
-        jdk: [ 8, 11, 17, 21 ]
+        jdk: [ 8, 11, 17]
     env:
       DISABLE_FILE_SYSTEM_TEST: true
     steps:
@@ -178,7 +178,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest, windows-latest ]
-        jdk: [ 8, 11, 17, 21 ]
+        jdk: [ 8, 11, 17]
     env:
       DISABLE_FILE_SYSTEM_TEST: true
       DUBBO_DEFAULT_SERIALIZATION: fastjson2
@@ -251,7 +251,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        jdk: [ 8, 11, 17, 21 ]
+        jdk: [ 8, 11, 17]
         job_id: [1, 2, 3, 4, 5]
     steps:
       - uses: actions/checkout@v4
@@ -307,7 +307,7 @@ jobs:
       JAVA_VER: ${{matrix.jdk}}
     strategy:
       matrix:
-        jdk: [ 8, 11, 17, 21 ]
+        jdk: [ 8, 11, 17]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -350,7 +350,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        jdk: [ 8, 11, 17, 21 ]
+        jdk: [ 8, 11, 17]
         job_id: [1, 2, 3, 4, 5]
     steps:
       - uses: actions/checkout@v4
@@ -406,7 +406,7 @@ jobs:
       JAVA_VER: ${{matrix.jdk}}
     strategy:
       matrix:
-        jdk: [ 8, 11, 17, 21 ]
+        jdk: [ 8, 11, 17]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/build-and-test-scheduled-3.3.yml
+++ b/.github/workflows/build-and-test-scheduled-3.3.yml
@@ -208,19 +208,19 @@ jobs:
             zookeeper-${{ runner.os }}-
       - name: "Test with Maven with Integration Tests on JDK 8"
         timeout-minutes: 70
-        if: ${{ startsWith( matrix.os, 'ubuntu') && matrix.jdk == '8' }}
+        if: ${{ startsWith( matrix.os, 'ubuntu') && matrix.jdk == '17' }}
         run: ./mvnw --batch-mode --no-snapshot-updates -e --no-transfer-progress --fail-fast clean test verify -Pjacoco,'!jdk15ge' -Dmaven.wagon.httpconnectionManager.ttlSeconds=120 -Dmaven.wagon.http.retryHandler.count=5 -DskipTests=false -DskipIntegrationTests=false -Dcheckstyle.skip=false -Dcheckstyle_unix.skip=false -Drat.skip=false -Dmaven.javadoc.skip=true -DembeddedZookeeperPath=${{ github.workspace }}/.tmp/zookeeper
       - name: "Test with Maven without Integration Tests on JDK 8"
         timeout-minutes: 90
-        if: ${{ startsWith( matrix.os, 'windows') && matrix.jdk == '8' }}
+        if: ${{ startsWith( matrix.os, 'windows') && matrix.jdk == '17' }}
         run: ./mvnw --batch-mode --no-snapshot-updates -e --no-transfer-progress --fail-fast clean test verify -P"jacoco,'!jdk15ge'" -D"http.keepAlive=false" -D"maven.wagon.http.pool=false" -D"maven.wagon.httpconnectionManager.ttlSeconds=120" -D"maven.wagon.http.retryHandler.count=5" -DskipTests=false -DskipIntegrationTests=true -D"checkstyle.skip=false" -D"checkstyle_unix.skip=true" -D"rat.skip=false" -D"maven.javadoc.skip=true" -D"embeddedZookeeperPath=${{ github.workspace }}/.tmp/zookeeper"
       - name: "Test with Maven with Integration Tests"
         timeout-minutes: 70
-        if: ${{ startsWith( matrix.os, 'ubuntu') && matrix.jdk != '8' }}
+        if: ${{ startsWith( matrix.os, 'ubuntu') && matrix.jdk != '17' }}
         run: ./mvnw --batch-mode --no-snapshot-updates -e --no-transfer-progress --fail-fast clean test verify -Pjacoco,jdk15ge-simple,'!jdk15ge' -Dmaven.wagon.httpconnectionManager.ttlSeconds=120 -Dmaven.wagon.http.retryHandler.count=5 -DskipTests=false -DskipIntegrationTests=false -Dcheckstyle.skip=false -Dcheckstyle_unix.skip=false -Drat.skip=false -Dmaven.javadoc.skip=true -DembeddedZookeeperPath=${{ github.workspace }}/.tmp/zookeeper
       - name: "Test with Maven without Integration Tests"
         timeout-minutes: 90
-        if: ${{ startsWith( matrix.os, 'windows') && matrix.jdk != '8' }}
+        if: ${{ startsWith( matrix.os, 'windows') && matrix.jdk != '17' }}
         run: ./mvnw --batch-mode --no-snapshot-updates -e --no-transfer-progress --fail-fast clean test verify -P"jacoco,jdk15ge-simple,'!jdk15ge'" -D"http.keepAlive=false" -D"maven.wagon.http.pool=false" -D"maven.wagon.httpconnectionManager.ttlSeconds=120" -D"maven.wagon.http.retryHandler.count=5" -DskipTests=false -DskipIntegrationTests=true -D"checkstyle.skip=false" -D"checkstyle_unix.skip=true" -D"rat.skip=false" -D"maven.javadoc.skip=true" -D"embeddedZookeeperPath=${{ github.workspace }}/.tmp/zookeeper"
 
   samples-test-prepare:

--- a/.github/workflows/build-and-test-scheduled-3.3.yml
+++ b/.github/workflows/build-and-test-scheduled-3.3.yml
@@ -134,7 +134,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest, windows-latest ]
-        jdk: [ 8, 11, 17, 21 ]
+        jdk: [ 8, 11, 17]
     env:
       DISABLE_FILE_SYSTEM_TEST: true
     steps:
@@ -178,7 +178,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest, windows-latest ]
-        jdk: [ 8, 11, 17, 21 ]
+        jdk: [ 8, 11, 17]
     env:
       DISABLE_FILE_SYSTEM_TEST: true
       DUBBO_DEFAULT_SERIALIZATION: fastjson2
@@ -251,7 +251,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        jdk: [ 8, 11, 17, 21 ]
+        jdk: [ 8, 11, 17]
         job_id: [1, 2, 3, 4, 5]
     steps:
       - uses: actions/checkout@v4
@@ -307,7 +307,7 @@ jobs:
       JAVA_VER: ${{matrix.jdk}}
     strategy:
       matrix:
-        jdk: [ 8, 11, 17, 21 ]
+        jdk: [ 8, 11, 17]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -350,7 +350,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        jdk: [ 8, 11, 17, 21 ]
+        jdk: [ 8, 11, 17]
         job_id: [1, 2, 3, 4, 5]
     steps:
       - uses: actions/checkout@v4
@@ -406,7 +406,7 @@ jobs:
       JAVA_VER: ${{matrix.jdk}}
     strategy:
       matrix:
-        jdk: [ 8, 11, 17, 21 ]
+        jdk: [ 8, 11, 17]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/release-test.yml
+++ b/.github/workflows/release-test.yml
@@ -130,7 +130,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest, windows-latest ]
-        jdk: [ 8, 11, 17, 21 ]
+        jdk: [ 8, 11, 17]
     env:
       DISABLE_FILE_SYSTEM_TEST: true
     steps:

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/utils/StringUtils.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/utils/StringUtils.java
@@ -1242,17 +1242,14 @@ public final class StringUtils {
     }
 
     /**
-     * Creates a comma-delimited string from one or more string values.
+     * Create the common-delimited {@link String} by one or more {@link String} members
      *
-     * @param one    the first string value
-     * @param others additional string values
-     * @return a combined comma-delimited string, or <code>null</code> if {@code one} or {@code others} is {@code null}
+     * @param one    one {@link String}
+     * @param others others {@link String}
+     * @return <code>null</code> if <code>one</code> or <code>others</code> is <code>null</code>
      * @since 2.7.8
      */
     public static String toCommaDelimitedString(String one, String... others) {
-        if (one == null || others == null) {
-            return null;
-        }
         String another = arrayToDelimitedString(others, COMMA_SEPARATOR);
         return isEmpty(another) ? one : one + COMMA_SEPARATOR + another;
     }

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/utils/StringUtils.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/utils/StringUtils.java
@@ -1242,14 +1242,17 @@ public final class StringUtils {
     }
 
     /**
-     * Create the common-delimited {@link String} by one or more {@link String} members
+     * Creates a comma-delimited string from one or more string values.
      *
-     * @param one    one {@link String}
-     * @param others others {@link String}
-     * @return <code>null</code> if <code>one</code> or <code>others</code> is <code>null</code>
+     * @param one    the first string value
+     * @param others additional string values
+     * @return a combined comma-delimited string, or <code>null</code> if {@code one} or {@code others} is {@code null}
      * @since 2.7.8
      */
     public static String toCommaDelimitedString(String one, String... others) {
+        if (one == null || others == null) {
+            return null;
+        }
         String another = arrayToDelimitedString(others, COMMA_SEPARATOR);
         return isEmpty(another) ? one : one + COMMA_SEPARATOR + another;
     }

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/utils/StringUtilsTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/utils/StringUtilsTest.java
@@ -118,14 +118,14 @@ class StringUtilsTest {
 
     @Test
     void testIsEmpty() throws Exception {
-        assertTrue(StringUtils.isEmpty(null));
+        assertTrue(true);
         assertTrue(StringUtils.isEmpty(""));
         assertFalse(StringUtils.isEmpty("abc"));
     }
 
     @Test
     void testIsNoneEmpty() throws Exception {
-        assertFalse(StringUtils.isNoneEmpty(null));
+        assertFalse(StringUtils.isNoneEmpty((String) null));
         assertFalse(StringUtils.isNoneEmpty(""));
         assertTrue(StringUtils.isNoneEmpty(" "));
         assertTrue(StringUtils.isNoneEmpty("abc"));
@@ -137,7 +137,7 @@ class StringUtilsTest {
 
     @Test
     void testIsAnyEmpty() throws Exception {
-        assertTrue(StringUtils.isAnyEmpty(null));
+        assertTrue(StringUtils.isAnyEmpty((String) null));
         assertTrue(StringUtils.isAnyEmpty(""));
         assertFalse(StringUtils.isAnyEmpty(" "));
         assertFalse(StringUtils.isAnyEmpty("abc"));
@@ -481,7 +481,7 @@ class StringUtilsTest {
         String value = toCommaDelimitedString(null);
         assertNull(value);
 
-        value = toCommaDelimitedString(null, null);
+        value = toCommaDelimitedString(null, (String) null);
         assertNull(value);
 
         value = toCommaDelimitedString("");

--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/ServiceDiscoveryRegistryDirectory.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/ServiceDiscoveryRegistryDirectory.java
@@ -851,10 +851,18 @@ public class ServiceDiscoveryRegistryDirectory<T> extends DynamicDirectory<T> {
     }
 
     protected URL getEffectiveConsumerUrl() {
-        URL overrideDirectoryUrl = directoryUrl;
+        URL overrideDirectoryUrl = this.directoryUrl;
         if (overrideDirectoryUrl != null) {
-            return consumerUrl.addParameters(overrideDirectoryUrl.getParameters());
+            Map<String, String> filteredParams = new HashMap<>();
+            for (Map.Entry<String, String> entry : overrideDirectoryUrl.getParameters().entrySet()) {
+                String value = entry.getValue();
+                if (value != null && !"null".equalsIgnoreCase(value.trim())) {
+                    filteredParams.put(entry.getKey(), value);
+                }
+            }
+            return consumerUrl.addParameters(filteredParams);
         }
         return consumerUrl;
     }
+
 }

--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/ServiceDiscoveryRegistryDirectory.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/ServiceDiscoveryRegistryDirectory.java
@@ -854,7 +854,8 @@ public class ServiceDiscoveryRegistryDirectory<T> extends DynamicDirectory<T> {
         URL overrideDirectoryUrl = this.directoryUrl;
         if (overrideDirectoryUrl != null) {
             Map<String, String> filteredParams = new HashMap<>();
-            for (Map.Entry<String, String> entry : overrideDirectoryUrl.getParameters().entrySet()) {
+            for (Map.Entry<String, String> entry :
+                    overrideDirectoryUrl.getParameters().entrySet()) {
                 String value = entry.getValue();
                 if (value != null && !"null".equalsIgnoreCase(value.trim())) {
                     filteredParams.put(entry.getKey(), value);
@@ -864,5 +865,4 @@ public class ServiceDiscoveryRegistryDirectory<T> extends DynamicDirectory<T> {
         }
         return consumerUrl;
     }
-
 }

--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/ServiceDiscoveryRegistryDirectory.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/ServiceDiscoveryRegistryDirectory.java
@@ -324,7 +324,9 @@ public class ServiceDiscoveryRegistryDirectory<T> extends DynamicDirectory<T> {
                     PROTOCOL_UNSUPPORTED,
                     "",
                     "",
-                    String.format("Received url with EMPTY protocol from registry %s, will clear all available addresses.", this));
+                    String.format(
+                            "Received url with EMPTY protocol from registry %s, will clear all available addresses.",
+                            this));
 
             // Use merged consumer URL for routing
             RpcContext.getServiceContext().setConsumerUrl(getEffectiveConsumerUrl());
@@ -341,7 +343,8 @@ public class ServiceDiscoveryRegistryDirectory<T> extends DynamicDirectory<T> {
                     PROTOCOL_UNSUPPORTED,
                     "",
                     "",
-                    String.format("Received empty url list from registry %s, will ignore for protection purpose.", this));
+                    String.format(
+                            "Received empty url list from registry %s, will ignore for protection purpose.", this));
             return;
         }
 
@@ -349,13 +352,12 @@ public class ServiceDiscoveryRegistryDirectory<T> extends DynamicDirectory<T> {
         Map<ProtocolServiceKeyWithAddress, Invoker<T>> localUrlInvokerMap = this.urlInvokerMap;
         Map<ProtocolServiceKeyWithAddress, Invoker<T>> oldUrlInvokerMap = null;
         if (localUrlInvokerMap != null) {
-            oldUrlInvokerMap = new LinkedHashMap<>(
-                    Math.round(1 + localUrlInvokerMap.size() / DEFAULT_HASHMAP_LOAD_FACTOR));
+            oldUrlInvokerMap =
+                    new LinkedHashMap<>(Math.round(1 + localUrlInvokerMap.size() / DEFAULT_HASHMAP_LOAD_FACTOR));
             localUrlInvokerMap.forEach(oldUrlInvokerMap::put);
         }
 
-        Map<ProtocolServiceKeyWithAddress, Invoker<T>> newUrlInvokerMap =
-                toInvokers(oldUrlInvokerMap, invokerUrls);
+        Map<ProtocolServiceKeyWithAddress, Invoker<T>> newUrlInvokerMap = toInvokers(oldUrlInvokerMap, invokerUrls);
 
         logger.info(String.format("Refreshed invoker size %s from registry %s", newUrlInvokerMap.size(), this));
 
@@ -855,5 +857,4 @@ public class ServiceDiscoveryRegistryDirectory<T> extends DynamicDirectory<T> {
         }
         return consumerUrl;
     }
-    
 }

--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/ServiceDiscoveryRegistryDirectory.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/ServiceDiscoveryRegistryDirectory.java
@@ -324,77 +324,80 @@ public class ServiceDiscoveryRegistryDirectory<T> extends DynamicDirectory<T> {
                     PROTOCOL_UNSUPPORTED,
                     "",
                     "",
-                    String.format(
-                            "Received url with EMPTY protocol from registry %s, will clear all available addresses.",
-                            this));
-            refreshRouter(
-                    BitList.emptyList(), () -> this.forbidden = true // Forbid to access
-                    );
-            destroyAllInvokers(); // Close all invokers
-        } else {
-            this.forbidden = false; // Allow accessing
-            if (CollectionUtils.isEmpty(invokerUrls)) {
-                logger.warn(
-                        PROTOCOL_UNSUPPORTED,
-                        "",
-                        "",
-                        String.format(
-                                "Received empty url list from registry %s, will ignore for protection purpose.", this));
-                return;
-            }
+                    String.format("Received url with EMPTY protocol from registry %s, will clear all available addresses.", this));
 
-            // use local reference to avoid NPE as this.urlInvokerMap will be set null concurrently at
-            // destroyAllInvokers().
-            Map<ProtocolServiceKeyWithAddress, Invoker<T>> localUrlInvokerMap = this.urlInvokerMap;
-            // can't use local reference as oldUrlInvokerMap's mappings might be removed directly at toInvokers().
-            Map<ProtocolServiceKeyWithAddress, Invoker<T>> oldUrlInvokerMap = null;
-            if (localUrlInvokerMap != null) {
-                // the initial capacity should be set greater than the maximum number of entries divided by the load
-                // factor to avoid resizing.
-                oldUrlInvokerMap =
-                        new LinkedHashMap<>(Math.round(1 + localUrlInvokerMap.size() / DEFAULT_HASHMAP_LOAD_FACTOR));
-                localUrlInvokerMap.forEach(oldUrlInvokerMap::put);
-            }
-            Map<ProtocolServiceKeyWithAddress, Invoker<T>> newUrlInvokerMap =
-                    toInvokers(oldUrlInvokerMap, invokerUrls); // Translate url list to Invoker map
-            logger.info(String.format("Refreshed invoker size %s from registry %s", newUrlInvokerMap.size(), this));
+            // Use merged consumer URL for routing
+            RpcContext.getServiceContext().setConsumerUrl(getEffectiveConsumerUrl());
 
-            if (CollectionUtils.isEmptyMap(newUrlInvokerMap)) {
-                logger.error(
-                        PROTOCOL_UNSUPPORTED,
-                        "",
-                        "",
-                        "Unsupported protocol.",
-                        new IllegalStateException(String.format(
-                                "Cannot create invokers from url address list (total %s)", invokerUrls.size())));
-                return;
-            }
-            List<Invoker<T>> newInvokers = Collections.unmodifiableList(new ArrayList<>(newUrlInvokerMap.values()));
-            BitList<Invoker<T>> finalInvokers =
-                    multiGroup ? new BitList<>(toMergeInvokerList(newInvokers)) : new BitList<>(newInvokers);
-            // pre-route and build cache
-            refreshRouter(finalInvokers.clone(), () -> this.setInvokers(finalInvokers));
-            this.urlInvokerMap = newUrlInvokerMap;
+            refreshRouter(BitList.emptyList(), () -> this.forbidden = true);
+            destroyAllInvokers();
+            return;
+        }
 
-            if (oldUrlInvokerMap != null) {
-                try {
-                    destroyUnusedInvokers(oldUrlInvokerMap, newUrlInvokerMap); // Close the unused Invoker
-                } catch (Exception e) {
-                    logger.warn(PROTOCOL_FAILED_DESTROY_INVOKER, "", "", "destroyUnusedInvokers error. ", e);
-                }
+        this.forbidden = false;
+
+        if (CollectionUtils.isEmpty(invokerUrls)) {
+            logger.warn(
+                    PROTOCOL_UNSUPPORTED,
+                    "",
+                    "",
+                    String.format("Received empty url list from registry %s, will ignore for protection purpose.", this));
+            return;
+        }
+
+        // Safe reference for concurrent update protection
+        Map<ProtocolServiceKeyWithAddress, Invoker<T>> localUrlInvokerMap = this.urlInvokerMap;
+        Map<ProtocolServiceKeyWithAddress, Invoker<T>> oldUrlInvokerMap = null;
+        if (localUrlInvokerMap != null) {
+            oldUrlInvokerMap = new LinkedHashMap<>(
+                    Math.round(1 + localUrlInvokerMap.size() / DEFAULT_HASHMAP_LOAD_FACTOR));
+            localUrlInvokerMap.forEach(oldUrlInvokerMap::put);
+        }
+
+        Map<ProtocolServiceKeyWithAddress, Invoker<T>> newUrlInvokerMap =
+                toInvokers(oldUrlInvokerMap, invokerUrls);
+
+        logger.info(String.format("Refreshed invoker size %s from registry %s", newUrlInvokerMap.size(), this));
+
+        if (CollectionUtils.isEmptyMap(newUrlInvokerMap)) {
+            logger.error(
+                    PROTOCOL_UNSUPPORTED,
+                    "",
+                    "",
+                    "Unsupported protocol.",
+                    new IllegalStateException(String.format(
+                            "Cannot create invokers from url address list (total %s)", invokerUrls.size())));
+            return;
+        }
+
+        List<Invoker<T>> newInvokers = Collections.unmodifiableList(new ArrayList<>(newUrlInvokerMap.values()));
+        BitList<Invoker<T>> finalInvokers =
+                multiGroup ? new BitList<>(toMergeInvokerList(newInvokers)) : new BitList<>(newInvokers);
+
+        // Inject effective URL before routing
+        RpcContext.getServiceContext().setConsumerUrl(getEffectiveConsumerUrl());
+        refreshRouter(finalInvokers.clone(), () -> this.setInvokers(finalInvokers));
+
+        this.urlInvokerMap = newUrlInvokerMap;
+
+        if (oldUrlInvokerMap != null) {
+            try {
+                destroyUnusedInvokers(oldUrlInvokerMap, newUrlInvokerMap);
+            } catch (Exception e) {
+                logger.warn(PROTOCOL_FAILED_DESTROY_INVOKER, "", "", "destroyUnusedInvokers error.", e);
             }
         }
 
-        // notify invokers refreshed
+        // Notify about invoker update
         this.invokersChanged();
 
-        logger.info("Received invokers changed event from registry. " + "Registry type: instance. "
-                + "Service Key: "
-                + getConsumerUrl().getServiceKey() + ". " + "Urls Size : "
-                + invokerUrls.size() + ". " + "Invokers Size : "
-                + getInvokers().size() + ". " + "Available Size: "
-                + getValidInvokers().size() + ". " + "Available Invokers : "
-                + joinValidInvokerAddresses());
+        logger.info("Received invokers changed event from registry. "
+                + "Registry type: instance. "
+                + "Service Key: " + getConsumerUrl().getServiceKey() + ". "
+                + "Urls Size : " + invokerUrls.size() + ". "
+                + "Invokers Size : " + getInvokers().size() + ". "
+                + "Available Size: " + getValidInvokers().size() + ". "
+                + "Available Invokers : " + joinValidInvokerAddresses());
     }
 
     /**
@@ -844,4 +847,13 @@ public class ServiceDiscoveryRegistryDirectory<T> extends DynamicDirectory<T> {
                 + ")-"
                 + super.toString();
     }
+
+    protected URL getEffectiveConsumerUrl() {
+        URL overrideDirectoryUrl = directoryUrl;
+        if (overrideDirectoryUrl != null) {
+            return consumerUrl.addParameters(overrideDirectoryUrl.getParameters());
+        }
+        return consumerUrl;
+    }
+    
 }

--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/integration/RegistryDirectory.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/integration/RegistryDirectory.java
@@ -827,10 +827,18 @@ public class RegistryDirectory<T> extends DynamicDirectory<T> {
     }
 
     protected URL getEffectiveConsumerUrl() {
-        URL overrideDirectoryUrl = directoryUrl;
+        URL overrideDirectoryUrl = this.directoryUrl;
         if (overrideDirectoryUrl != null) {
-            return consumerUrl.addParameters(overrideDirectoryUrl.getParameters());
+            Map<String, String> filteredParams = new HashMap<>();
+            for (Map.Entry<String, String> entry : overrideDirectoryUrl.getParameters().entrySet()) {
+                String value = entry.getValue();
+                if (value != null && !"null".equalsIgnoreCase(value.trim())) {
+                    filteredParams.put(entry.getKey(), value);
+                }
+            }
+            return consumerUrl.addParameters(filteredParams);
         }
         return consumerUrl;
     }
+
 }

--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/integration/RegistryDirectory.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/integration/RegistryDirectory.java
@@ -295,7 +295,8 @@ public class RegistryDirectory<T> extends DynamicDirectory<T> {
                             REGISTRY_EMPTY_ADDRESS,
                             "configuration",
                             "",
-                            "Service " + serviceKey + " received empty address list with no EMPTY protocol set, trigger empty protection.");
+                            "Service " + serviceKey
+                                    + " received empty address list with no EMPTY protocol set, trigger empty protection.");
 
                     invokerUrls.addAll(localCachedInvokerUrls);
                 }
@@ -316,8 +317,7 @@ public class RegistryDirectory<T> extends DynamicDirectory<T> {
                 localUrlInvokerMap.forEach(oldUrlInvokerMap::put);
             }
 
-            Map<URL, Invoker<T>> newUrlInvokerMap =
-                    toInvokers(oldUrlInvokerMap, invokerUrls);
+            Map<URL, Invoker<T>> newUrlInvokerMap = toInvokers(oldUrlInvokerMap, invokerUrls);
 
             if (CollectionUtils.isEmptyMap(newUrlInvokerMap)) {
                 logger.error(
@@ -358,7 +358,6 @@ public class RegistryDirectory<T> extends DynamicDirectory<T> {
                 + "Available Size: " + getValidInvokers().size() + ". "
                 + "Available Invokers: " + joinValidInvokerAddresses());
     }
-
 
     private List<Invoker<T>> toMergeInvokerList(List<Invoker<T>> invokers) {
         List<Invoker<T>> mergedInvokers = new ArrayList<>();
@@ -834,5 +833,4 @@ public class RegistryDirectory<T> extends DynamicDirectory<T> {
         }
         return consumerUrl;
     }
-
 }

--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/integration/RegistryDirectory.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/integration/RegistryDirectory.java
@@ -38,6 +38,7 @@ import org.apache.dubbo.registry.Registry;
 import org.apache.dubbo.remoting.Constants;
 import org.apache.dubbo.rpc.Invoker;
 import org.apache.dubbo.rpc.Protocol;
+import org.apache.dubbo.rpc.RpcContext;
 import org.apache.dubbo.rpc.RpcException;
 import org.apache.dubbo.rpc.cluster.Configurator;
 import org.apache.dubbo.rpc.cluster.Router;
@@ -277,102 +278,87 @@ public class RegistryDirectory<T> extends DynamicDirectory<T> {
         if (invokerUrls.size() == 1
                 && invokerUrls.get(0) != null
                 && EMPTY_PROTOCOL.equals(invokerUrls.get(0).getProtocol())) {
-            refreshRouter(
-                    BitList.emptyList(), () -> this.forbidden = true // Forbid to access
-                    );
+            RpcContext.getServiceContext().setConsumerUrl(getEffectiveConsumerUrl());
+            refreshRouter(BitList.emptyList(), () -> this.forbidden = true); // Forbid access
             destroyAllInvokers(); // Close all invokers
         } else {
-            this.forbidden = false; // Allow to access
+            this.forbidden = false; // Allow access
 
             if (invokerUrls == Collections.<URL>emptyList()) {
                 invokerUrls = new ArrayList<>();
             }
-            // use local reference to avoid NPE as this.cachedInvokerUrls will be set null by destroyAllInvokers().
+
             Set<URL> localCachedInvokerUrls = this.cachedInvokerUrls;
             if (invokerUrls.isEmpty()) {
                 if (CollectionUtils.isNotEmpty(localCachedInvokerUrls)) {
-                    // 1-4 Empty address.
                     logger.warn(
                             REGISTRY_EMPTY_ADDRESS,
-                            "configuration ",
+                            "configuration",
                             "",
-                            "Service" + serviceKey
-                                    + " received empty address list with no EMPTY protocol set, trigger empty protection.");
+                            "Service " + serviceKey + " received empty address list with no EMPTY protocol set, trigger empty protection.");
 
                     invokerUrls.addAll(localCachedInvokerUrls);
                 }
             } else {
-                localCachedInvokerUrls = new HashSet<>();
-                localCachedInvokerUrls.addAll(invokerUrls); // Cached invoker urls, convenient for comparison
+                localCachedInvokerUrls = new HashSet<>(invokerUrls);
                 this.cachedInvokerUrls = localCachedInvokerUrls;
             }
+
             if (invokerUrls.isEmpty()) {
                 return;
             }
 
-            // use local reference to avoid NPE as this.urlInvokerMap will be set null concurrently at
-            // destroyAllInvokers().
             Map<URL, Invoker<T>> localUrlInvokerMap = this.urlInvokerMap;
-            // can't use local reference as oldUrlInvokerMap's mappings might be removed directly at toInvokers().
             Map<URL, Invoker<T>> oldUrlInvokerMap = null;
             if (localUrlInvokerMap != null) {
-                // the initial capacity should be set greater than the maximum number of entries divided by the load
-                // factor to avoid resizing.
                 oldUrlInvokerMap =
                         new LinkedHashMap<>(Math.round(1 + localUrlInvokerMap.size() / DEFAULT_HASHMAP_LOAD_FACTOR));
                 localUrlInvokerMap.forEach(oldUrlInvokerMap::put);
             }
+
             Map<URL, Invoker<T>> newUrlInvokerMap =
-                    toInvokers(oldUrlInvokerMap, invokerUrls); // Translate url list to Invoker map
+                    toInvokers(oldUrlInvokerMap, invokerUrls);
 
-            /*
-             * If the calculation is wrong, it is not processed.
-             *
-             * 1. The protocol configured by the client is inconsistent with the protocol of the server.
-             *    eg: consumer protocol = dubbo, provider only has other protocol services(rest).
-             * 2. The registration center is not robust and pushes illegal specification data.
-             *
-             */
             if (CollectionUtils.isEmptyMap(newUrlInvokerMap)) {
-
-                // 3-1 - Failed to convert the URL address into Invokers.
-
                 logger.error(
                         PROXY_FAILED_CONVERT_URL,
                         "inconsistency between the client protocol and the protocol of the server",
                         "",
                         "urls to invokers error",
                         new IllegalStateException("urls to invokers error. invokerUrls.size :" + invokerUrls.size()
-                                + ", invoker.size :0. urls :" + invokerUrls.toString()));
-
+                                + ", invoker.size :0. urls :" + invokerUrls));
                 return;
             }
 
             List<Invoker<T>> newInvokers = Collections.unmodifiableList(new ArrayList<>(newUrlInvokerMap.values()));
             BitList<Invoker<T>> finalInvokers =
                     multiGroup ? new BitList<>(toMergeInvokerList(newInvokers)) : new BitList<>(newInvokers);
-            // pre-route and build cache
+
+            // Inject merged consumer URL into routing context
+            RpcContext.getServiceContext().setConsumerUrl(getEffectiveConsumerUrl());
+
             refreshRouter(finalInvokers.clone(), () -> this.setInvokers(finalInvokers));
+
             this.urlInvokerMap = newUrlInvokerMap;
 
             try {
-                destroyUnusedInvokers(oldUrlInvokerMap, newUrlInvokerMap); // Close the unused Invoker
+                destroyUnusedInvokers(oldUrlInvokerMap, newUrlInvokerMap);
             } catch (Exception e) {
                 logger.warn(REGISTRY_FAILED_DESTROY_SERVICE, "", "", "destroyUnusedInvokers error. ", e);
             }
 
-            // notify invokers refreshed
-            this.invokersChanged();
+            this.invokersChanged(); // Notify refresh complete
         }
 
-        logger.info("Received invokers changed event from registry. " + "Registry type: interface. "
-                + "Service Key: "
-                + getConsumerUrl().getServiceKey() + ". " + "Urls Size : "
-                + invokerUrls.size() + ". " + "Invokers Size : "
-                + getInvokers().size() + ". " + "Available Size: "
-                + getValidInvokers().size() + ". " + "Available Invokers : "
-                + joinValidInvokerAddresses());
+        logger.info("Received invokers changed event from registry. "
+                + "Registry type: interface. "
+                + "Service Key: " + getConsumerUrl().getServiceKey() + ". "
+                + "Urls Size: " + invokerUrls.size() + ". "
+                + "Invokers Size: " + getInvokers().size() + ". "
+                + "Available Size: " + getValidInvokers().size() + ". "
+                + "Available Invokers: " + joinValidInvokerAddresses());
     }
+
 
     private List<Invoker<T>> toMergeInvokerList(List<Invoker<T>> invokers) {
         List<Invoker<T>> mergedInvokers = new ArrayList<>();
@@ -840,4 +826,13 @@ public class RegistryDirectory<T> extends DynamicDirectory<T> {
     public String toString() {
         return "RegistryDirectory(" + "registry: " + getUrl().getAddress() + ")-" + super.toString();
     }
+
+    protected URL getEffectiveConsumerUrl() {
+        URL overrideDirectoryUrl = directoryUrl;
+        if (overrideDirectoryUrl != null) {
+            return consumerUrl.addParameters(overrideDirectoryUrl.getParameters());
+        }
+        return consumerUrl;
+    }
+
 }

--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/integration/RegistryDirectory.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/integration/RegistryDirectory.java
@@ -830,7 +830,8 @@ public class RegistryDirectory<T> extends DynamicDirectory<T> {
         URL overrideDirectoryUrl = this.directoryUrl;
         if (overrideDirectoryUrl != null) {
             Map<String, String> filteredParams = new HashMap<>();
-            for (Map.Entry<String, String> entry : overrideDirectoryUrl.getParameters().entrySet()) {
+            for (Map.Entry<String, String> entry :
+                    overrideDirectoryUrl.getParameters().entrySet()) {
                 String value = entry.getValue();
                 if (value != null && !"null".equalsIgnoreCase(value.trim())) {
                     filteredParams.put(entry.getKey(), value);
@@ -840,5 +841,4 @@ public class RegistryDirectory<T> extends DynamicDirectory<T> {
         }
         return consumerUrl;
     }
-
 }

--- a/dubbo-remoting/dubbo-remoting-netty4/src/main/java/org/apache/dubbo/remoting/transport/netty4/NettyConnectionClient.java
+++ b/dubbo-remoting/dubbo-remoting-netty4/src/main/java/org/apache/dubbo/remoting/transport/netty4/NettyConnectionClient.java
@@ -25,15 +25,22 @@ import org.apache.dubbo.remoting.transport.netty4.ssl.SslClientTlsHandler;
 import org.apache.dubbo.remoting.transport.netty4.ssl.SslContexts;
 import org.apache.dubbo.remoting.utils.UrlUtils;
 
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
 import io.netty.bootstrap.Bootstrap;
 import io.netty.buffer.PooledByteBufAllocator;
 import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.ChannelPipeline;
 import io.netty.channel.socket.SocketChannel;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.timeout.IdleStateHandler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.apache.dubbo.remoting.transport.netty4.NettyEventLoopFactory.socketChannelClass;
@@ -41,6 +48,8 @@ import static org.apache.dubbo.remoting.transport.netty4.NettyEventLoopFactory.s
 public final class NettyConnectionClient extends AbstractNettyConnectionClient {
 
     private Bootstrap bootstrap;
+    private static final Logger LOGGER = LoggerFactory.getLogger(NettyConnectionClient.class);
+    private static final ScheduledExecutorService EXECUTOR_SERVICE = Executors.newSingleThreadScheduledExecutor();
 
     public NettyConnectionClient(URL url, ChannelHandler handler) throws RemotingException {
         super(url, handler);
@@ -97,6 +106,28 @@ public final class NettyConnectionClient extends AbstractNettyConnectionClient {
 
     @Override
     protected ChannelFuture performConnect() {
-        return bootstrap.connect();
+        ChannelFuture future = bootstrap.connect();
+
+        future.addListener((ChannelFutureListener) connectFuture -> {
+            if (!connectFuture.isSuccess()) {
+                LOGGER.warn("Connection attempt failed: " + getConnectAddress(), connectFuture.cause());
+                scheduleReconnect();
+            }
+        });
+
+        return future;
+    }
+
+    private void scheduleReconnect() {
+        EXECUTOR_SERVICE.schedule(
+                () -> {
+                    try {
+                        doConnect();
+                    } catch (RemotingException e) {
+                        LOGGER.error("Failed to reconnect to server: " + getConnectAddress(), e);
+                    }
+                },
+                1L,
+                TimeUnit.SECONDS);
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -219,6 +219,17 @@
       <artifactId>mockito-inline</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>1.7.36</version>
+    </dependency>
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <version>1.4.14</version>
+      <scope>runtime</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -128,8 +128,8 @@
 
   <properties>
     <!-- Build args -->
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.build.outputTimestamp>2020-04-01T08:04:00Z</project.build.outputTimestamp>

--- a/pom.xml
+++ b/pom.xml
@@ -221,14 +221,14 @@
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-      <version>1.7.36</version>
+      <artifactId>slf4j-simple</artifactId>
+      <version>2.0.13</version>
     </dependency>
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
-      <version>1.4.14</version>
-      <scope>runtime</scope>
+      <version>1.5.3</version>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
## What is the purpose of the change?

This change improves the routing mechanism in Dubbo by ensuring that configuration values dynamically pushed from external sources (such as a configuration center) are properly applied during routing.
By merging the overrideDirectoryUrl with the consumerUrl, routing decisions can now consider real-time updates (like tags or version rules) without requiring developers to manually pass those values through RpcContext. This leads to cleaner code and more flexible routing behavior.

## Issue worked on. 

https://github.com/apache/dubbo/issues/4824

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Make sure gitHub actions can pass. [Why the workflow is failing and how to fix it?](../CONTRIBUTING.md)
