### PR TITLE
[3.3] Close channel handler context after the channel written operation is completed and Remove overflow check process to align with Netty http2 remote flow controller

### DIFF
--- a/dubbo-remoting/dubbo-remoting-http3/src/main/java/org/apache/dubbo/remoting/http3/netty4/NettyHttp3FrameCodec.java
+++ b/dubbo-remoting/dubbo-remoting-http3/src/main/java/org/apache/dubbo/remoting/http3/netty4/NettyHttp3FrameCodec.java
@@ -97,36 +97,37 @@ public class NettyHttp3FrameCodec extends Http3RequestStreamInboundHandler imple
     public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
         if (msg instanceof Http2Header) {
             Http2Header headers = (Http2Header) msg;
-            ctx.write(
+            ChannelFuture future = ctx.write(
                     new DefaultHttp3HeadersFrame(((NettyHttpHeaders<Http3Headers>) headers.headers()).getHeaders()),
                     promise);
             if (headers.isEndStream()) {
-                if (promise.isDone()) {
+                if (future.isDone()) {
                     ctx.close();
                 } else {
-                    promise.addListener((ChannelFutureListener) future -> ctx.close());
+                    future.addListener((ChannelFutureListener) f -> ctx.close());
                 }
             }
         } else if (msg instanceof Http2OutputMessage) {
             Http2OutputMessage message = (Http2OutputMessage) msg;
+            ChannelFuture future = null;
             try {
                 OutputStream body = message.getBody();
                 if (body == null) {
                     Http3DataFrame frame = new DefaultHttp3DataFrame(Unpooled.EMPTY_BUFFER);
-                    ctx.write(frame, promise);
+                    future = ctx.write(frame, promise);
                     return;
                 }
                 if (body instanceof ByteBufOutputStream) {
                     Http3DataFrame frame = new DefaultHttp3DataFrame(((ByteBufOutputStream) body).buffer());
-                    ctx.write(frame, promise);
+                    future = ctx.write(frame, promise);
                     return;
                 }
             } finally {
                 if (message.isEndStream()) {
-                    if (promise.isDone()) {
+                    if (future == null || future.isDone()) {
                         ctx.close();
                     } else {
-                        promise.addListener((ChannelFutureListener) future -> ctx.close());
+                        future.addListener((ChannelFutureListener) f -> ctx.close());
                     }
                 }
             }

--- a/dubbo-remoting/dubbo-remoting-http3/src/main/java/org/apache/dubbo/remoting/http3/netty4/NettyHttp3FrameCodec.java
+++ b/dubbo-remoting/dubbo-remoting-http3/src/main/java/org/apache/dubbo/remoting/http3/netty4/NettyHttp3FrameCodec.java
@@ -30,7 +30,6 @@ import java.net.SocketAddress;
 
 import io.netty.buffer.ByteBufInputStream;
 import io.netty.buffer.ByteBufOutputStream;
-import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandler.Sharable;
@@ -97,41 +96,43 @@ public class NettyHttp3FrameCodec extends Http3RequestStreamInboundHandler imple
     public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
         if (msg instanceof Http2Header) {
             Http2Header headers = (Http2Header) msg;
-            ChannelFuture future = ctx.write(
+            if (headers.isEndStream()) {
+                ChannelFuture future = ctx.write(
+                        new DefaultHttp3HeadersFrame(((NettyHttpHeaders<Http3Headers>) headers.headers()).getHeaders()),
+                        ctx.newPromise());
+                if (future.isDone()) {
+                    ctx.close(promise);
+                } else {
+                    future.addListener((ChannelFutureListener) f -> ctx.close(promise));
+                }
+                return;
+            }
+            ctx.write(
                     new DefaultHttp3HeadersFrame(((NettyHttpHeaders<Http3Headers>) headers.headers()).getHeaders()),
                     promise);
-            if (headers.isEndStream()) {
-                if (future.isDone()) {
-                    ctx.close();
-                } else {
-                    future.addListener((ChannelFutureListener) f -> ctx.close());
-                }
-            }
         } else if (msg instanceof Http2OutputMessage) {
             Http2OutputMessage message = (Http2OutputMessage) msg;
-            ChannelFuture future = null;
-            try {
-                OutputStream body = message.getBody();
+            OutputStream body = message.getBody();
+            assert body instanceof ByteBufOutputStream || body == null;
+            if (message.isEndStream()) {
                 if (body == null) {
-                    Http3DataFrame frame = new DefaultHttp3DataFrame(Unpooled.EMPTY_BUFFER);
-                    future = ctx.write(frame, promise);
+                    ctx.close(promise);
                     return;
                 }
-                if (body instanceof ByteBufOutputStream) {
-                    Http3DataFrame frame = new DefaultHttp3DataFrame(((ByteBufOutputStream) body).buffer());
-                    future = ctx.write(frame, promise);
-                    return;
+                ChannelFuture future =
+                        ctx.write(new DefaultHttp3DataFrame(((ByteBufOutputStream) body).buffer()), ctx.newPromise());
+                if (future.isDone()) {
+                    ctx.close(promise);
+                } else {
+                    future.addListener((ChannelFutureListener) f -> ctx.close(promise));
                 }
-            } finally {
-                if (message.isEndStream()) {
-                    if (future == null || future.isDone()) {
-                        ctx.close();
-                    } else {
-                        future.addListener((ChannelFutureListener) f -> ctx.close());
-                    }
-                }
+                return;
             }
-            throw new IllegalArgumentException("Http2OutputMessage body must be ByteBufOutputStream");
+            if (body == null) {
+                promise.trySuccess();
+                return;
+            }
+            ctx.write(new DefaultHttp3DataFrame(((ByteBufOutputStream) body).buffer()), promise);
         } else {
             ctx.write(msg, promise);
         }

--- a/dubbo-remoting/dubbo-remoting-http3/src/main/java/org/apache/dubbo/remoting/http3/netty4/NettyHttp3FrameCodec.java
+++ b/dubbo-remoting/dubbo-remoting-http3/src/main/java/org/apache/dubbo/remoting/http3/netty4/NettyHttp3FrameCodec.java
@@ -31,6 +31,7 @@ import java.net.SocketAddress;
 import io.netty.buffer.ByteBufInputStream;
 import io.netty.buffer.ByteBufOutputStream;
 import io.netty.buffer.Unpooled;
+import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandler.Sharable;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelOutboundHandler;
@@ -95,7 +96,11 @@ public class NettyHttp3FrameCodec extends Http3RequestStreamInboundHandler imple
                     new DefaultHttp3HeadersFrame(((NettyHttpHeaders<Http3Headers>) headers.headers()).getHeaders()),
                     promise);
             if (headers.isEndStream()) {
-                ctx.close();
+                if (promise.isDone()) {
+                    ctx.close();
+                } else {
+                    promise.addListener((ChannelFutureListener) future -> ctx.close());
+                }
             }
         } else if (msg instanceof Http2OutputMessage) {
             Http2OutputMessage message = (Http2OutputMessage) msg;
@@ -113,7 +118,11 @@ public class NettyHttp3FrameCodec extends Http3RequestStreamInboundHandler imple
                 }
             } finally {
                 if (message.isEndStream()) {
-                    ctx.close();
+                    if (promise.isDone()) {
+                        ctx.close();
+                    } else {
+                        promise.addListener((ChannelFutureListener) future -> ctx.close());
+                    }
                 }
             }
             throw new IllegalArgumentException("Http2OutputMessage body must be ByteBufOutputStream");

--- a/dubbo-remoting/dubbo-remoting-http3/src/main/java/org/apache/dubbo/remoting/http3/netty4/NettyHttp3FrameCodec.java
+++ b/dubbo-remoting/dubbo-remoting-http3/src/main/java/org/apache/dubbo/remoting/http3/netty4/NettyHttp3FrameCodec.java
@@ -31,6 +31,7 @@ import java.net.SocketAddress;
 import io.netty.buffer.ByteBufInputStream;
 import io.netty.buffer.ByteBufOutputStream;
 import io.netty.buffer.Unpooled;
+import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandler.Sharable;
 import io.netty.channel.ChannelHandlerContext;
@@ -68,8 +69,12 @@ public class NettyHttp3FrameCodec extends Http3RequestStreamInboundHandler imple
         Http3Headers pongHeader = new DefaultHttp3Headers(false);
         pongHeader.set(TRI_PING, "0");
         pongHeader.set(PseudoHeaderName.STATUS.value(), HttpStatus.OK.getStatusString());
-        ctx.write(new DefaultHttp3HeadersFrame(pongHeader));
-        ctx.close();
+        ChannelFuture future = ctx.write(new DefaultHttp3HeadersFrame(pongHeader), ctx.newPromise());
+        if (future.isDone()) {
+            ctx.close();
+        } else {
+            future.addListener((ChannelFutureListener) f -> ctx.close());
+        }
     }
 
     @Override

--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/TriHttp2RemoteFlowController.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/TriHttp2RemoteFlowController.java
@@ -408,8 +408,8 @@ public class TriHttp2RemoteFlowController implements Http2RemoteFlowController {
                     cancel(INTERNAL_ERROR, cause);
                 }
                 if (monitor.isOverFlowControl()) {
-                    cause = new Throwable();
-                    cancel(FLOW_CONTROL_ERROR, cause);
+                    // Let client continue receiving the pending bytes.
+                    logger.warn("TotalPendingBytes size overflow for stream: " + this.stream().id());
                 }
             }
             return writtenBytes;
@@ -778,11 +778,7 @@ public class TriHttp2RemoteFlowController implements Http2RemoteFlowController {
             } else if (isWritable(state) != state.markedWritability()) {
                 notifyWritabilityChanged(state);
             } else if (isOverFlowControl()) {
-                throw streamError(
-                        state.stream().id(),
-                        FLOW_CONTROL_ERROR,
-                        "TotalPendingBytes size overflow for stream: %d",
-                        state.stream().id());
+                logger.warn("TotalPendingBytes size overflow for stream: " + state.stream().id());
             }
         }
 

--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/TriHttp2RemoteFlowController.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/TriHttp2RemoteFlowController.java
@@ -407,10 +407,8 @@ public class TriHttp2RemoteFlowController implements Http2RemoteFlowController {
                 if (cancelled) {
                     cancel(INTERNAL_ERROR, cause);
                 }
-                if (monitor.isOverFlowControl()) {
-                    // Let receiver continue receiving the pending bytes.
-                    logger.warn("TotalPendingBytes size overflow for stream: " + this.stream().id());
-                }
+
+                // does not check overflow anymore: Let receiver continue receiving the pending bytes.
             }
             return writtenBytes;
         }
