### PR TITLE
Add serviceConfigV2 null check at metadata service export

### DIFF
--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/metadata/ConfigurableMetadataServiceExporter.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/metadata/ConfigurableMetadataServiceExporter.java
@@ -73,7 +73,7 @@ public class ConfigurableMetadataServiceExporter {
     }
 
     public synchronized ConfigurableMetadataServiceExporter export() {
-        if ((serviceConfig == null && serviceConfigV2 == null) || !isExported()) {
+        if (!isExported()) {
             if (MetadataServiceVersionUtils.needExportV1(applicationModel)) {
                 exportV1();
             }

--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/metadata/ConfigurableMetadataServiceExporter.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/metadata/ConfigurableMetadataServiceExporter.java
@@ -16,6 +16,7 @@
  */
 package org.apache.dubbo.config.metadata;
 
+import org.apache.dubbo.common.URL;
 import org.apache.dubbo.common.logger.ErrorTypeAwareLogger;
 import org.apache.dubbo.common.logger.LoggerFactory;
 import org.apache.dubbo.common.threadpool.manager.FrameworkExecutorRepository;
@@ -31,6 +32,7 @@ import org.apache.dubbo.registry.client.metadata.MetadataServiceDelegation;
 import org.apache.dubbo.registry.client.metadata.MetadataServiceDelegationV2;
 import org.apache.dubbo.rpc.model.ApplicationModel;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
@@ -71,7 +73,7 @@ public class ConfigurableMetadataServiceExporter {
     }
 
     public synchronized ConfigurableMetadataServiceExporter export() {
-        if (serviceConfig == null || !isExported()) {
+        if ((serviceConfig == null && serviceConfigV2 == null) || !isExported()) {
             if (MetadataServiceVersionUtils.needExportV1(applicationModel)) {
                 exportV1();
             }
@@ -84,11 +86,22 @@ public class ConfigurableMetadataServiceExporter {
                         CONFIG_METADATA_SERVICE_EXPORTED,
                         "",
                         "",
-                        "The MetadataService has been exported : " + serviceConfig.getExportedUrls());
+                        "The MetadataService has been exported : " + getExportedUrls());
             }
         }
 
         return this;
+    }
+
+    public List<URL> getExportedUrls() {
+        List<URL> urls = new ArrayList<>();
+        if (serviceConfig != null) {
+            urls.addAll(serviceConfig.getExportedUrls());
+        }
+        if (serviceConfigV2 != null) {
+            urls.addAll(serviceConfigV2.getExportedUrls());
+        }
+        return urls;
     }
 
     private static final String INTERNAL_METADATA_REGISTRY_ID = "internal-metadata-registry";

--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/metadata/ConfigurableMetadataServiceExporter.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/metadata/ConfigurableMetadataServiceExporter.java
@@ -93,6 +93,10 @@ public class ConfigurableMetadataServiceExporter {
         return this;
     }
 
+    /**
+     * Get exported urls which include v1 and v2 if existed
+     * @return exported urls
+     */
     public List<URL> getExportedUrls() {
         List<URL> urls = new ArrayList<>();
         if (serviceConfig != null) {


### PR DESCRIPTION
## What is the purpose of the change?
The condition ```serviceConfig == null``` at ```ConfigurableMetadataServiceExporter#export``` is always true since it will not be assgined when ```onlyUseMetadataV2``` is true, which will cause ```ConfigurableMetadataServiceExporter#export``` exported check failure. 

```
    public synchronized ConfigurableMetadataServiceExporter export() {
        if (serviceConfig == null || !isExported()) {
            if (MetadataServiceVersionUtils.needExportV1(applicationModel)) {
                exportV1();
            }
            if (MetadataServiceVersionUtils.needExportV2(applicationModel)) {
                exportV2();
            }
        } else {
            if (logger.isWarnEnabled()) {
                logger.warn(
                        CONFIG_METADATA_SERVICE_EXPORTED,
                        "",
                        "",
                        "The MetadataService has been exported : " + serviceConfig.getExportedUrls());
            }
        }

        return this;
    }
```

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Make sure gitHub actions can pass. [Why the workflow is failing and how to fix it?](../CONTRIBUTING.md)
