### PR TITLE
[ISSUE 15677] Support method level TPS in `DefaultTPSLimiter`

### DIFF
--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/filter/tps/DefaultTPSLimiter.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/filter/tps/DefaultTPSLimiter.java
@@ -39,27 +39,31 @@ public class DefaultTPSLimiter implements TPSLimiter {
 
     @Override
     public boolean isAllowable(URL url, Invocation invocation) {
+        boolean isMethodLevelTpsConfigured = url.hasMethodParameter(RpcUtils.getMethodName(invocation), TPS_LIMIT_RATE_KEY);
+        String key = isMethodLevelTpsConfigured
+                ? url.getServiceKey() + "#" + RpcUtils.getMethodName(invocation)
+                : url.getServiceKey();
         int rate = url.getMethodParameter(RpcUtils.getMethodName(invocation), TPS_LIMIT_RATE_KEY, -1);
         long interval = url.getMethodParameter(
                 RpcUtils.getMethodName(invocation), TPS_LIMIT_INTERVAL_KEY, DEFAULT_TPS_LIMIT_INTERVAL);
-        String serviceKey = url.getServiceKey();
+
         if (rate > 0) {
-            StatItem statItem = stats.get(serviceKey);
+            StatItem statItem = stats.get(key);
             if (statItem == null) {
-                stats.putIfAbsent(serviceKey, new StatItem(serviceKey, rate, interval));
-                statItem = stats.get(serviceKey);
+                stats.putIfAbsent(key, new StatItem(key, rate, interval));
+                statItem = stats.get(key);
             } else {
                 // rate or interval has changed, rebuild
                 if (statItem.getRate() != rate || statItem.getInterval() != interval) {
-                    stats.put(serviceKey, new StatItem(serviceKey, rate, interval));
-                    statItem = stats.get(serviceKey);
+                    stats.put(key, new StatItem(key, rate, interval));
+                    statItem = stats.get(key);
                 }
             }
             return statItem.isAllowable();
         } else {
-            StatItem statItem = stats.get(serviceKey);
+            StatItem statItem = stats.get(key);
             if (statItem != null) {
-                stats.remove(serviceKey);
+                stats.remove(key);
             }
         }
 

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/filter/tps/DefaultTPSLimiter.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/filter/tps/DefaultTPSLimiter.java
@@ -39,7 +39,8 @@ public class DefaultTPSLimiter implements TPSLimiter {
 
     @Override
     public boolean isAllowable(URL url, Invocation invocation) {
-        boolean isMethodLevelTpsConfigured = url.hasMethodParameter(RpcUtils.getMethodName(invocation), TPS_LIMIT_RATE_KEY);
+        boolean isMethodLevelTpsConfigured =
+                url.hasMethodParameter(RpcUtils.getMethodName(invocation), TPS_LIMIT_RATE_KEY);
         String key = isMethodLevelTpsConfigured
                 ? url.getServiceKey() + "#" + RpcUtils.getMethodName(invocation)
                 : url.getServiceKey();


### PR DESCRIPTION
Please refer to issue [15677](https://github.com/apache/dubbo/issues/15677) for more details.

Although I can now configure tps on a method level, the stats map in `DefaultTPSLimiter` is still using `serviceKey` as the key. So the method-level TPS doesn't work. For example, if I configure different TPS numbers on different methods, they are actually sharing the same StatItem, which is obtained by the service key.

Here is what I have done:

1. The key of StatItem Map should be `serviceKey + method` if the tps is configured for a method. Otherwise, uses `serviceKey`. TPS for a method has a higher priority than for a service.
2. Add tests for method-level tps precedence and isolation. 