### PR TITLE
Add a github action message after format issue found

### DIFF
--- a/.github/workflows/build-and-test-pr.yml
+++ b/.github/workflows/build-and-test-pr.yml
@@ -71,7 +71,7 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            core.setFailed("Formatting issues found!")
+            core.setFailed("Formatting issues found! \nRun \`mvn spotless:apply\` to fix.")
 
   license:
     name: "Check License"


### PR DESCRIPTION
## What is the purpose of the change?
 Currently, there are a lot of less familiar contributors who experience action failures when submitting PRS. One of the most common failures is the 'Check if code needs formatting' failure, such as: 

![image](https://github.com/user-attachments/assets/e7e7c0df-f8c6-424f-b445-da70263afac6)

https://github.com/apache/dubbo/pull/15378
https://github.com/apache/dubbo/pull/15262

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Make sure gitHub actions can pass. [Why the workflow is failing and how to fix it?](../CONTRIBUTING.md)
