### PR TITLE
[3.3] Add connection preface process to TripleHttp2Protocol

### DIFF
--- a/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/api/WireProtocol.java
+++ b/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/api/WireProtocol.java
@@ -32,4 +32,8 @@ public interface WireProtocol {
     void configClientPipeline(URL url, ChannelOperator operator, ContextOperator contextOperator);
 
     void close();
+
+    default boolean hasConnectionPreface() {
+        return false;
+    }
 }

--- a/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/api/connection/ConnectionHandler.java
+++ b/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/api/connection/ConnectionHandler.java
@@ -31,4 +31,11 @@ public interface ConnectionHandler {
      * @param channel Channel
      */
     void reconnect(Object channel);
+
+    /**
+     * when connection preface is received.
+     *
+     * @param channel Channel
+     */
+    void onConnectionPrefaceReceived(Object channel);
 }

--- a/dubbo-remoting/dubbo-remoting-netty4/src/main/java/org/apache/dubbo/remoting/transport/netty4/AbstractNettyConnectionClient.java
+++ b/dubbo-remoting/dubbo-remoting-netty4/src/main/java/org/apache/dubbo/remoting/transport/netty4/AbstractNettyConnectionClient.java
@@ -57,6 +57,8 @@ public abstract class AbstractNettyConnectionClient extends AbstractConnectionCl
 
     private ConnectionListener connectionListener;
 
+    private AtomicReference<Promise<Void>> connectionPrefaceReceivedPromiseRef;
+
     public static final AttributeKey<AbstractConnectionClient> CONNECTION = AttributeKey.valueOf("connection");
 
     public AbstractNettyConnectionClient(URL url, ChannelHandler handler) throws RemotingException {
@@ -81,6 +83,12 @@ public abstract class AbstractNettyConnectionClient extends AbstractConnectionCl
         isReconnecting = new AtomicBoolean(false);
         connectionListener = new ConnectionListener();
         increase();
+
+        // Create connection preface received promise for Http2 client since it should wait server http2 settings frame
+        // before sending client Headers frame, see details at https://github.com/apache/dubbo/issues/15233
+        if (protocol != null && protocol.hasConnectionPreface()) {
+            connectionPrefaceReceivedPromiseRef = new AtomicReference<>();
+        }
     }
 
     protected abstract void initBootstrap() throws Exception;
@@ -129,6 +137,11 @@ public abstract class AbstractNettyConnectionClient extends AbstractConnectionCl
         Future<Void> connectPromise = performConnect();
         connectPromise.addListener(connectionListener);
 
+        Promise<Void> connectionPrefaceReceivedPromise = null;
+        if (connectionPrefaceReceivedPromiseRef != null) {
+            connectionPrefaceReceivedPromise = getOrCreateConnectionPrefaceReceivedPromise();
+        }
+
         boolean ret = connectingPromise.awaitUninterruptibly(getConnectTimeout(), TimeUnit.MILLISECONDS);
         // destroy connectingPromise after used
         synchronized (this) {
@@ -167,6 +180,35 @@ public abstract class AbstractNettyConnectionClient extends AbstractConnectionCl
                     TRANSPORT_CLIENT_CONNECT_TIMEOUT, "provider crash", "", "Client-side timeout", remotingException);
 
             throw remotingException;
+        }
+
+        if (connectionPrefaceReceivedPromise != null) {
+            long retainedTimeout = getConnectTimeout() - System.currentTimeMillis() + start;
+            ret = connectionPrefaceReceivedPromise.awaitUninterruptibly(retainedTimeout, TimeUnit.MILLISECONDS);
+            // destroy connectionPrefaceReceivedPromise after used
+            synchronized (this) {
+                connectionPrefaceReceivedPromiseRef.set(null);
+            }
+            if (!ret || !connectionPrefaceReceivedPromise.isSuccess()) {
+                // 6-2 Client-side connection preface timeout
+                RemotingException remotingException = new RemotingException(
+                        this,
+                        "client(url: " + getUrl() + ") failed to connect to server " + getConnectAddress()
+                                + " client-side connection preface timeout " + getConnectTimeout() + "ms (elapsed: "
+                                + (System.currentTimeMillis() - start) + "ms) from netty client "
+                                + NetUtils.getLocalHost()
+                                + " using dubbo version "
+                                + Version.getVersion());
+
+                logger.error(
+                        TRANSPORT_CLIENT_CONNECT_TIMEOUT,
+                        "provider crash",
+                        "",
+                        "Client-side connection preface timeout",
+                        remotingException);
+
+                throw remotingException;
+            }
         }
     }
 
