### PR TITLE
Feature/triple http3 cleanup fix

### DIFF
--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/rest/mapping/DefaultRequestMappingRegistry.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/rest/mapping/DefaultRequestMappingRegistry.java
@@ -18,6 +18,7 @@ package org.apache.dubbo.rpc.protocol.tri.rest.mapping;
 
 import org.apache.dubbo.common.URL;
 import org.apache.dubbo.common.logger.FluentLogger;
+import org.apache.dubbo.common.resource.Disposable;
 import org.apache.dubbo.common.utils.ClassUtils;
 import org.apache.dubbo.config.context.ConfigManager;
 import org.apache.dubbo.config.nested.RestConfig;
@@ -58,7 +59,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
-public final class DefaultRequestMappingRegistry implements RequestMappingRegistry {
+public final class DefaultRequestMappingRegistry implements RequestMappingRegistry, Disposable {
 
     private static final FluentLogger LOGGER = FluentLogger.of(DefaultRequestMappingRegistry.class);
 

--- a/dubbo-rpc/dubbo-rpc-triple/src/test/java/org/apache/dubbo/rpc/protocol/tri/TripleHttp3ProtocolTest.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/test/java/org/apache/dubbo/rpc/protocol/tri/TripleHttp3ProtocolTest.java
@@ -32,6 +32,7 @@ import org.apache.dubbo.rpc.model.ModuleServiceRepository;
 import org.apache.dubbo.rpc.model.ProviderModel;
 import org.apache.dubbo.rpc.model.ServiceDescriptor;
 import org.apache.dubbo.rpc.model.ServiceMetadata;
+import org.apache.dubbo.rpc.protocol.tri.rest.mapping.DefaultRequestMappingRegistry;
 import org.apache.dubbo.rpc.protocol.tri.support.IGreeter;
 import org.apache.dubbo.rpc.protocol.tri.support.IGreeterImpl;
 import org.apache.dubbo.rpc.protocol.tri.support.MockStreamObserver;
@@ -41,17 +42,29 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 class TripleHttp3ProtocolTest {
 
+    private ApplicationModel applicationModel;
+
     @Test
     void testDemoProtocol() throws Exception {
-        IGreeterImpl serviceImpl = new IGreeterImpl();
+        // Full Environment Reset - Optimized
+        ApplicationModel oldAppModel = ApplicationModel.defaultModel();
+        if (oldAppModel != null) {
+            oldAppModel.destroy();
+            if (oldAppModel.getFrameworkModel() != null) {
+                oldAppModel.getFrameworkModel().destroy();
+            }
+        }
+        applicationModel = ApplicationModel.defaultModel();
 
+        // Fresh ApplicationModel ready
+        IGreeterImpl serviceImpl = new IGreeterImpl();
         int availablePort = NetUtils.getAvailablePort();
-        ApplicationModel applicationModel = ApplicationModel.defaultModel();
 
         Map<String, String> settings = new HashMap<>();
         settings.put(Constants.H3_SETTINGS_HTTP3_ENABLED, "true");
@@ -70,8 +83,7 @@ class TripleHttp3ProtocolTest {
 
         URL providerUrl = URL.valueOf("tri://127.0.0.1:" + availablePort + "/" + IGreeter.class.getName());
 
-        ModuleServiceRepository serviceRepository =
-                applicationModel.getDefaultModule().getServiceRepository();
+        ModuleServiceRepository serviceRepository = applicationModel.getDefaultModule().getServiceRepository();
         ServiceDescriptor serviceDescriptor = serviceRepository.registerService(IGreeter.class);
 
         ProviderModel providerModel = new ProviderModel(
@@ -84,43 +96,44 @@ class TripleHttp3ProtocolTest {
         providerUrl = providerUrl.setServiceModel(providerModel);
 
         Protocol protocol = new TripleProtocol(providerUrl.getOrDefaultFrameworkModel());
-        ProxyFactory proxy =
-                applicationModel.getExtensionLoader(ProxyFactory.class).getAdaptiveExtension();
+        ProxyFactory proxy = applicationModel.getExtensionLoader(ProxyFactory.class).getAdaptiveExtension();
         Invoker<IGreeter> invoker = proxy.getInvoker(serviceImpl, IGreeter.class, providerUrl);
+
         Exporter<IGreeter> export = protocol.export(invoker);
 
         URL consumerUrl = URL.valueOf("tri://127.0.0.1:" + availablePort + "/" + IGreeter.class.getName());
-
-        ConsumerModel consumerModel =
-                new ConsumerModel(consumerUrl.getServiceKey(), null, serviceDescriptor, null, null, null);
+        ConsumerModel consumerModel = new ConsumerModel(consumerUrl.getServiceKey(), null, serviceDescriptor, null, null, null);
         consumerUrl = consumerUrl.setServiceModel(consumerModel);
+
         IGreeter greeterProxy = proxy.getProxy(protocol.refer(IGreeter.class, consumerUrl));
         Thread.sleep(1000);
 
         Assertions.assertTrue(Http3Exchanger.isEnabled(providerUrl));
 
-        // 1. test unaryStream
+        // 1. Test unaryStream
         String REQUEST_MSG = "hello world";
         Assertions.assertEquals(REQUEST_MSG, greeterProxy.echo(REQUEST_MSG));
         Assertions.assertEquals(REQUEST_MSG, serviceImpl.echoAsync(REQUEST_MSG).get());
 
-        // 2. test serverStream
+        // 2. Test serverStream
         MockStreamObserver outboundMessageSubscriber1 = new MockStreamObserver();
         greeterProxy.serverStream(REQUEST_MSG, outboundMessageSubscriber1);
         outboundMessageSubscriber1.getLatch().await(3000, TimeUnit.MILLISECONDS);
         Assertions.assertEquals(REQUEST_MSG, outboundMessageSubscriber1.getOnNextData());
         Assertions.assertTrue(outboundMessageSubscriber1.isOnCompleted());
 
-        // 3. test bidirectionalStream
+        // 3. Test bidirectionalStream
         MockStreamObserver outboundMessageSubscriber2 = new MockStreamObserver();
         StreamObserver<String> inboundMessageObserver = greeterProxy.bidirectionalStream(outboundMessageSubscriber2);
         inboundMessageObserver.onNext(REQUEST_MSG);
         inboundMessageObserver.onCompleted();
         outboundMessageSubscriber2.getLatch().await(3000, TimeUnit.MILLISECONDS);
-        // verify client
+
+        // Verify client
         Assertions.assertEquals(IGreeter.SERVER_MSG, outboundMessageSubscriber2.getOnNextData());
         Assertions.assertTrue(outboundMessageSubscriber2.isOnCompleted());
-        // verify server
+
+        // Verify server
         MockStreamObserver serverOutboundMessageSubscriber = (MockStreamObserver) serviceImpl.getMockStreamObserver();
         serverOutboundMessageSubscriber.getLatch().await(1000, TimeUnit.MILLISECONDS);
         Assertions.assertEquals(REQUEST_MSG, serverOutboundMessageSubscriber.getOnNextData());
@@ -128,9 +141,24 @@ class TripleHttp3ProtocolTest {
 
         export.unexport();
         protocol.destroy();
-        // resource recycle.
         serviceRepository.destroy();
-        System.out.println("serviceRepository destroyed");
+        System.out.println("ServiceRepository destroyed at end of test");
+    }
+
+    @AfterEach
+    void cleanup() {
+        if (applicationModel != null) {
+            try {
+                DefaultRequestMappingRegistry registry =
+                        applicationModel.getFrameworkModel().getBeanFactory().getBean(DefaultRequestMappingRegistry.class);
+                if (registry != null) {
+                    registry.destroy();
+                    System.out.println("DefaultRequestMappingRegistry destroyed after test");
+                }
+            } catch (Exception e) {
+                System.err.println("Cleanup error: " + e.getMessage());
+            }
+        }
     }
 
     private static String getAbsolutePath(String resourcePath) throws Exception {

--- a/dubbo-rpc/dubbo-rpc-triple/src/test/java/org/apache/dubbo/rpc/protocol/tri/TripleHttp3ProtocolTest.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/test/java/org/apache/dubbo/rpc/protocol/tri/TripleHttp3ProtocolTest.java
@@ -138,4 +138,5 @@ class TripleHttp3ProtocolTest {
         Assertions.assertNotNull(resourceUrl, "Cert file '" + resourcePath + "' is required");
         return Paths.get(resourceUrl.toURI()).toAbsolutePath().toString();
     }
+
 }

--- a/dubbo-rpc/dubbo-rpc-triple/src/test/java/org/apache/dubbo/rpc/protocol/tri/TripleHttp3ProtocolTest.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/test/java/org/apache/dubbo/rpc/protocol/tri/TripleHttp3ProtocolTest.java
@@ -83,7 +83,8 @@ class TripleHttp3ProtocolTest {
 
         URL providerUrl = URL.valueOf("tri://127.0.0.1:" + availablePort + "/" + IGreeter.class.getName());
 
-        ModuleServiceRepository serviceRepository = applicationModel.getDefaultModule().getServiceRepository();
+        ModuleServiceRepository serviceRepository =
+                applicationModel.getDefaultModule().getServiceRepository();
         ServiceDescriptor serviceDescriptor = serviceRepository.registerService(IGreeter.class);
 
         ProviderModel providerModel = new ProviderModel(
@@ -96,13 +97,15 @@ class TripleHttp3ProtocolTest {
         providerUrl = providerUrl.setServiceModel(providerModel);
 
         Protocol protocol = new TripleProtocol(providerUrl.getOrDefaultFrameworkModel());
-        ProxyFactory proxy = applicationModel.getExtensionLoader(ProxyFactory.class).getAdaptiveExtension();
+        ProxyFactory proxy =
+                applicationModel.getExtensionLoader(ProxyFactory.class).getAdaptiveExtension();
         Invoker<IGreeter> invoker = proxy.getInvoker(serviceImpl, IGreeter.class, providerUrl);
 
         Exporter<IGreeter> export = protocol.export(invoker);
 
         URL consumerUrl = URL.valueOf("tri://127.0.0.1:" + availablePort + "/" + IGreeter.class.getName());
-        ConsumerModel consumerModel = new ConsumerModel(consumerUrl.getServiceKey(), null, serviceDescriptor, null, null, null);
+        ConsumerModel consumerModel =
+                new ConsumerModel(consumerUrl.getServiceKey(), null, serviceDescriptor, null, null, null);
         consumerUrl = consumerUrl.setServiceModel(consumerModel);
 
         IGreeter greeterProxy = proxy.getProxy(protocol.refer(IGreeter.class, consumerUrl));
@@ -149,8 +152,10 @@ class TripleHttp3ProtocolTest {
     void cleanup() {
         if (applicationModel != null) {
             try {
-                DefaultRequestMappingRegistry registry =
-                        applicationModel.getFrameworkModel().getBeanFactory().getBean(DefaultRequestMappingRegistry.class);
+                DefaultRequestMappingRegistry registry = applicationModel
+                        .getFrameworkModel()
+                        .getBeanFactory()
+                        .getBean(DefaultRequestMappingRegistry.class);
                 if (registry != null) {
                     registry.destroy();
                     System.out.println("DefaultRequestMappingRegistry destroyed after test");

--- a/dubbo-rpc/dubbo-rpc-triple/src/test/java/org/apache/dubbo/rpc/protocol/tri/TripleHttp3ProtocolTest.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/test/java/org/apache/dubbo/rpc/protocol/tri/TripleHttp3ProtocolTest.java
@@ -138,5 +138,4 @@ class TripleHttp3ProtocolTest {
         Assertions.assertNotNull(resourceUrl, "Cert file '" + resourcePath + "' is required");
         return Paths.get(resourceUrl.toURI()).toAbsolutePath().toString();
     }
-
 }

--- a/dubbo-rpc/dubbo-rpc-triple/src/test/java/org/apache/dubbo/rpc/protocol/tri/TripleHttp3ProtocolTest.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/test/java/org/apache/dubbo/rpc/protocol/tri/TripleHttp3ProtocolTest.java
@@ -32,7 +32,6 @@ import org.apache.dubbo.rpc.model.ModuleServiceRepository;
 import org.apache.dubbo.rpc.model.ProviderModel;
 import org.apache.dubbo.rpc.model.ServiceDescriptor;
 import org.apache.dubbo.rpc.model.ServiceMetadata;
-import org.apache.dubbo.rpc.protocol.tri.rest.mapping.DefaultRequestMappingRegistry;
 import org.apache.dubbo.rpc.protocol.tri.support.IGreeter;
 import org.apache.dubbo.rpc.protocol.tri.support.IGreeterImpl;
 import org.apache.dubbo.rpc.protocol.tri.support.MockStreamObserver;
@@ -153,21 +152,10 @@ class TripleHttp3ProtocolTest {
     }
 
     @AfterEach
-    void cleanup() {
+    void destroyApplicationModel() {
         if (applicationModel != null) {
-            try {
-                DefaultRequestMappingRegistry registry = applicationModel
-                        .getFrameworkModel()
-                        .getBeanFactory()
-                        .getBean(DefaultRequestMappingRegistry.class);
-                if (registry != null) {
-                    registry.destroy();
-                    LOGGER.info("DefaultRequestMappingRegistry destroyed after test");
-                }
-            } catch (Exception e) {
-                LOGGER.error("Cleanup error: {}", e.getMessage(), e);
-                throw e;
-            }
+            applicationModel.destroy();
+            LOGGER.info("ApplicationModel destroyed after test");
         }
     }
 

--- a/dubbo-rpc/dubbo-rpc-triple/src/test/java/org/apache/dubbo/rpc/protocol/tri/TripleHttp3ProtocolTest.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/test/java/org/apache/dubbo/rpc/protocol/tri/TripleHttp3ProtocolTest.java
@@ -45,10 +45,14 @@ import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 class TripleHttp3ProtocolTest {
 
     private ApplicationModel applicationModel;
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(TripleHttp3ProtocolTest.class);
 
     @Test
     void testDemoProtocol() throws Exception {
@@ -145,7 +149,7 @@ class TripleHttp3ProtocolTest {
         export.unexport();
         protocol.destroy();
         serviceRepository.destroy();
-        System.out.println("ServiceRepository destroyed at end of test");
+        LOGGER.info("ServiceRepository destroyed at end of test");
     }
 
     @AfterEach
@@ -158,10 +162,11 @@ class TripleHttp3ProtocolTest {
                         .getBean(DefaultRequestMappingRegistry.class);
                 if (registry != null) {
                     registry.destroy();
-                    System.out.println("DefaultRequestMappingRegistry destroyed after test");
+                    LOGGER.info("DefaultRequestMappingRegistry destroyed after test");
                 }
             } catch (Exception e) {
-                System.err.println("Cleanup error: " + e.getMessage());
+                LOGGER.error("Cleanup error: {}", e.getMessage(), e);
+                throw e;
             }
         }
     }


### PR DESCRIPTION
## What is the purpose of the change?

This pull request resolves the duplicate service mapping warnings observed during the execution of `TripleHttp3ProtocolTest`.
It ensures that each test is executed in a fully isolated environment by resetting both the `ApplicationModel` and `FrameworkModel` before initializing test logic.
By clearing previously registered services and protocol instances, this change guarantees cleaner test runs without interference or unexpected warnings.

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Make sure gitHub actions can pass. [Why the workflow is failing and how to fix it?](../CONTRIBUTING.md)
