### PR TITLE
Enhance Network Interface Configuration via Spring Environment

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/logger/support/FailsafeLogger.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/logger/support/FailsafeLogger.java
@@ -18,7 +18,6 @@ package org.apache.dubbo.common.logger.support;
 
 import org.apache.dubbo.common.Version;
 import org.apache.dubbo.common.logger.Logger;
-import org.apache.dubbo.common.utils.NetUtils;
 
 public class FailsafeLogger implements Logger {
 

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/logger/support/FailsafeLogger.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/logger/support/FailsafeLogger.java
@@ -47,8 +47,7 @@ public class FailsafeLogger implements Logger {
     }
 
     private String appendContextMessage(String msg) {
-        return " [DUBBO] " + msg + ", dubbo version: " + Version.getVersion() + ", current host: "
-                + NetUtils.getLocalHost();
+        return " [DUBBO] " + msg + ", dubbo version: " + Version.getVersion();
     }
 
     @Override

--- a/dubbo-spring-boot/dubbo-spring-boot-compatible/autoconfigure/src/main/java/org/apache/dubbo/spring/boot/context/event/DubboNetInterfaceConfigApplicationListener.java
+++ b/dubbo-spring-boot/dubbo-spring-boot-compatible/autoconfigure/src/main/java/org/apache/dubbo/spring/boot/context/event/DubboNetInterfaceConfigApplicationListener.java
@@ -1,0 +1,34 @@
+package org.apache.dubbo.spring.boot.context.event;
+
+import org.apache.dubbo.common.constants.CommonConstants;
+import org.apache.dubbo.common.utils.StringUtils;
+import org.springframework.boot.context.event.ApplicationPreparedEvent;
+import org.springframework.context.ApplicationListener;
+import org.springframework.core.env.ConfigurableEnvironment;
+
+/**
+ * @since 3.2
+ */
+public class DubboNetInterfaceConfigApplicationListener implements ApplicationListener<ApplicationPreparedEvent> {
+
+    @Override
+    public void onApplicationEvent(ApplicationPreparedEvent applicationPreparedEvent) {
+        ConfigurableEnvironment environment = applicationPreparedEvent.getApplicationContext()
+                .getEnvironment();
+        String preferredNetworkInterface = System.getProperty(CommonConstants.DUBBO_PREFERRED_NETWORK_INTERFACE);
+        if (StringUtils.isBlank(preferredNetworkInterface)) {
+            preferredNetworkInterface = environment.getProperty(CommonConstants.DUBBO_PREFERRED_NETWORK_INTERFACE);
+            if (StringUtils.isNotBlank(preferredNetworkInterface)) {
+                System.setProperty(CommonConstants.DUBBO_PREFERRED_NETWORK_INTERFACE, preferredNetworkInterface);
+            }
+        }
+        String ignoredNetworkInterface = System.getProperty(CommonConstants.DUBBO_NETWORK_IGNORED_INTERFACE);
+        if (StringUtils.isBlank(ignoredNetworkInterface)) {
+            ignoredNetworkInterface = environment.getProperty(CommonConstants.DUBBO_NETWORK_IGNORED_INTERFACE);
+            if (StringUtils.isNotBlank(ignoredNetworkInterface)) {
+                System.setProperty(CommonConstants.DUBBO_NETWORK_IGNORED_INTERFACE, ignoredNetworkInterface);
+            }
+        }
+    }
+}
+

--- a/dubbo-spring-boot/dubbo-spring-boot-compatible/autoconfigure/src/main/resources/META-INF/spring.factories
+++ b/dubbo-spring-boot/dubbo-spring-boot-compatible/autoconfigure/src/main/resources/META-INF/spring.factories
@@ -3,7 +3,8 @@ org.apache.dubbo.spring.boot.autoconfigure.DubboAutoConfiguration,\
 org.apache.dubbo.spring.boot.autoconfigure.DubboRelaxedBindingAutoConfiguration,\
 org.apache.dubbo.spring.boot.autoconfigure.DubboListenerAutoConfiguration
 org.springframework.context.ApplicationListener=\
-org.apache.dubbo.spring.boot.context.event.WelcomeLogoApplicationListener
+org.apache.dubbo.spring.boot.context.event.WelcomeLogoApplicationListener,\
+org.apache.dubbo.spring.boot.context.event.DubboNetInterfaceConfigApplicationListener
 org.springframework.boot.env.EnvironmentPostProcessor=\
 org.apache.dubbo.spring.boot.env.DubboDefaultPropertiesEnvironmentPostProcessor
 org.springframework.context.ApplicationContextInitializer=\

--- a/dubbo-spring-boot/dubbo-spring-boot-compatible/autoconfigure/src/test/java/org/apache/dubbo/spring/boot/context/DubboNetInterfaceConfigApplicationContextInitializerTest.java
+++ b/dubbo-spring-boot/dubbo-spring-boot-compatible/autoconfigure/src/test/java/org/apache/dubbo/spring/boot/context/DubboNetInterfaceConfigApplicationContextInitializerTest.java
@@ -1,0 +1,59 @@
+package org.apache.dubbo.spring.boot.context;
+
+import org.apache.dubbo.common.constants.CommonConstants;
+import org.apache.dubbo.spring.boot.context.event.DubboNetInterfaceConfigApplicationListener;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.context.event.ApplicationEnvironmentPreparedEvent;
+import org.springframework.context.ApplicationListener;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.MapPropertySource;
+import org.springframework.core.env.MutablePropertySources;
+
+import static org.apache.dubbo.common.constants.CommonConstants.DUBBO_NETWORK_IGNORED_INTERFACE;
+import static org.apache.dubbo.common.constants.CommonConstants.DUBBO_PREFERRED_NETWORK_INTERFACE;
+
+/**
+ * @since 3.2
+ */
+public class DubboNetInterfaceConfigApplicationContextInitializerTest {
+
+    private static final String USE_NETWORK_INTERFACE_NAME = "eth0";
+
+    private static final String IGNORED_NETWORK_INTERFACE_NAME = "eth1";
+
+    @Test
+    public void testInitialize() {
+        SpringApplication application =
+                new SpringApplication(DubboNetInterfaceConfigApplicationContextInitializerTest.class);
+        application.addListeners(new DubboNetInterfaceConfigApplicationListener());
+        application.addListeners(new NetworkInterfaceApplicationListener());
+        application.run();
+        String preferredNetworkInterface = System.getProperty(DUBBO_PREFERRED_NETWORK_INTERFACE);
+        String ignoredNetworkInterface = System.getProperty(DUBBO_NETWORK_IGNORED_INTERFACE);
+        Assert.assertEquals(USE_NETWORK_INTERFACE_NAME, preferredNetworkInterface);
+        Assert.assertEquals(IGNORED_NETWORK_INTERFACE_NAME, ignoredNetworkInterface);
+
+    }
+
+    static class NetworkInterfaceApplicationListener
+            implements ApplicationListener<ApplicationEnvironmentPreparedEvent> {
+
+        @Override
+        public void onApplicationEvent(ApplicationEnvironmentPreparedEvent applicationEnvironmentPreparedEvent) {
+            ConfigurableEnvironment environment = applicationEnvironmentPreparedEvent.getEnvironment();
+            MutablePropertySources propertySources = environment.getPropertySources();
+
+            Map<String, Object> map = new HashMap<>();
+            map.put(CommonConstants.DUBBO_PREFERRED_NETWORK_INTERFACE, USE_NETWORK_INTERFACE_NAME);
+            map.put(DUBBO_NETWORK_IGNORED_INTERFACE, IGNORED_NETWORK_INTERFACE_NAME);
+            propertySources.addLast(new MapPropertySource("networkInterfaceConfig", map));
+        }
+    }
+
+}


### PR DESCRIPTION
#6588 

This change allows the dubbo.network.interface.preferred configuration to be set via Spring configuration files, rather than requiring it to be specified as a system property at startup.

Currently, Dubbo determines the preferred network interface too early in the application lifecycle, due to logging mechanisms like FailsafeLogger that trigger host resolution (via NetUtils) before Spring configuration is available.

To address this, a new listener DubboNetInterfaceConfigApplicationListener is introduced. It listens for the ApplicationPreparedEvent, reads the network interface configuration from the Spring Environment, and sets it into system properties if not already configured. The listener is intentionally not registered as an ApplicationContextInitializer to avoid running before PropertySourceBootstrapConfiguration in Spring Cloud environments. Additionally, since the current Dubbo version does not yet depend on a Spring Boot version that supports ApplicationContextInitializedEvent, the ApplicationPreparedEvent is chosen as a safe extension point.

This change improves flexibility and integration with Spring-based configuration management, especially in Spring Cloud environments.