### PR TITLE
[3.3] Await channel initialization to ensure http2 client connection preface mechanism could work properly

### DIFF
--- a/dubbo-remoting/dubbo-remoting-netty4/src/main/java/org/apache/dubbo/remoting/transport/netty4/NettyConnectionClient.java
+++ b/dubbo-remoting/dubbo-remoting-netty4/src/main/java/org/apache/dubbo/remoting/transport/netty4/NettyConnectionClient.java
@@ -28,7 +28,6 @@ import org.apache.dubbo.remoting.transport.netty4.ssl.SslClientTlsHandler;
 import org.apache.dubbo.remoting.transport.netty4.ssl.SslContexts;
 import org.apache.dubbo.remoting.utils.UrlUtils;
 
-import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -55,18 +54,9 @@ public final class NettyConnectionClient extends AbstractNettyConnectionClient {
 
     private Bootstrap bootstrap;
 
+    private AtomicReference<Promise<Void>> channelInitializedPromiseRef;
+
     private AtomicReference<Promise<Void>> connectionPrefaceReceivedPromiseRef;
-
-    /**
-     * await connection preface only after the channel was initialized.
-     */
-    private boolean isChannelInitialized;
-
-    /**
-     * the countdown latch for
-     * {@link org.apache.dubbo.remoting.transport.netty4.NettyConnectionClient#isChannelInitialized}
-     */
-    private CountDownLatch channelInitializedLatch;
 
     public NettyConnectionClient(URL url, ChannelHandler handler) throws RemotingException {
         super(url, handler);
@@ -81,7 +71,7 @@ public final class NettyConnectionClient extends AbstractNettyConnectionClient {
     }
 
     protected void initBootstrap() {
-        channelInitializedLatch = new CountDownLatch(1);
+        channelInitializedPromiseRef = new AtomicReference<>();
         Bootstrap bootstrap = new Bootstrap();
         bootstrap
                 .group(NettyEventLoopFactory.NIO_EVENT_LOOP_GROUP.get())
@@ -117,9 +107,12 @@ public final class NettyConnectionClient extends AbstractNettyConnectionClient {
 
                 ChannelHandlerContext http2FrameCodecHandlerCtx = pipeline.context(Http2FrameCodec.class);
                 if (http2FrameCodecHandlerCtx != null) {
-                    // create connection preface received promise.
-                    connectionPrefaceReceivedPromiseRef = new AtomicReference<>();
-                    connectionPrefaceReceivedPromiseRef.set(new DefaultPromise<>(GlobalEventExecutor.INSTANCE));
+                    // create connection preface received promise if necessary.
+                    if (connectionPrefaceReceivedPromiseRef == null) {
+                        connectionPrefaceReceivedPromiseRef = new AtomicReference<>();
+                    }
+                    connectionPrefaceReceivedPromiseRef.compareAndSet(
+                            null, new DefaultPromise<>(GlobalEventExecutor.INSTANCE));
                     pipeline.addAfter(
                             http2FrameCodecHandlerCtx.name(),
                             "client-connection-preface-handler",
@@ -130,9 +123,11 @@ public final class NettyConnectionClient extends AbstractNettyConnectionClient {
                 ch.closeFuture().addListener(channelFuture -> clearNettyChannel());
                 // TODO support Socks5
 
-                // set channel initialized flag and count down the latch.
-                isChannelInitialized = true;
-                channelInitializedLatch.countDown();
+                // set channel initialized promise to success if necessary.
+                Promise<Void> channelInitializedPromise = channelInitializedPromiseRef.get();
+                if (channelInitializedPromise != null) {
+                    channelInitializedPromise.trySuccess(null);
+                }
             }
         });
         this.bootstrap = bootstrap;
@@ -147,6 +142,8 @@ public final class NettyConnectionClient extends AbstractNettyConnectionClient {
     @Override
     protected void doConnect() throws RemotingException {
         long start = System.currentTimeMillis();
+        // re-create channel initialized promise if necessary.
+        channelInitializedPromiseRef.compareAndSet(null, new DefaultPromise<>(GlobalEventExecutor.INSTANCE));
         super.doConnect();
         waitConnectionPreface(start);
     }
@@ -172,36 +169,28 @@ public final class NettyConnectionClient extends AbstractNettyConnectionClient {
      */
     private void waitConnectionPreface(long start) throws RemotingException {
         // await channel initialization to ensure connection preface received promise had been created when necessary.
-        if (!isChannelInitialized) {
-            long retainedTimeout = getConnectTimeout() - System.currentTimeMillis() + start;
-            try {
-                isChannelInitialized = channelInitializedLatch.await(retainedTimeout, TimeUnit.MILLISECONDS);
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-                throw new IllegalStateException(
-                        "client(url: " + getUrl() + ") failed to connect to server " + getConnectAddress(), e);
-            }
-            if (!isChannelInitialized) {
-                // 6-2 Client-side channel initialization timeout
-                RemotingException remotingException = new RemotingException(
-                        this,
-                        "client(url: " + getUrl() + ") failed to connect to server " + getConnectAddress()
-                                + " client-side channel initialization timeout " + getConnectTimeout()
-                                + "ms (elapsed: "
-                                + (System.currentTimeMillis() - start) + "ms) from netty client "
-                                + NetUtils.getLocalHost()
-                                + " using dubbo version "
-                                + Version.getVersion());
+        Promise<Void> channelInitializedPromise = channelInitializedPromiseRef.get();
+        long retainedTimeout = getConnectTimeout() - System.currentTimeMillis() + start;
+        boolean ret = channelInitializedPromise.awaitUninterruptibly(retainedTimeout, TimeUnit.MILLISECONDS);
+        // destroy channel initialized promise after used.
+        channelInitializedPromiseRef.set(null);
+        if (!ret || !channelInitializedPromise.isSuccess()) {
+            // 6-2 Client-side channel initialization timeout
+            RemotingException remotingException = new RemotingException(
+                    this,
+                    "client(url: " + getUrl() + ") failed to connect to server " + getConnectAddress()
+                            + " client-side channel initialization timeout " + getConnectTimeout() + "ms (elapsed: "
+                            + (System.currentTimeMillis() - start) + "ms) from netty client "
+                            + NetUtils.getLocalHost() + " using dubbo version " + Version.getVersion());
 
-                logger.error(
-                        TRANSPORT_CLIENT_CONNECT_TIMEOUT,
-                        "provider crash",
-                        "",
-                        "Client-side channel initialization timeout",
-                        remotingException);
+            logger.error(
+                    TRANSPORT_CLIENT_CONNECT_TIMEOUT,
+                    "provider crash",
+                    "",
+                    "Client-side channel initialization timeout",
+                    remotingException);
 
-                throw remotingException;
-            }
+            throw remotingException;
         }
 
         // await if connection preface received promise is not null.
@@ -209,16 +198,10 @@ public final class NettyConnectionClient extends AbstractNettyConnectionClient {
             return;
         }
         Promise<Void> connectionPrefaceReceivedPromise = connectionPrefaceReceivedPromiseRef.get();
-        if (connectionPrefaceReceivedPromise == null) {
-            return;
-        }
-        long retainedTimeout = getConnectTimeout() - System.currentTimeMillis() + start;
-        boolean ret = connectionPrefaceReceivedPromise.awaitUninterruptibly(retainedTimeout, TimeUnit.MILLISECONDS);
-        // await only once: destroy connection preface received promise after used.
-        synchronized (this) {
-            connectionPrefaceReceivedPromiseRef.set(null);
-            connectionPrefaceReceivedPromiseRef = null;
-        }
+        retainedTimeout = getConnectTimeout() - System.currentTimeMillis() + start;
+        ret = connectionPrefaceReceivedPromise.awaitUninterruptibly(retainedTimeout, TimeUnit.MILLISECONDS);
+        // destroy connection preface received promise after used.
+        connectionPrefaceReceivedPromiseRef.set(null);
         if (!ret || !connectionPrefaceReceivedPromise.isSuccess()) {
             // 6-2 Client-side connection preface timeout
             RemotingException remotingException = new RemotingException(

--- a/dubbo-remoting/dubbo-remoting-netty4/src/main/java/org/apache/dubbo/remoting/transport/netty4/NettyConnectionClient.java
+++ b/dubbo-remoting/dubbo-remoting-netty4/src/main/java/org/apache/dubbo/remoting/transport/netty4/NettyConnectionClient.java
@@ -106,7 +106,10 @@ public final class NettyConnectionClient extends AbstractNettyConnectionClient {
                 protocol.configClientPipeline(getUrl(), operator, nettySslContextOperator);
 
                 ChannelHandlerContext http2FrameCodecHandlerCtx = pipeline.context(Http2FrameCodec.class);
-                if (http2FrameCodecHandlerCtx != null) {
+                if (http2FrameCodecHandlerCtx == null) {
+                    // set connection preface received promise to null.
+                    connectionPrefaceReceivedPromiseRef = null;
+                } else {
                     // create connection preface received promise if necessary.
                     if (connectionPrefaceReceivedPromiseRef == null) {
                         connectionPrefaceReceivedPromiseRef = new AtomicReference<>();

--- a/dubbo-remoting/dubbo-remoting-netty4/src/main/java/org/apache/dubbo/remoting/transport/netty4/NettyConnectionClient.java
+++ b/dubbo-remoting/dubbo-remoting-netty4/src/main/java/org/apache/dubbo/remoting/transport/netty4/NettyConnectionClient.java
@@ -28,6 +28,7 @@ import org.apache.dubbo.remoting.transport.netty4.ssl.SslClientTlsHandler;
 import org.apache.dubbo.remoting.transport.netty4.ssl.SslContexts;
 import org.apache.dubbo.remoting.utils.UrlUtils;
 
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -56,6 +57,17 @@ public final class NettyConnectionClient extends AbstractNettyConnectionClient {
 
     private AtomicReference<Promise<Void>> connectionPrefaceReceivedPromiseRef;
 
+    /**
+     * await connection preface only after the channel was initialized.
+     */
+    private boolean isChannelInitialized;
+
+    /**
+     * the countdown latch for
+     * {@link org.apache.dubbo.remoting.transport.netty4.NettyConnectionClient#isChannelInitialized}
+     */
+    private CountDownLatch channelInitializedLatch;
+
     public NettyConnectionClient(URL url, ChannelHandler handler) throws RemotingException {
         super(url, handler);
     }
@@ -69,6 +81,7 @@ public final class NettyConnectionClient extends AbstractNettyConnectionClient {
     }
 
     protected void initBootstrap() {
+        channelInitializedLatch = new CountDownLatch(1);
         Bootstrap bootstrap = new Bootstrap();
         bootstrap
                 .group(NettyEventLoopFactory.NIO_EVENT_LOOP_GROUP.get())
@@ -104,7 +117,9 @@ public final class NettyConnectionClient extends AbstractNettyConnectionClient {
 
                 ChannelHandlerContext http2FrameCodecHandlerCtx = pipeline.context(Http2FrameCodec.class);
                 if (http2FrameCodecHandlerCtx != null) {
+                    // create connection preface received promise.
                     connectionPrefaceReceivedPromiseRef = new AtomicReference<>();
+                    connectionPrefaceReceivedPromiseRef.set(new DefaultPromise<>(GlobalEventExecutor.INSTANCE));
                     pipeline.addAfter(
                             http2FrameCodecHandlerCtx.name(),
                             "client-connection-preface-handler",
@@ -114,6 +129,10 @@ public final class NettyConnectionClient extends AbstractNettyConnectionClient {
                 // set null but do not close this client, it will be reconnecting in the future
                 ch.closeFuture().addListener(channelFuture -> clearNettyChannel());
                 // TODO support Socks5
+
+                // set channel initialized flag and count down the latch.
+                isChannelInitialized = true;
+                channelInitializedLatch.countDown();
             }
         });
         this.bootstrap = bootstrap;
@@ -121,9 +140,7 @@ public final class NettyConnectionClient extends AbstractNettyConnectionClient {
 
     @Override
     protected ChannelFuture performConnect() {
-        if (connectionPrefaceReceivedPromiseRef != null) {
-            connectionPrefaceReceivedPromiseRef.compareAndSet(null, new DefaultPromise<>(GlobalEventExecutor.INSTANCE));
-        }
+        // ChannelInitializer#initChannel will be invoked by Netty client work thread.
         return bootstrap.connect();
     }
 
@@ -154,23 +171,22 @@ public final class NettyConnectionClient extends AbstractNettyConnectionClient {
      * @param start start time of doConnect in milliseconds.
      */
     private void waitConnectionPreface(long start) throws RemotingException {
-        if (connectionPrefaceReceivedPromiseRef == null) {
-            return;
-        }
-        Promise<Void> connectionPrefaceReceivedPromise = connectionPrefaceReceivedPromiseRef.get();
-        if (connectionPrefaceReceivedPromise != null) {
+        // await channel initialization to ensure connection preface received promise had been created when necessary.
+        if (!isChannelInitialized) {
             long retainedTimeout = getConnectTimeout() - System.currentTimeMillis() + start;
-            boolean ret = connectionPrefaceReceivedPromise.awaitUninterruptibly(retainedTimeout, TimeUnit.MILLISECONDS);
-            // Only process once: destroy connectionPrefaceReceivedPromise after used
-            synchronized (this) {
-                connectionPrefaceReceivedPromiseRef.set(null);
+            try {
+                isChannelInitialized = channelInitializedLatch.await(retainedTimeout, TimeUnit.MILLISECONDS);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new IllegalStateException(
+                        "client(url: " + getUrl() + ") failed to connect to server " + getConnectAddress(), e);
             }
-            if (!ret || !connectionPrefaceReceivedPromise.isSuccess()) {
-                // 6-2 Client-side connection preface timeout
+            if (!isChannelInitialized) {
+                // 6-2 Client-side channel initialization timeout
                 RemotingException remotingException = new RemotingException(
                         this,
                         "client(url: " + getUrl() + ") failed to connect to server " + getConnectAddress()
-                                + " client-side connection preface timeout " + getConnectTimeout()
+                                + " client-side channel initialization timeout " + getConnectTimeout()
                                 + "ms (elapsed: "
                                 + (System.currentTimeMillis() - start) + "ms) from netty client "
                                 + NetUtils.getLocalHost()
@@ -181,11 +197,48 @@ public final class NettyConnectionClient extends AbstractNettyConnectionClient {
                         TRANSPORT_CLIENT_CONNECT_TIMEOUT,
                         "provider crash",
                         "",
-                        "Client-side connection preface timeout",
+                        "Client-side channel initialization timeout",
                         remotingException);
 
                 throw remotingException;
             }
+        }
+
+        // await if connection preface received promise is not null.
+        if (connectionPrefaceReceivedPromiseRef == null) {
+            return;
+        }
+        Promise<Void> connectionPrefaceReceivedPromise = connectionPrefaceReceivedPromiseRef.get();
+        if (connectionPrefaceReceivedPromise == null) {
+            return;
+        }
+        long retainedTimeout = getConnectTimeout() - System.currentTimeMillis() + start;
+        boolean ret = connectionPrefaceReceivedPromise.awaitUninterruptibly(retainedTimeout, TimeUnit.MILLISECONDS);
+        // await only once: destroy connection preface received promise after used.
+        synchronized (this) {
+            connectionPrefaceReceivedPromiseRef.set(null);
+            connectionPrefaceReceivedPromiseRef = null;
+        }
+        if (!ret || !connectionPrefaceReceivedPromise.isSuccess()) {
+            // 6-2 Client-side connection preface timeout
+            RemotingException remotingException = new RemotingException(
+                    this,
+                    "client(url: " + getUrl() + ") failed to connect to server " + getConnectAddress()
+                            + " client-side connection preface timeout " + getConnectTimeout()
+                            + "ms (elapsed: "
+                            + (System.currentTimeMillis() - start) + "ms) from netty client "
+                            + NetUtils.getLocalHost()
+                            + " using dubbo version "
+                            + Version.getVersion());
+
+            logger.error(
+                    TRANSPORT_CLIENT_CONNECT_TIMEOUT,
+                    "provider crash",
+                    "",
+                    "Client-side connection preface timeout",
+                    remotingException);
+
+            throw remotingException;
         }
     }
 }


### PR DESCRIPTION
## What is the purpose of the change?
the channel initialization is triggered by method performConnect, so performConnect should not check ```connectionPrefaceReceivedPromiseRef``` and set ```connectionPrefaceReceivedPromise```, they should be created at ChannelInitializer#initChannel.
![0f234fad6e98669fa72f62d7bb99b080](https://github.com/user-attachments/assets/25efa32f-cb64-4283-b6fe-bbcade2cc4a4)

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Make sure gitHub actions can pass. [Why the workflow is failing and how to fix it?](../CONTRIBUTING.md)
