### PR TITLE
NacosAggregateListener aggregates all instances into each service if dubbo-admin uses nacos as the registration center

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/constants/RegistryConstants.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/constants/RegistryConstants.java
@@ -149,4 +149,9 @@ public interface RegistryConstants {
      * for compatible, we should export noting suffix servicename, eg: ${interface}:${version}
      */
     String NACOE_REGISTER_COMPATIBLE = "nacos.register-compatible";
+
+    /**
+     * protocol of admin
+     */
+    String ADMIN_PROTOCOL = "admin";
 }

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/url/component/ServiceAddressURL.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/url/component/ServiceAddressURL.java
@@ -29,9 +29,9 @@ import static org.apache.dubbo.common.constants.CommonConstants.CONSUMER_SIDE;
 import static org.apache.dubbo.common.constants.CommonConstants.GROUP_KEY;
 import static org.apache.dubbo.common.constants.CommonConstants.SIDE_KEY;
 import static org.apache.dubbo.common.constants.CommonConstants.VERSION_KEY;
+import static org.apache.dubbo.common.constants.RegistryConstants.ADMIN_PROTOCOL;
 import static org.apache.dubbo.common.constants.RegistryConstants.CATEGORY_KEY;
 import static org.apache.dubbo.common.constants.RegistryConstants.PROVIDERS_CATEGORY;
-import static org.apache.dubbo.common.constants.RegistryConstants.ADMIN_PROTOCOL;
 
 public abstract class ServiceAddressURL extends URL {
 

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/url/component/ServiceAddressURL.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/url/component/ServiceAddressURL.java
@@ -23,6 +23,7 @@ import org.apache.dubbo.rpc.model.ServiceModel;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 import static org.apache.dubbo.common.constants.CommonConstants.APPLICATION_KEY;
 import static org.apache.dubbo.common.constants.CommonConstants.CONSUMER_SIDE;
@@ -31,8 +32,10 @@ import static org.apache.dubbo.common.constants.CommonConstants.SIDE_KEY;
 import static org.apache.dubbo.common.constants.CommonConstants.VERSION_KEY;
 import static org.apache.dubbo.common.constants.RegistryConstants.CATEGORY_KEY;
 import static org.apache.dubbo.common.constants.RegistryConstants.PROVIDERS_CATEGORY;
+import static org.apache.dubbo.common.constants.RegistryConstants.ADMIN_PROTOCOL;
 
 public abstract class ServiceAddressURL extends URL {
+
     protected final transient URL consumerURL;
 
     // cache
@@ -68,6 +71,9 @@ public abstract class ServiceAddressURL extends URL {
 
     @Override
     public String getServiceInterface() {
+        if (ADMIN_PROTOCOL.equals(consumerURL.getProtocol())) {
+            return super.getServiceInterface();
+        }
         return consumerURL.getServiceInterface();
     }
 

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/url/component/ServiceAddressURL.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/url/component/ServiceAddressURL.java
@@ -23,7 +23,6 @@ import org.apache.dubbo.rpc.model.ServiceModel;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Objects;
 
 import static org.apache.dubbo.common.constants.CommonConstants.APPLICATION_KEY;
 import static org.apache.dubbo.common.constants.CommonConstants.CONSUMER_SIDE;


### PR DESCRIPTION
in dubbo-admin case , NacosAggregateListener will aggregate all instances into each service. because every instances in NacosAggregateListener will be related to the consumerURL URL of each service when build DubboServiceAddressURL from instance and DubboServiceAddressURL#getServiceInterface is realized as  ## return consumerURL.getServiceInterface() ##

## What is the purpose of the change?

PR of the issue : https://github.com/apache/dubbo/issues/15267

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Make sure gitHub actions can pass. [Why the workflow is failing and how to fix it?](../CONTRIBUTING.md)
