### PR TITLE
Unset `DEBIAN_MIRROR` as the test image of Debian was already upgraded from buster to bullseye

### DIFF
--- a/.github/workflows/build-and-test-pr.yml
+++ b/.github/workflows/build-and-test-pr.yml
@@ -343,7 +343,7 @@ jobs:
           CANDIDATE_VERSIONS="dubbo.version:$DUBBO_VERSION;compiler.version:$DUBBO_VERSION;$CANDIDATE_VERSIONS;dubbo.compiler.version:$DUBBO_VERSION"
           echo "CANDIDATE_VERSIONS=$CANDIDATE_VERSIONS" >> $GITHUB_ENV
       - name: "Build test image"
-        run: cd test && bash -c 'DEBIAN_MIRROR=http://archive.debian.org/debian-archive ./build-test-image.sh'
+        run: cd test && bash -c ./build-test-image.sh
       - name: "Run tests"
         run: cd test && bash ./run-tests.sh
       - name: "merge jacoco result"
@@ -458,7 +458,7 @@ jobs:
           CANDIDATE_VERSIONS="dubbo.version:$DUBBO_VERSION;compiler.version:$DUBBO_VERSION;$CANDIDATE_VERSIONS;dubbo.compiler.version:$DUBBO_VERSION"
           echo "CANDIDATE_VERSIONS=$CANDIDATE_VERSIONS" >> $GITHUB_ENV
       - name: "Build test image"
-        run: cd test && bash -c 'DEBIAN_MIRROR=http://archive.debian.org/debian-archive ./build-test-image.sh'
+        run: cd test && bash -c ./build-test-image.sh
       - name: "Run tests"
         run: cd test && bash ./run-tests.sh
       - name: "merge jacoco result"

--- a/.github/workflows/build-and-test-scheduled-3.1.yml
+++ b/.github/workflows/build-and-test-scheduled-3.1.yml
@@ -288,7 +288,7 @@ jobs:
           echo "CANDIDATE_VERSIONS=$CANDIDATE_VERSIONS" >> $GITHUB_ENV
       - name: "Build test image"
         run: |
-          cd test && bash -c 'DEBIAN_MIRROR=http://archive.debian.org/debian-archive ./build-test-image.sh'
+          cd test && bash -c ./build-test-image.sh
       - name: "Run tests"
         run: cd test && bash ./run-tests.sh
       - name: "Upload test logs"
@@ -394,7 +394,7 @@ jobs:
           echo "CANDIDATE_VERSIONS=$CANDIDATE_VERSIONS" >> $GITHUB_ENV
       - name: "Build test image"
         run: |
-          cd test && bash -c 'DEBIAN_MIRROR=http://archive.debian.org/debian-archive ./build-test-image.sh'
+          cd test && bash -c ./build-test-image.sh
       - name: "Run tests"
         run: cd test && bash ./run-tests.sh
       - name: "Upload test logs"

--- a/.github/workflows/build-and-test-scheduled-3.2.yml
+++ b/.github/workflows/build-and-test-scheduled-3.2.yml
@@ -288,7 +288,7 @@ jobs:
           echo "CANDIDATE_VERSIONS=$CANDIDATE_VERSIONS" >> $GITHUB_ENV
       - name: "Build test image"
         run: |
-          cd test && bash -c 'DEBIAN_MIRROR=http://archive.debian.org/debian-archive ./build-test-image.sh'
+          cd test && bash -c ./build-test-image.sh
       - name: "Run tests"
         run: cd test && bash ./run-tests.sh
       - name: "Upload test logs"
@@ -394,7 +394,7 @@ jobs:
           echo "CANDIDATE_VERSIONS=$CANDIDATE_VERSIONS" >> $GITHUB_ENV
       - name: "Build test image"
         run: |
-          cd test && bash -c 'DEBIAN_MIRROR=http://archive.debian.org/debian-archive ./build-test-image.sh'
+          cd test && bash -c ./build-test-image.sh
       - name: "Run tests"
         run: cd test && bash ./run-tests.sh
       - name: "Upload test logs"

--- a/.github/workflows/build-and-test-scheduled-3.3.yml
+++ b/.github/workflows/build-and-test-scheduled-3.3.yml
@@ -288,7 +288,7 @@ jobs:
           echo "CANDIDATE_VERSIONS=$CANDIDATE_VERSIONS" >> $GITHUB_ENV
       - name: "Build test image"
         run: |
-          cd test && bash -c 'DEBIAN_MIRROR=http://archive.debian.org/debian-archive ./build-test-image.sh'
+          cd test && bash -c ./build-test-image.sh
       - name: "Run tests"
         run: cd test && bash ./run-tests.sh
       - name: "Upload test logs"
@@ -394,7 +394,7 @@ jobs:
           echo "CANDIDATE_VERSIONS=$CANDIDATE_VERSIONS" >> $GITHUB_ENV
       - name: "Build test image"
         run: |
-          cd test && bash -c 'DEBIAN_MIRROR=http://archive.debian.org/debian-archive ./build-test-image.sh'
+          cd test && bash -c ./build-test-image.sh
       - name: "Run tests"
         run: cd test && bash ./run-tests.sh
       - name: "Upload test logs"

--- a/.github/workflows/release-test.yml
+++ b/.github/workflows/release-test.yml
@@ -283,7 +283,7 @@ jobs:
           echo "CANDIDATE_VERSIONS=$CANDIDATE_VERSIONS" >> $GITHUB_ENV
       - name: "Build test image"
         run: |
-          cd test && bash -c 'DEBIAN_MIRROR=http://archive.debian.org/debian-archive ./build-test-image.sh'
+          cd test && bash -c ./build-test-image.sh
       - name: "Run tests"
         run: cd test && bash ./run-tests.sh
       - name: "Upload test result"
@@ -383,7 +383,7 @@ jobs:
           echo "CANDIDATE_VERSIONS=$CANDIDATE_VERSIONS" >> $GITHUB_ENV
       - name: "Build test image"
         run: |
-          cd test && bash -c 'DEBIAN_MIRROR=http://archive.debian.org/debian-archive ./build-test-image.sh'
+          cd test && bash -c ./build-test-image.sh
       - name: "Run tests"
         run: cd test && bash ./run-tests.sh
       - name: "Upload test result"


### PR DESCRIPTION
## What is the purpose of the change?
Unset ```DEBIAN_MIRROR``` which was set  in the workflow files.
```DEBIAN_MIRROR``` should not be set in dubbo workflows because the docker image name of ```dubbo-samples``` and ```dubbo-integration-cases``` was upgraded to ```bullseye```.
Debian changed the archive URL again, we don't know whether current Debian archive URL is temporary or not,  so it might be better to upgrade the test docker image version to the lastest - ```bullseye```. 

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Make sure gitHub actions can pass. [Why the workflow is failing and how to fix it?](../CONTRIBUTING.md)
