### PR TITLE
Prolong the timeout parameters of Zookeeper download for unit test at latest Windows server

### DIFF
--- a/dubbo-test/dubbo-test-check/src/main/java/org/apache/dubbo/test/check/registrycenter/initializer/DownloadZookeeperInitializer.java
+++ b/dubbo-test/dubbo-test-check/src/main/java/org/apache/dubbo/test/check/registrycenter/initializer/DownloadZookeeperInitializer.java
@@ -71,7 +71,7 @@ public class DownloadZookeeperInitializer extends ZookeeperInitializer {
     /**
      * The timeout when connect the download url.
      */
-    private static final int CONNECT_TIMEOUT = 10 * 1000;
+    private static final int CONNECT_TIMEOUT = 60 * 1000;
 
     /**
      * Returns {@code true} if the file exists with the given file path, otherwise {@code false}.

--- a/dubbo-test/dubbo-test-check/src/main/java/org/apache/dubbo/test/check/registrycenter/initializer/DownloadZookeeperInitializer.java
+++ b/dubbo-test/dubbo-test-check/src/main/java/org/apache/dubbo/test/check/registrycenter/initializer/DownloadZookeeperInitializer.java
@@ -66,7 +66,7 @@ public class DownloadZookeeperInitializer extends ZookeeperInitializer {
     /**
      * The timeout when download zookeeper binary archive file.
      */
-    private static final int REQUEST_TIMEOUT = 30 * 1000;
+    private static final int REQUEST_TIMEOUT = 180 * 1000;
 
     /**
      * The timeout when connect the download url.

--- a/dubbo-test/dubbo-test-check/src/main/java/org/apache/dubbo/test/check/registrycenter/initializer/DownloadZookeeperInitializer.java
+++ b/dubbo-test/dubbo-test-check/src/main/java/org/apache/dubbo/test/check/registrycenter/initializer/DownloadZookeeperInitializer.java
@@ -198,7 +198,8 @@ public class DownloadZookeeperInitializer extends ZookeeperInitializer {
                                 TESTING_REGISTRY_FAILED_TO_DOWNLOAD_ZK_FILE,
                                 "",
                                 "",
-                                "Failed to download the file, download url: " + url);
+                                "Failed to download the file, download url: " + url,
+                                t);
                         super.onThrowable(t);
                     }
                 });


### PR DESCRIPTION
## What is the purpose of the change?
There are timeout issues of Zookeeper binary download which might occur in the workflow actions which run at latest Windows server,
1. the download time might exceed 30 seconds,
```
2025-09-06T13:33:55.6304496Z The zookeeper binary archive file will be download from https://archive.apache.org/dist/zookeeper/zookeeper-3.6.0/apache-zookeeper-3.6.0-bin.tar.gz,
2025-09-06T13:33:55.6306075Z which will be saved in C:\Users\RUNNER~1\AppData\Local\Temp\zookeeper\apache-zookeeper-3.6.0-bin.tar.gz,
2025-09-06T13:33:55.6307411Z also it will be renamed to 'apache-zookeeper-bin.tar.gz' and moved into D:\a\dubbo\dubbo\.tmp\zookeeper\apache-zookeeper-bin.tar.gz.
2025-09-06T13:33:55.6308501Z , dubbo version: 3.3.6-SNAPSHOT, current host: 172.29.176.1
2025-09-06T13:34:26.2156195Z Sep 06, 2025 1:34:26 PM org.junit.platform.launcher.core.CompositeTestExecutionListener lambda$notifyEach$21
2025-09-06T13:34:26.2157758Z WARNING: TestExecutionListener [org.apache.dubbo.test.check.RegistryCenterStarted] threw exception for method: testPlanExecutionStarted(org.junit.platform.launcher.TestPlan@1c68601b)
2025-09-06T13:34:26.2159656Z java.lang.IllegalStateException: Failed to start zookeeper instance in unit test
2025-09-06T13:34:26.2160950Z 	at org.apache.dubbo.test.check.RegistryCenterStarted.testPlanExecutionStarted(RegistryCenterStarted.java:37)
2025-09-06T13:34:26.2162614Z 	at org.junit.platform.launcher.core.CompositeTestExecutionListener.lambda$testPlanExecutionStarted$12(CompositeTestExecutionListener.java:81)
2025-09-06T13:34:26.2164368Z 	at org.junit.platform.launcher.core.CompositeTestExecutionListener.lambda$notifyEach$21(CompositeTestExecutionListener.java:110)
2025-09-06T13:34:26.2165442Z 	at java.util.ArrayList.forEach(ArrayList.java:1259)
2025-09-06T13:34:26.2166129Z 	at org.junit.platform.launcher.core.IterationOrder$1.forEach(IterationOrder.java:23)
2025-09-06T13:34:26.2167368Z 	at org.junit.platform.launcher.core.CompositeTestExecutionListener.notifyEach(CompositeTestExecutionListener.java:108)
2025-09-06T13:34:26.2169086Z 	at org.junit.platform.launcher.core.CompositeTestExecutionListener.testPlanExecutionStarted(CompositeTestExecutionListener.java:80)
2025-09-06T13:34:26.2170700Z 	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:96)
2025-09-06T13:34:26.2172164Z 	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.lambda$execute$0(EngineExecutionOrchestrator.java:64)
2025-09-06T13:34:26.2173800Z 	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.withInterceptedStreams(EngineExecutionOrchestrator.java:150)
2025-09-06T13:34:26.2199113Z 	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:63)
2025-09-06T13:34:26.2200311Z 	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:109)
2025-09-06T13:34:26.2201465Z 	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:91)
2025-09-06T13:34:26.2202469Z 	at org.junit.platform.launcher.core.DelegatingLauncher.execute(DelegatingLauncher.java:47)
2025-09-06T13:34:26.2204381Z 	at org.junit.platform.launcher.core.InterceptingLauncher.lambda$execute$1(InterceptingLauncher.java:39)
2025-09-06T13:34:26.2206036Z 	at org.junit.platform.launcher.core.ClasspathAlignmentCheckingLauncherInterceptor.intercept(ClasspathAlignmentCheckingLauncherInterceptor.java:25)
2025-09-06T13:34:26.2207605Z 	at org.junit.platform.launcher.core.InterceptingLauncher.execute(InterceptingLauncher.java:38)
2025-09-06T13:34:26.2208661Z 	at org.junit.platform.launcher.core.DelegatingLauncher.execute(DelegatingLauncher.java:47)
2025-09-06T13:34:26.2209647Z 	at org.apache.maven.surefire.junitplatform.LazyLauncher.execute(LazyLauncher.java:56)
2025-09-06T13:34:26.2210818Z 	at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.execute(JUnitPlatformProvider.java:194)
2025-09-06T13:34:26.2212161Z 	at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.invokeAllTests(JUnitPlatformProvider.java:150)
2025-09-06T13:34:26.2213471Z 	at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.invoke(JUnitPlatformProvider.java:124)
2025-09-06T13:34:26.2214621Z 	at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:385)
2025-09-06T13:34:26.2215543Z 	at org.apache.maven.surefire.booter.ForkedBooter.execute(ForkedBooter.java:162)
2025-09-06T13:34:26.2216347Z 	at org.apache.maven.surefire.booter.ForkedBooter.run(ForkedBooter.java:507)
2025-09-06T13:34:26.2217389Z 	at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:495)
2025-09-06T13:34:26.2219411Z Caused by: java.lang.RuntimeException: Download zookeeper binary archive failed, download url:https://archive.apache.org/dist/zookeeper/zookeeper-3.6.0/apache-zookeeper-3.6.0-bin.tar.gz, file path:C:\Users\RUNNER~1\AppData\Local\Temp\zookeeper\apache-zookeeper-3.6.0-bin.tar.gz.
2025-09-06T13:34:26.2221151Z Or you can do something to avoid this problem as below:
2025-09-06T13:34:26.2221725Z 1. Download zookeeper binary archive manually regardless of the version
2025-09-06T13:34:26.2222617Z 2. Rename the downloaded file named 'apache-zookeeper-{version}-bin.tar.gz' to 'apache-zookeeper-bin.tar.gz'
2025-09-06T13:34:26.2223841Z 3. Put the renamed file in D:\a\dubbo\dubbo\.tmp\zookeeper\apache-zookeeper-bin.tar.gz, you maybe need to create the directory if necessary.
2025-09-06T13:34:26.2224555Z 
2025-09-06T13:34:26.2225419Z 	at org.apache.dubbo.test.check.registrycenter.initializer.DownloadZookeeperInitializer.doInitialize(DownloadZookeeperInitializer.java:125)
2025-09-06T13:34:26.2227124Z 	at org.apache.dubbo.test.check.registrycenter.initializer.ZookeeperInitializer.initialize(ZookeeperInitializer.java:41)
2025-09-06T13:34:26.2228606Z 	at org.apache.dubbo.test.check.registrycenter.ZookeeperRegistryCenter.startup(ZookeeperRegistryCenter.java:225)
2025-09-06T13:34:26.2229971Z 	at org.apache.dubbo.test.check.registrycenter.GlobalRegistryCenter.startup(GlobalRegistryCenter.java:35)
2025-09-06T13:34:26.2231329Z 	at org.apache.dubbo.test.check.RegistryCenterStarted.testPlanExecutionStarted(RegistryCenterStarted.java:34)
2025-09-06T13:34:26.2232185Z 	... 25 more
2025-09-06T13:34:26.2233185Z Caused by: java.util.concurrent.ExecutionException: java.util.concurrent.TimeoutException: Request timeout to archive.apache.org/65.108.204.189:443 after 30000 ms
```

3. the connection time might exceed 10 seconds,
```
2025-09-06T16:22:58.9225796Z The zookeeper binary archive file will be download from https://archive.apache.org/dist/zookeeper/zookeeper-3.6.0/apache-zookeeper-3.6.0-bin.tar.gz,
2025-09-06T16:22:58.9228138Z which will be saved in C:\Users\RUNNER~1\AppData\Local\Temp\zookeeper\apache-zookeeper-3.6.0-bin.tar.gz,
2025-09-06T16:22:58.9229435Z also it will be renamed to 'apache-zookeeper-bin.tar.gz' and moved into D:\a\dubbo\dubbo\.tmp\zookeeper\apache-zookeeper-bin.tar.gz.
2025-09-06T16:22:58.9230462Z , dubbo version: 3.3.6-SNAPSHOT, current host: 172.28.208.1
2025-09-06T16:23:09.6673388Z Sep 06, 2025 4:23:09 PM org.junit.platform.launcher.core.CompositeTestExecutionListener lambda$notifyEach$21
2025-09-06T16:23:09.6675263Z 16:23:09.551 |-WARN  [AsyncHttpClient-3-1] initializer.DownloadZookeeperInitializer:    -|  [DUBBO] Failed to download the file, download url: https://archive.apache.org/dist/zookeeper/zookeeper-3.6.0/apache-zookeeper-3.6.0-bin.tar.gz, dubbo version: 3.3.6-SNAPSHOT, current host: 172.28.208.1, error code: 81-3. This may be caused by , go to https://dubbo.apache.org/faq/81/3 to find instructions. 
2025-09-06T16:23:09.6678964Z io.netty.channel.ConnectTimeoutException: connection timed out after 10000 ms: archive.apache.org/65.108.204.189:443
2025-09-06T16:23:09.6680413Z 	at io.netty.channel.nio.AbstractNioChannel$AbstractNioUnsafe$1.run(AbstractNioChannel.java:308) ~[netty-transport-4.2.2.Final.jar:4.2.2.Final]
2025-09-06T16:23:09.6681445Z 	... 10 more
2025-09-06T16:23:09.6682143Z Wrapped by: java.net.ConnectException: connection timed out after 10000 ms: archive.apache.org/65.108.204.189:443
```

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Make sure gitHub actions can pass. [Why the workflow is failing and how to fix it?](../CONTRIBUTING.md)
