### PR TITLE
[3.3] Fix RpcUtils by getting method from invokerInterface if it is not null

### DIFF
--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/support/RpcUtils.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/support/RpcUtils.java
@@ -244,9 +244,7 @@ public class RpcUtils {
 
     private static Method getMethodByService(Invocation invocation, String service) throws NoSuchMethodException {
         Class<?> invokerInterface = invocation.getInvoker().getInterface();
-        Class<?> cls = invokerInterface != null
-                ? ReflectUtils.forName(invokerInterface.getClassLoader(), service)
-                : ReflectUtils.forName(service);
+        Class<?> cls = invokerInterface != null ? invokerInterface : ReflectUtils.forName(service);
         Method method = cls.getMethod(invocation.getMethodName(), invocation.getParameterTypes());
         if (method.getReturnType() == void.class) {
             return null;


### PR DESCRIPTION
## What is the purpose of the change?
if customer specifies service path name which is not a class name by calling ```registryService("someNameThatCustomerWanted", Xxx.class)```, just like this:
![9ea9ced45a102250203b1bfc5f88b6c](https://github.com/user-attachments/assets/bb28185c-60d5-4085-9dce-e27e8d3165a6)
RpcUtils#getMethodByService will encounter with problems:
![2fae3b5aa04ca84c5a7bcf5dcb8a0f1](https://github.com/user-attachments/assets/6ab1562b-e1d6-4d4a-ab66-4655b567e425)
the root cause is we don't known whether the path of urlAddress is a interface name or not.
![e7a67c9cbe4c5f3173ac07e2f12da61](https://github.com/user-attachments/assets/737a15fb-bb82-42fe-9eae-c798b0ca901b)

so the better way might be getting method from the ```invokerInterface``` if it is not null.
## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Make sure gitHub actions can pass. [Why the workflow is failing and how to fix it?](../CONTRIBUTING.md)
