### PR TITLE
fix: Fix the issue of triple bzip2 compressor close ByteArrayOutputStream

### DIFF
--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/compressor/Bzip2.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/compressor/Bzip2.java
@@ -47,11 +47,8 @@ public class Bzip2 implements Compressor, DeCompressor {
         }
 
         ByteArrayOutputStream out = new ByteArrayOutputStream();
-        BZip2CompressorOutputStream cos;
-        try {
-            cos = new BZip2CompressorOutputStream(out);
+        try (BZip2CompressorOutputStream cos = new BZip2CompressorOutputStream(out)) {
             cos.write(payloadByteArr);
-            cos.close();
         } catch (Exception e) {
             throw new IllegalStateException(e);
         }


### PR DESCRIPTION
fix issue #15355

## What is the purpose of the change?
Correctly close BZip2CompressorOutputStream using try with sources

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Make sure gitHub actions can pass. [Why the workflow is failing and how to fix it?](../CONTRIBUTING.md)
