### PR TITLE
[3.3] Support spotless on jdk8, correct palantirJavaFormat version on jdk11, update palantirJavaFormat  version on jdk21 

### DIFF
--- a/dubbo-dependencies-bom/pom.xml
+++ b/dubbo-dependencies-bom/pom.xml
@@ -181,9 +181,15 @@
     <maven_flatten_version>1.7.0</maven_flatten_version>
     <commons_compress_version>1.27.1</commons_compress_version>
     <spotless-maven-plugin.version>2.44.4</spotless-maven-plugin.version>
+    <spotless-maven-plugin.support-jdk8.version>2.30.0</spotless-maven-plugin.support-jdk8.version>
     <spotless.action>check</spotless.action>
     <dubbo-shared-resources.version>1.0.0</dubbo-shared-resources.version>
-    <palantirJavaFormat.version>2.38.0</palantirJavaFormat.version>
+    <!--
+     Choose palantirJavaFormat version 1.1.0 for jdk8, 2.28.0 for jdk11, 2.57.0 for jdk21,
+     refer to JVM_SUPPORT in PalantirJavaFormatStep.java at https://github.com/diffplug/spotless:
+     JVM_SUPPORT = Jvm.<String> support(NAME).add(8, "1.1.0").add(11, "2.28.0").add(21, "2.57.0");
+     -->
+    <palantirJavaFormat.version>2.28.0</palantirJavaFormat.version>
     <jakarta.xml.bind-api.version>4.0.2</jakarta.xml.bind-api.version>
     <jaxb-runtime.version>2.4.0-b180830.0438</jaxb-runtime.version>
     <!-- Spring boot buddy is lower than the delivery dependency package version and can only show the defined dependency version -->
@@ -996,6 +1002,50 @@
   </dependencyManagement>
 
   <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>com.diffplug.spotless</groupId>
+          <artifactId>spotless-maven-plugin</artifactId>
+          <configuration>
+            <java>
+              <removeUnusedImports />
+              <importOrder>
+                <file>dubbo-importorder.txt</file>
+              </importOrder>
+              <licenseHeader>
+                <file>checkstyle-header.txt</file>
+              </licenseHeader>
+            </java>
+            <pom>
+              <sortPom>
+                <expandEmptyElements>false</expandEmptyElements>
+                <spaceBeforeCloseEmptyElement>true</spaceBeforeCloseEmptyElement>
+              </sortPom>
+            </pom>
+            <upToDateChecking>
+              <enabled>true</enabled>
+            </upToDateChecking>
+          </configuration>
+          <dependencies>
+            <dependency>
+              <groupId>com.alibaba</groupId>
+              <artifactId>dubbo-shared-resources</artifactId>
+              <version>${dubbo-shared-resources.version}</version>
+            </dependency>
+          </dependencies>
+          <executions>
+            <execution>
+              <goals>
+                <goal>${spotless.action}</goal>
+              </goals>
+              <phase>process-sources</phase>
+            </execution>
+          </executions>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+
     <plugins>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
@@ -1052,6 +1102,40 @@
       </build>
     </profile>
     <profile>
+      <id>jdk8-jdk11</id>
+      <activation>
+        <jdk>[1.8, 11)</jdk>
+      </activation>
+      <properties>
+        <palantirJavaFormat.version>1.1.0</palantirJavaFormat.version>
+      </properties>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>com.diffplug.spotless</groupId>
+            <artifactId>spotless-maven-plugin</artifactId>
+            <version>${spotless-maven-plugin.support-jdk8.version}</version>
+            <configuration>
+              <java>
+                <palantirJavaFormat>
+                  <version>${palantirJavaFormat.version}</version>
+                </palantirJavaFormat>
+              </java>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>jdk21-spotless</id>
+      <activation>
+        <jdk>[21,)</jdk>
+      </activation>
+      <properties>
+        <palantirJavaFormat.version>2.57.0</palantirJavaFormat.version>
+      </properties>
+    </profile>
+    <profile>
       <id>java11+</id>
       <activation>
         <jdk>[11,)</jdk>
