### PR TITLE
feat: support environment variable keys with hyphens and dots for Dubbo configuration, fully compatible with legacy and Spring Boot styles

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/config/EnvironmentConfiguration.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/config/EnvironmentConfiguration.java
@@ -29,52 +29,45 @@ import java.util.Set;
  */
 public class EnvironmentConfiguration implements Configuration {
 
-    private final Map<String, String> envMap;
-
     @Override
     public Object getInternalProperty(String key) {
         if (StringUtils.isEmpty(key)) {
             return null;
         }
-        String value = envMap.get(key);
+        String value = getenv().get(key);
         if (value != null) {
             return value;
         }
         for (String candidateKey : generateCandidateEnvironmentKeys(key)) {
-            value = envMap.get(candidateKey);
+            value = getenv().get(candidateKey);
             if (value != null) {
                 return value;
             }
         }
 
         String osStyleKey = StringUtils.toOSStyleKey(key);
-        value = envMap.get(osStyleKey);
+        value = getenv().get(osStyleKey);
         return value;
     }
 
     private Set<String> generateCandidateEnvironmentKeys(String originalKey) {
         Set<String> candidates = new LinkedHashSet<>();
 
-        // Dots and hyphens to underscores, uppercase
-        String normalizedKey = originalKey
-                .replace(CommonConstants.DOT_SEPARATOR, CommonConstants.UNDERLINE_SEPARATOR)
-                .replace(CommonConstants.PROPERTIES_CHAR_SEPARATOR, CommonConstants.UNDERLINE_SEPARATOR);
+        String dotsToUnderscores =
+                originalKey.replace(CommonConstants.DOT_SEPARATOR, CommonConstants.UNDERLINE_SEPARATOR);
+        String normalizedKey = dotsToUnderscores.replace(
+                CommonConstants.PROPERTIES_CHAR_SEPARATOR, CommonConstants.UNDERLINE_SEPARATOR);
+
         candidates.add(normalizedKey.toUpperCase(Locale.ROOT));
 
-        // Dots to underscores, hyphens removed, uppercase (Spring Boot style)
-        String springLikeNoHyphens = originalKey
-                .replace(CommonConstants.DOT_SEPARATOR, CommonConstants.UNDERLINE_SEPARATOR)
+        String springLikeNoHyphens = dotsToUnderscores
                 .replace(CommonConstants.PROPERTIES_CHAR_SEPARATOR, "")
                 .toUpperCase(Locale.ROOT);
         candidates.add(springLikeNoHyphens);
 
-        // Dots to underscores, hyphens preserved, uppercase
-        String dotsToUnderscoresUpper = originalKey
-                .replace(CommonConstants.DOT_SEPARATOR, CommonConstants.UNDERLINE_SEPARATOR)
-                .toUpperCase(Locale.ROOT);
+        String dotsToUnderscoresUpper = dotsToUnderscores.toUpperCase(Locale.ROOT);
         candidates.add(dotsToUnderscoresUpper);
 
-        // Dots and hyphens to underscores, lowercase
         candidates.add(normalizedKey);
 
         return candidates;
@@ -82,15 +75,6 @@ public class EnvironmentConfiguration implements Configuration {
 
     public Map<String, String> getProperties() {
         return getenv();
-    }
-
-    // Adapt to System api, design for unit test
-    public EnvironmentConfiguration() {
-        this.envMap = System.getenv();
-    }
-
-    public EnvironmentConfiguration(Map<String, String> externalEnvMap) {
-        this.envMap = externalEnvMap;
     }
 
     protected Map<String, String> getenv() {

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/config/EnvironmentConfiguration.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/config/EnvironmentConfiguration.java
@@ -56,18 +56,21 @@ public class EnvironmentConfiguration implements Configuration {
         Set<String> candidates = new LinkedHashSet<>();
 
         // Dots and hyphens to underscores, uppercase
-        String normalizedKey = originalKey.replace(CommonConstants.DOT_SEPARATOR, CommonConstants.UNDERLINE_SEPARATOR)
+        String normalizedKey = originalKey
+                .replace(CommonConstants.DOT_SEPARATOR, CommonConstants.UNDERLINE_SEPARATOR)
                 .replace(CommonConstants.PROPERTIES_CHAR_SEPARATOR, CommonConstants.UNDERLINE_SEPARATOR);
         candidates.add(normalizedKey.toUpperCase(Locale.ROOT));
 
         // Dots to underscores, hyphens removed, uppercase (Spring Boot style)
-        String springLikeNoHyphens = originalKey.replace(CommonConstants.DOT_SEPARATOR, CommonConstants.UNDERLINE_SEPARATOR)
+        String springLikeNoHyphens = originalKey
+                .replace(CommonConstants.DOT_SEPARATOR, CommonConstants.UNDERLINE_SEPARATOR)
                 .replace(CommonConstants.PROPERTIES_CHAR_SEPARATOR, "")
                 .toUpperCase(Locale.ROOT);
         candidates.add(springLikeNoHyphens);
 
         // Dots to underscores, hyphens preserved, uppercase
-        String dotsToUnderscoresUpper = originalKey.replace(CommonConstants.DOT_SEPARATOR, CommonConstants.UNDERLINE_SEPARATOR)
+        String dotsToUnderscoresUpper = originalKey
+                .replace(CommonConstants.DOT_SEPARATOR, CommonConstants.UNDERLINE_SEPARATOR)
                 .toUpperCase(Locale.ROOT);
         candidates.add(dotsToUnderscoresUpper);
 

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/config/EnvironmentConfiguration.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/config/EnvironmentConfiguration.java
@@ -16,22 +16,65 @@
  */
 package org.apache.dubbo.common.config;
 
+import org.apache.dubbo.common.constants.CommonConstants;
 import org.apache.dubbo.common.utils.StringUtils;
 
+import java.util.LinkedHashSet;
+import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Configuration from system environment
  */
 public class EnvironmentConfiguration implements Configuration {
 
+    private final Map<String, String> envMap;
+
     @Override
     public Object getInternalProperty(String key) {
-        String value = getenv(key);
-        if (StringUtils.isEmpty(value)) {
-            value = getenv(StringUtils.toOSStyleKey(key));
+        if (StringUtils.isEmpty(key)) {
+            return null;
         }
+        String value = envMap.get(key);
+        if (value != null) {
+            return value;
+        }
+        for (String candidateKey : generateCandidateEnvironmentKeys(key)) {
+            value = envMap.get(candidateKey);
+            if (value != null) {
+                return value;
+            }
+        }
+
+        String osStyleKey = StringUtils.toOSStyleKey(key);
+        value = envMap.get(osStyleKey);
         return value;
+    }
+
+    private Set<String> generateCandidateEnvironmentKeys(String originalKey) {
+        Set<String> candidates = new LinkedHashSet<>();
+
+        // Dots and hyphens to underscores, uppercase
+        String normalizedKey = originalKey.replace(CommonConstants.DOT_SEPARATOR, CommonConstants.UNDERLINE_SEPARATOR)
+                .replace(CommonConstants.PROPERTIES_CHAR_SEPARATOR, CommonConstants.UNDERLINE_SEPARATOR);
+        candidates.add(normalizedKey.toUpperCase(Locale.ROOT));
+
+        // Dots to underscores, hyphens removed, uppercase (Spring Boot style)
+        String springLikeNoHyphens = originalKey.replace(CommonConstants.DOT_SEPARATOR, CommonConstants.UNDERLINE_SEPARATOR)
+                .replace(CommonConstants.PROPERTIES_CHAR_SEPARATOR, "")
+                .toUpperCase(Locale.ROOT);
+        candidates.add(springLikeNoHyphens);
+
+        // Dots to underscores, hyphens preserved, uppercase
+        String dotsToUnderscoresUpper = originalKey.replace(CommonConstants.DOT_SEPARATOR, CommonConstants.UNDERLINE_SEPARATOR)
+                .toUpperCase(Locale.ROOT);
+        candidates.add(dotsToUnderscoresUpper);
+
+        // Dots and hyphens to underscores, lowercase
+        candidates.add(normalizedKey);
+
+        return candidates;
     }
 
     public Map<String, String> getProperties() {
@@ -39,9 +82,12 @@ public class EnvironmentConfiguration implements Configuration {
     }
 
     // Adapt to System api, design for unit test
+    public EnvironmentConfiguration() {
+        this.envMap = System.getenv();
+    }
 
-    protected String getenv(String key) {
-        return System.getenv(key);
+    public EnvironmentConfiguration(Map<String, String> externalEnvMap) {
+        this.envMap = externalEnvMap;
     }
 
     protected Map<String, String> getenv() {

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/config/EnvironmentConfigurationTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/config/EnvironmentConfigurationTest.java
@@ -30,11 +30,20 @@ class EnvironmentConfigurationTest {
     private static final String MOCK_KEY = "DUBBO_KEY";
     private static final String MOCK_VALUE = "mockValue";
 
+    private EnvironmentConfiguration envConfig(Map<String, String> map) {
+        return new EnvironmentConfiguration() {
+            @Override
+            protected Map<String, String> getenv() {
+                return map;
+            }
+        };
+    }
+
     @Test
     void testGetInternalProperty() {
         Map<String, String> map = new HashMap<>();
         map.put(MOCK_KEY, MOCK_VALUE);
-        EnvironmentConfiguration configuration = new EnvironmentConfiguration(map);
+        EnvironmentConfiguration configuration = envConfig(map);
         Assertions.assertEquals(MOCK_VALUE, configuration.getInternalProperty("dubbo.key"));
         Assertions.assertEquals(MOCK_VALUE, configuration.getInternalProperty("key"));
         Assertions.assertEquals(MOCK_VALUE, configuration.getInternalProperty("dubbo_key"));
@@ -62,26 +71,26 @@ class EnvironmentConfigurationTest {
         envMap.put("DUBBO_ABC-DEF_GHI", "v3");
         envMap.put("dubbo_abc_def_ghi", "v4");
 
-        EnvironmentConfiguration configuration = new EnvironmentConfiguration(envMap);
+        EnvironmentConfiguration configuration = envConfig(envMap);
 
         String dubboKey = "dubbo.abc-def.ghi";
 
         Assertions.assertEquals("v1", configuration.getProperty(dubboKey));
 
         envMap.remove("DUBBO_ABC_DEF_GHI");
-        configuration = new EnvironmentConfiguration(envMap);
+        configuration = envConfig(envMap);
         Assertions.assertEquals("v2", configuration.getProperty(dubboKey));
 
         envMap.remove("DUBBO_ABCDEF_GHI");
-        configuration = new EnvironmentConfiguration(envMap);
+        configuration = envConfig(envMap);
         Assertions.assertEquals("v3", configuration.getProperty(dubboKey));
 
         envMap.remove("DUBBO_ABC-DEF_GHI");
-        configuration = new EnvironmentConfiguration(envMap);
+        configuration = envConfig(envMap);
         Assertions.assertEquals("v4", configuration.getProperty(dubboKey));
 
         envMap.remove("dubbo_abc_def_ghi");
-        configuration = new EnvironmentConfiguration(envMap);
+        configuration = envConfig(envMap);
         Assertions.assertNull(configuration.getProperty(dubboKey));
     }
 }

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/config/EnvironmentConfigurationTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/config/EnvironmentConfigurationTest.java
@@ -34,13 +34,7 @@ class EnvironmentConfigurationTest {
     void testGetInternalProperty() {
         Map<String, String> map = new HashMap<>();
         map.put(MOCK_KEY, MOCK_VALUE);
-        EnvironmentConfiguration configuration = new EnvironmentConfiguration() {
-            @Override
-            protected String getenv(String key) {
-                return map.get(key);
-            }
-        };
-        // this UT maybe only works on particular platform, assert only when value is not null.
+        EnvironmentConfiguration configuration = new EnvironmentConfiguration(map);
         Assertions.assertEquals(MOCK_VALUE, configuration.getInternalProperty("dubbo.key"));
         Assertions.assertEquals(MOCK_VALUE, configuration.getInternalProperty("key"));
         Assertions.assertEquals(MOCK_VALUE, configuration.getInternalProperty("dubbo_key"));
@@ -58,5 +52,36 @@ class EnvironmentConfigurationTest {
             }
         };
         Assertions.assertEquals(map, configuration.getProperties());
+    }
+
+    @Test
+    void testHyphenAndDotKeyResolveFromEnv() {
+        Map<String, String> envMap = new HashMap<>();
+        envMap.put("DUBBO_ABC_DEF_GHI", "v1");
+        envMap.put("DUBBO_ABCDEF_GHI", "v2");
+        envMap.put("DUBBO_ABC-DEF_GHI", "v3");
+        envMap.put("dubbo_abc_def_ghi", "v4");
+
+        EnvironmentConfiguration configuration = new EnvironmentConfiguration(envMap);
+
+        String dubboKey = "dubbo.abc-def.ghi";
+
+        Assertions.assertEquals("v1", configuration.getProperty(dubboKey));
+
+        envMap.remove("DUBBO_ABC_DEF_GHI");
+        configuration = new EnvironmentConfiguration(envMap);
+        Assertions.assertEquals("v2", configuration.getProperty(dubboKey));
+
+        envMap.remove("DUBBO_ABCDEF_GHI");
+        configuration = new EnvironmentConfiguration(envMap);
+        Assertions.assertEquals("v3", configuration.getProperty(dubboKey));
+
+        envMap.remove("DUBBO_ABC-DEF_GHI");
+        configuration = new EnvironmentConfiguration(envMap);
+        Assertions.assertEquals("v4", configuration.getProperty(dubboKey));
+
+        envMap.remove("dubbo_abc_def_ghi");
+        configuration = new EnvironmentConfiguration(envMap);
+        Assertions.assertNull(configuration.getProperty(dubboKey));
     }
 }


### PR DESCRIPTION
## What is the purpose of the change?
adds support for configuring Dubbo keys containing hyphens and dots via environment variables, fully compatible with legacy Dubbo and Spring Boot naming conventions. The new logic allows users to set configuration using various environment variable formats (e.g., underscores, uppercase, with or without hyphens), making Dubbo configuration more flexible and user-friendly. Comprehensive unit tests are included to ensure correctness and compatibility.

#15320

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Make sure gitHub actions can pass. [Why the workflow is failing and how to fix it?](../CONTRIBUTING.md)
