### PR TITLE
[3.3] Add http2 server connection preface process

### DIFF
--- a/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/netty4/h2/NettyHttp2FrameCodec.java
+++ b/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/netty4/h2/NettyHttp2FrameCodec.java
@@ -16,7 +16,7 @@
  */
 package org.apache.dubbo.remoting.http12.netty4.h2;
 
-import org.apache.dubbo.common.logger.Logger;
+import org.apache.dubbo.common.logger.ErrorTypeAwareLogger;
 import org.apache.dubbo.common.logger.LoggerFactory;
 import org.apache.dubbo.remoting.http12.h2.Http2Header;
 import org.apache.dubbo.remoting.http12.h2.Http2InputMessage;
@@ -29,6 +29,7 @@ import org.apache.dubbo.remoting.http12.netty4.NettyHttpHeaders;
 import java.io.OutputStream;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufInputStream;
@@ -41,16 +42,27 @@ import io.netty.handler.codec.http2.DefaultHttp2HeadersFrame;
 import io.netty.handler.codec.http2.Http2DataFrame;
 import io.netty.handler.codec.http2.Http2Headers;
 import io.netty.handler.codec.http2.Http2HeadersFrame;
+import io.netty.util.concurrent.ScheduledFuture;
+
+import static org.apache.dubbo.common.constants.LoggerCodeConstants.PROTOCOL_TIMEOUT_SERVER;
 
 public class NettyHttp2FrameCodec extends ChannelDuplexHandler {
 
-    private static final Logger logger = LoggerFactory.getLogger(NettyHttp2FrameCodec.class);
+    private static final ErrorTypeAwareLogger LOGGER =
+            LoggerFactory.getErrorTypeAwareLogger(NettyHttp2FrameCodec.class);
+
+    private static final long SETTINGS_FRAME_ARRIVAL_TIMEOUT = 3;
+
+    private final NettyHttp2SettingsHandler nettyHttp2SettingsHandler;
 
     private final List<CachedMsg> cachedMsgList = new LinkedList<>();
 
     private boolean settingsFrameArrived;
 
+    private ScheduledFuture<?> settingsFrameArrivalTimeoutFuture;
+
     public NettyHttp2FrameCodec(NettyHttp2SettingsHandler nettyHttp2SettingsHandler) {
+        this.nettyHttp2SettingsHandler = nettyHttp2SettingsHandler;
         if (!nettyHttp2SettingsHandler.subscribeSettingsFrameArrival(this)) {
             settingsFrameArrived = true;
         }
@@ -80,10 +92,29 @@ public class NettyHttp2FrameCodec extends ChannelDuplexHandler {
             return;
         }
 
-        if (logger.isDebugEnabled()) {
-            logger.debug("Cache writing msg before client connection preface arrival: {}", msg);
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("Cache writing msg before client connection preface arrival: {}", msg);
         }
         cachedMsgList.add(new CachedMsg(ctx, msg, promise));
+
+        if (settingsFrameArrivalTimeoutFuture == null) {
+            // close ctx and release resources if client connection preface does not arrive in time.
+            settingsFrameArrivalTimeoutFuture = ctx.executor()
+                    .schedule(
+                            () -> {
+                                LOGGER.error(
+                                        PROTOCOL_TIMEOUT_SERVER,
+                                        "",
+                                        "",
+                                        "client connection preface does not arrive in time.");
+                                // send RST_STREAM instead of GO_AWAY by calling close method to avoid client hanging.
+                                ctx.close();
+                                nettyHttp2SettingsHandler.unsubscribeSettingsFrameArrival(this);
+                                cachedMsgList.clear();
+                            },
+                            SETTINGS_FRAME_ARRIVAL_TIMEOUT,
+                            TimeUnit.SECONDS);
+        }
     }
 
     public void notifySettingsFrameArrival() throws Exception {
@@ -92,13 +123,17 @@ public class NettyHttp2FrameCodec extends ChannelDuplexHandler {
         }
         settingsFrameArrived = true;
 
-        if (logger.isDebugEnabled()) {
-            logger.debug("Begin cached channel msg writing when client connection preface arrived.");
+        if (settingsFrameArrivalTimeoutFuture != null) {
+            settingsFrameArrivalTimeoutFuture.cancel(false);
+        }
+
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("Begin cached channel msg writing when client connection preface arrived.");
         }
 
         for (CachedMsg cached : cachedMsgList) {
-            if (logger.isDebugEnabled()) {
-                logger.debug("Cached channel msg writing, ctx: {} msg: {}", cached.ctx, cached.msg);
+            if (LOGGER.isDebugEnabled()) {
+                LOGGER.debug("Cached channel msg writing, ctx: {} msg: {}", cached.ctx, cached.msg);
             }
             if (cached.msg instanceof Http2Header) {
                 super.write(cached.ctx, encodeHttp2HeadersFrame(((Http2Header) cached.msg)), cached.promise);
@@ -109,8 +144,8 @@ public class NettyHttp2FrameCodec extends ChannelDuplexHandler {
             }
         }
 
-        if (logger.isDebugEnabled()) {
-            logger.debug("End cached channel msg writing.");
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("End cached channel msg writing.");
         }
 
         cachedMsgList.clear();

--- a/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/netty4/h2/NettyHttp2FrameCodec.java
+++ b/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/netty4/h2/NettyHttp2FrameCodec.java
@@ -16,6 +16,8 @@
  */
 package org.apache.dubbo.remoting.http12.netty4.h2;
 
+import org.apache.dubbo.common.logger.Logger;
+import org.apache.dubbo.common.logger.LoggerFactory;
 import org.apache.dubbo.remoting.http12.h2.Http2Header;
 import org.apache.dubbo.remoting.http12.h2.Http2InputMessage;
 import org.apache.dubbo.remoting.http12.h2.Http2InputMessageFrame;
@@ -25,6 +27,8 @@ import org.apache.dubbo.remoting.http12.message.DefaultHttpHeaders;
 import org.apache.dubbo.remoting.http12.netty4.NettyHttpHeaders;
 
 import java.io.OutputStream;
+import java.util.LinkedList;
+import java.util.List;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufInputStream;
@@ -40,6 +44,18 @@ import io.netty.handler.codec.http2.Http2HeadersFrame;
 
 public class NettyHttp2FrameCodec extends ChannelDuplexHandler {
 
+    private static final Logger logger = LoggerFactory.getLogger(NettyHttp2FrameCodec.class);
+
+    private final List<CachedMsg> cachedMsgList = new LinkedList<>();
+
+    private boolean settingsFrameArrived;
+
+    public NettyHttp2FrameCodec(NettyHttp2SettingsHandler nettyHttp2SettingsHandler) {
+        if (!nettyHttp2SettingsHandler.subscribeSettingsFrameArrival(this)) {
+            settingsFrameArrived = true;
+        }
+    }
+
     @Override
     public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
         if (msg instanceof Http2HeadersFrame) {
@@ -53,13 +69,51 @@ public class NettyHttp2FrameCodec extends ChannelDuplexHandler {
 
     @Override
     public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
-        if (msg instanceof Http2Header) {
-            super.write(ctx, encodeHttp2HeadersFrame((Http2Header) msg), promise);
-        } else if (msg instanceof Http2OutputMessage) {
-            super.write(ctx, encodeHttp2DataFrame((Http2OutputMessage) msg), promise);
-        } else {
-            super.write(ctx, msg, promise);
+        if (settingsFrameArrived) {
+            if (msg instanceof Http2Header) {
+                super.write(ctx, encodeHttp2HeadersFrame((Http2Header) msg), promise);
+            } else if (msg instanceof Http2OutputMessage) {
+                super.write(ctx, encodeHttp2DataFrame((Http2OutputMessage) msg), promise);
+            } else {
+                super.write(ctx, msg, promise);
+            }
+            return;
         }
+
+        if (logger.isDebugEnabled()) {
+            logger.debug("Cache writing msg before client connection preface arrival: {}", msg);
+        }
+        cachedMsgList.add(new CachedMsg(ctx, msg, promise));
+    }
+
+    public void notifySettingsFrameArrival() throws Exception {
+        if (settingsFrameArrived) {
+            return;
+        }
+        settingsFrameArrived = true;
+
+        if (logger.isDebugEnabled()) {
+            logger.debug("Begin cached channel msg writing when client connection preface arrived.");
+        }
+
+        for (CachedMsg cached : cachedMsgList) {
+            if (logger.isDebugEnabled()) {
+                logger.debug("Cached channel msg writing, ctx: {} msg: {}", cached.ctx, cached.msg);
+            }
+            if (cached.msg instanceof Http2Header) {
+                super.write(cached.ctx, encodeHttp2HeadersFrame(((Http2Header) cached.msg)), cached.promise);
+            } else if (cached.msg instanceof Http2OutputMessage) {
+                super.write(cached.ctx, encodeHttp2DataFrame(((Http2OutputMessage) cached.msg)), cached.promise);
+            } else {
+                super.write(cached.ctx, cached.msg, cached.promise);
+            }
+        }
+
+        if (logger.isDebugEnabled()) {
+            logger.debug("End cached channel msg writing.");
+        }
+
+        cachedMsgList.clear();
     }
 
     private Http2Header onHttp2HeadersFrame(Http2HeadersFrame headersFrame) {
@@ -88,5 +142,17 @@ public class NettyHttp2FrameCodec extends ChannelDuplexHandler {
             return new DefaultHttp2DataFrame(buffer, outputMessage.isEndStream());
         }
         throw new IllegalArgumentException("Http2OutputMessage body must be ByteBufOutputStream");
+    }
+
+    private static class CachedMsg {
+        private final ChannelHandlerContext ctx;
+        private final Object msg;
+        private final ChannelPromise promise;
+
+        public CachedMsg(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) {
+            this.ctx = ctx;
+            this.msg = msg;
+            this.promise = promise;
+        }
     }
 }

--- a/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/netty4/h2/NettyHttp2SettingsHandler.java
+++ b/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/netty4/h2/NettyHttp2SettingsHandler.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.remoting.http12.netty4.h2;
+
+import org.apache.dubbo.common.logger.Logger;
+import org.apache.dubbo.common.logger.LoggerFactory;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.SimpleChannelInboundHandler;
+import io.netty.handler.codec.http2.Http2SettingsFrame;
+
+/**
+ * Add NettyHttp2SettingsHandler to pipeline because NettyHttp2FrameCodec could not receive Http2SettingsFrame.
+ * Http2SettingsFrame does not belong to Http2StreamFrame or Http2GoAwayFrame that Http2MultiplexHandler
+ * could process, NettyHttp2FrameCodec is wrapped in Http2MultiplexHandler as a child handler.
+ */
+public class NettyHttp2SettingsHandler extends SimpleChannelInboundHandler<Http2SettingsFrame> {
+
+    private static final Logger logger = LoggerFactory.getLogger(NettyHttp2SettingsHandler.class);
+
+    /**
+     * Http2SettingsFrame arrival notification subscribers.
+     */
+    private final Set<NettyHttp2FrameCodec> settingsFrameArrivalSubscribers = new HashSet<>();
+
+    private boolean settingsFrameArrived;
+
+    @Override
+    protected void channelRead0(ChannelHandlerContext ctx, Http2SettingsFrame msg) throws Exception {
+        if (logger.isDebugEnabled()) {
+            logger.debug("Receive client Http2 Settings frame of "
+                    + ctx.channel().localAddress() + " <- " + ctx.channel().remoteAddress());
+        }
+        settingsFrameArrived = true;
+
+        // Notify all subscribers that Http2SettingsFrame is arrived.
+        for (NettyHttp2FrameCodec nettyHttp2FrameCodec : settingsFrameArrivalSubscribers) {
+            nettyHttp2FrameCodec.notifySettingsFrameArrival();
+        }
+        settingsFrameArrivalSubscribers.clear();
+
+        ctx.pipeline().remove(this);
+    }
+
+    /**
+     * Save Http2SettingsFrame arrival notification subscriber if Http2SettingsFrame is not arrived.
+     * @param nettyHttp2FrameCodec the netty HTTP2 frame codec that will be notified.
+     * @return true: subscribe successful, false: Http2SettingsFrame arrived.
+     */
+    public boolean subscribeSettingsFrameArrival(NettyHttp2FrameCodec nettyHttp2FrameCodec) {
+        if (!settingsFrameArrived) {
+            settingsFrameArrivalSubscribers.add(nettyHttp2FrameCodec);
+            return true;
+        }
+        return false;
+    }
+}

--- a/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/netty4/h2/NettyHttp2SettingsHandler.java
+++ b/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/netty4/h2/NettyHttp2SettingsHandler.java
@@ -71,4 +71,8 @@ public class NettyHttp2SettingsHandler extends SimpleChannelInboundHandler<Http2
         }
         return false;
     }
+
+    public void unsubscribeSettingsFrameArrival(NettyHttp2FrameCodec nettyHttp2FrameCodec) {
+        settingsFrameArrivalSubscribers.remove(nettyHttp2FrameCodec);
+    }
 }

--- a/dubbo-remoting/dubbo-remoting-netty4/src/main/java/org/apache/dubbo/remoting/transport/netty4/http2/Http2ClientSettingsHandler.java
+++ b/dubbo-remoting/dubbo-remoting-netty4/src/main/java/org/apache/dubbo/remoting/transport/netty4/http2/Http2ClientSettingsHandler.java
@@ -39,8 +39,8 @@ public class Http2ClientSettingsHandler extends SimpleChannelInboundHandler<Http
     @Override
     protected void channelRead0(ChannelHandlerContext ctx, Http2SettingsFrame msg) throws Exception {
         if (logger.isDebugEnabled()) {
-            logger.debug("Receive Http2 Settings frame of " + ctx.channel().localAddress() + " -> "
-                    + ctx.channel().remoteAddress());
+            logger.debug("Receive server Http2 Settings frame of "
+                    + ctx.channel().localAddress() + " -> " + ctx.channel().remoteAddress());
         }
         // connectionPrefaceReceivedPromise will be set null after first used.
         Promise<Void> connectionPrefaceReceivedPromise = connectionPrefaceReceivedPromiseRef.get();
@@ -49,6 +49,7 @@ public class Http2ClientSettingsHandler extends SimpleChannelInboundHandler<Http
         } else {
             // Notify the connection preface is received when first inbound http2 settings frame is arrived.
             connectionPrefaceReceivedPromise.trySuccess(null);
+            ctx.pipeline().remove(this);
         }
     }
 }


### PR DESCRIPTION
## What is the purpose of the change?
HTTP/2 server should wait for connection preface before sending first http2 data frame to client, otherwise it might also encounter the similar issue like #15460 
![af0ce318e90deb46a33f21fe59b00ee8](https://github.com/user-attachments/assets/94be97e4-b408-4076-9be3-b23ffac31b8a)
The client posts a HTTP/1 request with ```h2c``` upgrade contents, but the server does not wait for the http2 settings frame before sending response.
<img width="1755" height="503" alt="7d4b50b7d544137e64fc1f019cd26df" src="https://github.com/user-attachments/assets/0ad43da7-9fbf-4ecd-a278-679740acf50c" />


## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Make sure gitHub actions can pass. [Why the workflow is failing and how to fix it?](../CONTRIBUTING.md)
