### PR TITLE
Implement full zero-copy output for Dubbo Triple protocol 

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/rpc/model/Pack.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/rpc/model/Pack.java
@@ -19,9 +19,31 @@ package org.apache.dubbo.rpc.model;
 public interface Pack {
 
     /**
+     * Pack object to byte array
      * @param obj instance
      * @return byte array
      * @throws Exception when error occurs
      */
     byte[] pack(Object obj) throws Exception;
+
+    /**
+     * Check if this Pack implementation supports zero-copy stream packing
+     * @return true if supports stream packing
+     */
+    default boolean supportsStreamPacking() {
+        return false;
+    }
+
+    /**
+     * Create a PackContext for zero-copy optimization.
+     * The context encapsulates both size calculation and stream writing.
+     *
+     * @param obj instance to pack
+     * @return PackContext instance
+     * @throws Exception when error occurs
+     */
+    default PackContext createPackContext(Object obj) throws Exception {
+        byte[] bytes = pack(obj);
+        return PackContext.of(bytes);
+    }
 }

--- a/dubbo-common/src/main/java/org/apache/dubbo/rpc/model/PackContext.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/rpc/model/PackContext.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.rpc.model;
+
+import java.io.OutputStream;
+
+/**
+ * Pack context for zero-copy optimization.
+ * Encapsulates both size calculation and stream writing capability.
+ */
+public interface PackContext {
+
+    /**
+     * Get the packed size in bytes
+     * @return size in bytes
+     */
+    int getSize();
+
+    /**
+     * Write packed data to output stream
+     * @param os output stream
+     * @throws Exception if write fails
+     */
+    void writeTo(OutputStream os) throws Exception;
+
+    /**
+     * Create a PackContext from byte array (fallback implementation)
+     * @param bytes byte array
+     * @return PackContext instance
+     */
+    static PackContext of(byte[] bytes) {
+        return new ByteArrayPackContext(bytes);
+    }
+
+    /**
+     * Default implementation backed by byte array
+     */
+    class ByteArrayPackContext implements PackContext {
+        private final byte[] bytes;
+
+        ByteArrayPackContext(byte[] bytes) {
+            this.bytes = bytes;
+        }
+
+        @Override
+        public int getSize() {
+            return bytes.length;
+        }
+
+        @Override
+        public void writeTo(OutputStream os) throws Exception {
+            os.write(bytes);
+        }
+    }
+}

