### PR TITLE
[3.3] Remove redundant version declaration from dubbo-remoting-zookeeper-curator5

### DIFF
--- a/dubbo-remoting/dubbo-remoting-zookeeper-curator5/pom.xml
+++ b/dubbo-remoting/dubbo-remoting-zookeeper-curator5/pom.xml
@@ -29,8 +29,6 @@
   <description>The zookeeper remoting module of dubbo project</description>
   <properties>
     <skip_maven_deploy>false</skip_maven_deploy>
-    <zookeeper_version>3.7.2</zookeeper_version>
-    <curator5_version>5.8.0</curator5_version>
   </properties>
   <dependencies>
     <dependency>
@@ -42,17 +40,14 @@
     <dependency>
       <groupId>org.apache.curator</groupId>
       <artifactId>curator-framework</artifactId>
-      <version>${curator5_version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.curator</groupId>
       <artifactId>curator-recipes</artifactId>
-      <version>${curator5_version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.zookeeper</groupId>
       <artifactId>zookeeper</artifactId>
-      <version>${zookeeper_version}</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
## What is the purpose of the change?
the versions of zookeeper and curator5 have been declared at ```dubbo-dependencies-bom```

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Make sure gitHub actions can pass. [Why the workflow is failing and how to fix it?](../CONTRIBUTING.md)