@@ -246,6 +288,16 @@ public abstract class AbstractNettyConnectionClient extends AbstractConnectionCl
         }
     }
 
+    public void onConnectionPrefaceReceived(Object channel) {
+        if (!(channel instanceof io.netty.channel.Channel) || connectionPrefaceReceivedPromiseRef == null) {
+            return;
+        }
+        Promise<Void> connectionPrefaceReceivedPromise = connectionPrefaceReceivedPromiseRef.get();
+        if (connectionPrefaceReceivedPromise != null) {
+            connectionPrefaceReceivedPromise.trySuccess(null);
+        }
+    }
+
     @Override
     protected Channel getChannel() {
         io.netty.channel.Channel c = getNettyChannel();
@@ -300,6 +352,11 @@ public abstract class AbstractNettyConnectionClient extends AbstractConnectionCl
     private Promise<Object> getOrCreateConnectingPromise() {
         connectingPromiseRef.compareAndSet(null, new DefaultPromise<>(GlobalEventExecutor.INSTANCE));
         return connectingPromiseRef.get();
+    }
+
+    private Promise<Void> getOrCreateConnectionPrefaceReceivedPromise() {
+        connectionPrefaceReceivedPromiseRef.compareAndSet(null, new DefaultPromise<>(GlobalEventExecutor.INSTANCE));
+        return connectionPrefaceReceivedPromiseRef.get();
     }
 
     public Promise<Void> getClosePromise() {

--- a/dubbo-remoting/dubbo-remoting-netty4/src/main/java/org/apache/dubbo/remoting/transport/netty4/NettyConnectionHandler.java
+++ b/dubbo-remoting/dubbo-remoting-netty4/src/main/java/org/apache/dubbo/remoting/transport/netty4/NettyConnectionHandler.java
@@ -84,6 +84,14 @@ public class NettyConnectionHandler extends ChannelInboundHandlerAdapter impleme
     }
 
     @Override
+    public void onConnectionPrefaceReceived(Object channel) {
+        if (!(channel instanceof Channel)) {
+            return;
+        }
+        connectionClient.onConnectionPrefaceReceived(channel);
+    }
+
+    @Override
     public void channelActive(ChannelHandlerContext ctx) {
         ctx.fireChannelActive();
         Channel ch = ctx.channel();

--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/TripleHttp2Protocol.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/TripleHttp2Protocol.java
@@ -41,6 +41,7 @@ import org.apache.dubbo.rpc.protocol.tri.h12.TripleProtocolDetector;
 import org.apache.dubbo.rpc.protocol.tri.h12.http1.DefaultHttp11ServerTransportListenerFactory;
 import org.apache.dubbo.rpc.protocol.tri.h12.http2.GenericHttp2ServerTransportListenerFactory;
 import org.apache.dubbo.rpc.protocol.tri.transport.TripleGoAwayHandler;
+import org.apache.dubbo.rpc.protocol.tri.transport.TripleHttp2SettingsHandler;
 import org.apache.dubbo.rpc.protocol.tri.transport.TripleServerConnectionHandler;
 import org.apache.dubbo.rpc.protocol.tri.transport.TripleTailHandler;
 import org.apache.dubbo.rpc.protocol.tri.websocket.DefaultWebSocketServerTransportListenerFactory;
@@ -96,6 +97,11 @@ public class TripleHttp2Protocol extends AbstractWireProtocol implements ScopeMo
     }
 
     @Override
+    public boolean hasConnectionPreface() {
+        return true;
+    }
+
+    @Override
     public void configClientPipeline(URL url, ChannelOperator operator, ContextOperator contextOperator) {
         TripleConfig tripleConfig = ConfigManager.getProtocolOrDefault(url).getTripleOrDefault();
         Http2FrameCodec codec = Http2FrameCodecBuilder.forClient()
@@ -116,6 +122,7 @@ public class TripleHttp2Protocol extends AbstractWireProtocol implements ScopeMo
         handlers.add(new ChannelHandlerPretender(new Http2MultiplexHandler(new ChannelDuplexHandler())));
         handlers.add(new ChannelHandlerPretender(new TriplePingPongHandler(UrlUtils.getCloseTimeout(url))));
         handlers.add(new ChannelHandlerPretender(new TripleGoAwayHandler()));
+        handlers.add(new ChannelHandlerPretender(new TripleHttp2SettingsHandler()));
         handlers.add(new ChannelHandlerPretender(new TripleTailHandler()));
         operator.configChannelHandler(handlers);
     }

--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/transport/TripleHttp2SettingsHandler.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/transport/TripleHttp2SettingsHandler.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.rpc.protocol.tri.transport;
+
+import org.apache.dubbo.common.logger.Logger;
+import org.apache.dubbo.common.logger.LoggerFactory;
+import org.apache.dubbo.remoting.Constants;
+import org.apache.dubbo.remoting.api.connection.ConnectionHandler;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.SimpleChannelInboundHandler;
+import io.netty.handler.codec.http2.Http2SettingsFrame;
+
+public class TripleHttp2SettingsHandler extends SimpleChannelInboundHandler<Http2SettingsFrame> {
+
+    private static final Logger logger = LoggerFactory.getLogger(TripleHttp2SettingsHandler.class);
+
+    public TripleHttp2SettingsHandler() {}
+
+    @Override
+    protected void channelRead0(ChannelHandlerContext ctx, Http2SettingsFrame msg) throws Exception {
+        final ConnectionHandler connectionHandler =
+                (ConnectionHandler) ctx.pipeline().get(Constants.CONNECTION_HANDLER_NAME);
+        if (logger.isDebugEnabled()) {
+            logger.debug("Receive Http2 Settings frame of " + ctx.channel().localAddress() + " -> "
+                    + ctx.channel().remoteAddress());
+        }
+        // Notify the connection preface is received.
+        connectionHandler.onConnectionPrefaceReceived(ctx.channel());
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change?
fixed #15233 ```No provider available``` issue, the roots of the issue is client sent large headers frame before receiving server connection preface (http2 settings frame), which cause server sent back go away frame and the connection was disconnected by the server.
![go away issue](https://github.com/user-attachments/assets/a60f02eb-1817-4bd7-ae6a-ecc4989d289a)
see details at https://httpwg.org/specs/rfc7540.html#ConnectionHeader
```
3.5. HTTP/2 Connection Preface
In HTTP/2, each endpoint is required to send a connection preface as a final confirmation of the protocol in use and to establish the initial settings for the HTTP/2 connection. The client and server each send a different connection preface.
The client connection preface starts with a sequence of 24 octets, which in hex notation is:
0x505249202a20485454502f322e300d0a0d0a534d0d0a0d0a
That is, the connection preface starts with the string PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n). This sequence MUST be followed by a SETTINGS frame (Section 6.5), which MAY be empty. 
... ...
The server connection preface consists of a potentially empty SETTINGS frame (Section 6.5) that MUST be the first frame the server sends in the HTTP/2 connection.
```

https://quafoo.gitbooks.io/http2-rfc7540-zh-cn-en/content/chapter3/section3.5.html
```
HTTP/2 Connection Preface / HTTP/2连接前奏
在HTTP/2中，要求两端都要发送一个连接前奏，作为对所使用协议的最终确认，并确定HTTP/2连接的初始设置。客户端和服务端各自发送不同的连接前奏。
客户端连接前奏以一个24字节的序列开始，用十六进制表示为：
0x505249202a20485454502f322e300d0a0d0a534d0d0a0d0a
即，连接前奏以字符串"PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n"开始。这个序列后面必须跟一个可以为空的 SETTINGS 帧( 6.5节 )。
... ...
服务端连接前奏包含一个可能为空的 SETTINGS 帧( 6.5节 )，它必须由服务端在HTTP/2连接中首先发送。
```

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Make sure gitHub actions can pass. [Why the workflow is failing and how to fix it?](../CONTRIBUTING.md)
