### PR TITLE
Fixed the issue of type loss in generalized call cases.

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/utils/PojoUtils.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/utils/PojoUtils.java
@@ -160,7 +160,7 @@ public class PojoUtils {
         }
 
         if (pojo instanceof LocalDate || pojo instanceof LocalDateTime || pojo instanceof LocalTime) {
-            return pojo.toString();
+            return pojo;
         }
 
         if (pojo instanceof Class) {

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/utils/PojoUtilsTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/utils/PojoUtilsTest.java
@@ -775,15 +775,15 @@ class PojoUtilsTest {
 
         Object localDateTimeGen = PojoUtils.generalize(LocalDateTime.now());
         Object localDateTime = PojoUtils.realize(localDateTimeGen, LocalDateTime.class);
-        assertEquals(localDateTimeGen, localDateTime.toString());
+        assertEquals(localDateTimeGen, localDateTime);
 
         Object localDateGen = PojoUtils.generalize(LocalDate.now());
         Object localDate = PojoUtils.realize(localDateGen, LocalDate.class);
-        assertEquals(localDateGen, localDate.toString());
+        assertEquals(localDateGen, localDate);
 
         Object localTimeGen = PojoUtils.generalize(LocalTime.now());
         Object localTime = PojoUtils.realize(localTimeGen, LocalTime.class);
-        assertEquals(localTimeGen, localTime.toString());
+        assertEquals(localTimeGen, localTime);
     }
 
     @Test


### PR DESCRIPTION
## What is the purpose of the change?

The serialization module supports the Java8 date type, so here we should directly return the java date type to avoid type loss.

## Checklist
- [ ] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Make sure gitHub actions can pass. [Why the workflow is failing and how to fix it?](../CONTRIBUTING.md)
