### PR TITLE
Set debian mirror to debian archive site for getting buster packages which used by current github ubuntu-latest docker building action

### DIFF
--- a/.github/workflows/build-and-test-pr.yml
+++ b/.github/workflows/build-and-test-pr.yml
@@ -334,7 +334,7 @@ jobs:
           CANDIDATE_VERSIONS="dubbo.version:$DUBBO_VERSION;compiler.version:$DUBBO_VERSION;$CANDIDATE_VERSIONS;dubbo.compiler.version:$DUBBO_VERSION"
           echo "CANDIDATE_VERSIONS=$CANDIDATE_VERSIONS" >> $GITHUB_ENV
       - name: "Build test image"
-        run: cd test && bash ./build-test-image.sh
+        run: cd test && bash -c 'DEBIAN_MIRROR=http://archive.debian.org/debian-archive ./build-test-image.sh'
       - name: "Run tests"
         run: cd test && bash ./run-tests.sh
       - name: "merge jacoco result"
@@ -449,7 +449,7 @@ jobs:
           CANDIDATE_VERSIONS="dubbo.version:$DUBBO_VERSION;compiler.version:$DUBBO_VERSION;$CANDIDATE_VERSIONS;dubbo.compiler.version:$DUBBO_VERSION"
           echo "CANDIDATE_VERSIONS=$CANDIDATE_VERSIONS" >> $GITHUB_ENV
       - name: "Build test image"
-        run: cd test && bash ./build-test-image.sh
+        run: cd test && bash -c 'DEBIAN_MIRROR=http://archive.debian.org/debian-archive ./build-test-image.sh'
       - name: "Run tests"
         run: cd test && bash ./run-tests.sh
       - name: "merge jacoco result"

--- a/.github/workflows/build-and-test-scheduled-3.1.yml
+++ b/.github/workflows/build-and-test-scheduled-3.1.yml
@@ -288,7 +288,7 @@ jobs:
           echo "CANDIDATE_VERSIONS=$CANDIDATE_VERSIONS" >> $GITHUB_ENV
       - name: "Build test image"
         run: |
-          cd test && bash ./build-test-image.sh
+          cd test && bash -c 'DEBIAN_MIRROR=http://archive.debian.org/debian-archive ./build-test-image.sh'
       - name: "Run tests"
         run: cd test && bash ./run-tests.sh
       - name: "Upload test logs"
@@ -394,7 +394,7 @@ jobs:
           echo "CANDIDATE_VERSIONS=$CANDIDATE_VERSIONS" >> $GITHUB_ENV
       - name: "Build test image"
         run: |
-          cd test && bash ./build-test-image.sh
+          cd test && bash -c 'DEBIAN_MIRROR=http://archive.debian.org/debian-archive ./build-test-image.sh'
       - name: "Run tests"
         run: cd test && bash ./run-tests.sh
       - name: "Upload test logs"

--- a/.github/workflows/build-and-test-scheduled-3.2.yml
+++ b/.github/workflows/build-and-test-scheduled-3.2.yml
@@ -288,7 +288,7 @@ jobs:
           echo "CANDIDATE_VERSIONS=$CANDIDATE_VERSIONS" >> $GITHUB_ENV
       - name: "Build test image"
         run: |
-          cd test && bash ./build-test-image.sh
+          cd test && bash -c 'DEBIAN_MIRROR=http://archive.debian.org/debian-archive ./build-test-image.sh'
       - name: "Run tests"
         run: cd test && bash ./run-tests.sh
       - name: "Upload test logs"
@@ -394,7 +394,7 @@ jobs:
           echo "CANDIDATE_VERSIONS=$CANDIDATE_VERSIONS" >> $GITHUB_ENV
       - name: "Build test image"
         run: |
-          cd test && bash ./build-test-image.sh
+          cd test && bash -c 'DEBIAN_MIRROR=http://archive.debian.org/debian-archive ./build-test-image.sh'
       - name: "Run tests"
         run: cd test && bash ./run-tests.sh
       - name: "Upload test logs"

--- a/.github/workflows/build-and-test-scheduled-3.3.yml
+++ b/.github/workflows/build-and-test-scheduled-3.3.yml
@@ -288,7 +288,7 @@ jobs:
           echo "CANDIDATE_VERSIONS=$CANDIDATE_VERSIONS" >> $GITHUB_ENV
       - name: "Build test image"
         run: |
-          cd test && bash ./build-test-image.sh
+          cd test && bash -c 'DEBIAN_MIRROR=http://archive.debian.org/debian-archive ./build-test-image.sh'
       - name: "Run tests"
         run: cd test && bash ./run-tests.sh
       - name: "Upload test logs"
@@ -394,7 +394,7 @@ jobs:
           echo "CANDIDATE_VERSIONS=$CANDIDATE_VERSIONS" >> $GITHUB_ENV
       - name: "Build test image"
         run: |
-          cd test && bash ./build-test-image.sh
+          cd test && bash -c 'DEBIAN_MIRROR=http://archive.debian.org/debian-archive ./build-test-image.sh'
       - name: "Run tests"
         run: cd test && bash ./run-tests.sh
       - name: "Upload test logs"

--- a/.github/workflows/release-test.yml
+++ b/.github/workflows/release-test.yml
@@ -283,7 +283,7 @@ jobs:
           echo "CANDIDATE_VERSIONS=$CANDIDATE_VERSIONS" >> $GITHUB_ENV
       - name: "Build test image"
         run: |
-          cd test && bash ./build-test-image.sh
+          cd test && bash -c 'DEBIAN_MIRROR=http://archive.debian.org/debian-archive ./build-test-image.sh'
       - name: "Run tests"
         run: cd test && bash ./run-tests.sh
       - name: "Upload test result"
@@ -383,7 +383,7 @@ jobs:
           echo "CANDIDATE_VERSIONS=$CANDIDATE_VERSIONS" >> $GITHUB_ENV
       - name: "Build test image"
         run: |
-          cd test && bash ./build-test-image.sh
+          cd test && bash -c 'DEBIAN_MIRROR=http://archive.debian.org/debian-archive ./build-test-image.sh'
       - name: "Run tests"
         run: cd test && bash ./run-tests.sh
       - name: "Upload test result"


### PR DESCRIPTION
## What is the purpose of the change?
The buster version that current github docker building action ubuntu-latest used had been taken from Debian main site to the archive site since July 12, 2025.

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Make sure gitHub actions can pass. [Why the workflow is failing and how to fix it?](../CONTRIBUTING.md)
