### PR TITLE
[3.3] Fix AbstractInterfaceConfig#setRegistry to avoid NPE at post-processing

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/config/AbstractInterfaceConfig.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/config/AbstractInterfaceConfig.java
@@ -718,9 +718,13 @@ public abstract class AbstractInterfaceConfig extends AbstractMethodConfig {
     }
 
     public void setRegistry(RegistryConfig registry) {
-        List<RegistryConfig> registries = new ArrayList<>(1);
-        registries.add(registry);
-        setRegistries(registries);
+        if (registry != null) {
+            List<RegistryConfig> registries = new ArrayList<>(1);
+            registries.add(registry);
+            setRegistries(registries);
+        } else {
+            this.registries = null;
+        }
     }
 
     public List<RegistryConfig> getRegistries() {


### PR DESCRIPTION
## What is the purpose of the change?
The method setRegistry of AbstractInterfaceConfig could add null to the registries list of the configuration object, and it will trigger NPE at post-processing.
```
Caused by: java.lang.NullPointerException
	at org.apache.dubbo.config.AbstractInterfaceConfig.lambda$postProcessAfterScopeModelChanged$0(AbstractInterfaceConfig.java:270)
	at java.util.ArrayList.forEach(ArrayList.java:1259)
	at org.apache.dubbo.config.AbstractInterfaceConfig.postProcessAfterScopeModelChanged(AbstractInterfaceConfig.java:269)
	at org.apache.dubbo.config.ServiceConfigBase.postProcessAfterScopeModelChanged(ServiceConfigBase.java:121)
	at org.apache.dubbo.config.ServiceConfig.postProcessAfterScopeModelChanged(ServiceConfig.java:181)
	at org.apache.dubbo.config.AbstractConfig.setScopeModel(AbstractConfig.java:452)
```
see details at https://github.com/apache/dubbo/actions/runs/15430607790/job/43427972014

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Make sure gitHub actions can pass. [Why the workflow is failing and how to fix it?](../CONTRIBUTING.md)
