### PR TITLE
Support Preferred Network Interface via Spring Environment and Fix Early Host Resolution

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/logger/support/FailsafeLogger.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/logger/support/FailsafeLogger.java
@@ -18,6 +18,7 @@ package org.apache.dubbo.common.logger.support;
 
 import org.apache.dubbo.common.Version;
 import org.apache.dubbo.common.logger.Logger;
+import org.apache.dubbo.common.utils.NetUtils;
 
 public class FailsafeLogger implements Logger {
 
@@ -46,7 +47,8 @@ public class FailsafeLogger implements Logger {
     }
 
     private String appendContextMessage(String msg) {
-        return " [DUBBO] " + msg + ", dubbo version: " + Version.getVersion();
+        return " [DUBBO] " + msg + ", dubbo version: " + Version.getVersion() + ", current host: "
+                + NetUtils.getLocalHost();
     }
 
     @Override

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/logger/support/FailsafeLogger.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/logger/support/FailsafeLogger.java
@@ -18,7 +18,6 @@ package org.apache.dubbo.common.logger.support;
 
 import org.apache.dubbo.common.Version;
 import org.apache.dubbo.common.logger.Logger;
-import org.apache.dubbo.common.utils.NetUtils;
 
 public class FailsafeLogger implements Logger {
 
@@ -47,8 +46,7 @@ public class FailsafeLogger implements Logger {
     }
 
     private String appendContextMessage(String msg) {
-        return " [DUBBO] " + msg + ", dubbo version: " + Version.getVersion() + ", current host: "
-                + NetUtils.getLocalHost();
+        return " [DUBBO] " + msg + ", dubbo version: " + Version.getVersion();
     }
 
     @Override

--- a/dubbo-spring-boot-project/dubbo-spring-boot/src/main/java/org/apache/dubbo/spring/boot/context/event/DubboNetInterfaceConfigApplicationListener.java
+++ b/dubbo-spring-boot-project/dubbo-spring-boot/src/main/java/org/apache/dubbo/spring/boot/context/event/DubboNetInterfaceConfigApplicationListener.java
@@ -21,11 +21,14 @@ import org.apache.dubbo.common.utils.StringUtils;
 
 import org.springframework.boot.context.event.ApplicationContextInitializedEvent;
 import org.springframework.context.ApplicationListener;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
 import org.springframework.core.env.ConfigurableEnvironment;
 
 /**
  * @since 3.3
  */
+@Order(Ordered.HIGHEST_PRECEDENCE + 20) // After LoggingApplicationListener#DEFAULT_ORDER
 public class DubboNetInterfaceConfigApplicationListener
         implements ApplicationListener<ApplicationContextInitializedEvent> {
 

--- a/dubbo-spring-boot-project/dubbo-spring-boot/src/main/java/org/apache/dubbo/spring/boot/context/event/DubboNetInterfaceConfigApplicationListener.java
+++ b/dubbo-spring-boot-project/dubbo-spring-boot/src/main/java/org/apache/dubbo/spring/boot/context/event/DubboNetInterfaceConfigApplicationListener.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.spring.boot.context.event;
+
+import org.apache.dubbo.common.constants.CommonConstants;
+import org.apache.dubbo.common.utils.StringUtils;
+
+import org.springframework.boot.context.event.ApplicationContextInitializedEvent;
+import org.springframework.context.ApplicationListener;
+import org.springframework.core.env.ConfigurableEnvironment;
+
+/**
+ * @since 3.3
+ */
+public class DubboNetInterfaceConfigApplicationListener
+        implements ApplicationListener<ApplicationContextInitializedEvent> {
+
+    @Override
+    public void onApplicationEvent(ApplicationContextInitializedEvent event) {
+        ConfigurableEnvironment environment = event.getApplicationContext().getEnvironment();
+        String preferredNetworkInterface =
+                System.getProperty(CommonConstants.DubboProperty.DUBBO_PREFERRED_NETWORK_INTERFACE);
+        if (StringUtils.isBlank(preferredNetworkInterface)) {
+            preferredNetworkInterface =
+                    environment.getProperty(CommonConstants.DubboProperty.DUBBO_PREFERRED_NETWORK_INTERFACE);
+            if (StringUtils.isNotBlank(preferredNetworkInterface)) {
+                System.setProperty(
+                        CommonConstants.DubboProperty.DUBBO_PREFERRED_NETWORK_INTERFACE, preferredNetworkInterface);
+            }
+        }
+        String ignoredNetworkInterface =
+                System.getProperty(CommonConstants.DubboProperty.DUBBO_NETWORK_IGNORED_INTERFACE);
+        if (StringUtils.isBlank(ignoredNetworkInterface)) {
+            ignoredNetworkInterface =
+                    environment.getProperty(CommonConstants.DubboProperty.DUBBO_NETWORK_IGNORED_INTERFACE);
+            if (StringUtils.isNotBlank(ignoredNetworkInterface)) {
+                System.setProperty(
+                        CommonConstants.DubboProperty.DUBBO_NETWORK_IGNORED_INTERFACE, ignoredNetworkInterface);
+            }
+        }
+    }
+}

--- a/dubbo-spring-boot-project/dubbo-spring-boot/src/main/java/org/apache/dubbo/spring/boot/context/event/WelcomeLogoApplicationListener.java
+++ b/dubbo-spring-boot-project/dubbo-spring-boot/src/main/java/org/apache/dubbo/spring/boot/context/event/WelcomeLogoApplicationListener.java
@@ -22,7 +22,7 @@ import org.apache.dubbo.common.logger.LoggerFactory;
 
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import org.springframework.boot.context.event.ApplicationEnvironmentPreparedEvent;
+import org.springframework.boot.context.event.ApplicationContextInitializedEvent;
 import org.springframework.context.ApplicationListener;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
@@ -38,12 +38,12 @@ import static org.apache.dubbo.spring.boot.util.DubboUtils.LINE_SEPARATOR;
  * @since 2.7.0
  */
 @Order(Ordered.HIGHEST_PRECEDENCE + 20 + 1) // After LoggingApplicationListener#DEFAULT_ORDER
-public class WelcomeLogoApplicationListener implements ApplicationListener<ApplicationEnvironmentPreparedEvent> {
+public class WelcomeLogoApplicationListener implements ApplicationListener<ApplicationContextInitializedEvent> {
 
     private static AtomicBoolean processed = new AtomicBoolean(false);
 
     @Override
-    public void onApplicationEvent(ApplicationEnvironmentPreparedEvent event) {
+    public void onApplicationEvent(ApplicationContextInitializedEvent event) {
 
         // Skip if processed before, prevent duplicated execution in Hierarchical ApplicationContext
         if (processed.get()) {

--- a/dubbo-spring-boot-project/dubbo-spring-boot/src/main/resources/META-INF/spring.factories
+++ b/dubbo-spring-boot-project/dubbo-spring-boot/src/main/resources/META-INF/spring.factories
@@ -1,5 +1,6 @@
 org.springframework.context.ApplicationListener=\
-org.apache.dubbo.spring.boot.context.event.WelcomeLogoApplicationListener
+org.apache.dubbo.spring.boot.context.event.WelcomeLogoApplicationListener,\
+  org.apache.dubbo.spring.boot.context.event.DubboNetInterfaceConfigApplicationListener
 org.springframework.boot.env.EnvironmentPostProcessor=\
 org.apache.dubbo.spring.boot.env.DubboDefaultPropertiesEnvironmentPostProcessor
 org.springframework.context.ApplicationContextInitializer=\

--- a/dubbo-spring-boot-project/dubbo-spring-boot/src/test/java/org/apache/dubbo/spring/boot/context/event/DubboNetInterfaceConfigApplicationListenerTest.java
+++ b/dubbo-spring-boot-project/dubbo-spring-boot/src/test/java/org/apache/dubbo/spring/boot/context/event/DubboNetInterfaceConfigApplicationListenerTest.java
@@ -16,18 +16,11 @@
  */
 package org.apache.dubbo.spring.boot.context.event;
 
-import org.apache.dubbo.common.utils.NetUtils;
 import org.apache.dubbo.common.utils.SystemPropertyConfigUtils;
 
-import java.lang.reflect.Method;
-import java.net.NetworkInterface;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
-import java.util.Objects;
-import java.util.Random;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.WebApplicationType;
@@ -47,49 +40,23 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  */
 public class DubboNetInterfaceConfigApplicationListenerTest {
 
-    private static String useNetworkInterfaceName = "eth0";
+    private static final String USE_NETWORK_INTERFACE_NAME = "eth0";
 
-    private static String ignoredNetworkInterfaceName = "eth1";
-
-    private static final String EMPTY_INTERFACE_NAME = "empty";
-
-    @SuppressWarnings("unchecked")
-    @BeforeEach
-    public void beforeFindRandomInterface() throws Exception {
-        Method getValidNetworkInterfaces = NetUtils.class.getDeclaredMethod("getValidNetworkInterfaces");
-        getValidNetworkInterfaces.setAccessible(true);
-        List<NetworkInterface> networkInterfaceList = (List<NetworkInterface>) getValidNetworkInterfaces.invoke(null);
-        if (networkInterfaceList == null || networkInterfaceList.isEmpty()) {
-            useNetworkInterfaceName = EMPTY_INTERFACE_NAME;
-            return;
-        }
-        int size = networkInterfaceList.size();
-        Random random = new Random();
-        NetworkInterface networkInterface = networkInterfaceList.get(random.nextInt(size));
-        useNetworkInterfaceName = networkInterface.getDisplayName();
-
-        networkInterface = networkInterfaceList.get(random.nextInt(size));
-        ignoredNetworkInterfaceName = networkInterface.getDisplayName();
-    }
+    private static final String IGNORED_NETWORK_INTERFACE_NAME = "eth1";
 
     @Test
     public void testOnApplicationEvent() {
 
-        SpringApplicationBuilder builder =
-                new SpringApplicationBuilder(DubboNetInterfaceConfigApplicationListenerTest.class);
+        SpringApplicationBuilder builder = new SpringApplicationBuilder(DubboNetInterfaceConfigApplicationListenerTest.class);
         builder.listeners(new NetworkInterfaceApplicationListener());
         builder.web(WebApplicationType.NONE);
         SpringApplication application = builder.build();
         application.run();
-        String preferredNetworkInterface;
-        if (Objects.equals(useNetworkInterfaceName, EMPTY_INTERFACE_NAME)) {
-            preferredNetworkInterface = SystemPropertyConfigUtils.getSystemProperty(DUBBO_PREFERRED_NETWORK_INTERFACE);
-        } else {
-            preferredNetworkInterface = NetUtils.findNetworkInterface().getDisplayName();
-        }
+
+        String preferredNetworkInterface = SystemPropertyConfigUtils.getSystemProperty(DUBBO_PREFERRED_NETWORK_INTERFACE);
         String ignoredNetworkInterface = SystemPropertyConfigUtils.getSystemProperty(DUBBO_NETWORK_IGNORED_INTERFACE);
-        assertEquals(useNetworkInterfaceName, preferredNetworkInterface);
-        assertEquals(ignoredNetworkInterfaceName, ignoredNetworkInterface);
+        assertEquals(USE_NETWORK_INTERFACE_NAME, preferredNetworkInterface);
+        assertEquals(IGNORED_NETWORK_INTERFACE_NAME, ignoredNetworkInterface);
     }
 
     static class NetworkInterfaceApplicationListener
@@ -101,8 +68,8 @@ public class DubboNetInterfaceConfigApplicationListenerTest {
             MutablePropertySources propertySources = environment.getPropertySources();
 
             Map<String, Object> map = new HashMap<>();
-            map.put(DUBBO_PREFERRED_NETWORK_INTERFACE, useNetworkInterfaceName);
-            map.put(DUBBO_NETWORK_IGNORED_INTERFACE, ignoredNetworkInterfaceName);
+            map.put(DUBBO_PREFERRED_NETWORK_INTERFACE, USE_NETWORK_INTERFACE_NAME);
+            map.put(DUBBO_NETWORK_IGNORED_INTERFACE, IGNORED_NETWORK_INTERFACE_NAME);
             propertySources.addLast(new MapPropertySource("networkInterfaceConfig", map));
         }
     }

--- a/dubbo-spring-boot-project/dubbo-spring-boot/src/test/java/org/apache/dubbo/spring/boot/context/event/DubboNetInterfaceConfigApplicationListenerTest.java
+++ b/dubbo-spring-boot-project/dubbo-spring-boot/src/test/java/org/apache/dubbo/spring/boot/context/event/DubboNetInterfaceConfigApplicationListenerTest.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.spring.boot.context.event;
+
+import org.apache.dubbo.common.utils.NetUtils;
+import org.apache.dubbo.common.utils.SystemPropertyConfigUtils;
+
+import java.lang.reflect.Method;
+import java.net.NetworkInterface;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Random;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.WebApplicationType;
+import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.boot.context.event.ApplicationEnvironmentPreparedEvent;
+import org.springframework.context.ApplicationListener;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.MapPropertySource;
+import org.springframework.core.env.MutablePropertySources;
+
+import static org.apache.dubbo.common.constants.CommonConstants.DubboProperty.DUBBO_NETWORK_IGNORED_INTERFACE;
+import static org.apache.dubbo.common.constants.CommonConstants.DubboProperty.DUBBO_PREFERRED_NETWORK_INTERFACE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * @since 3.3
+ */
+public class DubboNetInterfaceConfigApplicationListenerTest {
+
+    private static String useNetworkInterfaceName = "eth0";
+
+    private static String ignoredNetworkInterfaceName = "eth1";
+
+    private static final String EMPTY_INTERFACE_NAME = "empty";
+
+    @SuppressWarnings("unchecked")
+    @BeforeEach
+    public void beforeFindRandomInterface() throws Exception {
+        Method getValidNetworkInterfaces = NetUtils.class.getDeclaredMethod("getValidNetworkInterfaces");
+        getValidNetworkInterfaces.setAccessible(true);
+        List<NetworkInterface> networkInterfaceList = (List<NetworkInterface>) getValidNetworkInterfaces.invoke(null);
+        if (networkInterfaceList == null || networkInterfaceList.isEmpty()) {
+            useNetworkInterfaceName = EMPTY_INTERFACE_NAME;
+            return;
+        }
+        int size = networkInterfaceList.size();
+        Random random = new Random();
+        NetworkInterface networkInterface = networkInterfaceList.get(random.nextInt(size));
+        useNetworkInterfaceName = networkInterface.getDisplayName();
+
+        networkInterface = networkInterfaceList.get(random.nextInt(size));
+        ignoredNetworkInterfaceName = networkInterface.getDisplayName();
+    }
+
+    @Test
+    public void testOnApplicationEvent() {
+
+        SpringApplicationBuilder builder =
+                new SpringApplicationBuilder(DubboNetInterfaceConfigApplicationListenerTest.class);
+        builder.listeners(new NetworkInterfaceApplicationListener());
+        builder.web(WebApplicationType.NONE);
+        SpringApplication application = builder.build();
+        application.run();
+        String preferredNetworkInterface;
+        if (Objects.equals(useNetworkInterfaceName, EMPTY_INTERFACE_NAME)) {
+            preferredNetworkInterface = SystemPropertyConfigUtils.getSystemProperty(DUBBO_PREFERRED_NETWORK_INTERFACE);
+        } else {
+            preferredNetworkInterface = NetUtils.findNetworkInterface().getDisplayName();
+        }
+        String ignoredNetworkInterface = SystemPropertyConfigUtils.getSystemProperty(DUBBO_NETWORK_IGNORED_INTERFACE);
+        assertEquals(useNetworkInterfaceName, preferredNetworkInterface);
+        assertEquals(ignoredNetworkInterfaceName, ignoredNetworkInterface);
+    }
+
+    static class NetworkInterfaceApplicationListener
+            implements ApplicationListener<ApplicationEnvironmentPreparedEvent> {
+
+        @Override
+        public void onApplicationEvent(ApplicationEnvironmentPreparedEvent applicationEnvironmentPreparedEvent) {
+            ConfigurableEnvironment environment = applicationEnvironmentPreparedEvent.getEnvironment();
+            MutablePropertySources propertySources = environment.getPropertySources();
+
+            Map<String, Object> map = new HashMap<>();
+            map.put(DUBBO_PREFERRED_NETWORK_INTERFACE, useNetworkInterfaceName);
+            map.put(DUBBO_NETWORK_IGNORED_INTERFACE, ignoredNetworkInterfaceName);
+            propertySources.addLast(new MapPropertySource("networkInterfaceConfig", map));
+        }
+    }
+}

--- a/dubbo-spring-boot-project/dubbo-spring-boot/src/test/java/org/apache/dubbo/spring/boot/context/event/DubboNetInterfaceConfigApplicationListenerTest.java
+++ b/dubbo-spring-boot-project/dubbo-spring-boot/src/test/java/org/apache/dubbo/spring/boot/context/event/DubboNetInterfaceConfigApplicationListenerTest.java
@@ -47,13 +47,15 @@ public class DubboNetInterfaceConfigApplicationListenerTest {
     @Test
     public void testOnApplicationEvent() {
 
-        SpringApplicationBuilder builder = new SpringApplicationBuilder(DubboNetInterfaceConfigApplicationListenerTest.class);
+        SpringApplicationBuilder builder =
+                new SpringApplicationBuilder(DubboNetInterfaceConfigApplicationListenerTest.class);
         builder.listeners(new NetworkInterfaceApplicationListener());
         builder.web(WebApplicationType.NONE);
         SpringApplication application = builder.build();
         application.run();
 
-        String preferredNetworkInterface = SystemPropertyConfigUtils.getSystemProperty(DUBBO_PREFERRED_NETWORK_INTERFACE);
+        String preferredNetworkInterface =
+                SystemPropertyConfigUtils.getSystemProperty(DUBBO_PREFERRED_NETWORK_INTERFACE);
         String ignoredNetworkInterface = SystemPropertyConfigUtils.getSystemProperty(DUBBO_NETWORK_IGNORED_INTERFACE);
         assertEquals(USE_NETWORK_INTERFACE_NAME, preferredNetworkInterface);
         assertEquals(IGNORED_NETWORK_INTERFACE_NAME, ignoredNetworkInterface);


### PR DESCRIPTION
This change removes the logic in FailsafeLogger that appends the local host information to log messages. The motivation is that FailsafeLogger is used by the WelcomeLogoApplicationListener to print logs very early during application startup—before Spring’s configuration files are fully loaded. As a result, NetUtils resolves and caches the local host information prematurely. This prevents the application from re-evaluating the preferred network interface later based on user-defined configuration. To avoid this issue, the host resolution in FailsafeLogger has been removed.

A new class, DubboNetInterfaceConfigApplicationListener, has been introduced to retrieve the preferred network interface configuration from Spring’s Environment and set it as a system property—since NetUtils reads this value from environment variables. This listener listens to the ApplicationContextInitializedEvent, which ensures that the Spring Environment (including values from configuration centers) is fully prepared when the listener executes.