### PR TITLE
[ISSUE 15635] Add support for Zookeeper-based config center and metadata reporting in Demo

### DIFF
--- a/dubbo-demo/dubbo-demo-api/dubbo-demo-api-consumer/pom.xml
+++ b/dubbo-demo/dubbo-demo-api/dubbo-demo-api-consumer/pom.xml
@@ -48,6 +48,16 @@
     </dependency>
     <dependency>
       <groupId>org.apache.dubbo</groupId>
+      <artifactId>dubbo-configcenter-zookeeper</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.dubbo</groupId>
+      <artifactId>dubbo-metadata-report-zookeeper</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.dubbo</groupId>
       <artifactId>dubbo-rpc-dubbo</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/dubbo-demo/dubbo-demo-api/dubbo-demo-api-consumer/src/main/java/org/apache/dubbo/demo/consumer/Application.java
+++ b/dubbo-demo/dubbo-demo-api/dubbo-demo-api-consumer/src/main/java/org/apache/dubbo/demo/consumer/Application.java
@@ -19,6 +19,8 @@ package org.apache.dubbo.demo.consumer;
 import org.apache.dubbo.api.demo.DemoService;
 import org.apache.dubbo.common.constants.CommonConstants;
 import org.apache.dubbo.config.ApplicationConfig;
+import org.apache.dubbo.config.ConfigCenterConfig;
+import org.apache.dubbo.config.MetadataReportConfig;
 import org.apache.dubbo.config.ProtocolConfig;
 import org.apache.dubbo.config.ReferenceConfig;
 import org.apache.dubbo.config.RegistryConfig;
@@ -31,7 +33,7 @@ import org.slf4j.LoggerFactory;
 public class Application {
     private static final Logger logger = LoggerFactory.getLogger(Application.class);
 
-    private static final String REGISTRY_URL = "zookeeper://127.0.0.1:2181";
+    private static final String ZOOKEEPER_URL = "zookeeper://127.0.0.1:2181";
 
     public static void main(String[] args) {
         runWithBootstrap();
@@ -42,10 +44,15 @@ public class Application {
         reference.setInterface(DemoService.class);
         reference.setGeneric("true");
 
+        ConfigCenterConfig configCenterConfig = new ConfigCenterConfig();
+        configCenterConfig.setAddress(ZOOKEEPER_URL);
+
         DubboBootstrap bootstrap = DubboBootstrap.getInstance();
         bootstrap
                 .application(new ApplicationConfig("dubbo-demo-api-consumer"))
-                .registry(new RegistryConfig(REGISTRY_URL))
+                .configCenter(configCenterConfig)
+                .registry(new RegistryConfig(ZOOKEEPER_URL))
+                .metadataReport(new MetadataReportConfig(ZOOKEEPER_URL))
                 .protocol(new ProtocolConfig(CommonConstants.TRIPLE, -1))
                 .reference(reference)
                 .start();

--- a/dubbo-demo/dubbo-demo-api/dubbo-demo-api-provider/pom.xml
+++ b/dubbo-demo/dubbo-demo-api/dubbo-demo-api-provider/pom.xml
@@ -60,6 +60,16 @@
     </dependency>
     <dependency>
       <groupId>org.apache.dubbo</groupId>
+      <artifactId>dubbo-configcenter-zookeeper</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.dubbo</groupId>
+      <artifactId>dubbo-metadata-report-zookeeper</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.dubbo</groupId>
       <artifactId>dubbo-serialization-hessian2</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/dubbo-demo/dubbo-demo-api/dubbo-demo-api-provider/src/main/java/org/apache/dubbo/demo/provider/Application.java
+++ b/dubbo-demo/dubbo-demo-api/dubbo-demo-api-provider/src/main/java/org/apache/dubbo/demo/provider/Application.java
@@ -19,6 +19,8 @@ package org.apache.dubbo.demo.provider;
 import org.apache.dubbo.api.demo.DemoService;
 import org.apache.dubbo.common.constants.CommonConstants;
 import org.apache.dubbo.config.ApplicationConfig;
+import org.apache.dubbo.config.ConfigCenterConfig;
+import org.apache.dubbo.config.MetadataReportConfig;
 import org.apache.dubbo.config.ProtocolConfig;
 import org.apache.dubbo.config.RegistryConfig;
 import org.apache.dubbo.config.ServiceConfig;
@@ -26,7 +28,7 @@ import org.apache.dubbo.config.bootstrap.DubboBootstrap;
 
 public class Application {
 
-    private static final String REGISTRY_URL = "zookeeper://127.0.0.1:2181";
+    private static final String ZOOKEEPER_URL = "zookeeper://127.0.0.1:2181";
 
     public static void main(String[] args) {
         startWithBootstrap();
@@ -37,10 +39,15 @@ public class Application {
         service.setInterface(DemoService.class);
         service.setRef(new DemoServiceImpl());
 
+        ConfigCenterConfig configCenterConfig = new ConfigCenterConfig();
+        configCenterConfig.setAddress(ZOOKEEPER_URL);
+
         DubboBootstrap bootstrap = DubboBootstrap.getInstance();
         bootstrap
                 .application(new ApplicationConfig("dubbo-demo-api-provider"))
-                .registry(new RegistryConfig(REGISTRY_URL))
+                .configCenter(configCenterConfig)
+                .registry(new RegistryConfig(ZOOKEEPER_URL))
+                .metadataReport(new MetadataReportConfig(ZOOKEEPER_URL))
                 .protocol(new ProtocolConfig(CommonConstants.DUBBO, -1))
                 .service(service)
                 .start()


### PR DESCRIPTION
Currently, dubbo-demo-api-consumer and dubbo-demo-api-provider doesn't have the metadata-report and config-center dependencies like dubbo-metadata-report-zookeeper.

Because of this, when testing the dubbo.application.register-mode = instance mode in dubbo-demo-api-provider, the metadata would be missing in the zookeeper. This would result in the following error when starting dubbo-demo-api-consumer.

It would be better to add dubbo-metadata-report-zookeeper and dubbo-metadata-report-zookeeper to the demo as default. This will be more convenient for debugging.

Please refer to ISSUE [15635](https://github.com/apache/dubbo/issues/15635) for more details.

