### PR TITLE
Add os-maven-plugin to extensions for mvn install modules which need OS type dectection

### DIFF
--- a/dubbo-demo/dubbo-demo-spring-boot-idl/pom.xml
+++ b/dubbo-demo/dubbo-demo-spring-boot-idl/pom.xml
@@ -90,6 +90,7 @@
   <build>
     <plugins>
       <plugin>
+        <!-- add os-maven-plugin to plugins just for Eclipse m2e, not for `mvn install` -->
         <groupId>kr.motd.maven</groupId>
         <artifactId>os-maven-plugin</artifactId>
         <version>${maven_os_plugin_version}</version>
@@ -112,5 +113,13 @@
         </configuration>
       </plugin>
     </plugins>
+    <extensions>
+      <!-- add os-maven-plugin to extensions for `mvn install` -->
+      <extension>
+        <groupId>kr.motd.maven</groupId>
+        <artifactId>os-maven-plugin</artifactId>
+        <version>${maven_os_plugin_version}</version>
+      </extension>
+    </extensions>
   </build>
 </project>

--- a/dubbo-plugin/dubbo-security/pom.xml
+++ b/dubbo-plugin/dubbo-security/pom.xml
@@ -124,12 +124,27 @@
           <skip>true</skip>
         </configuration>
       </plugin>
+      <!-- add os-maven-plugin to plugins just for Eclipse m2e, not for `mvn install` -->
+      <plugin>
+        <groupId>kr.motd.maven</groupId>
+        <artifactId>os-maven-plugin</artifactId>
+        <version>${maven_os_plugin_version}</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>detect</goal>
+            </goals>
+            <phase>initialize</phase>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
     <extensions>
+      <!-- add os-maven-plugin to extensions for `mvn install` -->
       <extension>
         <groupId>kr.motd.maven</groupId>
         <artifactId>os-maven-plugin</artifactId>
-        <version>1.7.1</version>
+        <version>${maven_os_plugin_version}</version>
       </extension>
     </extensions>
   </build>

--- a/dubbo-remoting/dubbo-remoting-http3/pom.xml
+++ b/dubbo-remoting/dubbo-remoting-http3/pom.xml
@@ -53,4 +53,31 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <!-- add os-maven-plugin to plugins just for Eclipse m2e, not for `mvn install` -->
+      <plugin>
+        <groupId>kr.motd.maven</groupId>
+        <artifactId>os-maven-plugin</artifactId>
+        <version>${maven_os_plugin_version}</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>detect</goal>
+            </goals>
+            <phase>initialize</phase>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+    <extensions>
+      <!-- add os-maven-plugin to extensions for `mvn install` -->
+      <extension>
+        <groupId>kr.motd.maven</groupId>
+        <artifactId>os-maven-plugin</artifactId>
+        <version>${maven_os_plugin_version}</version>
+      </extension>
+    </extensions>
+  </build>
 </project>

--- a/dubbo-rpc/dubbo-rpc-triple/pom.xml
+++ b/dubbo-rpc/dubbo-rpc-triple/pom.xml
@@ -132,6 +132,7 @@
   </dependencies>
   <build>
     <plugins>
+      <!-- add os-maven-plugin to plugins just for Eclipse m2e, not for `mvn install` -->
       <plugin>
         <groupId>kr.motd.maven</groupId>
         <artifactId>os-maven-plugin</artifactId>
@@ -193,5 +194,13 @@
         </executions>
       </plugin>
     </plugins>
+    <extensions>
+      <!-- add os-maven-plugin to extensions for `mvn install` -->
+      <extension>
+        <groupId>kr.motd.maven</groupId>
+        <artifactId>os-maven-plugin</artifactId>
+        <version>${maven_os_plugin_version}</version>
+      </extension>
+    </extensions>
   </build>
 </project>


### PR DESCRIPTION
## What is the purpose of the change?
The  netty-codec-native-quic classifier of netty-codec-http3 4.2.2.Final is defined by ```${os.detected.name}-${os.detected.arch}```  which could not be determined during ```mvn install``` due to missing os-maven-plugin extension, and it will cause running ```mvn install``` failure on ```dubbo-rpc-triple``` or ```dubbo-remoting-http12``` module.

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Make sure gitHub actions can pass. [Why the workflow is failing and how to fix it?](../CONTRIBUTING.md)
