### PR TITLE
[3.3] Optimize SlidingWindowTest#testGetPaneData to avoid assertion failure triggered by running slowly on the docker container

### DIFF
--- a/dubbo-metrics/dubbo-metrics-api/src/test/java/org/apache/dubbo/metrics/aggregate/SlidingWindowTest.java
+++ b/dubbo-metrics/dubbo-metrics-api/src/test/java/org/apache/dubbo/metrics/aggregate/SlidingWindowTest.java
@@ -53,9 +53,10 @@ class SlidingWindowTest {
     @Test
     void testGetPaneData() {
         assertNull(window.getPaneValue(/* invalid time*/ -1L));
-        window.currentPane();
-        assertNotNull(window.getPaneValue(System.currentTimeMillis()));
-        assertNull(window.getPaneValue(System.currentTimeMillis() + window.getPaneIntervalInMs()));
+        long time = System.currentTimeMillis();
+        window.currentPane(time);
+        assertNotNull(window.getPaneValue(time));
+        assertNull(window.getPaneValue(time + window.getPaneIntervalInMs()));
     }
 
     @Test


### PR DESCRIPTION
## What is the purpose of the change?
Assertion failure occurred at SlidingWindowTest#testGetPaneData once in a while, e.g. https://github.com/apache/dubbo/actions/runs/15430607790/job/43427972607
```
2025-06-04T00:40:12.2083202Z [ERROR] org.apache.dubbo.metrics.aggregate.SlidingWindowTest.testGetPaneData -- Time elapsed: 0.016 s <<< FAILURE!
2025-06-04T00:40:12.2084298Z org.opentest4j.AssertionFailedError: expected: not <null>
2025-06-04T00:40:12.2085422Z 	at org.junit.jupiter.api.AssertionFailureBuilder.build(AssertionFailureBuilder.java:152)
2025-06-04T00:40:12.2086592Z 	at org.junit.jupiter.api.AssertionFailureBuilder.buildAndThrow(AssertionFailureBuilder.java:132)
2025-06-04T00:40:12.2087633Z 	at org.junit.jupiter.api.AssertNotNull.failNull(AssertNotNull.java:49)
2025-06-04T00:40:12.2088505Z 	at org.junit.jupiter.api.AssertNotNull.assertNotNull(AssertNotNull.java:35)
2025-06-04T00:40:12.2089515Z 	at org.junit.jupiter.api.AssertNotNull.assertNotNull(AssertNotNull.java:30)
2025-06-04T00:40:12.2090361Z 	at org.junit.jupiter.api.Assertions.assertNotNull(Assertions.java:304)
2025-06-04T00:40:12.2091519Z 	at org.apache.dubbo.metrics.aggregate.SlidingWindowTest.testGetPaneData(SlidingWindowTest.java:57)
2025-06-04T00:40:12.2092520Z 	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
2025-06-04T00:40:12.2093195Z 	at java.base/java.util.ArrayList.forEach(ArrayList.java:1596)
2025-06-04T00:40:12.2093863Z 	at java.base/java.util.ArrayList.forEach(ArrayList.java:1596)
```
the reason is it's logical has problem:
```
    void testGetPaneData() {
        assertNull(window.getPaneValue(/* invalid time*/ -1L));
        window.currentPane();  //  paneIntervalInMs=intervalInMs / paneCount = 2000/10 = 200ms, let's say the currentTimeMillis of running this code was 199, then this code created pane with paneIdx 0 (199/200=0), 
        assertNotNull(window.getPaneValue(System.currentTimeMillis())); // let's say currentTimeMillis of running this code is 200, getPaneValue will get pane with paneIdx 1 (200/200=1) and get null.
        assertNull(window.getPaneValue(System.currentTimeMillis() + window.getPaneIntervalInMs()));
    }
```

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Make sure gitHub actions can pass. [Why the workflow is failing and how to fix it?](../CONTRIBUTING.md)