--- a/dubbo-plugin/dubbo-compiler/src/main/resources/Dubbo3TripleStub.mustache
+++ b/dubbo-plugin/dubbo-compiler/src/main/resources/Dubbo3TripleStub.mustache
@@ -66,38 +66,182 @@ public final class {{className}} {
 
     private static final StubMethodDescriptor {{methodName}}Method = new StubMethodDescriptor("{{originMethodName}}",
     {{inputType}}.class, {{outputType}}.class, MethodDescriptor.RpcType.UNARY,
-    obj -> ((com.google.protobuf.Message) obj).toByteArray(),obj -> ((com.google.protobuf.Message) obj).toByteArray(), {{inputType}}::parseFrom,
+    obj -> ((com.google.protobuf.Message) obj).toByteArray(), new org.apache.dubbo.rpc.model.Pack() {
+        @Override
+        public byte[] pack(Object obj) throws Exception {
+            return ((com.google.protobuf.Message) obj).toByteArray();
+        }
+        @Override
+        public boolean supportsStreamPacking() {
+            return true;
+        }
+        @Override
+        public org.apache.dubbo.rpc.model.PackContext createPackContext(Object obj) throws Exception {
+            final com.google.protobuf.Message message = (com.google.protobuf.Message) obj;
+            return new org.apache.dubbo.rpc.model.PackContext() {
+                private final int size = message.getSerializedSize();
+                @Override
+                public int getSize() {
+                    return size;
+                }
+                @Override
+                public void writeTo(java.io.OutputStream os) throws Exception {
+                    message.writeTo(os);
+                }
+            };
+        }
+    }, {{inputType}}::parseFrom,
     {{outputType}}::parseFrom);
 
     private static final StubMethodDescriptor {{methodName}}AsyncMethod = new StubMethodDescriptor("{{originMethodName}}",
     {{inputType}}.class, java.util.concurrent.CompletableFuture.class, MethodDescriptor.RpcType.UNARY,
-    obj -> ((com.google.protobuf.Message) obj).toByteArray(), obj -> ((com.google.protobuf.Message) obj).toByteArray(), {{inputType}}::parseFrom,
+    obj -> ((com.google.protobuf.Message) obj).toByteArray(), new org.apache.dubbo.rpc.model.Pack() {
+        @Override
+        public byte[] pack(Object obj) throws Exception {
+            return ((com.google.protobuf.Message) obj).toByteArray();
+        }
+        @Override
+        public boolean supportsStreamPacking() {
+            return true;
+        }
+        @Override
+        public org.apache.dubbo.rpc.model.PackContext createPackContext(Object obj) throws Exception {
+            final com.google.protobuf.Message message = (com.google.protobuf.Message) obj;
+            return new org.apache.dubbo.rpc.model.PackContext() {
+                private final int size = message.getSerializedSize();
+                @Override
+                public int getSize() {
+                    return size;
+                }
+                @Override
+                public void writeTo(java.io.OutputStream os) throws Exception {
+                    message.writeTo(os);
+                }
+            };
+        }
+    }, {{inputType}}::parseFrom,
     {{outputType}}::parseFrom);
 
     private static final StubMethodDescriptor {{methodName}}ProxyAsyncMethod = new StubMethodDescriptor("{{originMethodName}}Async",
     {{inputType}}.class, {{outputType}}.class, MethodDescriptor.RpcType.UNARY,
-    obj -> ((com.google.protobuf.Message) obj).toByteArray(), obj -> ((com.google.protobuf.Message) obj).toByteArray(), {{inputType}}::parseFrom,
+    obj -> ((com.google.protobuf.Message) obj).toByteArray(), new org.apache.dubbo.rpc.model.Pack() {
+        @Override
+        public byte[] pack(Object obj) throws Exception {
+            return ((com.google.protobuf.Message) obj).toByteArray();
+        }
+        @Override
+        public boolean supportsStreamPacking() {
+            return true;
+        }
+        @Override
+        public org.apache.dubbo.rpc.model.PackContext createPackContext(Object obj) throws Exception {
+            final com.google.protobuf.Message message = (com.google.protobuf.Message) obj;
+            return new org.apache.dubbo.rpc.model.PackContext() {
+                private final int size = message.getSerializedSize();
+                @Override
+                public int getSize() {
+                    return size;
+                }
+                @Override
+                public void writeTo(java.io.OutputStream os) throws Exception {
+                    message.writeTo(os);
+                }
+            };
+        }
+    }, {{inputType}}::parseFrom,
     {{outputType}}::parseFrom);
 {{/unaryMethods}}
 {{#serverStreamingMethods}}
 
     private static final StubMethodDescriptor {{methodName}}Method = new StubMethodDescriptor("{{originMethodName}}",
     {{inputType}}.class, {{outputType}}.class, MethodDescriptor.RpcType.SERVER_STREAM,
-    obj -> ((com.google.protobuf.Message) obj).toByteArray(), obj -> ((com.google.protobuf.Message) obj).toByteArray(), {{inputType}}::parseFrom,
+    obj -> ((com.google.protobuf.Message) obj).toByteArray(), new org.apache.dubbo.rpc.model.Pack() {
+        @Override
+        public byte[] pack(Object obj) throws Exception {
+            return ((com.google.protobuf.Message) obj).toByteArray();
+        }
+        @Override
+        public boolean supportsStreamPacking() {
+            return true;
+        }
+        @Override
+        public org.apache.dubbo.rpc.model.PackContext createPackContext(Object obj) throws Exception {
+            final com.google.protobuf.Message message = (com.google.protobuf.Message) obj;
+            return new org.apache.dubbo.rpc.model.PackContext() {
+                private final int size = message.getSerializedSize();
+                @Override
+                public int getSize() {
+                    return size;
+                }
+                @Override
+                public void writeTo(java.io.OutputStream os) throws Exception {
+                    message.writeTo(os);
+                }
+            };
+        }
+    }, {{inputType}}::parseFrom,
     {{outputType}}::parseFrom);
 {{/serverStreamingMethods}}
 {{#clientStreamingMethods}}
 
     private static final StubMethodDescriptor {{methodName}}Method = new StubMethodDescriptor("{{originMethodName}}",
     {{inputType}}.class, {{outputType}}.class, MethodDescriptor.RpcType.CLIENT_STREAM,
-    obj -> ((com.google.protobuf.Message) obj).toByteArray(), obj -> ((com.google.protobuf.Message) obj).toByteArray(), {{inputType}}::parseFrom,
+    obj -> ((com.google.protobuf.Message) obj).toByteArray(), new org.apache.dubbo.rpc.model.Pack() {
+        @Override
+        public byte[] pack(Object obj) throws Exception {
+            return ((com.google.protobuf.Message) obj).toByteArray();
+        }
+        @Override
+        public boolean supportsStreamPacking() {
+            return true;
+        }
+        @Override
+        public org.apache.dubbo.rpc.model.PackContext createPackContext(Object obj) throws Exception {
+            final com.google.protobuf.Message message = (com.google.protobuf.Message) obj;
+            return new org.apache.dubbo.rpc.model.PackContext() {
+                private final int size = message.getSerializedSize();
+                @Override
+                public int getSize() {
+                    return size;
+                }
+                @Override
+                public void writeTo(java.io.OutputStream os) throws Exception {
+                    message.writeTo(os);
+                }
+            };
+        }
+    }, {{inputType}}::parseFrom,
     {{outputType}}::parseFrom);
 {{/clientStreamingMethods}}
 {{#biStreamingWithoutClientStreamMethods}}
 
     private static final StubMethodDescriptor {{methodName}}Method = new StubMethodDescriptor("{{originMethodName}}",
     {{inputType}}.class, {{outputType}}.class, MethodDescriptor.RpcType.BI_STREAM,
-    obj -> ((com.google.protobuf.Message) obj).toByteArray(), obj -> ((com.google.protobuf.Message) obj).toByteArray(), {{inputType}}::parseFrom,
+    obj -> ((com.google.protobuf.Message) obj).toByteArray(), new org.apache.dubbo.rpc.model.Pack() {
+        @Override
+        public byte[] pack(Object obj) throws Exception {
+            return ((com.google.protobuf.Message) obj).toByteArray();
+        }
+        @Override
+        public boolean supportsStreamPacking() {
+            return true;
+        }
+        @Override
+        public org.apache.dubbo.rpc.model.PackContext createPackContext(Object obj) throws Exception {
+            final com.google.protobuf.Message message = (com.google.protobuf.Message) obj;
+            return new org.apache.dubbo.rpc.model.PackContext() {
+                private final int size = message.getSerializedSize();
+                @Override
+                public int getSize() {
+                    return size;
+                }
+                @Override
+                public void writeTo(java.io.OutputStream os) throws Exception {
+                    message.writeTo(os);
+                }
+            };
+        }
+    }, {{inputType}}::parseFrom,
     {{outputType}}::parseFrom);
 {{/biStreamingWithoutClientStreamMethods}}
 

--- a/dubbo-plugin/dubbo-compiler/src/main/resources/MutinyDubbo3TripleStub.mustache
+++ b/dubbo-plugin/dubbo-compiler/src/main/resources/MutinyDubbo3TripleStub.mustache
@@ -71,7 +71,31 @@ public final class {{className}} {
     {{/javaDoc}}
     private static final StubMethodDescriptor {{methodName}}Method = new StubMethodDescriptor("{{originMethodName}}",
         {{inputType}}.class, {{outputType}}.class, MethodDescriptor.RpcType.UNARY,
-        obj -> ((com.google.protobuf.Message) obj).toByteArray(), obj -> ((com.google.protobuf.Message) obj).toByteArray(), {{inputType}}::parseFrom,
+        obj -> ((com.google.protobuf.Message) obj).toByteArray(), new org.apache.dubbo.rpc.model.Pack() {
+            @Override
+            public byte[] pack(Object obj) throws Exception {
+                return ((com.google.protobuf.Message) obj).toByteArray();
+            }
+            @Override
+            public boolean supportsStreamPacking() {
+                return true;
+            }
+            @Override
+            public org.apache.dubbo.rpc.model.PackContext createPackContext(Object obj) throws Exception {
+                final com.google.protobuf.Message message = (com.google.protobuf.Message) obj;
+                return new org.apache.dubbo.rpc.model.PackContext() {
+                    private final int size = message.getSerializedSize();
+                    @Override
+                    public int getSize() {
+                        return size;
+                    }
+                    @Override
+                    public void writeTo(java.io.OutputStream os) throws Exception {
+                        message.writeTo(os);
+                    }
+                };
+            }
+        }, {{inputType}}::parseFrom,
         {{outputType}}::parseFrom);
 {{/unaryMethods}}
 
@@ -81,7 +105,31 @@ public final class {{className}} {
     {{/javaDoc}}
     private static final StubMethodDescriptor {{methodName}}Method = new StubMethodDescriptor("{{originMethodName}}",
         {{inputType}}.class, {{outputType}}.class, MethodDescriptor.RpcType.SERVER_STREAM,
-        obj -> ((com.google.protobuf.Message) obj).toByteArray(), obj -> ((com.google.protobuf.Message) obj).toByteArray(), {{inputType}}::parseFrom,
+        obj -> ((com.google.protobuf.Message) obj).toByteArray(), new org.apache.dubbo.rpc.model.Pack() {
+            @Override
+            public byte[] pack(Object obj) throws Exception {
+                return ((com.google.protobuf.Message) obj).toByteArray();
+            }
+            @Override
+            public boolean supportsStreamPacking() {
+                return true;
+            }
+            @Override
+            public org.apache.dubbo.rpc.model.PackContext createPackContext(Object obj) throws Exception {
+                final com.google.protobuf.Message message = (com.google.protobuf.Message) obj;
+                return new org.apache.dubbo.rpc.model.PackContext() {
+                    private final int size = message.getSerializedSize();
+                    @Override
+                    public int getSize() {
+                        return size;
+                    }
+                    @Override
+                    public void writeTo(java.io.OutputStream os) throws Exception {
+                        message.writeTo(os);
+                    }
+                };
+            }
+        }, {{inputType}}::parseFrom,
         {{outputType}}::parseFrom);
 {{/serverStreamingMethods}}
 
@@ -91,7 +139,31 @@ public final class {{className}} {
     {{/javaDoc}}
     private static final StubMethodDescriptor {{methodName}}Method = new StubMethodDescriptor("{{originMethodName}}",
         {{inputType}}.class, {{outputType}}.class, MethodDescriptor.RpcType.CLIENT_STREAM,
-        obj -> ((com.google.protobuf.Message) obj).toByteArray(), obj -> ((com.google.protobuf.Message) obj).toByteArray(), {{inputType}}::parseFrom,
+        obj -> ((com.google.protobuf.Message) obj).toByteArray(), new org.apache.dubbo.rpc.model.Pack() {
+            @Override
+            public byte[] pack(Object obj) throws Exception {
+                return ((com.google.protobuf.Message) obj).toByteArray();
+            }
+            @Override
+            public boolean supportsStreamPacking() {
+                return true;
+            }
+            @Override
+            public org.apache.dubbo.rpc.model.PackContext createPackContext(Object obj) throws Exception {
+                final com.google.protobuf.Message message = (com.google.protobuf.Message) obj;
+                return new org.apache.dubbo.rpc.model.PackContext() {
+                    private final int size = message.getSerializedSize();
+                    @Override
+                    public int getSize() {
+                        return size;
+                    }
+                    @Override
+                    public void writeTo(java.io.OutputStream os) throws Exception {
+                        message.writeTo(os);
+                    }
+                };
+            }
+        }, {{inputType}}::parseFrom,
         {{outputType}}::parseFrom);
 {{/clientStreamingMethods}}
 
@@ -101,7 +173,31 @@ public final class {{className}} {
     {{/javaDoc}}
     private static final StubMethodDescriptor {{methodName}}Method = new StubMethodDescriptor("{{originMethodName}}",
         {{inputType}}.class, {{outputType}}.class, MethodDescriptor.RpcType.BI_STREAM,
-        obj -> ((com.google.protobuf.Message) obj).toByteArray(), obj -> ((com.google.protobuf.Message) obj).toByteArray(), {{inputType}}::parseFrom,
+        obj -> ((com.google.protobuf.Message) obj).toByteArray(), new org.apache.dubbo.rpc.model.Pack() {
+            @Override
+            public byte[] pack(Object obj) throws Exception {
+                return ((com.google.protobuf.Message) obj).toByteArray();
+            }
+            @Override
+            public boolean supportsStreamPacking() {
+                return true;
+            }
+            @Override
+            public org.apache.dubbo.rpc.model.PackContext createPackContext(Object obj) throws Exception {
+                final com.google.protobuf.Message message = (com.google.protobuf.Message) obj;
+                return new org.apache.dubbo.rpc.model.PackContext() {
+                    private final int size = message.getSerializedSize();
+                    @Override
+                    public int getSize() {
+                        return size;
+                    }
+                    @Override
+                    public void writeTo(java.io.OutputStream os) throws Exception {
+                        message.writeTo(os);
+                    }
+                };
+            }
+        }, {{inputType}}::parseFrom,
         {{outputType}}::parseFrom);
 {{/biStreamingWithoutClientStreamMethods}}
 

--- a/dubbo-plugin/dubbo-compiler/src/main/resources/ReactorDubbo3TripleStub.mustache
+++ b/dubbo-plugin/dubbo-compiler/src/main/resources/ReactorDubbo3TripleStub.mustache
@@ -71,7 +71,31 @@ public final class {{className}} {
     {{/javaDoc}}
     private static final StubMethodDescriptor {{methodName}}Method = new StubMethodDescriptor("{{originMethodName}}",
         {{inputType}}.class, {{outputType}}.class, MethodDescriptor.RpcType.UNARY,
-        obj -> ((com.google.protobuf.Message) obj).toByteArray(), obj -> ((com.google.protobuf.Message) obj).toByteArray(), {{inputType}}::parseFrom,
+        obj -> ((com.google.protobuf.Message) obj).toByteArray(), new org.apache.dubbo.rpc.model.Pack() {
+            @Override
+            public byte[] pack(Object obj) throws Exception {
+                return ((com.google.protobuf.Message) obj).toByteArray();
+            }
+            @Override
+            public boolean supportsStreamPacking() {
+                return true;
+            }
+            @Override
+            public org.apache.dubbo.rpc.model.PackContext createPackContext(Object obj) throws Exception {
+                final com.google.protobuf.Message message = (com.google.protobuf.Message) obj;
+                return new org.apache.dubbo.rpc.model.PackContext() {
+                    private final int size = message.getSerializedSize();
+                    @Override
+                    public int getSize() {
+                        return size;
+                    }
+                    @Override
+                    public void writeTo(java.io.OutputStream os) throws Exception {
+                        message.writeTo(os);
+                    }
+                };
+            }
+        }, {{inputType}}::parseFrom,
         {{outputType}}::parseFrom);
 {{/unaryMethods}}
 
@@ -81,7 +105,31 @@ public final class {{className}} {
     {{/javaDoc}}
     private static final StubMethodDescriptor {{methodName}}Method = new StubMethodDescriptor("{{originMethodName}}",
         {{inputType}}.class, {{outputType}}.class, MethodDescriptor.RpcType.SERVER_STREAM,
-        obj -> ((com.google.protobuf.Message) obj).toByteArray(), obj -> ((com.google.protobuf.Message) obj).toByteArray(), {{inputType}}::parseFrom,
+        obj -> ((com.google.protobuf.Message) obj).toByteArray(), new org.apache.dubbo.rpc.model.Pack() {
+            @Override
+            public byte[] pack(Object obj) throws Exception {
+                return ((com.google.protobuf.Message) obj).toByteArray();
+            }
+            @Override
+            public boolean supportsStreamPacking() {
+                return true;
+            }
+            @Override
+            public org.apache.dubbo.rpc.model.PackContext createPackContext(Object obj) throws Exception {
+                final com.google.protobuf.Message message = (com.google.protobuf.Message) obj;
+                return new org.apache.dubbo.rpc.model.PackContext() {
+                    private final int size = message.getSerializedSize();
+                    @Override
+                    public int getSize() {
+                        return size;
+                    }
+                    @Override
+                    public void writeTo(java.io.OutputStream os) throws Exception {
+                        message.writeTo(os);
+                    }
+                };
+            }
+        }, {{inputType}}::parseFrom,
         {{outputType}}::parseFrom);
 {{/serverStreamingMethods}}
 
@@ -91,7 +139,31 @@ public final class {{className}} {
     {{/javaDoc}}
     private static final StubMethodDescriptor {{methodName}}Method = new StubMethodDescriptor("{{originMethodName}}",
         {{inputType}}.class, {{outputType}}.class, MethodDescriptor.RpcType.CLIENT_STREAM,
-        obj -> ((com.google.protobuf.Message) obj).toByteArray(), obj -> ((com.google.protobuf.Message) obj).toByteArray(), {{inputType}}::parseFrom,
+        obj -> ((com.google.protobuf.Message) obj).toByteArray(), new org.apache.dubbo.rpc.model.Pack() {
+            @Override
+            public byte[] pack(Object obj) throws Exception {
+                return ((com.google.protobuf.Message) obj).toByteArray();
+            }
+            @Override
+            public boolean supportsStreamPacking() {
+                return true;
+            }
+            @Override
+            public org.apache.dubbo.rpc.model.PackContext createPackContext(Object obj) throws Exception {
+                final com.google.protobuf.Message message = (com.google.protobuf.Message) obj;
+                return new org.apache.dubbo.rpc.model.PackContext() {
+                    private final int size = message.getSerializedSize();
+                    @Override
+                    public int getSize() {
+                        return size;
+                    }
+                    @Override
+                    public void writeTo(java.io.OutputStream os) throws Exception {
+                        message.writeTo(os);
+                    }
+                };
+            }
+        }, {{inputType}}::parseFrom,
         {{outputType}}::parseFrom);
 {{/clientStreamingMethods}}
 
@@ -101,7 +173,31 @@ public final class {{className}} {
     {{/javaDoc}}
     private static final StubMethodDescriptor {{methodName}}Method = new StubMethodDescriptor("{{originMethodName}}",
         {{inputType}}.class, {{outputType}}.class, MethodDescriptor.RpcType.BI_STREAM,
-        obj -> ((com.google.protobuf.Message) obj).toByteArray(), obj -> ((com.google.protobuf.Message) obj).toByteArray(), {{inputType}}::parseFrom,
+        obj -> ((com.google.protobuf.Message) obj).toByteArray(), new org.apache.dubbo.rpc.model.Pack() {
+            @Override
+            public byte[] pack(Object obj) throws Exception {
+                return ((com.google.protobuf.Message) obj).toByteArray();
+            }
+            @Override
+            public boolean supportsStreamPacking() {
+                return true;
+            }
+            @Override
+            public org.apache.dubbo.rpc.model.PackContext createPackContext(Object obj) throws Exception {
+                final com.google.protobuf.Message message = (com.google.protobuf.Message) obj;
+                return new org.apache.dubbo.rpc.model.PackContext() {
+                    private final int size = message.getSerializedSize();
+                    @Override
+                    public int getSize() {
+                        return size;
+                    }
+                    @Override
+                    public void writeTo(java.io.OutputStream os) throws Exception {
+                        message.writeTo(os);
+                    }
+                };
+            }
+        }, {{inputType}}::parseFrom,
         {{outputType}}::parseFrom);
 {{/biStreamingWithoutClientStreamMethods}}
 

--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/PbArrayPacker.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/PbArrayPacker.java
@@ -17,6 +17,9 @@
 package org.apache.dubbo.rpc.protocol.tri;
 
 import org.apache.dubbo.rpc.model.Pack;
+import org.apache.dubbo.rpc.model.PackContext;
+
+import java.io.OutputStream;
 
 import com.google.protobuf.Message;
 
@@ -38,7 +41,45 @@ public class PbArrayPacker implements Pack {
         return PB_PACK.pack(obj);
     }
 
+    @Override
+    public boolean supportsStreamPacking() {
+        return true;
+    }
+
+    @Override
+    public PackContext createPackContext(Object obj) throws Exception {
+        Message message = extractMessage(obj);
+        return new ProtobufPackContext(message);
+    }
+
     public boolean isSingleArgument() {
         return singleArgument;
+    }
+
+    private Message extractMessage(Object obj) {
+        if (!singleArgument) {
+            obj = ((Object[]) obj)[0];
+        }
+        return (Message) obj;
+    }
+
+    private static class ProtobufPackContext implements PackContext {
+        private final Message message;
+        private final int size;
+
+        ProtobufPackContext(Message message) {
+            this.message = message;
+            this.size = message.getSerializedSize();
+        }
+
+        @Override
+        public int getSize() {
+            return size;
+        }
+
+        @Override
+        public void writeTo(OutputStream os) throws Exception {
+            message.writeTo(os);
+        }
     }
 }

--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/PbArrayPacker.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/PbArrayPacker.java
@@ -37,4 +37,8 @@ public class PbArrayPacker implements Pack {
         }
         return PB_PACK.pack(obj);
     }
+
+    public boolean isSingleArgument() {
+        return singleArgument;
+    }
 }

--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/ReflectionPackableMethod.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/ReflectionPackableMethod.java
@@ -50,7 +50,6 @@ public class ReflectionPackableMethod implements PackableMethod {
     private static final String REACTOR_RETURN_CLASS = "reactor.core.publisher.Mono";
     private static final String RX_RETURN_CLASS = "io.reactivex.Single";
     private static final String GRPC_STREAM_CLASS = "io.grpc.stub.StreamObserver";
-    private static final Pack PB_PACK = o -> ((Message) o).toByteArray();
 
     private final Pack requestPack;
     private final Pack responsePack;
@@ -89,7 +88,7 @@ public class ReflectionPackableMethod implements PackableMethod {
         this.needWrapper = needWrap(method, actualRequestTypes, actualResponseType);
         if (!needWrapper) {
             requestPack = new PbArrayPacker(singleArgument);
-            responsePack = PB_PACK;
+            responsePack = new PbArrayPacker(true);
             requestUnpack = new PbUnpack<>(actualRequestTypes[0]);
             responseUnpack = new PbUnpack<>(actualResponseType);
         } else {

--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/ReflectionPackableMethod.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/ReflectionPackableMethod.java
@@ -38,8 +38,6 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.stream.Stream;
 
-import com.google.protobuf.Message;
-
 import static org.apache.dubbo.common.constants.CommonConstants.$ECHO;
 import static org.apache.dubbo.common.utils.ProtobufUtils.isProtobufClass;
 

--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/h12/grpc/GrpcCompositeCodec.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/h12/grpc/GrpcCompositeCodec.java
@@ -16,8 +16,6 @@
  */
 package org.apache.dubbo.rpc.protocol.tri.h12.grpc;
 
-import com.google.protobuf.Message;
-
 import org.apache.dubbo.common.URL;
 import org.apache.dubbo.common.config.ConfigurationUtils;
 import org.apache.dubbo.common.io.StreamUtils;
@@ -43,6 +41,7 @@ import java.io.OutputStream;
 import java.nio.charset.Charset;
 import java.util.concurrent.ConcurrentHashMap;
 
+import com.google.protobuf.Message;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufOutputStream;
 
@@ -121,8 +120,7 @@ public class GrpcCompositeCodec implements HttpMessageCodec {
                 }
             }
 
-
-            outputStream.write(0);  // gRPC compression flag: 0 = identity (no compression)
+            outputStream.write(0); // gRPC compression flag: 0 = identity (no compression)
             byte[] bytes = packableMethod.packResponse(data);
             writeLength(outputStream, bytes.length);
             outputStream.write(bytes);
@@ -165,8 +163,7 @@ public class GrpcCompositeCodec implements HttpMessageCodec {
         }
     }
 
-    private Message extractProtobufMessage(Object data, PbArrayPacker packer)
-            throws ClassCastException {
+    private Message extractProtobufMessage(Object data, PbArrayPacker packer) throws ClassCastException {
         if (!packer.isSingleArgument() && data instanceof Object[]) {
             Object[] arr = (Object[]) data;
             if (arr.length > 0) {

--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/h12/grpc/GrpcCompositeCodec.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/h12/grpc/GrpcCompositeCodec.java
@@ -16,6 +16,8 @@
  */
 package org.apache.dubbo.rpc.protocol.tri.h12.grpc;
 
+import com.google.protobuf.Message;
+
 import org.apache.dubbo.common.URL;
 import org.apache.dubbo.common.config.ConfigurationUtils;
 import org.apache.dubbo.common.io.StreamUtils;
@@ -24,19 +26,25 @@ import org.apache.dubbo.common.utils.ConcurrentHashMapUtils;
 import org.apache.dubbo.common.utils.UrlUtils;
 import org.apache.dubbo.remoting.http12.exception.DecodeException;
 import org.apache.dubbo.remoting.http12.exception.EncodeException;
+import org.apache.dubbo.remoting.http12.exception.HttpOverPayloadException;
 import org.apache.dubbo.remoting.http12.exception.HttpStatusException;
 import org.apache.dubbo.remoting.http12.message.HttpMessageCodec;
 import org.apache.dubbo.remoting.http12.message.MediaType;
 import org.apache.dubbo.rpc.model.FrameworkModel;
 import org.apache.dubbo.rpc.model.MethodDescriptor;
+import org.apache.dubbo.rpc.model.Pack;
 import org.apache.dubbo.rpc.model.PackableMethod;
 import org.apache.dubbo.rpc.model.PackableMethodFactory;
+import org.apache.dubbo.rpc.protocol.tri.PbArrayPacker;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.charset.Charset;
 import java.util.concurrent.ConcurrentHashMap;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufOutputStream;
 
 import static org.apache.dubbo.common.constants.CommonConstants.DEFAULT_KEY;
 import static org.apache.dubbo.common.constants.CommonConstants.DUBBO_PACKABLE_METHOD_FACTORY;
@@ -78,12 +86,43 @@ public class GrpcCompositeCodec implements HttpMessageCodec {
 
     @Override
     public void encode(OutputStream outputStream, Object data, Charset charset) throws EncodeException {
-        // protobuf
-        // TODO int compressed = Identity.MESSAGE_ENCODING.equals(requestMetadata.compressor.getMessageEncoding()) ? 0 :
-        // 1;
         try {
-            int compressed = 0;
-            outputStream.write(compressed);
+            if (packableMethod != null
+                    && !packableMethod.needWrapper()
+                    && outputStream instanceof ByteBufOutputStream) {
+
+                Pack responsePack = packableMethod.getResponsePack();
+
+                if (responsePack instanceof PbArrayPacker) {
+                    PbArrayPacker pbPacker = (PbArrayPacker) responsePack;
+                    ByteBufOutputStream bbos = (ByteBufOutputStream) outputStream;
+                    ByteBuf buffer = bbos.buffer();
+
+                    try {
+                        com.google.protobuf.Message message = extractProtobufMessage(data, pbPacker);
+
+                        int payloadSize = message.getSerializedSize();
+                        int totalSize = 5 + payloadSize;
+                        buffer.ensureWritable(totalSize);
+
+                        // gRPC frame header (5 bytes): 1 byte compression flag + 4 bytes length
+                        buffer.writeByte(0);
+                        buffer.writeInt(payloadSize);
+
+                        message.writeTo(outputStream);
+
+                        return;
+
+                    } catch (IndexOutOfBoundsException | HttpOverPayloadException e) {
+                        if (e instanceof HttpOverPayloadException) {
+                            throw e;
+                        }
+                    }
+                }
+            }
+
+
+            outputStream.write(0);  // gRPC compression flag: 0 = identity (no compression)
             byte[] bytes = packableMethod.packResponse(data);
             writeLength(outputStream, bytes.length);
             outputStream.write(bytes);
@@ -124,6 +163,18 @@ public class GrpcCompositeCodec implements HttpMessageCodec {
         } catch (IOException e) {
             throw new EncodeException(e);
         }
+    }
+
+    private Message extractProtobufMessage(Object data, PbArrayPacker packer)
+            throws ClassCastException {
+        if (!packer.isSingleArgument() && data instanceof Object[]) {
+            Object[] arr = (Object[]) data;
+            if (arr.length > 0) {
+                return (Message) arr[0];
+            }
+            throw new IllegalArgumentException("Empty array data for Protobuf message");
+        }
+        return (Message) data;
     }
 
     @Override

--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/h12/grpc/GrpcCompositeCodec.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/h12/grpc/GrpcCompositeCodec.java
@@ -31,9 +31,9 @@ import org.apache.dubbo.remoting.http12.message.MediaType;
 import org.apache.dubbo.rpc.model.FrameworkModel;
 import org.apache.dubbo.rpc.model.MethodDescriptor;
 import org.apache.dubbo.rpc.model.Pack;
+import org.apache.dubbo.rpc.model.PackContext;
 import org.apache.dubbo.rpc.model.PackableMethod;
 import org.apache.dubbo.rpc.model.PackableMethodFactory;
-import org.apache.dubbo.rpc.protocol.tri.PbArrayPacker;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -41,7 +41,6 @@ import java.io.OutputStream;
 import java.nio.charset.Charset;
 import java.util.concurrent.ConcurrentHashMap;
 
-import com.google.protobuf.Message;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufOutputStream;
 
@@ -92,23 +91,19 @@ public class GrpcCompositeCodec implements HttpMessageCodec {
 
                 Pack responsePack = packableMethod.getResponsePack();
 
-                if (responsePack instanceof PbArrayPacker) {
-                    PbArrayPacker pbPacker = (PbArrayPacker) responsePack;
+                if (responsePack.supportsStreamPacking()) {
                     ByteBufOutputStream bbos = (ByteBufOutputStream) outputStream;
                     ByteBuf buffer = bbos.buffer();
 
                     try {
-                        com.google.protobuf.Message message = extractProtobufMessage(data, pbPacker);
-
-                        int payloadSize = message.getSerializedSize();
+                        PackContext ctx = responsePack.createPackContext(data);
+                        int payloadSize = ctx.getSize();
                         int totalSize = 5 + payloadSize;
                         buffer.ensureWritable(totalSize);
 
-                        // gRPC frame header (5 bytes): 1 byte compression flag + 4 bytes length
                         buffer.writeByte(0);
                         buffer.writeInt(payloadSize);
-
-                        message.writeTo(outputStream);
+                        ctx.writeTo(outputStream);
 
                         return;
 
@@ -120,7 +115,7 @@ public class GrpcCompositeCodec implements HttpMessageCodec {
                 }
             }
 
-            outputStream.write(0); // gRPC compression flag: 0 = identity (no compression)
+            outputStream.write(0);
             byte[] bytes = packableMethod.packResponse(data);
             writeLength(outputStream, bytes.length);
             outputStream.write(bytes);
@@ -161,17 +156,6 @@ public class GrpcCompositeCodec implements HttpMessageCodec {
         } catch (IOException e) {
             throw new EncodeException(e);
         }
-    }
-
-    private Message extractProtobufMessage(Object data, PbArrayPacker packer) throws ClassCastException {
-        if (!packer.isSingleArgument() && data instanceof Object[]) {
-            Object[] arr = (Object[]) data;
-            if (arr.length > 0) {
-                return (Message) arr[0];
-            }
-            throw new IllegalArgumentException("Empty array data for Protobuf message");
-        }
-        return (Message) data;
     }
 
     @Override


### PR DESCRIPTION
The patch implements zero-copy encoding for protobuf responses on the Triple server side. When needWrapper() is false and the stream is a ByteBufOutputStream, the encoder writes the 5-byte gRPC header directly into the buffer and streams the
  Message without creating an intermediate byte[]. To enable that path, ReflectionPackableMethod now exposes a PbArrayPacker for protobuf responses. All non-protobuf/wrapper or compressed cases continue to use the original byte-array fallback.