### PR TITLE
Set grpc_version at parent pom to 1.73 which is same as grpc.version at dubbo-dependencies-bom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -169,7 +169,8 @@
     <spring-boot-3.version>3.5.0</spring-boot-3.version>
 
     <protobuf-protoc_version>3.22.3</protobuf-protoc_version>
-    <grpc_version>1.54.0</grpc_version>
+    <!-- grpc_version should be same as grpc.version at dubbo-dependencies-bom -->
+    <grpc_version>1.73.0</grpc_version>
     <spotless-maven-plugin.version>2.44.5</spotless-maven-plugin.version>
     <dubbo-shared-resources.version>1.0.0</dubbo-shared-resources.version>
     <palantirJavaFormat.version>2.38.0</palantirJavaFormat.version>


### PR DESCRIPTION
## What is the purpose of the change?
grpc_version at parent pom should be same as grpc.version at dubbo-dependencies-bom, otherwise LifecycleExecutionException might be thrown during PR error-code-inspecting step,
```
Error:  Failed to execute goal org.xolstice.maven.plugins:protobuf-maven-plugin:0.6.1:compile-custom (default) on project dubbo-security: protoc did not exit cleanly. Review output for more information. -> [Help 1]
org.apache.maven.lifecycle.LifecycleExecutionException: Failed to execute goal org.xolstice.maven.plugins:protobuf-maven-plugin:0.6.1:compile-custom (default) on project dubbo-security: protoc did not exit cleanly. Review output for more information.
```

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Make sure gitHub actions can pass. [Why the workflow is failing and how to fix it?](../CONTRIBUTING.md)
