### PR TITLE
Fire ping ack event when receiving `TRI_PING` Http3 Headers frame

### DIFF
--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/TriplePingPongHandler.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/TriplePingPongHandler.java
@@ -48,16 +48,31 @@ public class TriplePingPongHandler extends ChannelDuplexHandler {
 
     @Override
     public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
+        if (evt instanceof PingAckEvent) {
+            if (pingAckTimeoutFuture != null) {
+                pingAckTimeoutFuture.cancel(true);
+                pingAckTimeoutFuture = null;
+            }
+            return;
+        }
         if (!(evt instanceof IdleStateEvent)) {
             ctx.fireUserEventTriggered(evt);
             return;
         }
-        ctx.writeAndFlush(new DefaultHttp2PingFrame(0));
         if (pingAckTimeoutFuture == null) {
             pingAckTimeoutFuture =
                     ctx.executor().schedule(new CloseChannelTask(ctx), pingAckTimeout, TimeUnit.MILLISECONDS);
         }
-        // not null means last ping ack not received
+        // pingAckTimeoutFuture not null means last ping ack not received
+        ctx.writeAndFlush(new DefaultHttp2PingFrame(0));
+    }
+
+    public static class PingAckEvent {
+
+        @SuppressWarnings("InstantiationOfUtilityClass")
+        public static final PingAckEvent INSTANCE = new PingAckEvent();
+
+        private PingAckEvent() {}
     }
 
     private static class CloseChannelTask implements Runnable {

--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/h3/Http3ClientFrameCodec.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/h3/Http3ClientFrameCodec.java
@@ -23,6 +23,7 @@ import org.apache.dubbo.remoting.http3.netty4.Constants;
 import org.apache.dubbo.remoting.http3.netty4.Http2HeadersAdapter;
 import org.apache.dubbo.remoting.http3.netty4.Http3HeadersAdapter;
 import org.apache.dubbo.rpc.protocol.tri.TripleHeaderEnum;
+import org.apache.dubbo.rpc.protocol.tri.TriplePingPongHandler.PingAckEvent;
 
 import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelDuplexHandler;
@@ -30,12 +31,10 @@ import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandler.Sharable;
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.channel.ChannelPipeline;
 import io.netty.channel.ChannelPromise;
 import io.netty.handler.codec.http2.DefaultHttp2DataFrame;
 import io.netty.handler.codec.http2.DefaultHttp2GoAwayFrame;
 import io.netty.handler.codec.http2.DefaultHttp2HeadersFrame;
-import io.netty.handler.codec.http2.DefaultHttp2PingFrame;
 import io.netty.handler.codec.http2.DefaultHttp2ResetFrame;
 import io.netty.handler.codec.http2.Http2DataFrame;
 import io.netty.handler.codec.http2.Http2Headers.PseudoHeaderName;
@@ -83,9 +82,7 @@ public class Http3ClientFrameCodec extends ChannelDuplexHandler {
     }
 
     private void pingAck(ChannelHandlerContext ctx) {
-        ChannelPipeline pipeline = ctx.channel().parent().pipeline();
-        pipeline.fireChannelRead(new DefaultHttp2PingFrame(0, true));
-        pipeline.fireChannelReadComplete();
+        ctx.channel().parent().pipeline().fireUserEventTriggered(PingAckEvent.INSTANCE);
     }
 
     @Override


### PR DESCRIPTION
## What is the purpose of the change?
```
private void pingAck(ChannelHandlerContext ctx) {
        ChannelPipeline pipeline = ctx.channel().parent().pipeline();
        pipeline.fireChannelRead(new DefaultHttp2PingFrame(0, true));
        pipeline.fireChannelReadComplete();
```
might break Netty event handling process, it might be better to use event notification to do the same thing.

Let Netty manage ```fireChannelReadComplete()``` as part of its internal event flow. Application should focus on implementing business logic in overridden ```channelReadComplete()``` handlers rather than manually triggering the event

In Netty, fireChannelReadComplete() should not be invoked directly due to its critical role in the framework's event processing pipeline:
1.‌ Event Propagation Mechanism‌
This method is designed to notify the ChannelPipeline when a read operation completes, automatically triggered by Netty's internal NioEventLoop after socket buffer processing. Direct invocation disrupts the event sequence and may cause data handling inconsistencies.
2. Coordination with channelRead()‌
channelRead(): Processes fully decoded application-layer messages (e.g., after protocol decoding). 
channelReadComplete(): Signals the end of a socket read cycle, potentially called multiple times due to packet fragmentation.
Manual calls might bypass essential message processing steps in channelRead()
3. Risks of Direct Invocation‌
‌Duplicate Processing‌: May trigger redundant business logic executions.
‌Resource Leaks‌: Could lead to buffer reference count mismanagement if not handled properly.

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Make sure gitHub actions can pass. [Why the workflow is failing and how to fix it?](../CONTRIBUTING.md)
