### PR TITLE
[3.3] Add jre range annotation to oauth2 test cases which need jdk17+

### DIFF
--- a/dubbo-plugin/dubbo-spring-security/src/test/java/org/apache/dubbo/spring/security/jackson/ObjectMapperCodecTest.java
+++ b/dubbo-plugin/dubbo-spring-security/src/test/java/org/apache/dubbo/spring/security/jackson/ObjectMapperCodecTest.java
@@ -22,6 +22,8 @@ import java.util.Collections;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledForJreRange;
+import org.junit.jupiter.api.condition.JRE;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClient;
 import org.springframework.security.oauth2.client.registration.ClientRegistration;
@@ -39,7 +41,7 @@ import org.springframework.security.oauth2.server.resource.authentication.Bearer
 
 public class ObjectMapperCodecTest {
 
-    private ObjectMapperCodec mapper = new ObjectMapperCodec();
+    private final ObjectMapperCodec mapper = new ObjectMapperCodec();
 
     @Test
     public void testOAuth2AuthorizedClientCodec() {
@@ -54,6 +56,7 @@ public class ObjectMapperCodecTest {
         Assertions.assertNotNull(deserialize);
     }
 
+    @EnabledForJreRange(min = JRE.JAVA_17)
     @Test
     public void bearerTokenAuthenticationTest() {
         BearerTokenAuthentication bearerTokenAuthentication = new BearerTokenAuthentication(
@@ -70,6 +73,7 @@ public class ObjectMapperCodecTest {
         Assertions.assertNotNull(deserialize);
     }
 
+    @EnabledForJreRange(min = JRE.JAVA_17)
     @Test
     public void oAuth2ClientAuthenticationTokenTest() {
         OAuth2ClientAuthenticationToken oAuth2ClientAuthenticationToken = new OAuth2ClientAuthenticationToken(
@@ -83,6 +87,7 @@ public class ObjectMapperCodecTest {
         Assertions.assertNotNull(deserialize);
     }
 
+    @EnabledForJreRange(min = JRE.JAVA_17)
     @Test
     public void registeredClientTest() {
         RegisteredClient registeredClient = RegisteredClient.withId("id")


### PR DESCRIPTION
## What is the purpose of the change?
The OAuth2 test cases of ```dubbo-spring-security``` could only run on jdk17+

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Make sure gitHub actions can pass. [Why the workflow is failing and how to fix it?](../CONTRIBUTING.md)