@@ -1068,39 +1152,8 @@
                 <palantirJavaFormat>
                   <version>${palantirJavaFormat.version}</version>
                 </palantirJavaFormat>
-                <removeUnusedImports />
-                <importOrder>
-                  <file>dubbo-importorder.txt</file>
-                </importOrder>
-                <licenseHeader>
-                  <file>checkstyle-header.txt</file>
-                </licenseHeader>
               </java>
-              <pom>
-                <sortPom>
-                  <expandEmptyElements>false</expandEmptyElements>
-                  <spaceBeforeCloseEmptyElement>true</spaceBeforeCloseEmptyElement>
-                </sortPom>
-              </pom>
-              <upToDateChecking>
-                <enabled>true</enabled>
-              </upToDateChecking>
             </configuration>
-            <dependencies>
-              <dependency>
-                <groupId>com.alibaba</groupId>
-                <artifactId>dubbo-shared-resources</artifactId>
-                <version>${dubbo-shared-resources.version}</version>
-              </dependency>
-            </dependencies>
-            <executions>
-              <execution>
-                <goals>
-                  <goal>${spotless.action}</goal>
-                </goals>
-                <phase>process-sources</phase>
-              </execution>
-            </executions>
           </plugin>
         </plugins>
       </build>

--- a/pom.xml
+++ b/pom.xml
@@ -170,6 +170,7 @@
     <protobuf-protoc_version>3.22.3</protobuf-protoc_version>
     <grpc_version>1.54.0</grpc_version>
     <spotless-maven-plugin.version>2.44.4</spotless-maven-plugin.version>
+    <spotless-maven-plugin.support-jdk8.version>2.30.0</spotless-maven-plugin.support-jdk8.version>
     <dubbo-shared-resources.version>1.0.0</dubbo-shared-resources.version>
     <palantirJavaFormat.version>2.38.0</palantirJavaFormat.version>
     <revision>3.3.4-SNAPSHOT</revision>
@@ -288,6 +289,86 @@
                 <goal>compile</goal>
               </goals>
               <phase>generate-sources</phase>
