### PR TITLE
Fix ClassCastException caused by overly broad type check in Dubbo tracing integration with Spring WebFlux.

### DIFF
--- a/dubbo-metrics/dubbo-tracing/src/main/java/org/apache/dubbo/tracing/handler/DubboClientTracingObservationHandler.java
+++ b/dubbo-metrics/dubbo-tracing/src/main/java/org/apache/dubbo/tracing/handler/DubboClientTracingObservationHandler.java
@@ -20,7 +20,6 @@ import org.apache.dubbo.tracing.context.DubboClientContext;
 
 import io.micrometer.observation.Observation;
 import io.micrometer.observation.ObservationHandler;
-import io.micrometer.observation.transport.SenderContext;
 import io.micrometer.tracing.Tracer;
 
 public class DubboClientTracingObservationHandler<T extends DubboClientContext> implements ObservationHandler<T> {
@@ -35,6 +34,6 @@ public class DubboClientTracingObservationHandler<T extends DubboClientContext> 
 
     @Override
     public boolean supportsContext(Observation.Context context) {
-        return context instanceof SenderContext;
+        return context instanceof DubboClientContext;
     }
 }

--- a/dubbo-metrics/dubbo-tracing/src/main/java/org/apache/dubbo/tracing/handler/DubboServerTracingObservationHandler.java
+++ b/dubbo-metrics/dubbo-tracing/src/main/java/org/apache/dubbo/tracing/handler/DubboServerTracingObservationHandler.java
@@ -21,7 +21,6 @@ import org.apache.dubbo.tracing.context.DubboServerContext;
 
 import io.micrometer.observation.Observation;
 import io.micrometer.observation.ObservationHandler;
-import io.micrometer.observation.transport.ReceiverContext;
 import io.micrometer.tracing.TraceContext;
 import io.micrometer.tracing.Tracer;
 
@@ -46,6 +45,6 @@ public class DubboServerTracingObservationHandler<T extends DubboServerContext> 
 
     @Override
     public boolean supportsContext(Observation.Context context) {
-        return context instanceof ReceiverContext;
+        return context instanceof DubboServerContext;
     }
 }


### PR DESCRIPTION
## What is the purpose of the change?
Fix ClassCastException caused by overly broad type check in Dubbo tracing integration with Spring WebFlux.
#15349 

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Make sure gitHub actions can pass. [Why the workflow is failing and how to fix it?](../CONTRIBUTING.md)
