### PR TITLE
[Feature] Add spring 6.1.5,spring-boot 3.2.3,jdk17 to the candidate versions of dubbo workflows

### DIFF
--- a/.github/workflows/build-and-test-pr.yml
+++ b/.github/workflows/build-and-test-pr.yml
@@ -133,7 +133,7 @@ jobs:
         run: rm -rf ~/.m2/repository/org/apache/dubbo
       - name: "Build Dubbo with maven"
         run: |
-          ./mvnw ${{ env.MAVEN_ARGS }} clean install -Psources,'!demo',skip-spotless,checkstyle -Dmaven.test.skip=true -DembeddedZookeeperPath=${{ github.workspace }}/.tmp/zookeeper
+          ./mvnw ${{ env.MAVEN_ARGS }} clean install -Psources,skip-spotless,checkstyle -Dmaven.test.skip=true -DembeddedZookeeperPath=${{ github.workspace }}/.tmp/zookeeper
       - name: "Save dubbo cache"
         uses: actions/cache/save@v4
         with:
@@ -248,7 +248,7 @@ jobs:
         timeout-minutes: 90
         run: |
           set -o pipefail
-          ./mvnw ${{ env.MAVEN_ARGS }} clean test verify -Pjacoco,jdk15ge-simple,'!jdk15ge','!demo',skip-spotless -DtrimStackTrace=false -Dmaven.test.skip=false -Dcheckstyle.skip=false -Dcheckstyle_unix.skip=false -Drat.skip=false -DembeddedZookeeperPath=${{ github.workspace }}/.tmp/zookeeper 2>&1 | tee >(grep -n -B 1 -A 200 "FAILURE! -- in" > test_errors.log)
+          ./mvnw ${{ env.MAVEN_ARGS }} clean test verify -Pjacoco,jdk15ge-simple,'!jdk15ge-add-open',skip-spotless -DtrimStackTrace=false -Dmaven.test.skip=false -Dcheckstyle.skip=false -Dcheckstyle_unix.skip=false -Drat.skip=false -DembeddedZookeeperPath=${{ github.workspace }}/.tmp/zookeeper 2>&1 | tee >(grep -n -B 1 -A 200 "FAILURE! -- in" > test_errors.log)
       - name: "Print test error log"
         if: failure()
         run: cat test_errors.log
@@ -626,7 +626,7 @@ jobs:
       - name: "Compile Dubbo (Linux)"
         run: |
           cd ${{ github.workspace }}/dubbo
-          ./mvnw ${{ env.MAVEN_ARGS }} -T 2C clean install -P '!demo',skip-spotless -Dmaven.test.skip=true -Dcheckstyle.skip=true -Dcheckstyle_unix.skip=true -Drat.skip=true
+          ./mvnw ${{ env.MAVEN_ARGS }} -T 2C clean install -P skip-spotless -Dmaven.test.skip=true -Dcheckstyle.skip=true -Dcheckstyle_unix.skip=true -Drat.skip=true
       - name: "Run Error Code Inspecting"
         env:
           DUBBO_ECI_REPORT_AS_ERROR: true
@@ -679,7 +679,7 @@ jobs:
       - name: "Compile Dubbo (Linux)"
         run: |
           cd ${{ github.workspace }}/dubbo
-          ./mvnw ${{ env.MAVEN_ARGS }} -T 2C clean install -P '!demo',skip-spotless -Dmaven.test.skip=true -Dcheckstyle.skip=true -Dcheckstyle_unix.skip=true -Drat.skip=true
+          ./mvnw ${{ env.MAVEN_ARGS }} -T 2C clean install -P skip-spotless -Dmaven.test.skip=true -Dcheckstyle.skip=true -Dcheckstyle_unix.skip=true -Drat.skip=true
       - name: "Checkout dubbo-samples repository"
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/build-and-test-pr.yml
+++ b/.github/workflows/build-and-test-pr.yml
@@ -13,8 +13,8 @@ env:
   VERSIONS_LIMIT: 4
   JACOCO_ENABLE: true
   CANDIDATE_VERSIONS: '
-    spring.version:5.3.24;
-    spring-boot.version:2.7.6;
+    spring.version:5.3.24,6.1.5;
+    spring-boot.version:2.7.6,3.2.3;
     '
   MAVEN_OPTS: >-
     -XX:+UseG1GC

--- a/.github/workflows/build-and-test-pr.yml
+++ b/.github/workflows/build-and-test-pr.yml
@@ -221,7 +221,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: "Set up JDK ${{ matrix.jdk }}"
+      - name: "Set up JDK 21"
         uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
@@ -285,15 +285,16 @@ jobs:
           path: test/jobs
   samples-test-job:
     needs: [check-format, build-source, samples-test-prepare]
-    name: "Samples Test on ubuntu-latest (JobId: ${{matrix.job_id}})"
+    name: "Samples Test on ubuntu-latest (JobId: ${{matrix.job_id}} Java: ${{matrix.java}})"
     runs-on: ubuntu-latest
     timeout-minutes: 90
     env:
