### PR TITLE
[3.3] Add listener to NacosMetadataReport casListenMap without serviceKey checking

### DIFF
--- a/dubbo-metadata/dubbo-metadata-report-nacos/src/main/java/org/apache/dubbo/metadata/store/nacos/NacosMetadataReport.java
+++ b/dubbo-metadata/dubbo-metadata-report-nacos/src/main/java/org/apache/dubbo/metadata/store/nacos/NacosMetadataReport.java
@@ -300,13 +300,16 @@ public class NacosMetadataReport extends AbstractMetadataReport {
         return new ConfigItem(content, casMd5);
     }
 
+    /**
+     * allow adding listener without checking if the serviceKey is existed in the map.
+     * there are multiple references which have the same serviceKey but might have multiple listeners,
+     * because the extra parameters of their subscribed URLs might be different.
+     */
     @Override
     public Set<String> getServiceAppMapping(String serviceKey, MappingListener listener, URL url) {
         String group = DEFAULT_MAPPING_GROUP;
 
-        if (null == casListenerMap.get(buildListenerKey(serviceKey, group))) {
-            addCasServiceMappingListener(serviceKey, group, listener);
-        }
+        addCasServiceMappingListener(serviceKey, group, listener);
         String content = getConfig(serviceKey, group);
         return ServiceNameMapping.getAppNames(content);
     }


### PR DESCRIPTION
## What is the purpose of the change?
try to fix https://github.com/apache/dubbo/issues/15305

the reason that we should allow adding listener without checking if the ```serviceKey``` is existed in the ```casListenMap``` of  ```NacosMetadataReport ``` is there are multiple references which have the same ```serviceKey``` but might have multiple listeners, because the extra parameters of their subscribed URLs might be defined differently in the consumer application.
   
## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Make sure gitHub actions can pass. [Why the workflow is failing and how to fix it?](../CONTRIBUTING.md)
