### PR TITLE
[3.3] Remove oauth2 test cases which could not been compiled with jdk8 or jdk11

### DIFF
--- a/dubbo-plugin/dubbo-spring-security/src/test/java/org/apache/dubbo/spring/security/jackson/ObjectMapperCodecTest.java
+++ b/dubbo-plugin/dubbo-spring-security/src/test/java/org/apache/dubbo/spring/security/jackson/ObjectMapperCodecTest.java
@@ -18,30 +18,18 @@ package org.apache.dubbo.spring.security.jackson;
 
 import java.time.Duration;
 import java.time.Instant;
-import java.util.Collections;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.EnabledForJreRange;
-import org.junit.jupiter.api.condition.JRE;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClient;
 import org.springframework.security.oauth2.client.registration.ClientRegistration;
 import org.springframework.security.oauth2.core.AuthorizationGrantType;
 import org.springframework.security.oauth2.core.ClientAuthenticationMethod;
-import org.springframework.security.oauth2.core.DefaultOAuth2AuthenticatedPrincipal;
 import org.springframework.security.oauth2.core.OAuth2AccessToken;
-import org.springframework.security.oauth2.core.OAuth2AccessToken.TokenType;
-import org.springframework.security.oauth2.server.authorization.authentication.OAuth2ClientAuthenticationToken;
-import org.springframework.security.oauth2.server.authorization.client.RegisteredClient;
-import org.springframework.security.oauth2.server.authorization.settings.ClientSettings;
-import org.springframework.security.oauth2.server.authorization.settings.OAuth2TokenFormat;
-import org.springframework.security.oauth2.server.authorization.settings.TokenSettings;
-import org.springframework.security.oauth2.server.resource.authentication.BearerTokenAuthentication;
 
 public class ObjectMapperCodecTest {
 
-    private final ObjectMapperCodec mapper = new ObjectMapperCodec();
+    private ObjectMapperCodec mapper = new ObjectMapperCodec();
 
     @Test
     public void testOAuth2AuthorizedClientCodec() {
@@ -52,66 +40,6 @@ public class ObjectMapperCodecTest {
         String content = mapper.serialize(authorizedClient);
 
         OAuth2AuthorizedClient deserialize = mapper.deserialize(content.getBytes(), OAuth2AuthorizedClient.class);
-
-        Assertions.assertNotNull(deserialize);
-    }
-
-    @EnabledForJreRange(min = JRE.JAVA_17)
-    @Test
-    public void bearerTokenAuthenticationTest() {
-        BearerTokenAuthentication bearerTokenAuthentication = new BearerTokenAuthentication(
-                new DefaultOAuth2AuthenticatedPrincipal(
-                        "principal-name",
-                        Collections.singletonMap("name", "kali"),
-                        Collections.singleton(new SimpleGrantedAuthority("1"))),
-                new OAuth2AccessToken(TokenType.BEARER, "111", Instant.MIN, Instant.MAX),
-                Collections.emptyList());
-        String content = mapper.serialize(bearerTokenAuthentication);
-
-        BearerTokenAuthentication deserialize = mapper.deserialize(content.getBytes(), BearerTokenAuthentication.class);
-
-        Assertions.assertNotNull(deserialize);
-    }
-
-    @EnabledForJreRange(min = JRE.JAVA_17)
-    @Test
-    public void oAuth2ClientAuthenticationTokenTest() {
-        OAuth2ClientAuthenticationToken oAuth2ClientAuthenticationToken = new OAuth2ClientAuthenticationToken(
-                "client-id", ClientAuthenticationMethod.CLIENT_SECRET_POST, "111", Collections.emptyMap());
-
-        String content = mapper.serialize(oAuth2ClientAuthenticationToken);
-
-        OAuth2ClientAuthenticationToken deserialize =
-                mapper.deserialize(content.getBytes(), OAuth2ClientAuthenticationToken.class);
-
-        Assertions.assertNotNull(deserialize);
-    }
-
-    @EnabledForJreRange(min = JRE.JAVA_17)
-    @Test
-    public void registeredClientTest() {
-        RegisteredClient registeredClient = RegisteredClient.withId("id")
-                .clientId("client-id")
-                .clientName("client-name")
-                .authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
-                .redirectUri("https://example.com")
-                .clientAuthenticationMethod(ClientAuthenticationMethod.CLIENT_SECRET_JWT)
-                .clientSecret("client-secret")
-                .clientIdIssuedAt(Instant.MIN)
-                .clientSecretExpiresAt(Instant.MAX)
-                .tokenSettings(TokenSettings.builder()
-                        .accessTokenFormat(OAuth2TokenFormat.REFERENCE)
-                        .accessTokenTimeToLive(Duration.ofSeconds(1000))
-                        .build())
-                .clientSettings(ClientSettings.builder()
-                        .setting("name", "value")
-                        .requireProofKey(true)
-                        .build())
-                .build();
-
-        String content = mapper.serialize(registeredClient);
-
-        RegisteredClient deserialize = mapper.deserialize(content.getBytes(), RegisteredClient.class);
 
         Assertions.assertNotNull(deserialize);
     }


### PR DESCRIPTION
## What is the purpose of the change?
Remove oauth2 unit test cases which could not been compiled with jdk8 or jdk11, a separate unit testing project should be created for these cases.

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Make sure gitHub actions can pass. [Why the workflow is failing and how to fix it?](../CONTRIBUTING.md)