+            </execution>
+          </executions>
+        </plugin>
+        <plugin>
+          <groupId>com.diffplug.spotless</groupId>
+          <artifactId>spotless-maven-plugin</artifactId>
+          <configuration>
+            <java>
+              <excludes>
+                <exclude>src/main/java/org/apache/dubbo/common/threadlocal/InternalThreadLocal.java</exclude>
+                <exclude>src/main/java/org/apache/dubbo/common/threadlocal/InternalThreadLocalMap.java</exclude>
+                <exclude>src/main/java/org/apache/dubbo/common/timer/HashedWheelTimer.java</exclude>
+                <exclude>src/main/java/org/apache/dubbo/common/timer/Timeout.java</exclude>
+                <exclude>src/main/java/org/apache/dubbo/common/timer/Timer.java</exclude>
+                <exclude>src/main/java/org/apache/dubbo/common/timer/TimerTask.java</exclude>
+                <exclude>src/main/java/org/apache/dubbo/common/utils/CIDRUtils.java</exclude>
+                <exclude>src/main/java/org/apache/dubbo/common/utils/Utf8Utils.java</exclude>
+                <exclude>src/test/java/org/apache/dubbo/config/spring/EmbeddedZooKeeper.java</exclude>
+                <exclude>src/main/java/org/apache/dubbo/test/common/utils/TestSocketUtils.java</exclude>
+                <exclude>src/main/java/org/apache/dubbo/rpc/protocol/tri/TriHttp2RemoteFlowController.java</exclude>
+                <exclude>src/main/java/org/apache/dubbo/rpc/protocol/tri/rest/cors/CorsHeaderFilter.java</exclude>
+                <exclude>src/main/java/org/apache/dubbo/common/threadpool/serial/SerializingExecutor.java</exclude>
+                <exclude>src/main/java/org/apache/dubbo/maven/plugin/aot/AbstractAotMojo.java</exclude>
+                <exclude>src/main/java/org/apache/dubbo/maven/plugin/aot/AbstractDependencyFilterMojo.java</exclude>
+                <exclude>src/main/java/org/apache/dubbo/maven/plugin/aot/CommandLineBuilder.java</exclude>
+                <exclude>src/main/java/org/apache/dubbo/maven/plugin/aot/DependencyFilter.java</exclude>
+                <exclude>src/main/java/org/apache/dubbo/maven/plugin/aot/Exclude.java</exclude>
+                <exclude>src/main/java/org/apache/dubbo/maven/plugin/aot/ExcludeFilter.java</exclude>
+                <exclude>src/main/java/org/apache/dubbo/maven/plugin/aot/FilterableDependency.java</exclude>
+                <exclude>src/main/java/org/apache/dubbo/maven/plugin/aot/Include.java</exclude>
+                <exclude>src/main/java/org/apache/dubbo/maven/plugin/aot/IncludeFilter.java</exclude>
+                <exclude>src/main/java/org/apache/dubbo/maven/plugin/aot/JavaCompilerPluginConfiguration.java</exclude>
+                <exclude>src/main/java/org/apache/dubbo/maven/plugin/aot/JavaExecutable.java</exclude>
+                <exclude>src/main/java/org/apache/dubbo/maven/plugin/aot/JavaProcessExecutor.java</exclude>
+                <exclude>src/main/java/org/apache/dubbo/maven/plugin/aot/MatchingGroupIdFilter.java</exclude>
+                <exclude>src/main/java/org/apache/dubbo/maven/plugin/aot/RunArguments.java</exclude>
+                <exclude>src/main/java/org/apache/dubbo/maven/plugin/aot/RunProcess.java</exclude>
+                <exclude>src/main/java/org/apache/dubbo/aot/generate/BasicJsonWriter.java</exclude>
+                <exclude>src/main/java/org/apache/dubbo/aot/api/ExecutableMode.java</exclude>
+                <exclude>src/main/java/org/apache/dubbo/aot/api/MemberCategory.java</exclude>
+                <exclude>src/main/java/org/apache/dubbo/metrics/aggregate/DubboMergingDigest.java</exclude>
+                <exclude>src/main/java/org/apache/dubbo/metrics/aggregate/DubboAbstractTDigest.java</exclude>
+                <exclude>src/main/java/org/apache/dubbo/common/logger/helpers/FormattingTuple.java</exclude>
+                <exclude>src/main/java/org/apache/dubbo/common/logger/helpers/MessageFormatter.java</exclude>
+                <exclude>src/main/java/org/apache/dubbo/maven/plugin/protoc/DubboProtocCompilerMojo.java</exclude>
+                <exclude>src/main/java/org/apache/dubbo/gen/utils/ProtoTypeMap.java</exclude>
+                <exclude>src/main/java/org/apache/dubbo/spring/boot/autoconfigure/DubboTriple3AutoConfiguration.java</exclude>
+                <exclude>**/generated-sources/**</exclude>
+              </excludes>
+              <removeUnusedImports />
+              <importOrder>
+                <file>dubbo-importorder.txt</file>
+              </importOrder>
+              <licenseHeader>
+                <file>checkstyle-header.txt</file>
+              </licenseHeader>
+            </java>
+            <pom>
+              <sortPom>
+                <expandEmptyElements>false</expandEmptyElements>
+                <spaceBeforeCloseEmptyElement>true</spaceBeforeCloseEmptyElement>
+              </sortPom>
+            </pom>
+            <upToDateChecking>
+              <enabled>true</enabled>
+            </upToDateChecking>
+          </configuration>
+          <dependencies>
+            <dependency>
+              <groupId>com.alibaba</groupId>
+              <artifactId>dubbo-shared-resources</artifactId>
+              <version>${dubbo-shared-resources.version}</version>
+            </dependency>
+          </dependencies>
+          <executions>
+            <execution>
+              <goals>
+                <goal>${spotless.action}</goal>
+              </goals>
+              <phase>process-sources</phase>
             </execution>
           </executions>
         </plugin>
@@ -822,13 +903,29 @@
     </profile>
 
     <profile>
-      <id>jdk9-jdk11-spotless</id>
+      <id>jdk8-jdk11-spotless</id>
       <activation>
         <jdk>[1.8, 11)</jdk>
       </activation>
       <properties>
         <palantirJavaFormat.version>1.1.0</palantirJavaFormat.version>
       </properties>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>com.diffplug.spotless</groupId>
+            <artifactId>spotless-maven-plugin</artifactId>
+            <version>${spotless-maven-plugin.support-jdk8.version}</version>
+            <configuration>
+              <java>
+                <palantirJavaFormat>
+                  <version>${palantirJavaFormat.version}</version>
+                </palantirJavaFormat>
+              </java>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
     </profile>
 
     <profile>
@@ -847,7 +944,7 @@
         <jdk>[21,)</jdk>
       </activation>
       <properties>
-        <palantirJavaFormat.version>2.39.0</palantirJavaFormat.version>
+        <palantirJavaFormat.version>2.57.0</palantirJavaFormat.version>
       </properties>
     </profile>
 
@@ -865,83 +962,11 @@
             <version>${spotless-maven-plugin.version}</version>
             <configuration>
               <java>
-                <excludes>
-                  <exclude>src/main/java/org/apache/dubbo/common/threadlocal/InternalThreadLocal.java</exclude>
-                  <exclude>src/main/java/org/apache/dubbo/common/threadlocal/InternalThreadLocalMap.java</exclude>
-                  <exclude>src/main/java/org/apache/dubbo/common/timer/HashedWheelTimer.java</exclude>
-                  <exclude>src/main/java/org/apache/dubbo/common/timer/Timeout.java</exclude>
-                  <exclude>src/main/java/org/apache/dubbo/common/timer/Timer.java</exclude>
-                  <exclude>src/main/java/org/apache/dubbo/common/timer/TimerTask.java</exclude>
-                  <exclude>src/main/java/org/apache/dubbo/common/utils/CIDRUtils.java</exclude>
-                  <exclude>src/main/java/org/apache/dubbo/common/utils/Utf8Utils.java</exclude>
-                  <exclude>src/test/java/org/apache/dubbo/config/spring/EmbeddedZooKeeper.java</exclude>
-                  <exclude>src/main/java/org/apache/dubbo/test/common/utils/TestSocketUtils.java</exclude>
-                  <exclude>src/main/java/org/apache/dubbo/rpc/protocol/tri/TriHttp2RemoteFlowController.java</exclude>
-                  <exclude>src/main/java/org/apache/dubbo/rpc/protocol/tri/rest/cors/CorsHeaderFilter.java</exclude>
-                  <exclude>src/main/java/org/apache/dubbo/common/threadpool/serial/SerializingExecutor.java</exclude>
-                  <exclude>src/main/java/org/apache/dubbo/maven/plugin/aot/AbstractAotMojo.java</exclude>
-                  <exclude>src/main/java/org/apache/dubbo/maven/plugin/aot/AbstractDependencyFilterMojo.java</exclude>
-                  <exclude>src/main/java/org/apache/dubbo/maven/plugin/aot/CommandLineBuilder.java</exclude>
-                  <exclude>src/main/java/org/apache/dubbo/maven/plugin/aot/DependencyFilter.java</exclude>
-                  <exclude>src/main/java/org/apache/dubbo/maven/plugin/aot/Exclude.java</exclude>
-                  <exclude>src/main/java/org/apache/dubbo/maven/plugin/aot/ExcludeFilter.java</exclude>
-                  <exclude>src/main/java/org/apache/dubbo/maven/plugin/aot/FilterableDependency.java</exclude>
-                  <exclude>src/main/java/org/apache/dubbo/maven/plugin/aot/Include.java</exclude>
-                  <exclude>src/main/java/org/apache/dubbo/maven/plugin/aot/IncludeFilter.java</exclude>
-                  <exclude>src/main/java/org/apache/dubbo/maven/plugin/aot/JavaCompilerPluginConfiguration.java</exclude>
-                  <exclude>src/main/java/org/apache/dubbo/maven/plugin/aot/JavaExecutable.java</exclude>
-                  <exclude>src/main/java/org/apache/dubbo/maven/plugin/aot/JavaProcessExecutor.java</exclude>
-                  <exclude>src/main/java/org/apache/dubbo/maven/plugin/aot/MatchingGroupIdFilter.java</exclude>
-                  <exclude>src/main/java/org/apache/dubbo/maven/plugin/aot/RunArguments.java</exclude>
-                  <exclude>src/main/java/org/apache/dubbo/maven/plugin/aot/RunProcess.java</exclude>
-                  <exclude>src/main/java/org/apache/dubbo/aot/generate/BasicJsonWriter.java</exclude>
-                  <exclude>src/main/java/org/apache/dubbo/aot/api/ExecutableMode.java</exclude>
-                  <exclude>src/main/java/org/apache/dubbo/aot/api/MemberCategory.java</exclude>
-                  <exclude>src/main/java/org/apache/dubbo/metrics/aggregate/DubboMergingDigest.java</exclude>
-                  <exclude>src/main/java/org/apache/dubbo/metrics/aggregate/DubboAbstractTDigest.java</exclude>
-                  <exclude>src/main/java/org/apache/dubbo/common/logger/helpers/FormattingTuple.java</exclude>
-                  <exclude>src/main/java/org/apache/dubbo/common/logger/helpers/MessageFormatter.java</exclude>
-                  <exclude>src/main/java/org/apache/dubbo/maven/plugin/protoc/DubboProtocCompilerMojo.java</exclude>
-                  <exclude>src/main/java/org/apache/dubbo/gen/utils/ProtoTypeMap.java</exclude>
-                  <exclude>src/main/java/org/apache/dubbo/spring/boot/autoconfigure/DubboTriple3AutoConfiguration.java</exclude>
-                  <exclude>**/generated-sources/**</exclude>
-                </excludes>
                 <palantirJavaFormat>
                   <version>${palantirJavaFormat.version}</version>
                 </palantirJavaFormat>
-                <removeUnusedImports />
-                <importOrder>
-                  <file>dubbo-importorder.txt</file>
-                </importOrder>
-                <licenseHeader>
-                  <file>checkstyle-header.txt</file>
-                </licenseHeader>
               </java>
-              <pom>
-                <sortPom>
-                  <expandEmptyElements>false</expandEmptyElements>
-                  <spaceBeforeCloseEmptyElement>true</spaceBeforeCloseEmptyElement>
-                </sortPom>
-              </pom>
-              <upToDateChecking>
-                <enabled>true</enabled>
-              </upToDateChecking>
             </configuration>
-            <dependencies>
-              <dependency>
-                <groupId>com.alibaba</groupId>
-                <artifactId>dubbo-shared-resources</artifactId>
-                <version>${dubbo-shared-resources.version}</version>
-              </dependency>
-            </dependencies>
-            <executions>
-              <execution>
-                <goals>
-                  <goal>${spotless.action}</goal>
-                </goals>
-                <phase>process-sources</phase>
-              </execution>
-            </executions>
           </plugin>
         </plugins>
       </build>


### PR DESCRIPTION
## What is the purpose of the change?
1. for the convenience of fixing major formatting issues by running ```mvn spotless:apply``` on jdk8 with palantirJavaFormat  1.1.0
2. correct palantirJavaFormat version to 2.28.0 on jdk11
3. update palantirJavaFormat version to 2.57.0 on jdk21

refer to JVM_SUPPORT in PalantirJavaFormatStep.java at https://github.com/diffplug/spotless
```
private static final Jvm.Support<String> JVM_SUPPORT = Jvm.<String> support(NAME).add(8, "1.1.0").add(11, "2.28.0").add(21, "2.57.0");
```
## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Make sure gitHub actions can pass. [Why the workflow is failing and how to fix it?](../CONTRIBUTING.md)
