### PR TITLE
Support automatic REST route registration and invocation for custom @Mapping methods in Triple stub service implementation classes.

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/rpc/model/StubServiceDescriptor.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/rpc/model/StubServiceDescriptor.java
@@ -20,6 +20,7 @@ import org.apache.dubbo.common.utils.CollectionUtils;
 import org.apache.dubbo.metadata.definition.ServiceDefinitionBuilder;
 import org.apache.dubbo.metadata.definition.model.FullServiceDefinition;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -46,7 +47,8 @@ public class StubServiceDescriptor implements ServiceDescriptor {
     }
 
     public void addMethod(MethodDescriptor methodDescriptor) {
-        methods.put(methodDescriptor.getMethodName(), Collections.singletonList(methodDescriptor));
+        methods.computeIfAbsent(methodDescriptor.getMethodName(), k -> new ArrayList<>())
+                .add(methodDescriptor);
         Map<String, MethodDescriptor> descMap =
                 descToMethods.computeIfAbsent(methodDescriptor.getMethodName(), k -> new HashMap<>());
         descMap.put(methodDescriptor.getParamDesc(), methodDescriptor);

--- a/dubbo-plugin/dubbo-compiler/src/main/resources/Dubbo3TripleStub.mustache
+++ b/dubbo-plugin/dubbo-compiler/src/main/resources/Dubbo3TripleStub.mustache
@@ -236,6 +236,20 @@ public final class {{className}} {
             handlers.put({{methodName}}Method.getMethodName(), new BiStreamMethodHandler<>(this::{{methodName}}));
         {{/biStreamingWithoutClientStreamMethods}}
 
+            Class<?> userImplementationClass = this.getClass();
+            java.lang.reflect.Method[] allUserDeclaredMethods = userImplementationClass.getDeclaredMethods();
+
+            for (java.lang.reflect.Method userMethod : allUserDeclaredMethods) {
+                if (userMethod.isAnnotationPresent(org.apache.dubbo.remoting.http12.rest.Mapping.class)) {
+                    if (!handlers.containsKey(userMethod.getName()) &&
+                        userMethod.getDeclaringClass() != Object.class &&
+                        !java.lang.reflect.Modifier.isStatic(userMethod.getModifiers()) &&
+                        !userMethod.isBridge()) {
+                        handlers.put(userMethod.getName(), new org.apache.dubbo.rpc.stub.ReflectionMappingMethodHandler(this, userMethod));
+                    }
+                }
+            }
+
             return new StubInvoker<>(this, url, {{interfaceClassName}}.class, handlers);
         }
     {{#unaryMethods}}

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/stub/ReflectionMappingMethodHandler.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/stub/ReflectionMappingMethodHandler.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.rpc.stub;
+
+import org.apache.dubbo.rpc.RpcException;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.concurrent.CompletableFuture;
+
+public class ReflectionMappingMethodHandler implements StubMethodHandler<Object[], Object> {
+    private final Object serviceInstance;
+    private final Method method;
+
+    public ReflectionMappingMethodHandler(Object serviceInstance, Method method) {
+        this.serviceInstance = serviceInstance;
+        this.method = method;
+        this.method.setAccessible(true);
+    }
+
+    @Override
+    public CompletableFuture<?> invoke(Object[] arguments) {
+        try {
+            Object result = method.invoke(serviceInstance, arguments);
+
+            if (result instanceof CompletableFuture) {
+                return (CompletableFuture<?>) result;
+            }
+            return CompletableFuture.completedFuture(result);
+        } catch (InvocationTargetException e) {
+            Throwable targetException = e.getTargetException();
+            CompletableFuture<?> future = new CompletableFuture<>();
+            future.completeExceptionally(targetException);
+            return future;
+        } catch (IllegalAccessException | IllegalArgumentException e) {
+            CompletableFuture<?> future = new CompletableFuture<>();
+            future.completeExceptionally(new RpcException(
+                    "Reflection call failed for @Mapping method '" + method.getName() + "': " + e.getMessage(), e));
+            return future;
+        } catch (Throwable t) {
+            CompletableFuture<?> future = new CompletableFuture<>();
+            future.completeExceptionally(new RpcException(
+                    "Unexpected error invoking @Mapping method '" + method.getName() + "': " + t.getMessage(), t));
+            return future;
+        }
+    }
+}

--- a/dubbo-rpc/dubbo-rpc-api/src/test/java/org/apache/dubbo/rpc/stub/ReflectionMappingMethodHandlerTest.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/test/java/org/apache/dubbo/rpc/stub/ReflectionMappingMethodHandlerTest.java
@@ -102,7 +102,8 @@ class ReflectionMappingMethodHandlerTest {
 
     @Test
     void testBusinessExceptionMethodInvoke() {
-        ReflectionMappingMethodHandler handler = new ReflectionMappingMethodHandler(testService, throwBusinessExceptionMethod);
+        ReflectionMappingMethodHandler handler =
+                new ReflectionMappingMethodHandler(testService, throwBusinessExceptionMethod);
         Object[] args = new Object[] {"test-error"};
         CompletableFuture<?> future = handler.invoke(args);
 
@@ -123,7 +124,6 @@ class ReflectionMappingMethodHandlerTest {
         Assertions.assertInstanceOf(NullPointerException.class, cause); // The original NPE
         Assertions.assertEquals("Input was null", cause.getMessage());
     }
-
 
     @Test
     void testIllegalArgumentExceptionFromReflection() {

--- a/dubbo-rpc/dubbo-rpc-api/src/test/java/org/apache/dubbo/rpc/stub/ReflectionMappingMethodHandlerTest.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/test/java/org/apache/dubbo/rpc/stub/ReflectionMappingMethodHandlerTest.java
@@ -1,0 +1,140 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.rpc.stub;
+
+import org.apache.dubbo.rpc.RpcException;
+
+import java.lang.reflect.Method;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit test for {@link ReflectionMappingMethodHandler}
+ * This test verifies the handler's ability to invoke arbitrary methods via reflection,
+ * without needing a direct dependency on the @Mapping annotation itself.
+ */
+class ReflectionMappingMethodHandlerTest {
+
+    static class TestService {
+        public String hello(String name) {
+            return "Hello " + name;
+        }
+
+        public CompletableFuture<String> helloAsync(String name) {
+            CompletableFuture<String> future = new CompletableFuture<>();
+            future.complete("Hello Async " + name);
+            return future;
+        }
+
+        public void voidMethod(String input) {
+            if ("nullInput".equals(input)) {
+                throw new NullPointerException("Input was null");
+            }
+        }
+
+        public String throwBusinessException(String input) {
+            throw new BusinessException("Business exception thrown: " + input);
+        }
+    }
+
+    static class BusinessException extends RuntimeException {
+        public BusinessException(String message) {
+            super(message);
+        }
+    }
+
+    private TestService testService;
+    private Method helloMethod;
+    private Method helloAsyncMethod;
+    private Method voidMethod;
+    private Method throwBusinessExceptionMethod;
+
+    @BeforeEach
+    void setUp() throws NoSuchMethodException {
+        testService = new TestService();
+        helloMethod = TestService.class.getMethod("hello", String.class);
+        helloAsyncMethod = TestService.class.getMethod("helloAsync", String.class);
+        voidMethod = TestService.class.getMethod("voidMethod", String.class);
+        throwBusinessExceptionMethod = TestService.class.getMethod("throwBusinessException", String.class);
+    }
+
+    @Test
+    void testSyncMethodInvoke() throws ExecutionException, InterruptedException {
+        ReflectionMappingMethodHandler handler = new ReflectionMappingMethodHandler(testService, helloMethod);
+        Object[] args = new Object[] {"World"};
+        CompletableFuture<?> future = handler.invoke(args);
+        Assertions.assertEquals("Hello World", future.get());
+    }
+
+    @Test
+    void testAsyncMethodInvoke() throws ExecutionException, InterruptedException {
+        ReflectionMappingMethodHandler handler = new ReflectionMappingMethodHandler(testService, helloAsyncMethod);
+        Object[] args = new Object[] {"Async"};
+        CompletableFuture<?> future = handler.invoke(args);
+        Assertions.assertEquals("Hello Async Async", future.get());
+    }
+
+    @Test
+    void testVoidMethodInvoke() throws ExecutionException, InterruptedException {
+        ReflectionMappingMethodHandler handler = new ReflectionMappingMethodHandler(testService, voidMethod);
+        Object[] args = new Object[] {"test"};
+        CompletableFuture<?> future = handler.invoke(args);
+        Assertions.assertNull(future.get());
+    }
+
+    @Test
+    void testBusinessExceptionMethodInvoke() {
+        ReflectionMappingMethodHandler handler = new ReflectionMappingMethodHandler(testService, throwBusinessExceptionMethod);
+        Object[] args = new Object[] {"test-error"};
+        CompletableFuture<?> future = handler.invoke(args);
+
+        ExecutionException ex = Assertions.assertThrows(ExecutionException.class, future::get);
+        Throwable cause = ex.getCause();
+        Assertions.assertInstanceOf(BusinessException.class, cause);
+        Assertions.assertEquals("Business exception thrown: test-error", cause.getMessage());
+    }
+
+    @Test
+    void testOtherRuntimeExceptionMethodInvoke() {
+        ReflectionMappingMethodHandler handler = new ReflectionMappingMethodHandler(testService, voidMethod);
+        Object[] args = new Object[] {"nullInput"}; // This will cause voidMethod to throw NullPointerException
+        CompletableFuture<?> future = handler.invoke(args);
+
+        ExecutionException ex = Assertions.assertThrows(ExecutionException.class, future::get);
+        Throwable cause = ex.getCause();
+        Assertions.assertInstanceOf(NullPointerException.class, cause); // The original NPE
+        Assertions.assertEquals("Input was null", cause.getMessage());
+    }
+
+
+    @Test
+    void testIllegalArgumentExceptionFromReflection() {
+        ReflectionMappingMethodHandler handler = new ReflectionMappingMethodHandler(testService, helloMethod);
+        Object[] args = new Object[] {};
+
+        CompletableFuture<?> future = handler.invoke(args);
+        ExecutionException ex = Assertions.assertThrows(ExecutionException.class, future::get);
+        Throwable cause = ex.getCause();
+        Assertions.assertInstanceOf(RpcException.class, cause);
+        Assertions.assertTrue(cause.getMessage().contains("Reflection call failed for @Mapping method 'hello'"));
+        Assertions.assertInstanceOf(IllegalArgumentException.class, cause.getCause());
+    }
+}

--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/rest/mapping/DefaultRequestMappingRegistry.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/rest/mapping/DefaultRequestMappingRegistry.java
@@ -31,6 +31,7 @@ import org.apache.dubbo.rpc.model.MethodDescriptor;
 import org.apache.dubbo.rpc.model.ReflectionMethodDescriptor;
 import org.apache.dubbo.rpc.model.ReflectionServiceDescriptor;
 import org.apache.dubbo.rpc.model.ServiceDescriptor;
+import org.apache.dubbo.rpc.model.StubServiceDescriptor;
 import org.apache.dubbo.rpc.protocol.tri.DescriptorUtils;
 import org.apache.dubbo.rpc.protocol.tri.TripleProtocol;
 import org.apache.dubbo.rpc.protocol.tri.rest.Messages;
@@ -139,11 +140,12 @@ public final class DefaultRequestMappingRegistry implements RequestMappingRegist
                         return;
                     }
                     if (md == null) {
-                        if (!(sd instanceof ReflectionServiceDescriptor)) {
-                            return;
-                        }
                         md = new ReflectionMethodDescriptor(method);
-                        ((ReflectionServiceDescriptor) sd).addMethod(md);
+                        if (sd instanceof ReflectionServiceDescriptor) {
+                            ((ReflectionServiceDescriptor) sd).addMethod(md);
+                        } else if (sd instanceof StubServiceDescriptor) {
+                            ((StubServiceDescriptor) sd).addMethod(md);
+                        }
                         methodMeta.setMethodDescriptor(md);
                     }
                     if (classMapping != null) {


### PR DESCRIPTION
## What is the purpose of the change?
Support automatic REST route registration and invocation for custom @Mapping methods in Triple stub service implementation classes.
#15366

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Make sure gitHub actions can pass. [Why the workflow is failing and how to fix it?](../CONTRIBUTING.md)
