### PR TITLE
[3.3] Declare clientSettings and tokenSettings as Object type to avoid compilation error with jdk8 or jdk11

### DIFF
--- a/dubbo-plugin/dubbo-spring-security/pom.xml
+++ b/dubbo-plugin/dubbo-spring-security/pom.xml
@@ -61,6 +61,12 @@
 
     <dependency>
       <groupId>org.springframework.security</groupId>
+      <artifactId>spring-security-oauth2-core</artifactId>
+      <optional>true</optional>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-oauth2-client</artifactId>
       <scope>test</scope>
       <optional>true</optional>
@@ -70,6 +76,7 @@
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-oauth2-authorization-server</artifactId>
       <version>${spring.oauth2.server}</version>
+      <scope>test</scope>
       <optional>true</optional>
     </dependency>
     <!-- spring security -->

--- a/dubbo-plugin/dubbo-spring-security/src/main/java/org/apache/dubbo/spring/security/oauth2/RegisteredClientMixin.java
+++ b/dubbo-plugin/dubbo-spring-security/src/main/java/org/apache/dubbo/spring/security/oauth2/RegisteredClientMixin.java
@@ -26,8 +26,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import org.springframework.security.oauth2.core.AuthorizationGrantType;
 import org.springframework.security.oauth2.core.ClientAuthenticationMethod;
-import org.springframework.security.oauth2.server.authorization.settings.ClientSettings;
-import org.springframework.security.oauth2.server.authorization.settings.TokenSettings;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS)
 @JsonAutoDetect(
@@ -38,6 +36,11 @@ import org.springframework.security.oauth2.server.authorization.settings.TokenSe
 @JsonIgnoreProperties(ignoreUnknown = true)
 abstract class RegisteredClientMixin {
 
+    /**
+     * declare clientSettings and tokenSettings as Object type to avoid COMPILATION ERROR when compile it with jdk8
+     * or jdk11, both ClientSettings and TokenSettings class file version are 61.0 which is higher than the version
+     * which jdk8 (class file version: 52.0) or jdk11 (class file version: 55.0) could support.
+     */
     @JsonCreator
     public RegisteredClientMixin(
             @JsonProperty("id") String id,
@@ -51,6 +54,6 @@ abstract class RegisteredClientMixin {
             @JsonProperty("redirectUris") Set<String> redirectUris,
             @JsonProperty("postLogoutRedirectUris") Set<String> postLogoutRedirectUris,
             @JsonProperty("scopes") Set<String> scopes,
-            @JsonProperty("clientSettings") ClientSettings clientSettings,
-            @JsonProperty("tokenSettings") TokenSettings tokenSettings) {}
+            @JsonProperty("clientSettings") Object clientSettings,
+            @JsonProperty("tokenSettings") Object tokenSettings) {}
 }


### PR DESCRIPTION
## What is the purpose of the change?
1. the class file version of ClientSettings and TokenSettings is 61.0 (compiled by jdk17), it will cause compilation error when building dubbo using jdk8 or jdk11.
2. ```spring-security-oauth2-authorization-server``` is only used in the test cases,  depending on ```spring-security-oauth2-core``` is enough.

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Make sure gitHub actions can pass. [Why the workflow is failing and how to fix it?](../CONTRIBUTING.md)
