### PR TITLE
fix: toCommaDelimitedString returns "null,null" when inputs are null

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/utils/StringUtils.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/utils/StringUtils.java
@@ -1250,6 +1250,12 @@ public final class StringUtils {
      * @since 2.7.8
      */
     public static String toCommaDelimitedString(String one, String... others) {
+        if (one == null) {
+            return null;
+        }
+        if (others == null) {
+            return one;
+        }
         String another = arrayToDelimitedString(others, COMMA_SEPARATOR);
         return isEmpty(another) ? one : one + COMMA_SEPARATOR + another;
     }

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/utils/StringUtils.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/utils/StringUtils.java
@@ -1242,11 +1242,11 @@ public final class StringUtils {
     }
 
     /**
-     * Create the common-delimited {@link String} by one or more {@link String} members
+     * Creates a comma-delimited string from one or more string values.
      *
-     * @param one    one {@link String}
-     * @param others others {@link String}
-     * @return <code>null</code> if <code>one</code> or <code>others</code> is <code>null</code>
+     * @param one    the first string value
+     * @param others additional string values
+     * @return the combined string, or null if the first value is null
      * @since 2.7.8
      */
     public static String toCommaDelimitedString(String one, String... others) {

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/utils/StringUtilsTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/utils/StringUtilsTest.java
@@ -474,6 +474,7 @@ class StringUtilsTest {
 
     /**
      * Test {@link StringUtils#toCommaDelimitedString(String, String...)}
+     *
      * @since 2.7.8
      */
     @Test
@@ -483,6 +484,9 @@ class StringUtilsTest {
 
         value = toCommaDelimitedString(null, null);
         assertNull(value);
+
+        value = toCommaDelimitedString("one", null);
+        assertEquals("one", value);
 
         value = toCommaDelimitedString("");
         assertEquals("", value);


### PR DESCRIPTION
## Issue

https://github.com/apache/dubbo/issues/15321

## What is the purpose of the change?

This change corrects the behavior of StringUtils.toCommaDelimitedString(String one, String... others) to return null when either argument is null, as described in its Javadoc. Previously, the method would return a string like "null,null", which could lead to misleading outputs and test failures. This update ensures consistency between the method's implementation and its documented contract.

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Make sure gitHub actions can pass. [Why the workflow is failing and how to fix it?](../CONTRIBUTING.md)

