### PR TITLE
Fix AbortPolicyWithReportTest as `con` could be used as a directory name in latest Windows server 2025 

### DIFF
--- a/dubbo-common/src/test/java/org/apache/dubbo/common/threadpool/support/AbortPolicyWithReportTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/threadpool/support/AbortPolicyWithReportTest.java
@@ -156,9 +156,9 @@ class AbortPolicyWithReportTest {
         final String os =
                 SystemPropertyConfigUtils.getSystemProperty(SYSTEM_OS_NAME).toLowerCase();
         if (os.contains(OS_WIN_PREFIX)) {
-            // "con" is one of Windows reserved names,
+            // colon is a reserved character which could not be used in a file or directory name,
             // https://docs.microsoft.com/en-us/windows/win32/fileio/naming-a-file
-            return "con";
+            return "c:o:n";
         } else {
             return "/dev/full/" + UUID.randomUUID().toString();
         }


### PR DESCRIPTION
## What is the purpose of the change?
AbortPolicyWithReportTest will always fail at Microsoft Windows Server 2025 10.0.26100,
```
Error:  Failures: 
Error:    AbortPolicyWithReportTest.jStackDumpTest_dumpDirectoryNotExists_cannotBeCreatedTakeUserHome:151 expected: <C:\Users\runneradmin> but was: <con>
```

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Make sure gitHub actions can pass. [Why the workflow is failing and how to fix it?](../CONTRIBUTING.md)
