### PR TITLE
Replace `mockito-inline` with `mockito-core`

### DIFF
--- a/dubbo-dependencies-bom/pom.xml
+++ b/dubbo-dependencies-bom/pom.xml
@@ -161,7 +161,7 @@
     <awaitility_version>4.3.0</awaitility_version>
     <hamcrest_version>2.2</hamcrest_version>
     <cglib_version>2.2.2</cglib_version>
-    <mockito_version>4.11.0</mockito_version>
+    <mockito_version>5.18.0</mockito_version>
     <spock_version>2.3-groovy-4.0</spock_version>
 
     <jaxb_version>2.2.7</jaxb_version>
@@ -768,12 +768,6 @@
       <dependency>
         <groupId>org.mockito</groupId>
         <artifactId>mockito-core</artifactId>
-        <version>${mockito_version}</version>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.mockito</groupId>
-        <artifactId>mockito-inline</artifactId>
         <version>${mockito_version}</version>
         <scope>test</scope>
       </dependency>

--- a/dubbo-test/dubbo-test-spring/pom.xml
+++ b/dubbo-test/dubbo-test-spring/pom.xml
@@ -155,11 +155,6 @@
       <artifactId>mockito-core</artifactId>
       <scope>compile</scope>
     </dependency>
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-inline</artifactId>
-      <scope>compile</scope>
-    </dependency>
 
     <dependency>
       <groupId>org.apache.curator</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -216,11 +216,6 @@
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-inline</artifactId>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 
   <build>


### PR DESCRIPTION
## What is the purpose of the change?

### Replace `mockito-inline` with `mockito-core`

In version 5.x mockito switched their default mockmaker to `mockito-inline` ([source](https://github.com/mockito/mockito/releases/tag/v5.0.0)).
The corresponding artifact became obsolete and can be replaced with `mockito-core`

This PR replaces / removes the artifact and switches on `mockito-core` which in turn allows upgrading to latest `5.18.0`.

### Testing done

Build locally without issues.

## Checklist
- [ ] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit-test to verify your logic correction. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Make sure gitHub actions can pass. [Why the workflow is failing and how to fix it?](../CONTRIBUTING.md)
