### PR TITLE
[test] Fix typo in test method names of FailSafeClusterInvokerTest

### DIFF
--- a/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/support/FailSafeClusterInvokerTest.java
+++ b/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/support/FailSafeClusterInvokerTest.java
@@ -82,7 +82,7 @@ class FailSafeClusterInvokerTest {
 
     // TODO assert error log
     @Test
-    void testInvokeExceptoin() {
+    void testInvokeException() {
         resetInvokerToException();
         FailsafeClusterInvoker<DemoService> invoker = new FailsafeClusterInvoker<DemoService>(dic);
         invoker.invoke(invocation);
@@ -90,8 +90,7 @@ class FailSafeClusterInvokerTest {
     }
 
     @Test
-    void testInvokeNoExceptoin() {
-
+    void testInvokeNoException() {
         resetInvokerToNoException();
 
         FailsafeClusterInvoker<DemoService> invoker = new FailsafeClusterInvoker<DemoService>(dic);


### PR DESCRIPTION
Fix spelling mistakes in test method names:
- testInvokeExceptoin -> testInvokeException
- testInvokeNoExceptoin -> testInvokeNoException

## What is the purpose of the change?

Fix typos in test method names to improve code readability and maintain consistent naming conventions.

The changes are:
1. Correct the spelling of "Exceptoin" to "Exception" in test method names
2. This is a test-only change and does not affect any production code
3. The change improves code quality by maintaining consistent and correct spelling

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Make sure gitHub actions can pass. [Why the workflow is failing and how to fix it?](../CONTRIBUTING.md)
