### PR TITLE
[3.3] Replace ConcurrentHashMap#computeIfAbsent for performance improvement and prevention of deadlock

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/extension/ExtensionLoader.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/extension/ExtensionLoader.java
@@ -33,6 +33,7 @@ import org.apache.dubbo.common.utils.ArrayUtils;
 import org.apache.dubbo.common.utils.ClassLoaderResourceLoader;
 import org.apache.dubbo.common.utils.ClassUtils;
 import org.apache.dubbo.common.utils.CollectionUtils;
+import org.apache.dubbo.common.utils.ConcurrentHashMapUtils;
 import org.apache.dubbo.common.utils.ConcurrentHashSet;
 import org.apache.dubbo.common.utils.ConfigUtils;
 import org.apache.dubbo.common.utils.Holder;
@@ -141,7 +142,7 @@ public class ExtensionLoader<T> {
 
     private static final Map<String, String> specialSPILoadingStrategyMap = getSpecialSPILoadingStrategyMap();
 
-    private static SoftReference<Map<java.net.URL, List<String>>> urlListMapCache =
+    private static SoftReference<ConcurrentHashMap<java.net.URL, List<String>>> urlListMapCache =
             new SoftReference<>(new ConcurrentHashMap<>());
 
     private static final List<String> ignoredInjectMethodsDesc = getIgnoredInjectMethodsDesc();
@@ -1189,7 +1190,7 @@ public class ExtensionLoader<T> {
     }
 
     private List<String> getResourceContent(java.net.URL resourceURL) throws IOException {
-        Map<java.net.URL, List<String>> urlListMap = urlListMapCache.get();
+        ConcurrentHashMap<java.net.URL, List<String>> urlListMap = urlListMapCache.get();
         if (urlListMap == null) {
             synchronized (ExtensionLoader.class) {
                 if ((urlListMap = urlListMapCache.get()) == null) {
@@ -1199,7 +1200,7 @@ public class ExtensionLoader<T> {
             }
         }
 
-        List<String> contentList = urlListMap.computeIfAbsent(resourceURL, key -> {
+        List<String> contentList = ConcurrentHashMapUtils.computeIfAbsent(urlListMap, resourceURL, key -> {
             List<String> newContentList = new ArrayList<>();
 
             try (BufferedReader reader =

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/serialization/ClassHolder.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/serialization/ClassHolder.java
@@ -16,18 +16,17 @@
  */
 package org.apache.dubbo.common.serialization;
 
+import org.apache.dubbo.common.utils.ConcurrentHashMapUtils;
 import org.apache.dubbo.common.utils.ConcurrentHashSet;
 
-import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 public class ClassHolder {
-    private final Map<String, Set<Class<?>>> classCache = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<String, Set<Class<?>>> classCache = new ConcurrentHashMap<>();
 
     public void storeClass(Class<?> clazz) {
-        classCache
-                .computeIfAbsent(clazz.getName(), k -> new ConcurrentHashSet<>())
+        ConcurrentHashMapUtils.computeIfAbsent(classCache, clazz.getName(), k -> new ConcurrentHashSet<>())
                 .add(clazz);
     }
 

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/utils/PojoUtils.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/utils/PojoUtils.java
@@ -763,7 +763,7 @@ public class PojoUtils {
 
         if (result != null) {
             ConcurrentMap<String, Field> fields =
-                    CLASS_FIELD_CACHE.computeIfAbsent(cls, k -> new ConcurrentHashMap<>());
+                    ConcurrentHashMapUtils.computeIfAbsent(CLASS_FIELD_CACHE, cls, k -> new ConcurrentHashMap<>());
             fields.putIfAbsent(fieldName, result);
         }
         return result;

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/utils/UrlUtils.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/utils/UrlUtils.java
@@ -696,7 +696,8 @@ public class UrlUtils {
         return Optional.ofNullable(url.getServiceModel())
                 .map(ServiceModel::getServiceMetadata)
                 .map(ServiceMetadata::getAttributeMap)
-                .map(stringObjectMap -> (T) stringObjectMap.computeIfAbsent(key, k -> fn.apply(url)))
+                .map(stringObjectMap ->
+                        (T) ConcurrentHashMapUtils.computeIfAbsent(stringObjectMap, key, k -> fn.apply(url)))
                 .orElse(null);
     }
 }

--- a/dubbo-common/src/main/java/org/apache/dubbo/rpc/model/ServiceMetadata.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/rpc/model/ServiceMetadata.java
@@ -41,7 +41,7 @@ public class ServiceMetadata extends BaseServiceMetadata {
     /**
      * used locally
      */
-    private final Map<String, Object> attributeMap = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<String, Object> attributeMap = new ConcurrentHashMap<>();
 
     public ServiceMetadata(String serviceInterfaceName, String group, String version, Class<?> serviceType) {
         this.serviceInterfaceName = serviceInterfaceName;
@@ -63,7 +63,7 @@ public class ServiceMetadata extends BaseServiceMetadata {
         return attachments;
     }
 
-    public Map<String, Object> getAttributeMap() {
+    public ConcurrentHashMap<String, Object> getAttributeMap() {
         return attributeMap;
     }
 

--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/ServiceConfig.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/ServiceConfig.java
@@ -30,6 +30,7 @@ import org.apache.dubbo.common.threadpool.manager.FrameworkExecutorRepository;
 import org.apache.dubbo.common.url.component.ServiceConfigURL;
 import org.apache.dubbo.common.utils.ClassUtils;
 import org.apache.dubbo.common.utils.CollectionUtils;
+import org.apache.dubbo.common.utils.ConcurrentHashMapUtils;
 import org.apache.dubbo.common.utils.ConfigUtils;
 import org.apache.dubbo.common.utils.NetUtils;
 import org.apache.dubbo.common.utils.StringUtils;
@@ -158,7 +159,7 @@ public class ServiceConfig<T> extends ServiceConfigBase<T> {
     /**
      * The exported services
      */
-    private final Map<RegisterTypeEnum, List<Exporter<?>>> exporters = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<RegisterTypeEnum, List<Exporter<?>>> exporters = new ConcurrentHashMap<>();
 
     private final List<ServiceListener> serviceListeners = new ArrayList<>();
 
@@ -969,8 +970,7 @@ public class ServiceConfig<T> extends ServiceConfigBase<T> {
             invoker = new DelegateProviderMetaDataInvoker(invoker, this);
         }
         Exporter<?> exporter = protocolSPI.export(invoker);
-        exporters
-                .computeIfAbsent(registerType, k -> new CopyOnWriteArrayList<>())
+        ConcurrentHashMapUtils.computeIfAbsent(exporters, registerType, k -> new CopyOnWriteArrayList<>())
                 .add(exporter);
     }
 

--- a/dubbo-configcenter/dubbo-configcenter-apollo/src/main/java/org/apache/dubbo/configcenter/support/apollo/ApolloDynamicConfiguration.java
+++ b/dubbo-configcenter/dubbo-configcenter-apollo/src/main/java/org/apache/dubbo/configcenter/support/apollo/ApolloDynamicConfiguration.java
@@ -23,6 +23,7 @@ import org.apache.dubbo.common.config.configcenter.ConfigurationListener;
 import org.apache.dubbo.common.config.configcenter.DynamicConfiguration;
 import org.apache.dubbo.common.logger.ErrorTypeAwareLogger;
 import org.apache.dubbo.common.logger.LoggerFactory;
+import org.apache.dubbo.common.utils.ConcurrentHashMapUtils;
 import org.apache.dubbo.common.utils.StringUtils;
 import org.apache.dubbo.common.utils.SystemPropertyConfigUtils;
 import org.apache.dubbo.metrics.config.event.ConfigCenterEvent;
@@ -167,7 +168,8 @@ public class ApolloDynamicConfiguration implements DynamicConfiguration {
      */
     @Override
     public void addListener(String key, String group, ConfigurationListener listener) {
-        ApolloListener apolloListener = listeners.computeIfAbsent(group + key, k -> createTargetListener(key, group));
+        ApolloListener apolloListener =
+                ConcurrentHashMapUtils.computeIfAbsent(listeners, group + key, k -> createTargetListener(key, group));
         apolloListener.addListener(listener);
         dubboConfig.addChangeListener(apolloListener, Collections.singleton(key));
     }

--- a/dubbo-metadata/dubbo-metadata-report-nacos/src/main/java/org/apache/dubbo/metadata/store/nacos/NacosMetadataReport.java
+++ b/dubbo-metadata/dubbo-metadata-report-nacos/src/main/java/org/apache/dubbo/metadata/store/nacos/NacosMetadataReport.java
@@ -22,6 +22,7 @@ import org.apache.dubbo.common.config.configcenter.ConfigChangedEvent;
 import org.apache.dubbo.common.config.configcenter.ConfigItem;
 import org.apache.dubbo.common.config.configcenter.ConfigurationListener;
 import org.apache.dubbo.common.constants.LoggerCodeConstants;
+import org.apache.dubbo.common.utils.ConcurrentHashMapUtils;
 import org.apache.dubbo.common.utils.JsonUtils;
 import org.apache.dubbo.common.utils.MD5Utils;
 import org.apache.dubbo.common.utils.StringUtils;
@@ -79,9 +80,9 @@ public class NacosMetadataReport extends AbstractMetadataReport {
      */
     private String group;
 
-    private Map<String, NacosConfigListener> watchListenerMap = new ConcurrentHashMap<>();
+    private ConcurrentHashMap<String, NacosConfigListener> watchListenerMap = new ConcurrentHashMap<>();
 
-    private Map<String, MappingDataListener> casListenerMap = new ConcurrentHashMap<>();
+    private ConcurrentHashMap<String, MappingDataListener> casListenerMap = new ConcurrentHashMap<>();
 
     private MD5Utils md5Utils = new MD5Utils();
 
@@ -336,8 +337,8 @@ public class NacosMetadataReport extends AbstractMetadataReport {
     }
 
     private void addCasServiceMappingListener(String serviceKey, String group, MappingListener listener) {
-        MappingDataListener mappingDataListener = casListenerMap.computeIfAbsent(
-                buildListenerKey(serviceKey, group), k -> new MappingDataListener(serviceKey, group));
+        MappingDataListener mappingDataListener = ConcurrentHashMapUtils.computeIfAbsent(
+                casListenerMap, buildListenerKey(serviceKey, group), k -> new MappingDataListener(serviceKey, group));
         mappingDataListener.addListeners(listener);
         addListener(serviceKey, DEFAULT_MAPPING_GROUP, mappingDataListener);
     }
@@ -355,8 +356,8 @@ public class NacosMetadataReport extends AbstractMetadataReport {
 
     public void addListener(String key, String group, ConfigurationListener listener) {
         String listenerKey = buildListenerKey(key, group);
-        NacosConfigListener nacosConfigListener =
-                watchListenerMap.computeIfAbsent(listenerKey, k -> createTargetListener(key, group));
+        NacosConfigListener nacosConfigListener = ConcurrentHashMapUtils.computeIfAbsent(
+                watchListenerMap, listenerKey, k -> createTargetListener(key, group));
         nacosConfigListener.addListener(listener);
         try {
             configService.addListener(key, group, nacosConfigListener);

--- a/dubbo-metrics/dubbo-metrics-api/src/main/java/org/apache/dubbo/metrics/data/RtStatComposite.java
+++ b/dubbo-metrics/dubbo-metrics-api/src/main/java/org/apache/dubbo/metrics/data/RtStatComposite.java
@@ -16,6 +16,7 @@
  */
 package org.apache.dubbo.metrics.data;
 
+import org.apache.dubbo.common.utils.ConcurrentHashMapUtils;
 import org.apache.dubbo.metrics.model.MethodMetric;
 import org.apache.dubbo.metrics.model.Metric;
 import org.apache.dubbo.metrics.model.MetricsCategory;
@@ -57,7 +58,7 @@ public class RtStatComposite extends AbstractMetricsExport {
         super(applicationModel);
     }
 
-    private final Map<String, List<LongContainer<? extends Number>>> rtStats = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<String, List<LongContainer<? extends Number>>> rtStats = new ConcurrentHashMap<>();
 
     public void init(MetricsPlaceValue... placeValues) {
         if (placeValues == null) {
@@ -66,7 +67,8 @@ public class RtStatComposite extends AbstractMetricsExport {
         for (MetricsPlaceValue placeValue : placeValues) {
             List<LongContainer<? extends Number>> containers = initStats(placeValue);
             for (LongContainer<? extends Number> container : containers) {
-                rtStats.computeIfAbsent(container.getMetricsKeyWrapper().getType(), k -> new ArrayList<>())
+                ConcurrentHashMapUtils.computeIfAbsent(
+                                rtStats, container.getMetricsKeyWrapper().getType(), k -> new ArrayList<>())
                         .add(container);
             }
         }

--- a/dubbo-metrics/dubbo-metrics-api/src/main/java/org/apache/dubbo/metrics/data/ServiceStatComposite.java
+++ b/dubbo-metrics/dubbo-metrics-api/src/main/java/org/apache/dubbo/metrics/data/ServiceStatComposite.java
@@ -17,6 +17,7 @@
 package org.apache.dubbo.metrics.data;
 
 import org.apache.dubbo.common.utils.CollectionUtils;
+import org.apache.dubbo.common.utils.ConcurrentHashMapUtils;
 import org.apache.dubbo.metrics.model.MetricsCategory;
 import org.apache.dubbo.metrics.model.ServiceKeyMetric;
 import org.apache.dubbo.metrics.model.key.MetricsKeyWrapper;
@@ -45,8 +46,8 @@ public class ServiceStatComposite extends AbstractMetricsExport {
         super(applicationModel);
     }
 
-    private final Map<MetricsKeyWrapper, Map<ServiceKeyMetric, AtomicLong>> serviceWrapperNumStats =
-            new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<MetricsKeyWrapper, ConcurrentHashMap<ServiceKeyMetric, AtomicLong>>
+            serviceWrapperNumStats = new ConcurrentHashMap<>();
 
     public void initWrapper(List<MetricsKeyWrapper> metricsKeyWrappers) {
         if (CollectionUtils.isEmpty(metricsKeyWrappers)) {
@@ -71,10 +72,10 @@ public class ServiceStatComposite extends AbstractMetricsExport {
         if (extra != null) {
             serviceKeyMetric.setExtraInfo(extra);
         }
-        Map<ServiceKeyMetric, AtomicLong> map = serviceWrapperNumStats.get(wrapper);
+        ConcurrentHashMap<ServiceKeyMetric, AtomicLong> map = serviceWrapperNumStats.get(wrapper);
         AtomicLong metrics = map.get(serviceKeyMetric);
         if (metrics == null) {
-            metrics = map.computeIfAbsent(serviceKeyMetric, k -> new AtomicLong(0L));
+            metrics = ConcurrentHashMapUtils.computeIfAbsent(map, serviceKeyMetric, k -> new AtomicLong(0L));
             samplesChanged.set(true);
         }
         metrics.getAndAdd(size);
@@ -93,10 +94,10 @@ public class ServiceStatComposite extends AbstractMetricsExport {
         if (extra != null) {
             serviceKeyMetric.setExtraInfo(extra);
         }
-        Map<ServiceKeyMetric, AtomicLong> stats = serviceWrapperNumStats.get(wrapper);
+        ConcurrentHashMap<ServiceKeyMetric, AtomicLong> stats = serviceWrapperNumStats.get(wrapper);
         AtomicLong metrics = stats.get(serviceKeyMetric);
         if (metrics == null) {
-            metrics = stats.computeIfAbsent(serviceKeyMetric, k -> new AtomicLong(0L));
+            metrics = ConcurrentHashMapUtils.computeIfAbsent(stats, serviceKeyMetric, k -> new AtomicLong(0L));
             samplesChanged.set(true);
         }
         metrics.set(num);

--- a/dubbo-metrics/dubbo-metrics-api/src/main/java/org/apache/dubbo/metrics/listener/AbstractMetricsListener.java
+++ b/dubbo-metrics/dubbo-metrics-api/src/main/java/org/apache/dubbo/metrics/listener/AbstractMetricsListener.java
@@ -16,22 +16,24 @@
  */
 package org.apache.dubbo.metrics.listener;
 
+import org.apache.dubbo.common.utils.ConcurrentHashMapUtils;
 import org.apache.dubbo.common.utils.ReflectionUtils;
 import org.apache.dubbo.metrics.event.MetricsEvent;
 
-import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 public abstract class AbstractMetricsListener<E extends MetricsEvent> implements MetricsListener<E> {
 
-    private final Map<Class<?>, Boolean> eventMatchCache = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<Class<?>, Boolean> eventMatchCache = new ConcurrentHashMap<>();
 
     /**
      * Whether to support the general determination of event points depends on the event type
      */
     public boolean isSupport(MetricsEvent event) {
-        Boolean eventMatch = eventMatchCache.computeIfAbsent(
-                event.getClass(), clazz -> ReflectionUtils.match(getClass(), AbstractMetricsListener.class, event));
+        Boolean eventMatch = ConcurrentHashMapUtils.computeIfAbsent(
+                eventMatchCache,
+                event.getClass(),
+                clazz -> ReflectionUtils.match(getClass(), AbstractMetricsListener.class, event));
         return event.isAvailable() && eventMatch;
     }
 

--- a/dubbo-metrics/dubbo-metrics-api/src/main/java/org/apache/dubbo/metrics/model/MetricsSupport.java
+++ b/dubbo-metrics/dubbo-metrics-api/src/main/java/org/apache/dubbo/metrics/model/MetricsSupport.java
@@ -19,6 +19,7 @@ package org.apache.dubbo.metrics.model;
 import org.apache.dubbo.common.Version;
 import org.apache.dubbo.common.lang.Nullable;
 import org.apache.dubbo.common.utils.CollectionUtils;
+import org.apache.dubbo.common.utils.ConcurrentHashMapUtils;
 import org.apache.dubbo.common.utils.StringUtils;
 import org.apache.dubbo.metrics.collector.MethodMetricsCollector;
 import org.apache.dubbo.metrics.collector.ServiceMetricsCollector;
@@ -36,6 +37,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 
@@ -304,7 +306,7 @@ public class MetricsSupport {
     /**
      * Generate a complete indicator item for an interface/method
      */
-    public static <T> void fillZero(Map<?, Map<T, AtomicLong>> data) {
+    public static <T> void fillZero(ConcurrentHashMap<?, ConcurrentHashMap<T, AtomicLong>> data) {
         if (CollectionUtils.isEmptyMap(data)) {
             return;
         }
@@ -312,7 +314,7 @@ public class MetricsSupport {
                 data.values().stream().flatMap(map -> map.keySet().stream()).collect(Collectors.toSet());
         data.forEach((keyWrapper, mapVal) -> {
             for (T key : allKeyMetrics) {
-                mapVal.computeIfAbsent(key, k -> new AtomicLong(0));
+                ConcurrentHashMapUtils.computeIfAbsent(mapVal, key, k -> new AtomicLong(0));
             }
         });
     }

--- a/dubbo-metrics/dubbo-metrics-api/src/test/java/org/apache/dubbo/metrics/MetricsSupportTest.java
+++ b/dubbo-metrics/dubbo-metrics-api/src/test/java/org/apache/dubbo/metrics/MetricsSupportTest.java
@@ -26,8 +26,7 @@ import org.apache.dubbo.metrics.model.key.MetricsPlaceValue;
 import org.apache.dubbo.rpc.model.ApplicationModel;
 import org.apache.dubbo.rpc.model.FrameworkModel;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
 
 import org.junit.jupiter.api.Assertions;
@@ -44,16 +43,17 @@ public class MetricsSupportTest {
         config.setName("MockMetrics");
         applicationModel.getApplicationConfigManager().setApplication(config);
 
-        Map<MetricsKeyWrapper, Map<ServiceKeyMetric, AtomicLong>> data = new HashMap<>();
+        ConcurrentHashMap<MetricsKeyWrapper, ConcurrentHashMap<ServiceKeyMetric, AtomicLong>> data =
+                new ConcurrentHashMap<>();
         MetricsKeyWrapper key1 = new MetricsKeyWrapper(
                 METRIC_REQUESTS, MetricsPlaceValue.of(CommonConstants.PROVIDER, MetricsLevel.METHOD));
         MetricsKeyWrapper key2 = new MetricsKeyWrapper(
                 METRIC_REQUESTS, MetricsPlaceValue.of(CommonConstants.CONSUMER, MetricsLevel.METHOD));
         ServiceKeyMetric sm1 = new ServiceKeyMetric(applicationModel, "a.b.c");
         ServiceKeyMetric sm2 = new ServiceKeyMetric(applicationModel, "a.b.d");
-        data.computeIfAbsent(key1, k -> new HashMap<>()).put(sm1, new AtomicLong(1));
-        data.computeIfAbsent(key1, k -> new HashMap<>()).put(sm2, new AtomicLong(1));
-        data.put(key2, new HashMap<>());
+        data.computeIfAbsent(key1, k -> new ConcurrentHashMap<>()).put(sm1, new AtomicLong(1));
+        data.computeIfAbsent(key1, k -> new ConcurrentHashMap<>()).put(sm2, new AtomicLong(1));
+        data.put(key2, new ConcurrentHashMap<>());
         Assertions.assertEquals(
                 2, data.values().stream().mapToLong(map -> map.values().size()).sum());
         MetricsSupport.fillZero(data);

--- a/dubbo-metrics/dubbo-metrics-config-center/src/main/java/org/apache/dubbo/metrics/config/collector/ConfigCenterMetricsCollector.java
+++ b/dubbo-metrics/dubbo-metrics-config-center/src/main/java/org/apache/dubbo/metrics/config/collector/ConfigCenterMetricsCollector.java
@@ -17,6 +17,7 @@
 package org.apache.dubbo.metrics.config.collector;
 
 import org.apache.dubbo.common.extension.Activate;
+import org.apache.dubbo.common.utils.ConcurrentHashMapUtils;
 import org.apache.dubbo.config.context.ConfigManager;
 import org.apache.dubbo.metrics.collector.CombMetricsCollector;
 import org.apache.dubbo.metrics.collector.MetricsCollector;
@@ -30,7 +31,6 @@ import org.apache.dubbo.rpc.model.ApplicationModel;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -48,7 +48,7 @@ public class ConfigCenterMetricsCollector extends CombMetricsCollector<ConfigCen
     private final ApplicationModel applicationModel;
     private final AtomicBoolean samplesChanged = new AtomicBoolean(true);
 
-    private final Map<ConfigCenterMetric, AtomicLong> updatedMetrics = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<ConfigCenterMetric, AtomicLong> updatedMetrics = new ConcurrentHashMap<>();
 
     public ConfigCenterMetricsCollector(ApplicationModel applicationModel) {
         super(null);
@@ -79,7 +79,7 @@ public class ConfigCenterMetricsCollector extends CombMetricsCollector<ConfigCen
                 new ConfigCenterMetric(applicationModel.getApplicationName(), key, group, protocol, changeTypeName);
         AtomicLong metrics = updatedMetrics.get(metric);
         if (metrics == null) {
-            metrics = updatedMetrics.computeIfAbsent(metric, k -> new AtomicLong(0L));
+            metrics = ConcurrentHashMapUtils.computeIfAbsent(updatedMetrics, metric, k -> new AtomicLong(0L));
             samplesChanged.set(true);
         }
         metrics.addAndGet(size);

--- a/dubbo-metrics/dubbo-metrics-default/src/main/java/org/apache/dubbo/metrics/collector/AggregateMetricsCollector.java
+++ b/dubbo-metrics/dubbo-metrics-default/src/main/java/org/apache/dubbo/metrics/collector/AggregateMetricsCollector.java
@@ -38,7 +38,6 @@ import org.apache.dubbo.rpc.model.ApplicationModel;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -61,8 +60,8 @@ public class AggregateMetricsCollector implements MetricsCollector<RequestEvent>
     private int bucketNum = DEFAULT_BUCKET_NUM;
     private int timeWindowSeconds = DEFAULT_TIME_WINDOW_SECONDS;
     private int qpsTimeWindowMillSeconds = DEFAULT_QPS_TIME_WINDOW_MILL_SECONDS;
-    private final Map<MetricsKeyWrapper, ConcurrentHashMap<MethodMetric, TimeWindowCounter>> methodTypeCounter =
-            new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<MetricsKeyWrapper, ConcurrentHashMap<MethodMetric, TimeWindowCounter>>
+            methodTypeCounter = new ConcurrentHashMap<>();
     private final ConcurrentMap<MethodMetric, TimeWindowQuantile> rt = new ConcurrentHashMap<>();
     private final ConcurrentHashMap<MethodMetric, TimeWindowCounter> qps = new ConcurrentHashMap<>();
     private final ApplicationModel applicationModel;
@@ -204,8 +203,8 @@ public class AggregateMetricsCollector implements MetricsCollector<RequestEvent>
         MethodMetric metric =
                 new MethodMetric(applicationModel, event.getAttachmentValue(MetricsConstants.INVOCATION), serviceLevel);
 
-        ConcurrentMap<MethodMetric, TimeWindowCounter> counter =
-                methodTypeCounter.computeIfAbsent(metricsKeyWrapper, k -> new ConcurrentHashMap<>());
+        ConcurrentMap<MethodMetric, TimeWindowCounter> counter = ConcurrentHashMapUtils.computeIfAbsent(
+                methodTypeCounter, metricsKeyWrapper, k -> new ConcurrentHashMap<>());
 
         TimeWindowCounter windowCounter = counter.get(metric);
         if (windowCounter == null) {
@@ -391,8 +390,8 @@ public class AggregateMetricsCollector implements MetricsCollector<RequestEvent>
         MethodMetric metric =
                 new MethodMetric(applicationModel, event.getAttachmentValue(MetricsConstants.INVOCATION), serviceLevel);
 
-        ConcurrentMap<MethodMetric, TimeWindowCounter> counter =
-                methodTypeCounter.computeIfAbsent(metricsKeyWrapper, k -> new ConcurrentHashMap<>());
+        ConcurrentMap<MethodMetric, TimeWindowCounter> counter = ConcurrentHashMapUtils.computeIfAbsent(
+                methodTypeCounter, metricsKeyWrapper, k -> new ConcurrentHashMap<>());
 
         ConcurrentHashMapUtils.computeIfAbsent(
                 counter, metric, methodMetric -> new TimeWindowCounter(bucketNum, timeWindowSeconds));

--- a/dubbo-metrics/dubbo-metrics-default/src/main/java/org/apache/dubbo/metrics/collector/sample/MetricsCountSampler.java
+++ b/dubbo-metrics/dubbo-metrics-default/src/main/java/org/apache/dubbo/metrics/collector/sample/MetricsCountSampler.java
@@ -19,12 +19,12 @@ package org.apache.dubbo.metrics.collector.sample;
 import org.apache.dubbo.metrics.model.Metric;
 
 import java.util.Optional;
-import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
 
 public interface MetricsCountSampler<S, K, M extends Metric> extends MetricsSampler {
 
     void inc(S source, K metricName);
 
-    Optional<ConcurrentMap<M, AtomicLong>> getCount(K metricName);
+    Optional<ConcurrentHashMap<M, AtomicLong>> getCount(K metricName);
 }

--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/DefaultServiceInstance.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/DefaultServiceInstance.java
@@ -16,6 +16,7 @@
  */
 package org.apache.dubbo.registry.client;
 
+import org.apache.dubbo.common.utils.ConcurrentHashMapUtils;
 import org.apache.dubbo.common.utils.JsonUtils;
 import org.apache.dubbo.metadata.MetadataInfo;
 import org.apache.dubbo.rpc.model.ApplicationModel;
@@ -73,7 +74,7 @@ public class DefaultServiceInstance implements ServiceInstance {
 
     private transient List<Endpoint> endpoints;
     private transient ApplicationModel applicationModel;
-    private transient Map<String, InstanceAddressURL> instanceAddressURL = new ConcurrentHashMap<>();
+    private transient ConcurrentHashMap<String, InstanceAddressURL> instanceAddressURL = new ConcurrentHashMap<>();
 
     public DefaultServiceInstance() {}
 
@@ -291,8 +292,8 @@ public class DefaultServiceInstance implements ServiceInstance {
 
     @Override
     public InstanceAddressURL toURL(String protocol) {
-        return instanceAddressURL.computeIfAbsent(
-                protocol, key -> new InstanceAddressURL(this, serviceMetadata, protocol));
+        return ConcurrentHashMapUtils.computeIfAbsent(
+                instanceAddressURL, protocol, key -> new InstanceAddressURL(this, serviceMetadata, protocol));
     }
 
     @Override

--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/ServiceDiscoveryRegistry.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/ServiceDiscoveryRegistry.java
@@ -82,7 +82,7 @@ public class ServiceDiscoveryRegistry extends FailbackRegistry {
 
     /* apps - listener */
     private final Map<String, ServiceInstancesChangedListener> serviceListeners = new ConcurrentHashMap<>();
-    private final Map<String, Set<MappingListener>> mappingListeners = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<String, Set<MappingListener>> mappingListeners = new ConcurrentHashMap<>();
     /* This lock has the same scope and lifecycle as its corresponding instance listener.
     It's used to make sure that only one interface mapping to the same app list can do subscribe or unsubscribe at the same moment.
     And the lock should be destroyed when listener destroying its corresponding instance listener.
@@ -218,8 +218,8 @@ public class ServiceDiscoveryRegistry extends FailbackRegistry {
                     // it's protected by the mapping lock, so it won't override the event value.
                     mappingListener.updateInitialApps(mappingByUrl);
                     synchronized (mappingListeners) {
-                        mappingListeners
-                                .computeIfAbsent(url.getProtocolServiceKey(), (k) -> new ConcurrentHashSet<>())
+                        ConcurrentHashMapUtils.computeIfAbsent(
+                                        mappingListeners, url.getProtocolServiceKey(), (k) -> new ConcurrentHashSet<>())
                                 .add(mappingListener);
                     }
                 } catch (Exception e) {

--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/event/listener/ServiceInstancesChangedListener.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/event/listener/ServiceInstancesChangedListener.java
@@ -24,6 +24,7 @@ import org.apache.dubbo.common.logger.ErrorTypeAwareLogger;
 import org.apache.dubbo.common.logger.LoggerFactory;
 import org.apache.dubbo.common.threadpool.manager.FrameworkExecutorRepository;
 import org.apache.dubbo.common.utils.CollectionUtils;
+import org.apache.dubbo.common.utils.ConcurrentHashMapUtils;
 import org.apache.dubbo.common.utils.ConcurrentHashSet;
 import org.apache.dubbo.metadata.MetadataInfo;
 import org.apache.dubbo.metadata.MetadataInfo.ServiceInfo;
@@ -77,7 +78,7 @@ public class ServiceInstancesChangedListener {
 
     protected final Set<String> serviceNames;
     protected final ServiceDiscovery serviceDiscovery;
-    protected Map<String, Set<NotifyListenerWithKey>> listeners;
+    protected ConcurrentHashMap<String, Set<NotifyListenerWithKey>> listeners;
 
     protected AtomicBoolean destroyed = new AtomicBoolean(false);
 
@@ -254,8 +255,8 @@ public class ServiceInstancesChangedListener {
             return;
         }
 
-        Set<NotifyListenerWithKey> notifyListeners =
-                this.listeners.computeIfAbsent(url.getServiceKey(), _k -> new ConcurrentHashSet<>());
+        Set<NotifyListenerWithKey> notifyListeners = ConcurrentHashMapUtils.computeIfAbsent(
+                this.listeners, url.getServiceKey(), _k -> new ConcurrentHashSet<>());
         String protocol = listener.getConsumerUrl().getParameter(PROTOCOL_KEY, url.getProtocol());
         ProtocolServiceKey protocolServiceKey = new ProtocolServiceKey(
                 url.getServiceInterface(),

--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/integration/ExporterFactory.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/integration/ExporterFactory.java
@@ -16,17 +16,17 @@
  */
 package org.apache.dubbo.registry.integration;
 
+import org.apache.dubbo.common.utils.ConcurrentHashMapUtils;
 import org.apache.dubbo.rpc.Exporter;
 
-import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
 
 public class ExporterFactory {
-    private final Map<String, ReferenceCountExporter<?>> exporters = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<String, ReferenceCountExporter<?>> exporters = new ConcurrentHashMap<>();
 
     protected ReferenceCountExporter<?> createExporter(String providerKey, Callable<Exporter<?>> exporterProducer) {
-        return exporters.computeIfAbsent(providerKey, key -> {
+        return ConcurrentHashMapUtils.computeIfAbsent(exporters, providerKey, key -> {
             try {
                 return new ReferenceCountExporter<>(exporterProducer.call(), key, this);
             } catch (Exception e) {

--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/support/AbstractRegistry.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/support/AbstractRegistry.java
@@ -21,6 +21,7 @@ import org.apache.dubbo.common.logger.ErrorTypeAwareLogger;
 import org.apache.dubbo.common.logger.LoggerFactory;
 import org.apache.dubbo.common.threadpool.manager.FrameworkExecutorRepository;
 import org.apache.dubbo.common.utils.CollectionUtils;
+import org.apache.dubbo.common.utils.ConcurrentHashMapUtils;
 import org.apache.dubbo.common.utils.ConcurrentHashSet;
 import org.apache.dubbo.common.utils.ConfigUtils;
 import org.apache.dubbo.common.utils.StringUtils;
@@ -452,7 +453,8 @@ public abstract class AbstractRegistry implements Registry {
         if (logger.isInfoEnabled()) {
             logger.info("Subscribe: " + url);
         }
-        Set<NotifyListener> listeners = subscribed.computeIfAbsent(url, n -> new ConcurrentHashSet<>());
+        Set<NotifyListener> listeners =
+                ConcurrentHashMapUtils.computeIfAbsent(subscribed, url, n -> new ConcurrentHashSet<>());
         listeners.add(listener);
     }
 
@@ -567,7 +569,8 @@ public abstract class AbstractRegistry implements Registry {
         if (result.size() == 0) {
             return;
         }
-        Map<String, List<URL>> categoryNotified = notified.computeIfAbsent(url, u -> new ConcurrentHashMap<>());
+        Map<String, List<URL>> categoryNotified =
+                ConcurrentHashMapUtils.computeIfAbsent(notified, url, u -> new ConcurrentHashMap<>());
         for (Map.Entry<String, List<URL>> entry : result.entrySet()) {
             String category = entry.getKey();
             List<URL> categoryList = entry.getValue();

--- a/dubbo-registry/dubbo-registry-multicast/src/main/java/org/apache/dubbo/registry/multicast/MulticastRegistry.java
+++ b/dubbo-registry/dubbo-registry-multicast/src/main/java/org/apache/dubbo/registry/multicast/MulticastRegistry.java
@@ -20,6 +20,7 @@ import org.apache.dubbo.common.URL;
 import org.apache.dubbo.common.logger.ErrorTypeAwareLogger;
 import org.apache.dubbo.common.logger.LoggerFactory;
 import org.apache.dubbo.common.utils.CollectionUtils;
+import org.apache.dubbo.common.utils.ConcurrentHashMapUtils;
 import org.apache.dubbo.common.utils.ConcurrentHashSet;
 import org.apache.dubbo.common.utils.ExecutorUtil;
 import org.apache.dubbo.common.utils.NamedThreadFactory;
@@ -345,7 +346,7 @@ public class MulticastRegistry extends FailbackRegistry {
         for (Map.Entry<URL, Set<NotifyListener>> entry : getSubscribed().entrySet()) {
             URL key = entry.getKey();
             if (UrlUtils.isMatch(key, url)) {
-                Set<URL> urls = received.computeIfAbsent(key, k -> new ConcurrentHashSet<>());
+                Set<URL> urls = ConcurrentHashMapUtils.computeIfAbsent(received, key, k -> new ConcurrentHashSet<>());
                 urls.add(url);
                 List<URL> list = toList(urls);
                 for (final NotifyListener listener : entry.getValue()) {

--- a/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/message/codec/CodecUtils.java
+++ b/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/message/codec/CodecUtils.java
@@ -20,6 +20,7 @@ import org.apache.dubbo.common.URL;
 import org.apache.dubbo.common.config.Configuration;
 import org.apache.dubbo.common.config.ConfigurationUtils;
 import org.apache.dubbo.common.utils.Assert;
+import org.apache.dubbo.common.utils.ConcurrentHashMapUtils;
 import org.apache.dubbo.common.utils.StringUtils;
 import org.apache.dubbo.remoting.http12.exception.UnsupportedMediaTypeException;
 import org.apache.dubbo.remoting.http12.message.HttpMessageDecoder;
@@ -32,7 +33,6 @@ import org.apache.dubbo.rpc.model.FrameworkModel;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -42,8 +42,10 @@ public final class CodecUtils {
     private final FrameworkModel frameworkModel;
     private final List<HttpMessageDecoderFactory> decoderFactories;
     private final List<HttpMessageEncoderFactory> encoderFactories;
-    private final Map<String, Optional<HttpMessageEncoderFactory>> encoderCache = new ConcurrentHashMap<>();
-    private final Map<String, Optional<HttpMessageDecoderFactory>> decoderCache = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<String, Optional<HttpMessageEncoderFactory>> encoderCache =
+            new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<String, Optional<HttpMessageDecoderFactory>> decoderCache =
+            new ConcurrentHashMap<>();
     private Set<String> disallowedContentTypes = Collections.emptySet();
 
     public CodecUtils(FrameworkModel frameworkModel) {
@@ -80,7 +82,7 @@ public final class CodecUtils {
 
     public Optional<HttpMessageDecoderFactory> determineHttpMessageDecoderFactory(String mediaType) {
         Assert.notNull(mediaType, "mediaType must not be null");
-        return decoderCache.computeIfAbsent(mediaType, k -> {
+        return ConcurrentHashMapUtils.computeIfAbsent(decoderCache, mediaType, k -> {
             for (HttpMessageDecoderFactory factory : decoderFactories) {
                 if (factory.supports(k)
                         && !disallowedContentTypes.contains(factory.mediaType().getName())) {
@@ -93,7 +95,7 @@ public final class CodecUtils {
 
     public Optional<HttpMessageEncoderFactory> determineHttpMessageEncoderFactory(String mediaType) {
         Assert.notNull(mediaType, "mediaType must not be null");
-        return encoderCache.computeIfAbsent(mediaType, k -> {
+        return ConcurrentHashMapUtils.computeIfAbsent(encoderCache, mediaType, k -> {
             for (HttpMessageEncoderFactory factory : encoderFactories) {
                 if (factory.supports(k)
                         && !disallowedContentTypes.contains(factory.mediaType().getName())) {

--- a/dubbo-rpc/dubbo-rpc-dubbo/src/main/java/org/apache/dubbo/rpc/protocol/dubbo/filter/TraceFilter.java
+++ b/dubbo-rpc/dubbo-rpc-dubbo/src/main/java/org/apache/dubbo/rpc/protocol/dubbo/filter/TraceFilter.java
@@ -21,6 +21,7 @@ import org.apache.dubbo.common.extension.Activate;
 import org.apache.dubbo.common.logger.ErrorTypeAwareLogger;
 import org.apache.dubbo.common.logger.LoggerFactory;
 import org.apache.dubbo.common.utils.CollectionUtils;
+import org.apache.dubbo.common.utils.ConcurrentHashMapUtils;
 import org.apache.dubbo.common.utils.ConcurrentHashSet;
 import org.apache.dubbo.common.utils.JsonUtils;
 import org.apache.dubbo.common.utils.StringUtils;
@@ -60,7 +61,7 @@ public class TraceFilter implements Filter {
         channel.setAttribute(TRACE_MAX, max);
         channel.setAttribute(TRACE_COUNT, new AtomicInteger());
         String key = StringUtils.isNotEmpty(method) ? type.getName() + "." + method : type.getName();
-        Set<Channel> channels = TRACERS.computeIfAbsent(key, k -> new ConcurrentHashSet<>());
+        Set<Channel> channels = ConcurrentHashMapUtils.computeIfAbsent(TRACERS, key, k -> new ConcurrentHashSet<>());
         channels.add(channel);
     }
 

--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/Http3Exchanger.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/Http3Exchanger.java
@@ -21,6 +21,7 @@ import org.apache.dubbo.common.config.Configuration;
 import org.apache.dubbo.common.constants.LoggerCodeConstants;
 import org.apache.dubbo.common.logger.FluentLogger;
 import org.apache.dubbo.common.utils.ClassUtils;
+import org.apache.dubbo.common.utils.ConcurrentHashMapUtils;
 import org.apache.dubbo.remoting.ChannelHandler;
 import org.apache.dubbo.remoting.RemotingException;
 import org.apache.dubbo.remoting.RemotingServer;
@@ -56,7 +57,7 @@ public final class Http3Exchanger {
 
     private static final FluentLogger LOGGER = FluentLogger.of(Http3Exchanger.class);
     private static final boolean HAS_NETTY_HTTP3 = ClassUtils.isPresent("io.netty.incubator.codec.http3.Http3");
-    private static final Map<String, RemotingServer> SERVERS = new ConcurrentHashMap<>();
+    private static final ConcurrentHashMap<String, RemotingServer> SERVERS = new ConcurrentHashMap<>();
     private static final Map<String, AbstractConnectionClient> CLIENTS = new ConcurrentHashMap<>(16);
     private static final ChannelHandler HANDLER = new ChannelHandlerAdapter();
 
@@ -80,7 +81,7 @@ public final class Http3Exchanger {
 
     public static RemotingServer bind(URL url) {
         if (isEnabled(url)) {
-            return SERVERS.computeIfAbsent(url.getAddress(), addr -> {
+            return ConcurrentHashMapUtils.computeIfAbsent(SERVERS, url.getAddress(), addr -> {
                 try {
                     URL serverUrl = url.putAttribute(PIPELINE_CONFIGURATOR_KEY, configServerPipeline(url));
                     return new NettyHttp3Server(serverUrl, HANDLER);

--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/h12/grpc/GrpcCompositeCodec.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/h12/grpc/GrpcCompositeCodec.java
@@ -20,6 +20,7 @@ import org.apache.dubbo.common.URL;
 import org.apache.dubbo.common.config.ConfigurationUtils;
 import org.apache.dubbo.common.io.StreamUtils;
 import org.apache.dubbo.common.utils.ArrayUtils;
+import org.apache.dubbo.common.utils.ConcurrentHashMapUtils;
 import org.apache.dubbo.common.utils.UrlUtils;
 import org.apache.dubbo.remoting.http12.exception.DecodeException;
 import org.apache.dubbo.remoting.http12.exception.EncodeException;
@@ -64,9 +65,11 @@ public class GrpcCompositeCodec implements HttpMessageCodec {
             return;
         }
 
-        packableMethod = UrlUtils.computeServiceAttribute(
-                        url, PACKABLE_METHOD_CACHE, k -> new ConcurrentHashMap<MethodDescriptor, PackableMethod>())
-                .computeIfAbsent(methodDescriptor, md -> frameworkModel
+        packableMethod = ConcurrentHashMapUtils.computeIfAbsent(
+                UrlUtils.computeServiceAttribute(
+                        url, PACKABLE_METHOD_CACHE, k -> new ConcurrentHashMap<MethodDescriptor, PackableMethod>()),
+                methodDescriptor,
+                md -> frameworkModel
                         .getExtensionLoader(PackableMethodFactory.class)
                         .getExtension(ConfigurationUtils.getGlobalConfiguration(url.getApplicationModel())
                                 .getString(DUBBO_PACKABLE_METHOD_FACTORY, DEFAULT_KEY))


### PR DESCRIPTION
## What is the purpose of the change?
Fix the codes that still use ConcurrentHashMap#computeIfAbsent which might have performance issue and deadlock risk,
see details at 
1. [ConcurrentHashMapUtils无法解决jdk8的循环bug](https://github.com/apache/dubbo/issues/11986)
2. [dubbo.metrics publishEvent blocked on ConcurrentHashMap.computeIfAbsent](https://github.com/apache/dubbo/issues/15333)

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Make sure gitHub actions can pass. [Why the workflow is failing and how to fix it?](../CONTRIBUTING.md)