@@ -670,14 +668,6 @@ public class TriHttp2RemoteFlowController implements Http2RemoteFlowController {
         final boolean isWritableConnection() {
             return connectionState.windowSize() - totalPendingBytes > 0 && isChannelWritable();
         }
-
-        final boolean isOverFlowControl() {
-            if (connectionState.windowSize() == 0) {
-                return true;
-            } else {
-                return false;
-            }
-        }
     }
 
     /**
@@ -777,9 +767,8 @@ public class TriHttp2RemoteFlowController implements Http2RemoteFlowController {
                 checkAllWritabilityChanged();
             } else if (isWritable(state) != state.markedWritability()) {
                 notifyWritabilityChanged(state);
-            } else if (isOverFlowControl()) {
-                logger.warn("TotalPendingBytes size overflow for stream: " + state.stream().id());
             }
+            // does not check overflow anymore: Let receiver continue receiving the pending bytes.
         }
 
         private void checkAllWritabilityChanged() throws Http2Exception {

--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/TriHttp2RemoteFlowController.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/TriHttp2RemoteFlowController.java
@@ -408,7 +408,7 @@ public class TriHttp2RemoteFlowController implements Http2RemoteFlowController {
                     cancel(INTERNAL_ERROR, cause);
                 }
                 if (monitor.isOverFlowControl()) {
-                    // Let client continue receiving the pending bytes.
+                    // Let receiver continue receiving the pending bytes.
                     logger.warn("TotalPendingBytes size overflow for stream: " + this.stream().id());
                 }
             }

--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/h3/Http3ClientFrameCodec.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/h3/Http3ClientFrameCodec.java
@@ -116,7 +116,21 @@ public class Http3ClientFrameCodec extends ChannelDuplexHandler {
         } else if (msg instanceof Http2DataFrame) {
             Http2DataFrame frame = (Http2DataFrame) msg;
             if (frame.isEndStream()) {
-                ((QuicStreamChannel) ctx.channel()).shutdownOutput(promise);
+                if (Unpooled.EMPTY_BUFFER.equals(frame.content())) {
+                    ((QuicStreamChannel) ctx.channel()).shutdownOutput(promise);
+                    return;
+                }
+                ChannelFuture future = ctx.write(new DefaultHttp3DataFrame(frame.content()), ctx.newPromise());
+                if (future.isDone()) {
+                    ((QuicStreamChannel) ctx.channel()).shutdownOutput(promise);
+                } else {
+                    future.addListener(
+                            (ChannelFutureListener) f -> ((QuicStreamChannel) ctx.channel()).shutdownOutput(promise));
+                }
+                return;
+            }
+            if (Unpooled.EMPTY_BUFFER.equals(frame.content())) {
+                promise.trySuccess();
                 return;
             }
             ctx.write(new DefaultHttp3DataFrame(frame.content()), promise);

--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/h3/Http3ClientFrameCodec.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/h3/Http3ClientFrameCodec.java
@@ -26,6 +26,8 @@ import org.apache.dubbo.rpc.protocol.tri.TripleHeaderEnum;
 
 import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelDuplexHandler;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandler.Sharable;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPipeline;
@@ -99,9 +101,15 @@ public class Http3ClientFrameCodec extends ChannelDuplexHandler {
     public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
         if (msg instanceof Http2HeadersFrame) {
             Http2HeadersFrame frame = (Http2HeadersFrame) msg;
-            ctx.write(new DefaultHttp3HeadersFrame(new Http3HeadersAdapter(frame.headers())), promise);
+            ChannelFuture future =
+                    ctx.write(new DefaultHttp3HeadersFrame(new Http3HeadersAdapter(frame.headers())), promise);
             if (frame.isEndStream()) {
-                ((QuicStreamChannel) ctx.channel()).shutdownOutput(promise);
+                if (future.isDone()) {
+                    ((QuicStreamChannel) ctx.channel()).shutdownOutput(promise);
+                } else {
+                    future.addListener(
+                            (ChannelFutureListener) f -> ((QuicStreamChannel) ctx.channel()).shutdownOutput(promise));
+                }
             }
         } else if (msg instanceof Http2DataFrame) {
             Http2DataFrame frame = (Http2DataFrame) msg;

--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/h3/Http3ClientFrameCodec.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/h3/Http3ClientFrameCodec.java
@@ -101,16 +101,18 @@ public class Http3ClientFrameCodec extends ChannelDuplexHandler {
     public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
         if (msg instanceof Http2HeadersFrame) {
             Http2HeadersFrame frame = (Http2HeadersFrame) msg;
-            ChannelFuture future =
-                    ctx.write(new DefaultHttp3HeadersFrame(new Http3HeadersAdapter(frame.headers())), promise);
             if (frame.isEndStream()) {
+                ChannelFuture future = ctx.write(
+                        new DefaultHttp3HeadersFrame(new Http3HeadersAdapter(frame.headers())), ctx.newPromise());
                 if (future.isDone()) {
                     ((QuicStreamChannel) ctx.channel()).shutdownOutput(promise);
                 } else {
                     future.addListener(
                             (ChannelFutureListener) f -> ((QuicStreamChannel) ctx.channel()).shutdownOutput(promise));
                 }
+                return;
             }
+            ctx.write(new DefaultHttp3HeadersFrame(new Http3HeadersAdapter(frame.headers())), promise);
         } else if (msg instanceof Http2DataFrame) {
             Http2DataFrame frame = (Http2DataFrame) msg;
             if (frame.isEndStream()) {

--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/stream/AbstractTripleClientStream.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/stream/AbstractTripleClientStream.java
@@ -409,6 +409,9 @@ public abstract class AbstractTripleClientStream extends AbstractStream implemen
 
         @Override
         public void onHeader(Http2Headers headers, boolean endStream) {
+            if (LOGGER.isDebugEnabled()) {
+                LOGGER.debug("endStream: {} HEADERS: {}", endStream, headers);
+            }
             executor.execute(() -> {
                 if (endStream) {
                     if (!halfClosed) {
@@ -428,6 +431,9 @@ public abstract class AbstractTripleClientStream extends AbstractStream implemen
 
         @Override
         public void onData(ByteBuf data, boolean endStream) {
+            if (LOGGER.isDebugEnabled()) {
+                LOGGER.debug("endStream: {} DATA: {}", endStream, data.toString(StandardCharsets.UTF_8));
+            }
             try {
                 executor.execute(() -> doOnData(data, endStream));
             } catch (Throwable t) {


### PR DESCRIPTION
## What is the purpose of the change?
#15501 

1. Close channel handler context after the channel written operation is completed.
gRPC or HTTP/2 sender should not close stream immediately after sending http output message or trailers, otherwise the receiver will encounter troubles during receiving packets due to ‌premature stream closure.
see details at https://github.com/apache/dubbo/issues/15520

2. Remove overflow check process to align with Netty http2 remote flow controller, refer to [DefaultHttp2RemoteFlowController](https://github.com/netty/netty/blob/4.2/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2RemoteFlowController.java)

if http2 sender throws StreamException when the window size of connectionState is zero:
![dd8a27ae29eb78e4755824889c574115](https://github.com/user-attachments/assets/7f1c4c96-ae55-4f6b-a041-0c1cd61d33b5)
the receiver might get ResourceAccessException caused by closed IOException during receiving response :
![image](https://github.com/user-attachments/assets/be575b28-a723-4c76-a043-2ccef4ee2598)

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Make sure gitHub actions can pass. [Why the workflow is failing and how to fix it?](../CONTRIBUTING.md)
