### PR TITLE
Revert "Fixed the issue of type loss in generalized call cases (#15562)" to avoid performance regression

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/utils/PojoUtils.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/utils/PojoUtils.java
@@ -160,7 +160,7 @@ public class PojoUtils {
         }
 
         if (pojo instanceof LocalDate || pojo instanceof LocalDateTime || pojo instanceof LocalTime) {
-            return pojo;
+            return pojo.toString();
         }
 
         if (pojo instanceof Class) {

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/utils/PojoUtilsTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/utils/PojoUtilsTest.java
@@ -772,15 +772,15 @@ class PojoUtilsTest {
 
         Object localDateTimeGen = PojoUtils.generalize(LocalDateTime.now());
         Object localDateTime = PojoUtils.realize(localDateTimeGen, LocalDateTime.class);
-        assertEquals(localDateTimeGen, localDateTime);
+        assertEquals(localDateTimeGen, localDateTime.toString());
 
         Object localDateGen = PojoUtils.generalize(LocalDate.now());
         Object localDate = PojoUtils.realize(localDateGen, LocalDate.class);
-        assertEquals(localDateGen, localDate);
+        assertEquals(localDateGen, localDate.toString());
 
         Object localTimeGen = PojoUtils.generalize(LocalTime.now());
         Object localTime = PojoUtils.realize(localTimeGen, LocalTime.class);
-        assertEquals(localTimeGen, localTime);
+        assertEquals(localTimeGen, localTime.toString());
     }
 
     @Test


### PR DESCRIPTION
This reverts commit ef5bf4af962b48f5e6de1d08ec7aaf1d825f06b7.

## What is the purpose of the change?
revert #15562 to avoid performance regression, current dubbo 3.3 take hessian as default serialization protocol which will call ```Class.forName``` for each LocalDate,LocalDateTime,LocalTime deserialization if applying #15562.

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Make sure gitHub actions can pass. [Why the workflow is failing and how to fix it?](../CONTRIBUTING.md)
