### PR TITLE
Fix NacosNamingServiceUtilsTest UnknownHostException

### DIFF
--- a/dubbo-registry/dubbo-registry-nacos/src/test/java/org/apache/dubbo/registry/nacos/util/NacosNamingServiceUtilsTest.java
+++ b/dubbo-registry/dubbo-registry-nacos/src/test/java/org/apache/dubbo/registry/nacos/util/NacosNamingServiceUtilsTest.java
@@ -57,7 +57,7 @@ class NacosNamingServiceUtilsTest {
 
     @Test
     void testToServiceInstance() {
-        URL registryUrl = URL.valueOf("test://test:8080/test");
+        URL registryUrl = URL.valueOf("nacos://127.0.0.1:8080/test");
         Instance instance = new Instance();
         instance.setServiceName("serviceName");
         instance.setIp("1.1.1.1");
@@ -78,7 +78,7 @@ class NacosNamingServiceUtilsTest {
 
     @Test
     void testCreateNamingService() {
-        URL url = URL.valueOf("test://test:8080/test?backup=backup&nacos.check=false");
+        URL url = URL.valueOf("nacos://127.0.0.1:8080/test?backup=127.0.0.1&nacos.check=false");
         NacosNamingServiceWrapper namingService = NacosNamingServiceUtils.createNamingService(url);
         Assertions.assertNotNull(namingService);
     }


### PR DESCRIPTION
## What is the purpose of the change?
should not use faked hostname at NacosNamingServiceUtilsTest, otherwise ```UnknownHostException``` warning will occur during testing like this
```
2025-07-19T15:37:27.6350145Z Jul 19, 2025 3:37:27 PM com.alibaba.nacos.shaded.io.grpc.internal.ManagedChannelImpl$NameResolverListener handleErrorInSyncContext
2025-07-19T15:37:27.6352003Z WARNING: [Channel<345>: (test:9080)] Failed to resolve name. status=Status{code=UNAVAILABLE, description=Unable to resolve host test, cause=java.lang.RuntimeException: java.net.UnknownHostException: test
2025-07-19T15:37:27.6353296Z 	at com.alibaba.nacos.shaded.io.grpc.internal.DnsNameResolver.resolveAddresses(DnsNameResolver.java:223)
2025-07-19T15:37:27.6354400Z 	at com.alibaba.nacos.shaded.io.grpc.internal.DnsNameResolver.doResolve(DnsNameResolver.java:282)
2025-07-19T15:37:27.6355240Z 	at com.alibaba.nacos.shaded.io.grpc.internal.DnsNameResolver$Resolve.run(DnsNameResolver.java:318)
2025-07-19T15:37:27.6356041Z 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
2025-07-19T15:37:27.6356636Z 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
2025-07-19T15:37:27.6357072Z 	at java.lang.Thread.run(Thread.java:750)
2025-07-19T15:37:27.6357462Z Caused by: java.net.UnknownHostException: test
2025-07-19T15:37:27.6358042Z 	at java.net.InetAddress$CachedAddresses.get(InetAddress.java:764)
2025-07-19T15:37:27.6358548Z 	at java.net.InetAddress.getAllByName0(InetAddress.java:1291)
2025-07-19T15:37:27.6358952Z 	at java.net.InetAddress.getAllByName(InetAddress.java:1144)
2025-07-19T15:37:27.6359341Z 	at java.net.InetAddress.getAllByName(InetAddress.java:1065)
2025-07-19T15:37:27.6359971Z 	at com.alibaba.nacos.shaded.io.grpc.internal.DnsNameResolver$JdkAddressResolver.resolveAddress(DnsNameResolver.java:632)
2025-07-19T15:37:27.6360858Z 	at com.alibaba.nacos.shaded.io.grpc.internal.DnsNameResolver.resolveAddresses(DnsNameResolver.java:219)
2025-07-19T15:37:27.6361360Z 	... 5 more
2025-07-19T15:37:27.6361535Z }
2025-07-19T15:37:27.8396151Z 15:37:27.835 |-INFO  [main] registry.nacos.NacosNamingServiceWrapper:71  -|  [DUBBO] Nacos batch register enable: true, dubbo version: 3.3.6-SNAPSHOT, current host: 10.1.0.185
2025-07-19T15:37:27.8398534Z 15:37:27.837 |-INFO  [main] registry.nacos.NacosNamingServiceWrapper:71  -|  [DUBBO] Nacos batch register enable: true, dubbo version: 3.3.6-SNAPSHOT, current host: 10.1.0.185
2025-07-19T15:37:27.8402851Z 15:37:27.837 |-INFO  [main] pache.dubbo.registry.nacos.NacosRegistry:426 -|  [DUBBO] Register: nacos://127.0.0.1:3333/org.apache.dubbo.registry.nacos.NacosService?category=providers&group=default&interface=org.apache.dubbo.registry.nacos.NacosService&methods=test1,test2&notify=false&side=provider&version=1.0.0, dubbo version: 3.3.6-SNAPSHOT, current host: 10.1.0.185
2025-07-19T15:37:27.8406864Z 15:37:27.838 |-INFO  [main] pache.dubbo.registry.nacos.NacosRegistry:439 -|  [DUBBO] Unregister: nacos://127.0.0.1:3333/org.apache.dubbo.registry.nacos.NacosService?category=providers&group=default&interface=org.apache.dubbo.registry.nacos.NacosService&methods=test1,test2&notify=false&side=provider&version=1.0.0, dubbo version: 3.3.6-SNAPSHOT, current host: 10.1.0.185
2025-07-19T15:37:27.9354741Z 15:37:27.842 |-INFO  [main] .auth.spi.client.ClientAuthPluginManager:56  -| [ClientAuthPluginManager] Load ClientAuthService com.alibaba.nacos.client.auth.impl.NacosClientAuthServiceImpl success.
2025-07-19T15:37:27.9356707Z 15:37:27.842 |-INFO  [main] .auth.spi.client.ClientAuthPluginManager:56  -| [ClientAuthPluginManager] Load ClientAuthService com.alibaba.nacos.client.auth.ram.RamClientAuthServiceImpl success.
2025-07-19T15:37:28.0355237Z Jul 19, 2025 3:37:27 PM com.alibaba.nacos.shaded.io.grpc.internal.ManagedChannelImpl$NameResolverListener handleErrorInSyncContext
2025-07-19T15:37:28.0356462Z WARNING: [Channel<383>: (backup:9848)] Failed to resolve name. status=Status{code=UNAVAILABLE, description=Unable to resolve host backup, cause=java.lang.RuntimeException: java.net.UnknownHostException: backup
2025-07-19T15:37:28.0357526Z 	at com.alibaba.nacos.shaded.io.grpc.internal.DnsNameResolver.resolveAddresses(DnsNameResolver.java:223)
2025-07-19T15:37:28.0358510Z 	at com.alibaba.nacos.shaded.io.grpc.internal.DnsNameResolver.doResolve(DnsNameResolver.java:282)
2025-07-19T15:37:28.0359229Z 	at com.alibaba.nacos.shaded.io.grpc.internal.DnsNameResolver$Resolve.run(DnsNameResolver.java:318)
2025-07-19T15:37:28.0359895Z 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
2025-07-19T15:37:28.0360490Z 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
2025-07-19T15:37:28.0360924Z 	at java.lang.Thread.run(Thread.java:750)
2025-07-19T15:37:28.0367500Z Caused by: java.net.UnknownHostException: backup
2025-07-19T15:37:28.0368265Z 	at java.net.InetAddress$CachedAddresses.get(InetAddress.java:764)
2025-07-19T15:37:28.0368706Z 	at java.net.InetAddress.getAllByName0(InetAddress.java:1291)
2025-07-19T15:37:28.0369113Z 	at java.net.InetAddress.getAllByName(InetAddress.java:1144)
2025-07-19T15:37:28.0369494Z 	at java.net.InetAddress.getAllByName(InetAddress.java:1065)
2025-07-19T15:37:28.0370096Z 	at com.alibaba.nacos.shaded.io.grpc.internal.DnsNameResolver$JdkAddressResolver.resolveAddress(DnsNameResolver.java:632)
2025-07-19T15:37:28.0370992Z 	at com.alibaba.nacos.shaded.io.grpc.internal.DnsNameResolver.resolveAddresses(DnsNameResolver.java:219)
2025-07-19T15:37:28.0371547Z 	... 5 more
```

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Make sure gitHub actions can pass. [Why the workflow is failing and how to fix it?](../CONTRIBUTING.md)