-      JAVA_VER: 8
+      JAVA_VER: ${{matrix.java}}
       TEST_CASE_FILE: jobs/testjob_${{matrix.job_id}}.txt
     strategy:
       fail-fast: false
       matrix:
+        java: [ 8, 17 ]
         job_id: [1,2,3]
     steps:
       - uses: actions/checkout@v4
@@ -323,11 +324,11 @@ jobs:
         with:
           name: samples-test-list
           path: test/jobs/
-      - name: "Set up JDK 8"
+      - name: "Set up JDK ${{matrix.java}}"
         uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
-          java-version: 8
+          java-version: ${{matrix.java}}
       - name: "Init Candidate Versions"
         run: |
           DUBBO_VERSION="${{needs.build-source.outputs.version}}"
@@ -342,26 +343,30 @@ jobs:
       - name: "Upload jacoco"
         uses: actions/upload-artifact@v4
         with:
-          name: samples-jacoco-result-${{matrix.job_id}}
+          name: samples-jacoco-result-${{matrix.job_id}}-java${{matrix.java}}
           path: target/jacoco*.exec
       - name: "Upload test result"
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: samples-test-result-${{matrix.job_id}}
+          name: samples-test-result-${{matrix.job_id}}-java${{matrix.java}}
           path: test/jobs/*-result*
       - name: "Upload test logs"
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: samples-test-logs-${{matrix.job_id}}
+          name: samples-test-logs-${{matrix.job_id}}-java${{matrix.java}}
           path: test/logs/*
   samples-test-result:
     needs: [check-format, samples-test-job]
+    name: "Samples Test Result on ubuntu-latest (JobId: ${{matrix.job_id}} Java: ${{matrix.java}})"
     if: always()
     runs-on: ubuntu-latest
     env:
-      JAVA_VER: 8
+      JAVA_VER: ${{matrix.java}}
+    strategy:
+      matrix:
+        java: [ 8, 17 ]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -370,8 +375,9 @@ jobs:
       - name: "Download test result"
         uses: actions/download-artifact@v4
         with:
-          pattern: samples-test-result-*
+          pattern: samples-test-result-*-java${{matrix.java}}
           path: test/jobs/
+          merge-multiple: true
       - name: "Merge test result"
         run: ./test/scripts/merge-test-results.sh
 
@@ -394,15 +400,16 @@ jobs:
           path: test/jobs
   integration-test-job:
     needs: [check-format, build-source, integration-test-prepare]
-    name: "Integration Test on ubuntu-latest (JobId: ${{matrix.job_id}})"
+    name: "Integration Test on ubuntu-latest (JobId: ${{matrix.job_id}} Java: ${{matrix.java}})"
     runs-on: ubuntu-latest
     timeout-minutes: 90
     env:
-      JAVA_VER: 8
+      JAVA_VER: ${{matrix.java}}
       TEST_CASE_FILE: jobs/testjob_${{matrix.job_id}}.txt
     strategy:
       fail-fast: false
       matrix:
+        java: [ 8, 17 ]
         job_id: [1,2,3]
     steps:
       - uses: actions/checkout@v4
@@ -432,11 +439,11 @@ jobs:
         with:
           name: test-list
           path: test/jobs/
-      - name: "Set up JDK 8"
+      - name: "Set up JDK ${{matrix.java}}"
         uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
-          java-version: 8
+          java-version: ${{matrix.java}}
       - name: "Init Candidate Versions"
         run: |
           DUBBO_VERSION="${{needs.build-source.outputs.version}}"
@@ -451,26 +458,30 @@ jobs:
       - name: "Upload jacoco"
         uses: actions/upload-artifact@v4
         with:
-          name: jacoco-result-${{matrix.job_id}}
+          name: jacoco-result-${{matrix.job_id}}-java${{matrix.java}}
           path: target/jacoco*.exec
       - name: "Upload test result"
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: test-result-${{matrix.job_id}}
+          name: test-result-${{matrix.job_id}}-java${{matrix.java}}
           path: test/jobs/*-result*
       - name: "Upload test logs"
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: integration-test-logs-${{matrix.job_id}}
+          name: integration-test-logs-${{matrix.job_id}}-java${{matrix.java}}
           path: test/logs/*
   integration-test-result:
+    name: "Integration Test Result on ubuntu-latest (JobId: ${{matrix.job_id}} Java: ${{matrix.java}})"
     needs: [check-format, integration-test-job]
     if: always()
     runs-on: ubuntu-latest
     env:
-      JAVA_VER: 8
+      JAVA_VER: ${{matrix.java}}
+    strategy:
+      matrix:
+        java: [ 8, 17 ]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -479,14 +490,19 @@ jobs:
       - name: "Download test result"
         uses: actions/download-artifact@v4
         with:
-          pattern: test-result-*
+          pattern: test-result-*-java${{matrix.java}}
           path: test/jobs/
+          merge-multiple: true
       - name: "Merge test result"
         run: ./test/scripts/merge-test-results.sh
 
   samples-jacoco-result-merge:
+    name: "Samples Jacoco Result on ubuntu-latest (JobId: ${{matrix.job_id}} Java: ${{matrix.java}})"
     runs-on: ubuntu-latest
     needs: [check-format, samples-test-result]
+    strategy:
+      matrix:
+        java: [ 8, 17 ]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/checkout@v4
@@ -510,9 +526,10 @@ jobs:
       - name: "Restore samples jacoco exec"
         uses: actions/download-artifact@v4
         with:
-          pattern: samples-jacoco-result-*
+          pattern: samples-jacoco-result-*-java${{matrix.java}}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path: dubbo-samples/target/
+          merge-multiple: true
       - name: "Merge samples jacoco result"
         run: |
           cd ${{ github.workspace }}/dubbo-samples/test/dubbo-test-jacoco-merger
@@ -524,14 +541,18 @@ jobs:
         uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          flags: samples-tests
+          flags: samples-tests-java${{matrix.java}}
           verbose: true
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   integration-jacoco-result-merge:
+    name: "Integration Jacoco Result on ubuntu-latest (JobId: ${{matrix.job_id}} Java: ${{matrix.java}})"
     runs-on: ubuntu-latest
     needs: [check-format, integration-test-result, samples-test-result]
+    strategy:
+      matrix:
+        java: [ 8, 17 ]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/checkout@v4
@@ -555,9 +576,10 @@ jobs:
       - name: "Restore integration test jacoco exec"
         uses: actions/download-artifact@v4
         with:
-          pattern: jacoco-result-*
+          pattern: jacoco-result-*-java${{matrix.java}}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path: dubbo-integration-cases/target/
+          merge-multiple: true
       - name: "Merge integration test jacoco result"
         run: |
           cd ${{ github.workspace }}/dubbo-integration-cases/test/dubbo-test-jacoco-merger
@@ -569,7 +591,7 @@ jobs:
         uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          flags: integration-tests
+          flags: integration-tests-java${{matrix.java}}
           verbose: true
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/build-and-test-scheduled-3.1.yml
+++ b/.github/workflows/build-and-test-scheduled-3.1.yml
@@ -217,11 +217,11 @@ jobs:
       - name: "Test with Maven with Integration Tests"
         timeout-minutes: 70
         if: ${{ startsWith( matrix.os, 'ubuntu') && matrix.jdk != '8' }}
-        run: ./mvnw --batch-mode --no-snapshot-updates -e --no-transfer-progress --fail-fast clean test verify -Pjacoco,jdk15ge-simple,'!jdk15ge' -Dmaven.wagon.httpconnectionManager.ttlSeconds=120 -Dmaven.wagon.http.retryHandler.count=5 -DskipTests=false -DskipIntegrationTests=false -Dcheckstyle.skip=false -Dcheckstyle_unix.skip=false -Drat.skip=false -Dmaven.javadoc.skip=true -DembeddedZookeeperPath=${{ github.workspace }}/.tmp/zookeeper
+        run: ./mvnw --batch-mode --no-snapshot-updates -e --no-transfer-progress --fail-fast clean test verify -Pjacoco,'!jdk15ge' -Dmaven.wagon.httpconnectionManager.ttlSeconds=120 -Dmaven.wagon.http.retryHandler.count=5 -DskipTests=false -DskipIntegrationTests=false -Dcheckstyle.skip=false -Dcheckstyle_unix.skip=false -Drat.skip=false -Dmaven.javadoc.skip=true -DembeddedZookeeperPath=${{ github.workspace }}/.tmp/zookeeper
       - name: "Test with Maven without Integration Tests"
         timeout-minutes: 90
         if: ${{ startsWith( matrix.os, 'windows') && matrix.jdk != '8' }}
-        run: ./mvnw --batch-mode --no-snapshot-updates -e --no-transfer-progress --fail-fast clean test verify -P"jacoco,jdk15ge-simple,'!jdk15ge'" -D"http.keepAlive=false" -D"maven.wagon.http.pool=false" -D"maven.wagon.httpconnectionManager.ttlSeconds=120" -D"maven.wagon.http.retryHandler.count=5" -DskipTests=false -DskipIntegrationTests=true -D"checkstyle.skip=false" -D"checkstyle_unix.skip=true" -D"rat.skip=false" -D"maven.javadoc.skip=true" -D"embeddedZookeeperPath=${{ github.workspace }}/.tmp/zookeeper"
+        run: ./mvnw --batch-mode --no-snapshot-updates -e --no-transfer-progress --fail-fast clean test verify -P"jacoco,'!jdk15ge'" -D"http.keepAlive=false" -D"maven.wagon.http.pool=false" -D"maven.wagon.httpconnectionManager.ttlSeconds=120" -D"maven.wagon.http.retryHandler.count=5" -DskipTests=false -DskipIntegrationTests=true -D"checkstyle.skip=false" -D"checkstyle_unix.skip=true" -D"rat.skip=false" -D"maven.javadoc.skip=true" -D"embeddedZookeeperPath=${{ github.workspace }}/.tmp/zookeeper"
 
   samples-test-prepare:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-and-test-scheduled-3.1.yml
+++ b/.github/workflows/build-and-test-scheduled-3.1.yml
@@ -325,6 +325,7 @@ jobs:
           pattern: samples-test-result-${{matrix.jdk}}-*
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path: test/jobs/
+          merge-multiple: true
       - name: "Merge test result"
         run: ./test/scripts/merge-test-results.sh
 
@@ -430,6 +431,7 @@ jobs:
           pattern: integration-test-result-${{matrix.jdk}}-*
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path: test/jobs/
+          merge-multiple: true
       - name: "Merge test result"
         run: ./test/scripts/merge-test-results.sh
 

--- a/.github/workflows/build-and-test-scheduled-3.2.yml
+++ b/.github/workflows/build-and-test-scheduled-3.2.yml
@@ -325,6 +325,7 @@ jobs:
           pattern: samples-test-result-${{matrix.jdk}}-*
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path: test/jobs/
+          merge-multiple: true
       - name: "Merge test result"
         run: ./test/scripts/merge-test-results.sh
 
@@ -430,6 +431,7 @@ jobs:
           pattern: integration-test-result-${{matrix.jdk}}-*
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path: test/jobs/
+          merge-multiple: true
       - name: "Merge test result"
         run: ./test/scripts/merge-test-results.sh
 

--- a/.github/workflows/build-and-test-scheduled-3.2.yml
+++ b/.github/workflows/build-and-test-scheduled-3.2.yml
@@ -209,19 +209,19 @@ jobs:
       - name: "Test with Maven with Integration Tests on JDK 8"
         timeout-minutes: 70
         if: ${{ startsWith( matrix.os, 'ubuntu') && matrix.jdk == '8' }}
-        run: ./mvnw --batch-mode --no-snapshot-updates -e --no-transfer-progress --fail-fast clean test verify -Pjacoco,'!jdk15ge' -Dmaven.wagon.httpconnectionManager.ttlSeconds=120 -Dmaven.wagon.http.retryHandler.count=5 -DskipTests=false -DskipIntegrationTests=false -Dcheckstyle.skip=false -Dcheckstyle_unix.skip=false -Drat.skip=false -Dmaven.javadoc.skip=true -DembeddedZookeeperPath=${{ github.workspace }}/.tmp/zookeeper
+        run: ./mvnw --batch-mode --no-snapshot-updates -e --no-transfer-progress --fail-fast clean test verify -Pjacoco,'!jdk15ge-add-open' -Dmaven.wagon.httpconnectionManager.ttlSeconds=120 -Dmaven.wagon.http.retryHandler.count=5 -DskipTests=false -DskipIntegrationTests=false -Dcheckstyle.skip=false -Dcheckstyle_unix.skip=false -Drat.skip=false -Dmaven.javadoc.skip=true -DembeddedZookeeperPath=${{ github.workspace }}/.tmp/zookeeper
       - name: "Test with Maven without Integration Tests on JDK 8"
         timeout-minutes: 90
         if: ${{ startsWith( matrix.os, 'windows') && matrix.jdk == '8' }}
-        run: ./mvnw --batch-mode --no-snapshot-updates -e --no-transfer-progress --fail-fast clean test verify -P"jacoco,'!jdk15ge'" -D"http.keepAlive=false" -D"maven.wagon.http.pool=false" -D"maven.wagon.httpconnectionManager.ttlSeconds=120" -D"maven.wagon.http.retryHandler.count=5" -DskipTests=false -DskipIntegrationTests=true -D"checkstyle.skip=false" -D"checkstyle_unix.skip=true" -D"rat.skip=false" -D"maven.javadoc.skip=true" -D"embeddedZookeeperPath=${{ github.workspace }}/.tmp/zookeeper"
+        run: ./mvnw --batch-mode --no-snapshot-updates -e --no-transfer-progress --fail-fast clean test verify -P"jacoco,'!jdk15ge-add-open'" -D"http.keepAlive=false" -D"maven.wagon.http.pool=false" -D"maven.wagon.httpconnectionManager.ttlSeconds=120" -D"maven.wagon.http.retryHandler.count=5" -DskipTests=false -DskipIntegrationTests=true -D"checkstyle.skip=false" -D"checkstyle_unix.skip=true" -D"rat.skip=false" -D"maven.javadoc.skip=true" -D"embeddedZookeeperPath=${{ github.workspace }}/.tmp/zookeeper"
       - name: "Test with Maven with Integration Tests"
         timeout-minutes: 70
         if: ${{ startsWith( matrix.os, 'ubuntu') && matrix.jdk != '8' }}
-        run: ./mvnw --batch-mode --no-snapshot-updates -e --no-transfer-progress --fail-fast clean test verify -Pjacoco,jdk15ge-simple,'!jdk15ge' -Dmaven.wagon.httpconnectionManager.ttlSeconds=120 -Dmaven.wagon.http.retryHandler.count=5 -DskipTests=false -DskipIntegrationTests=false -Dcheckstyle.skip=false -Dcheckstyle_unix.skip=false -Drat.skip=false -Dmaven.javadoc.skip=true -DembeddedZookeeperPath=${{ github.workspace }}/.tmp/zookeeper
+        run: ./mvnw --batch-mode --no-snapshot-updates -e --no-transfer-progress --fail-fast clean test verify -Pjacoco,jdk15ge-simple,'!jdk15ge-add-open' -Dmaven.wagon.httpconnectionManager.ttlSeconds=120 -Dmaven.wagon.http.retryHandler.count=5 -DskipTests=false -DskipIntegrationTests=false -Dcheckstyle.skip=false -Dcheckstyle_unix.skip=false -Drat.skip=false -Dmaven.javadoc.skip=true -DembeddedZookeeperPath=${{ github.workspace }}/.tmp/zookeeper
       - name: "Test with Maven without Integration Tests"
         timeout-minutes: 90
         if: ${{ startsWith( matrix.os, 'windows') && matrix.jdk != '8' }}
-        run: ./mvnw --batch-mode --no-snapshot-updates -e --no-transfer-progress --fail-fast clean test verify -P"jacoco,jdk15ge-simple,'!jdk15ge'" -D"http.keepAlive=false" -D"maven.wagon.http.pool=false" -D"maven.wagon.httpconnectionManager.ttlSeconds=120" -D"maven.wagon.http.retryHandler.count=5" -DskipTests=false -DskipIntegrationTests=true -D"checkstyle.skip=false" -D"checkstyle_unix.skip=true" -D"rat.skip=false" -D"maven.javadoc.skip=true" -D"embeddedZookeeperPath=${{ github.workspace }}/.tmp/zookeeper"
+        run: ./mvnw --batch-mode --no-snapshot-updates -e --no-transfer-progress --fail-fast clean test verify -P"jacoco,jdk15ge-simple,'!jdk15ge-add-open'" -D"http.keepAlive=false" -D"maven.wagon.http.pool=false" -D"maven.wagon.httpconnectionManager.ttlSeconds=120" -D"maven.wagon.http.retryHandler.count=5" -DskipTests=false -DskipIntegrationTests=true -D"checkstyle.skip=false" -D"checkstyle_unix.skip=true" -D"rat.skip=false" -D"maven.javadoc.skip=true" -D"embeddedZookeeperPath=${{ github.workspace }}/.tmp/zookeeper"
 
   samples-test-prepare:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-and-test-scheduled-3.3.yml
+++ b/.github/workflows/build-and-test-scheduled-3.3.yml
@@ -209,19 +209,19 @@ jobs:
       - name: "Test with Maven with Integration Tests on JDK 8"
         timeout-minutes: 70
         if: ${{ startsWith( matrix.os, 'ubuntu') && matrix.jdk == '8' }}
-        run: ./mvnw --batch-mode --no-snapshot-updates -e --no-transfer-progress --fail-fast clean test verify -Pjacoco,'!jdk15ge' -Dmaven.wagon.httpconnectionManager.ttlSeconds=120 -Dmaven.wagon.http.retryHandler.count=5 -DskipTests=false -DskipIntegrationTests=false -Dcheckstyle.skip=false -Dcheckstyle_unix.skip=false -Drat.skip=false -Dmaven.javadoc.skip=true -DembeddedZookeeperPath=${{ github.workspace }}/.tmp/zookeeper
+        run: ./mvnw --batch-mode --no-snapshot-updates -e --no-transfer-progress --fail-fast clean test verify -Pjacoco,'!jdk15ge-add-open' -Dmaven.wagon.httpconnectionManager.ttlSeconds=120 -Dmaven.wagon.http.retryHandler.count=5 -DskipTests=false -DskipIntegrationTests=false -Dcheckstyle.skip=false -Dcheckstyle_unix.skip=false -Drat.skip=false -Dmaven.javadoc.skip=true -DembeddedZookeeperPath=${{ github.workspace }}/.tmp/zookeeper
       - name: "Test with Maven without Integration Tests on JDK 8"
         timeout-minutes: 90
         if: ${{ startsWith( matrix.os, 'windows') && matrix.jdk == '8' }}
-        run: ./mvnw --batch-mode --no-snapshot-updates -e --no-transfer-progress --fail-fast clean test verify -P"jacoco,'!jdk15ge'" -D"http.keepAlive=false" -D"maven.wagon.http.pool=false" -D"maven.wagon.httpconnectionManager.ttlSeconds=120" -D"maven.wagon.http.retryHandler.count=5" -DskipTests=false -DskipIntegrationTests=true -D"checkstyle.skip=false" -D"checkstyle_unix.skip=true" -D"rat.skip=false" -D"maven.javadoc.skip=true" -D"embeddedZookeeperPath=${{ github.workspace }}/.tmp/zookeeper"
+        run: ./mvnw --batch-mode --no-snapshot-updates -e --no-transfer-progress --fail-fast clean test verify -P"jacoco,'!jdk15ge-add-open'" -D"http.keepAlive=false" -D"maven.wagon.http.pool=false" -D"maven.wagon.httpconnectionManager.ttlSeconds=120" -D"maven.wagon.http.retryHandler.count=5" -DskipTests=false -DskipIntegrationTests=true -D"checkstyle.skip=false" -D"checkstyle_unix.skip=true" -D"rat.skip=false" -D"maven.javadoc.skip=true" -D"embeddedZookeeperPath=${{ github.workspace }}/.tmp/zookeeper"
       - name: "Test with Maven with Integration Tests"
         timeout-minutes: 70
         if: ${{ startsWith( matrix.os, 'ubuntu') && matrix.jdk != '8' }}
-        run: ./mvnw --batch-mode --no-snapshot-updates -e --no-transfer-progress --fail-fast clean test verify -Pjacoco,jdk15ge-simple,'!jdk15ge' -Dmaven.wagon.httpconnectionManager.ttlSeconds=120 -Dmaven.wagon.http.retryHandler.count=5 -DskipTests=false -DskipIntegrationTests=false -Dcheckstyle.skip=false -Dcheckstyle_unix.skip=false -Drat.skip=false -Dmaven.javadoc.skip=true -DembeddedZookeeperPath=${{ github.workspace }}/.tmp/zookeeper
+        run: ./mvnw --batch-mode --no-snapshot-updates -e --no-transfer-progress --fail-fast clean test verify -Pjacoco,jdk15ge-simple,'!jdk15ge-add-open' -Dmaven.wagon.httpconnectionManager.ttlSeconds=120 -Dmaven.wagon.http.retryHandler.count=5 -DskipTests=false -DskipIntegrationTests=false -Dcheckstyle.skip=false -Dcheckstyle_unix.skip=false -Drat.skip=false -Dmaven.javadoc.skip=true -DembeddedZookeeperPath=${{ github.workspace }}/.tmp/zookeeper
       - name: "Test with Maven without Integration Tests"
         timeout-minutes: 90
         if: ${{ startsWith( matrix.os, 'windows') && matrix.jdk != '8' }}
-        run: ./mvnw --batch-mode --no-snapshot-updates -e --no-transfer-progress --fail-fast clean test verify -P"jacoco,jdk15ge-simple,'!jdk15ge'" -D"http.keepAlive=false" -D"maven.wagon.http.pool=false" -D"maven.wagon.httpconnectionManager.ttlSeconds=120" -D"maven.wagon.http.retryHandler.count=5" -DskipTests=false -DskipIntegrationTests=true -D"checkstyle.skip=false" -D"checkstyle_unix.skip=true" -D"rat.skip=false" -D"maven.javadoc.skip=true" -D"embeddedZookeeperPath=${{ github.workspace }}/.tmp/zookeeper"
+        run: ./mvnw --batch-mode --no-snapshot-updates -e --no-transfer-progress --fail-fast clean test verify -P"jacoco,jdk15ge-simple,'!jdk15ge-add-open'" -D"http.keepAlive=false" -D"maven.wagon.http.pool=false" -D"maven.wagon.httpconnectionManager.ttlSeconds=120" -D"maven.wagon.http.retryHandler.count=5" -DskipTests=false -DskipIntegrationTests=true -D"checkstyle.skip=false" -D"checkstyle_unix.skip=true" -D"rat.skip=false" -D"maven.javadoc.skip=true" -D"embeddedZookeeperPath=${{ github.workspace }}/.tmp/zookeeper"
 
   samples-test-prepare:
     runs-on: ubuntu-latest
@@ -511,7 +511,7 @@ jobs:
       - name: "Compile Dubbo (Linux)"
         run: |
           cd ${{ github.workspace }}/dubbo
-          ./mvnw ${{ env.MAVEN_ARGS }} -T 2C clean install -P '!demo',skip-spotless -Dmaven.test.skip=true -Dcheckstyle.skip=true -Dcheckstyle_unix.skip=true -Drat.skip=true
+          ./mvnw ${{ env.MAVEN_ARGS }} -T 2C clean install -P skip-spotless -Dmaven.test.skip=true -Dcheckstyle.skip=true -Dcheckstyle_unix.skip=true -Drat.skip=true
       - name: "Checkout dubbo-samples repository"
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/build-and-test-scheduled-3.3.yml
+++ b/.github/workflows/build-and-test-scheduled-3.3.yml
@@ -16,8 +16,8 @@ env:
   VERSIONS_LIMIT: 4
   ALL_REMOTE_VERSION: true
   CANDIDATE_VERSIONS: '
-    spring.version:5.3.24;
-    spring-boot.version:2.7.6;
+    spring.version:5.3.24,6.1.5;
+    spring-boot.version:2.7.6,3.2.3;
     '
 
 jobs:

--- a/.github/workflows/build-and-test-scheduled-3.3.yml
+++ b/.github/workflows/build-and-test-scheduled-3.3.yml
@@ -325,6 +325,7 @@ jobs:
           pattern: samples-test-result-${{matrix.jdk}}-*
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path: test/jobs/
+          merge-multiple: true
       - name: "Merge test result"
         run: ./test/scripts/merge-test-results.sh
 
@@ -430,6 +431,7 @@ jobs:
           pattern: integration-test-result-${{matrix.jdk}}-*
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path: test/jobs/
+          merge-multiple: true
       - name: "Merge test result"
         run: ./test/scripts/merge-test-results.sh
 

--- a/.github/workflows/release-test.yml
+++ b/.github/workflows/release-test.yml
@@ -314,6 +314,7 @@ jobs:
           pattern: samples-test-result-${{matrix.jdk}}-*
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path: test/jobs/
+          merge-multiple: true
       - name: "Merge test result"
         run: ./test/scripts/merge-test-results.sh
 
@@ -413,6 +414,7 @@ jobs:
           pattern: integration-test-result-${{matrix.jdk}}-*
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path: test/jobs/
+          merge-multiple: true
       - name: "Merge test result"
         run: ./test/scripts/merge-test-results.sh
 

--- a/.github/workflows/release-test.yml
+++ b/.github/workflows/release-test.yml
@@ -17,8 +17,8 @@ env:
   VERSIONS_LIMIT: 4
   ALL_REMOTE_VERSION: true
   CANDIDATE_VERSIONS: '
-    spring.version:5.3.24;
-    spring-boot.version:2.7.6;
+    spring.version:5.3.24,6.1.5;
+    spring-boot.version:2.7.6,3.2.3;
     '
 
 jobs:

--- a/.github/workflows/release-test.yml
+++ b/.github/workflows/release-test.yml
@@ -204,19 +204,19 @@ jobs:
       - name: "Test with Maven with Integration Tests on JDK 8"
         timeout-minutes: 70
         if: ${{ startsWith( matrix.os, 'ubuntu') && matrix.jdk == '8' }}
-        run: ./mvnw --batch-mode --no-snapshot-updates -e --no-transfer-progress --fail-fast clean test verify -Pjacoco,'!jdk15ge' -Dmaven.wagon.httpconnectionManager.ttlSeconds=120 -Dmaven.wagon.http.retryHandler.count=5 -DskipTests=false -DskipIntegrationTests=false -Dcheckstyle.skip=false -Dcheckstyle_unix.skip=false -Drat.skip=false -Dmaven.javadoc.skip=true -DembeddedZookeeperPath=${{ github.workspace }}/.tmp/zookeeper
+        run: ./mvnw --batch-mode --no-snapshot-updates -e --no-transfer-progress --fail-fast clean test verify -Pjacoco,'!jdk15ge-add-open' -Dmaven.wagon.httpconnectionManager.ttlSeconds=120 -Dmaven.wagon.http.retryHandler.count=5 -DskipTests=false -DskipIntegrationTests=false -Dcheckstyle.skip=false -Dcheckstyle_unix.skip=false -Drat.skip=false -Dmaven.javadoc.skip=true -DembeddedZookeeperPath=${{ github.workspace }}/.tmp/zookeeper
       - name: "Test with Maven without Integration Tests on JDK 8"
         timeout-minutes: 90
         if: ${{ startsWith( matrix.os, 'windows') && matrix.jdk == '8' }}
-        run: ./mvnw --batch-mode --no-snapshot-updates -e --no-transfer-progress --fail-fast clean test verify -P"jacoco,'!jdk15ge'" -D"http.keepAlive=false" -D"maven.wagon.http.pool=false" -D"maven.wagon.httpconnectionManager.ttlSeconds=120" -D"maven.wagon.http.retryHandler.count=5" -DskipTests=false -DskipIntegrationTests=true -D"checkstyle.skip=false" -D"checkstyle_unix.skip=true" -D"rat.skip=false" -D"maven.javadoc.skip=true" -D"embeddedZookeeperPath=${{ github.workspace }}/.tmp/zookeeper"
+        run: ./mvnw --batch-mode --no-snapshot-updates -e --no-transfer-progress --fail-fast clean test verify -P"jacoco,'!jdk15ge-add-open'" -D"http.keepAlive=false" -D"maven.wagon.http.pool=false" -D"maven.wagon.httpconnectionManager.ttlSeconds=120" -D"maven.wagon.http.retryHandler.count=5" -DskipTests=false -DskipIntegrationTests=true -D"checkstyle.skip=false" -D"checkstyle_unix.skip=true" -D"rat.skip=false" -D"maven.javadoc.skip=true" -D"embeddedZookeeperPath=${{ github.workspace }}/.tmp/zookeeper"
       - name: "Test with Maven with Integration Tests"
         timeout-minutes: 70
         if: ${{ startsWith( matrix.os, 'ubuntu') && matrix.jdk != '8' }}
-        run: ./mvnw --batch-mode --no-snapshot-updates -e --no-transfer-progress --fail-fast clean test verify -Pjacoco,jdk15ge-simple,'!jdk15ge' -Dmaven.wagon.httpconnectionManager.ttlSeconds=120 -Dmaven.wagon.http.retryHandler.count=5 -DskipTests=false -DskipIntegrationTests=false -Dcheckstyle.skip=false -Dcheckstyle_unix.skip=false -Drat.skip=false -Dmaven.javadoc.skip=true -DembeddedZookeeperPath=${{ github.workspace }}/.tmp/zookeeper
+        run: ./mvnw --batch-mode --no-snapshot-updates -e --no-transfer-progress --fail-fast clean test verify -Pjacoco,jdk15ge-simple,'!jdk15ge-add-open' -Dmaven.wagon.httpconnectionManager.ttlSeconds=120 -Dmaven.wagon.http.retryHandler.count=5 -DskipTests=false -DskipIntegrationTests=false -Dcheckstyle.skip=false -Dcheckstyle_unix.skip=false -Drat.skip=false -Dmaven.javadoc.skip=true -DembeddedZookeeperPath=${{ github.workspace }}/.tmp/zookeeper
       - name: "Test with Maven without Integration Tests"
         timeout-minutes: 90
         if: ${{ startsWith( matrix.os, 'windows') && matrix.jdk != '8' }}
-        run: ./mvnw --batch-mode --no-snapshot-updates -e --no-transfer-progress --fail-fast clean test verify -P"jacoco,jdk15ge-simple,'!jdk15ge'" -D"http.keepAlive=false" -D"maven.wagon.http.pool=false" -D"maven.wagon.httpconnectionManager.ttlSeconds=120" -D"maven.wagon.http.retryHandler.count=5" -DskipTests=false -DskipIntegrationTests=true -D"checkstyle.skip=false" -D"checkstyle_unix.skip=true" -D"rat.skip=false" -D"maven.javadoc.skip=true" -D"embeddedZookeeperPath=${{ github.workspace }}/.tmp/zookeeper"
+        run: ./mvnw --batch-mode --no-snapshot-updates -e --no-transfer-progress --fail-fast clean test verify -P"jacoco,jdk15ge-simple,'!jdk15ge-add-open'" -D"http.keepAlive=false" -D"maven.wagon.http.pool=false" -D"maven.wagon.httpconnectionManager.ttlSeconds=120" -D"maven.wagon.http.retryHandler.count=5" -DskipTests=false -DskipIntegrationTests=true -D"checkstyle.skip=false" -D"checkstyle_unix.skip=true" -D"rat.skip=false" -D"maven.javadoc.skip=true" -D"embeddedZookeeperPath=${{ github.workspace }}/.tmp/zookeeper"
 
   samples-test-prepare:
     runs-on: ubuntu-latest
@@ -492,7 +492,7 @@ jobs:
       - name: "Compile Dubbo (Linux)"
         run: |
           cd ${{ github.workspace }}/dubbo
-          ./mvnw ${{ env.MAVEN_ARGS }} -T 2C clean install -P '!demo',skip-spotless -Dmaven.test.skip=true -Dcheckstyle.skip=true -Dcheckstyle_unix.skip=true -Drat.skip=true
+          ./mvnw ${{ env.MAVEN_ARGS }} -T 2C clean install -P skip-spotless -Dmaven.test.skip=true -Dcheckstyle.skip=true -Dcheckstyle_unix.skip=true -Drat.skip=true
       - name: "Checkout dubbo-samples repository"
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## What is the purpose of the change?
1. Add spring 6.1.5 and spring-boot 3.2.3 to the candidate versions of  PR,3.3,release-test workflows.
2. Add jdk17 jobs to PR workflow.
3. Fix wrong profile ids in workflows.

There are many integration and samples test projects could only run on spring 6.* and jdk17+. We can promptly identify any issues with the testing program or dubbo if the candidate versions include spring6 and jdk17.
e.g. ```No provider available``` issue of ```dubbo-samples/dubbo-servicediscovery-migration```:
see details at https://github.com/apache/dubbo-samples/actions/runs/15306242647/job/43059693107
![image](https://github.com/user-attachments/assets/9229d811-4023-41fb-b2b5-d7f087736853)

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Make sure gitHub actions can pass. [Why the workflow is failing and how to fix it?](../CONTRIBUTING.md)
