### PR TITLE
3.3 fix: attachment parameter transparency (#15557)

### DIFF
--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/filter/support/ConsumerContextFilter.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/filter/support/ConsumerContextFilter.java
@@ -78,9 +78,6 @@ public class ConsumerContextFilter implements ClusterFilter, ClusterFilter.Liste
                     ((RpcInvocation) invocation).addObjectAttachments(selected);
                 }
             }
-        } else {
-            ((RpcInvocation) invocation)
-                    .addObjectAttachments(RpcContext.getServerAttachment().getObjectAttachments());
         }
         Map<String, Object> contextAttachments =
                 RpcContext.getClientAttachment().getObjectAttachments();


### PR DESCRIPTION
## What is the purpose of the change?

fix: attachment parameter transparenc #15557

For testing, you can use https://github.com/apache/dubbo-samples/tree/master/2-advanced/dubbo-samples-rpccontext, but `resources/META-INF/dubbo/internal/org.apache.dubbo.rpc.PenetrateAttachmentSelector` needs to be removed.

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Make sure gitHub actions can pass. [Why the workflow is failing and how to fix it?](../CONTRIBUTING.md)
