### PR TITLE
Specify the jsr310 time format based on the configuration when generic invoke

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/convert/jsr310/AbstractTemporalAccessorConverter.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/convert/jsr310/AbstractTemporalAccessorConverter.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.common.convert.jsr310;
+
+import org.apache.dubbo.common.utils.CollectionUtils;
+
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.TemporalAccessor;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.BiFunction;
+
+public abstract class AbstractTemporalAccessorConverter {
+
+    private final List<DateTimeFormatter> dateTimeFormatterList;
+
+    public AbstractTemporalAccessorConverter() {
+        this.dateTimeFormatterList = Collections.emptyList();
+    }
+
+    public AbstractTemporalAccessorConverter(List<DateTimeFormatter> dateTimeFormatterList) {
+        this.dateTimeFormatterList = dateTimeFormatterList;
+    }
+
+    public Object generalize(TemporalAccessor accessor) {
+        if (CollectionUtils.isNotEmpty(dateTimeFormatterList)) {
+            for (DateTimeFormatter dateTimeFormatter : dateTimeFormatterList) {
+                try {
+                    return dateTimeFormatter.format(accessor);
+                } catch (Exception ignore) {
+                }
+            }
+        }
+        return accessor.toString();
+    }
+
+    public <T extends TemporalAccessor> T realize(
+            Object obj, BiFunction<String, DateTimeFormatter, T> parse, DateTimeFormatter defaultDateTimeFormatter) {
+        String text = obj.toString();
+        if (CollectionUtils.isNotEmpty(dateTimeFormatterList)) {
+            for (DateTimeFormatter dateTimeFormatter : dateTimeFormatterList) {
+                try {
+                    return parse.apply(text, dateTimeFormatter);
+                } catch (Exception ignore) {
+                }
+            }
+        }
+        return parse.apply(text, defaultDateTimeFormatter);
+    }
+}

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/convert/jsr310/DefaultLocalDateConverter.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/convert/jsr310/DefaultLocalDateConverter.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.common.convert.jsr310;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+public class DefaultLocalDateConverter extends AbstractTemporalAccessorConverter implements LocalDateConverter {
+
+    public DefaultLocalDateConverter() {}
+
+    public DefaultLocalDateConverter(List<DateTimeFormatter> dateTimeFormatterSet) {
+        super(dateTimeFormatterSet);
+    }
+
+    @Override
+    public Object generalize(LocalDate localDate) {
+        return super.generalize(localDate);
+    }
+
+    @Override
+    public LocalDate realize(Object obj) {
+        return super.realize(obj, LocalDate::parse, DateTimeFormatter.ISO_LOCAL_DATE);
+    }
+}

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/convert/jsr310/DefaultLocalDateTimeConverter.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/convert/jsr310/DefaultLocalDateTimeConverter.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.common.convert.jsr310;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+public class DefaultLocalDateTimeConverter extends AbstractTemporalAccessorConverter implements LocalDateTimeConverter {
+
+    public DefaultLocalDateTimeConverter() {}
+
+    public DefaultLocalDateTimeConverter(List<DateTimeFormatter> dateTimeFormatterSet) {
+        super(dateTimeFormatterSet);
+    }
+
+    @Override
+    public Object generalize(LocalDateTime localDateTime) {
+        return super.generalize(localDateTime);
+    }
+
+    @Override
+    public LocalDateTime realize(Object obj) {
+        return super.realize(obj, LocalDateTime::parse, DateTimeFormatter.ISO_LOCAL_DATE_TIME);
+    }
+}

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/convert/jsr310/DefaultLocalTimeConverter.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/convert/jsr310/DefaultLocalTimeConverter.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.common.convert.jsr310;
+
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+public class DefaultLocalTimeConverter extends AbstractTemporalAccessorConverter implements LocalTimeConverter {
+
+    public DefaultLocalTimeConverter() {}
+
+    public DefaultLocalTimeConverter(List<DateTimeFormatter> dateTimeFormatterSet) {
+        super(dateTimeFormatterSet);
+    }
+
+    @Override
+    public Object generalize(LocalTime localTime) {
+        return super.generalize(localTime);
+    }
+
+    @Override
+    public LocalTime realize(Object obj) {
+        return super.realize(obj, LocalTime::parse, DateTimeFormatter.ISO_LOCAL_TIME);
+    }
+}

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/convert/jsr310/Jsr310Converter.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/convert/jsr310/Jsr310Converter.java
@@ -21,5 +21,4 @@ public interface Jsr310Converter<T> {
     Object generalize(T t);
 
     T realize(Object obj);
-
 }

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/convert/jsr310/Jsr310Converter.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/convert/jsr310/Jsr310Converter.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.common.convert.jsr310;
+
+public interface Jsr310Converter<T> {
+
+    Object generalize(T t);
+
+    T realize(Object obj);
+
+}

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/convert/jsr310/LocalDateConverter.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/convert/jsr310/LocalDateConverter.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.common.convert.jsr310;
+
+import org.apache.dubbo.common.extension.SPI;
+
+import java.time.LocalDate;
+
+@SPI("default")
+public interface LocalDateConverter extends Jsr310Converter<LocalDate> {}

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/convert/jsr310/LocalDateTimeConverter.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/convert/jsr310/LocalDateTimeConverter.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.common.convert.jsr310;
+
+import org.apache.dubbo.common.extension.SPI;
+
+import java.time.LocalDateTime;
+
+@SPI("default")
+public interface LocalDateTimeConverter extends Jsr310Converter<LocalDateTime> {}

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/convert/jsr310/LocalTimeConverter.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/convert/jsr310/LocalTimeConverter.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.common.convert.jsr310;
+
+import org.apache.dubbo.common.extension.SPI;
+
+import java.time.LocalTime;
+
+@SPI("default")
+public interface LocalTimeConverter extends Jsr310Converter<LocalTime> {}

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/utils/PojoUtils.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/utils/PojoUtils.java
@@ -18,6 +18,11 @@ package org.apache.dubbo.common.utils;
 
 import org.apache.dubbo.common.config.ConfigurationUtils;
 import org.apache.dubbo.common.constants.CommonConstants;
+import org.apache.dubbo.common.convert.jsr310.Jsr310Converter;
+import org.apache.dubbo.common.convert.jsr310.LocalDateConverter;
+import org.apache.dubbo.common.convert.jsr310.LocalDateTimeConverter;
+import org.apache.dubbo.common.convert.jsr310.LocalTimeConverter;
+import org.apache.dubbo.common.extension.ExtensionLoader;
 import org.apache.dubbo.common.logger.ErrorTypeAwareLogger;
 import org.apache.dubbo.common.logger.LoggerFactory;
 import org.apache.dubbo.rpc.model.ApplicationModel;
@@ -100,6 +105,20 @@ public class PojoUtils {
             Boolean.class,
             Character.class);
 
+    private static final Map<Class<?>, Jsr310Converter> JSR_310_CONVERTER_CACHE = new ConcurrentHashMap<>();
+
+    static {
+        registerJsr310Converter(
+                LocalDateTime.class,
+                ExtensionLoader.getExtensionLoader(LocalDateTimeConverter.class).getDefaultExtension());
+        registerJsr310Converter(
+                LocalDate.class,
+                ExtensionLoader.getExtensionLoader(LocalDateConverter.class).getDefaultExtension());
+        registerJsr310Converter(
+                LocalTime.class,
+                ExtensionLoader.getExtensionLoader(LocalTimeConverter.class).getDefaultExtension());
+    }
+
     public static Object[] generalize(Object[] objs) {
         Object[] dests = new Object[objs.length];
         for (int i = 0; i < objs.length; i++) {
@@ -145,8 +164,10 @@ public class PojoUtils {
         if (pojo instanceof Enum<?>) {
             return ((Enum<?>) pojo).name();
         }
-        if (pojo.getClass().isArray()
-                && Enum.class.isAssignableFrom(pojo.getClass().getComponentType())) {
+
+        Class<?> pojoClazz = pojo.getClass();
+        if (pojoClazz.isArray()
+                && Enum.class.isAssignableFrom(pojoClazz.getComponentType())) {
             int len = Array.getLength(pojo);
             String[] values = new String[len];
             for (int i = 0; i < len; i++) {
@@ -155,12 +176,12 @@ public class PojoUtils {
             return values;
         }
 
-        if (ReflectUtils.isPrimitives(pojo.getClass())) {
+        if (ReflectUtils.isPrimitives(pojoClazz)) {
             return pojo;
         }
 
-        if (pojo instanceof LocalDate || pojo instanceof LocalDateTime || pojo instanceof LocalTime) {
-            return pojo.toString();
+        if (JSR_310_CONVERTER_CACHE.containsKey(pojoClazz)) {
+            return JSR_310_CONVERTER_CACHE.get(pojoClazz).generalize(pojoClazz.cast(pojo));
         }
 
         if (pojo instanceof Class) {
@@ -173,7 +194,7 @@ public class PojoUtils {
         }
         history.put(pojo, pojo);
 
-        if (pojo.getClass().isArray()) {
+        if (pojoClazz.isArray()) {
             int len = Array.getLength(pojo);
             Object[] dest = new Object[len];
             history.put(pojo, dest);
@@ -205,9 +226,9 @@ public class PojoUtils {
         Map<String, Object> map = new HashMap<>();
         history.put(pojo, map);
         if (GENERIC_WITH_CLZ) {
-            map.put("class", pojo.getClass().getName());
+            map.put("class", pojoClazz.getName());
         }
-        for (Method method : pojo.getClass().getMethods()) {
+        for (Method method : pojoClazz.getMethods()) {
             if (ReflectUtils.isBeanPropertyReadMethod(method)) {
                 ReflectUtils.makeAccessible(method);
                 try {
@@ -220,7 +241,7 @@ public class PojoUtils {
             }
         }
         // public field
-        for (Field field : pojo.getClass().getFields()) {
+        for (Field field : pojoClazz.getFields()) {
             if (ReflectUtils.isPublicInstanceField(field)) {
                 try {
                     Object fieldValue = field.get(pojo);
@@ -360,6 +381,10 @@ public class PojoUtils {
 
         if (type != null && type.isEnum() && pojo.getClass() == String.class) {
             return Enum.valueOf((Class<Enum>) type, (String) pojo);
+        }
+
+        if (null != type && JSR_310_CONVERTER_CACHE.containsKey(type)) {
+            return JSR_310_CONVERTER_CACHE.get(type).realize(pojo);
         }
 
         if (ReflectUtils.isPrimitives(pojo.getClass())
@@ -904,5 +929,9 @@ public class PojoUtils {
             // ignore other type currently
             return null;
         }
+    }
+
+    public static <T> void registerJsr310Converter(Class<T> clazz, Jsr310Converter<T> jsr310Converter) {
+        JSR_310_CONVERTER_CACHE.put(clazz, jsr310Converter);
     }
 }

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/utils/PojoUtils.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/utils/PojoUtils.java
@@ -166,8 +166,7 @@ public class PojoUtils {
         }
 
         Class<?> pojoClazz = pojo.getClass();
-        if (pojoClazz.isArray()
-                && Enum.class.isAssignableFrom(pojoClazz.getComponentType())) {
+        if (pojoClazz.isArray() && Enum.class.isAssignableFrom(pojoClazz.getComponentType())) {
             int len = Array.getLength(pojo);
             String[] values = new String[len];
             for (int i = 0; i < len; i++) {

--- a/dubbo-common/src/main/resources/META-INF/dubbo/internal/org.apache.dubbo.common.convert.jsr310.LocalDateConverter
+++ b/dubbo-common/src/main/resources/META-INF/dubbo/internal/org.apache.dubbo.common.convert.jsr310.LocalDateConverter
@@ -1,0 +1,1 @@
+default=org.apache.dubbo.common.convert.jsr310.DefaultLocalDateConverter

--- a/dubbo-common/src/main/resources/META-INF/dubbo/internal/org.apache.dubbo.common.convert.jsr310.LocalDateTimeConverter
+++ b/dubbo-common/src/main/resources/META-INF/dubbo/internal/org.apache.dubbo.common.convert.jsr310.LocalDateTimeConverter
@@ -1,0 +1,1 @@
+default=org.apache.dubbo.common.convert.jsr310.DefaultLocalDateTimeConverter

--- a/dubbo-common/src/main/resources/META-INF/dubbo/internal/org.apache.dubbo.common.convert.jsr310.LocalTimeConverter
+++ b/dubbo-common/src/main/resources/META-INF/dubbo/internal/org.apache.dubbo.common.convert.jsr310.LocalTimeConverter
@@ -1,0 +1,1 @@
+default=org.apache.dubbo.common.convert.jsr310.DefaultLocalTimeConverter

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/utils/PojoUtilsTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/utils/PojoUtilsTest.java
@@ -16,6 +16,8 @@
  */
 package org.apache.dubbo.common.utils;
 
+import org.apache.dubbo.common.convert.jsr310.DefaultLocalDateTimeConverter;
+import org.apache.dubbo.common.convert.jsr310.DefaultLocalTimeConverter;
 import org.apache.dubbo.common.model.Person;
 import org.apache.dubbo.common.model.SerializablePerson;
 import org.apache.dubbo.common.model.User;
@@ -37,8 +39,10 @@ import java.text.SimpleDateFormat;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -1061,6 +1065,37 @@ class PojoUtilsTest {
         public int hashCode() {
             return Objects.hash(NameA, NameAbsent);
         }
+    }
+
+    @Test
+    public void testJava8TimeWithCustomFormat() {
+        String localDateTimeFormat = "yyyy-MM-dd HH:mm:ss";
+        List<DateTimeFormatter> dateTimeFormatterList =
+                Collections.singletonList(DateTimeFormatter.ofPattern(localDateTimeFormat));
+        PojoUtils.registerJsr310Converter(
+                LocalDateTime.class, new DefaultLocalDateTimeConverter(dateTimeFormatterList));
+
+        String localTimeFormat = "HH:mm:ss";
+        List<DateTimeFormatter> localTimeFormatterList =
+                Collections.singletonList(DateTimeFormatter.ofPattern(localTimeFormat));
+        PojoUtils.registerJsr310Converter(LocalTime.class, new DefaultLocalTimeConverter(localTimeFormatterList));
+
+        LocalDateTime now = LocalDateTime.now();
+        Object localDateTimeGen = PojoUtils.generalize(now);
+        Object localDateTime = PojoUtils.realize(localDateTimeGen, LocalDateTime.class);
+        assertTrue(localDateTime instanceof LocalDateTime);
+        assertEquals(localDateTimeGen.toString().length(), localDateTimeFormat.length());
+
+        LocalTime nowTime = LocalTime.now();
+        Object localTimeGen = PojoUtils.generalize(nowTime);
+        Object localTime = PojoUtils.realize(localTimeGen, LocalTime.class);
+        assertTrue(localTime instanceof LocalTime);
+        assertEquals(localTimeGen.toString().length(), localTimeFormat.length());
+
+        // revert to default
+        PojoUtils.registerJsr310Converter(
+                LocalDateTime.class, new DefaultLocalDateTimeConverter(Collections.emptyList()));
+        PojoUtils.registerJsr310Converter(LocalTime.class, new DefaultLocalTimeConverter(Collections.emptyList()));
     }
 
     public enum Day {

--- a/dubbo-distribution/dubbo-all-shaded/pom.xml
+++ b/dubbo-distribution/dubbo-all-shaded/pom.xml
@@ -958,6 +958,15 @@
                   <resource>META-INF/dubbo/internal/org.apache.dubbo.registry.integration.ServiceURLCustomizer</resource>
                 </transformer>
 
+                <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
+                  <resource>META-INF/dubbo/internal/org.apache.dubbo.common.convert.jsr310.LocalDateTimeConverter</resource>
+                </transformer>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
+                  <resource>META-INF/dubbo/internal/org.apache.dubbo.common.convert.jsr310.LocalDateConverter</resource>
+                </transformer>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
+                  <resource>META-INF/dubbo/internal/org.apache.dubbo.common.convert.jsr310.LocalTimeConverter</resource>
+                </transformer>
               </transformers>
               <filters>
                 <filter>

--- a/dubbo-distribution/dubbo-all/pom.xml
+++ b/dubbo-distribution/dubbo-all/pom.xml
@@ -955,6 +955,16 @@
                 <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
                   <resource>META-INF/dubbo/internal/org.apache.dubbo.registry.integration.ServiceURLCustomizer</resource>
                 </transformer>
+
+                <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
+                  <resource>META-INF/dubbo/internal/org.apache.dubbo.common.convert.jsr310.LocalDateTimeConverter</resource>
+                </transformer>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
+                  <resource>META-INF/dubbo/internal/org.apache.dubbo.common.convert.jsr310.LocalDateConverter</resource>
+                </transformer>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
+                  <resource>META-INF/dubbo/internal/org.apache.dubbo.common.convert.jsr310.LocalTimeConverter</resource>
+                </transformer>
               </transformers>
               <filters>
                 <filter>

--- a/dubbo-distribution/dubbo-core-spi/pom.xml
+++ b/dubbo-distribution/dubbo-core-spi/pom.xml
@@ -547,6 +547,15 @@
                 <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
                   <resource>META-INF/dubbo/internal/org.apache.dubbo.registry.integration.ServiceURLCustomizer</resource>
                 </transformer>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
+                  <resource>META-INF/dubbo/internal/org.apache.dubbo.common.convert.jsr310.LocalDateTimeConverter</resource>
+                </transformer>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
+                  <resource>META-INF/dubbo/internal/org.apache.dubbo.common.convert.jsr310.LocalDateConverter</resource>
+                </transformer>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
+                  <resource>META-INF/dubbo/internal/org.apache.dubbo.common.convert.jsr310.LocalTimeConverter</resource>
+                </transformer>
               </transformers>
               <filters>
                 <filter>

--- a/dubbo-spring-boot-project/dubbo-spring-boot-autoconfigure/src/main/java/org/apache/dubbo/spring/boot/autoconfigure/Jsr310ConverterApplicationListener.java
+++ b/dubbo-spring-boot-project/dubbo-spring-boot-autoconfigure/src/main/java/org/apache/dubbo/spring/boot/autoconfigure/Jsr310ConverterApplicationListener.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.spring.boot.autoconfigure;
+
+import org.apache.dubbo.common.convert.jsr310.DefaultLocalDateConverter;
+import org.apache.dubbo.common.convert.jsr310.DefaultLocalDateTimeConverter;
+import org.apache.dubbo.common.convert.jsr310.DefaultLocalTimeConverter;
+import org.apache.dubbo.common.utils.PojoUtils;
+import org.apache.dubbo.common.utils.StringUtils;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
+
+import org.springframework.boot.context.event.ApplicationEnvironmentPreparedEvent;
+import org.springframework.context.ApplicationListener;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Role;
+import org.springframework.core.env.ConfigurableEnvironment;
+
+import static org.springframework.beans.factory.config.BeanDefinition.ROLE_INFRASTRUCTURE;
+
+/**
+ * @description: Specify the time format based on the configuration when generic invoke
+ * @since 3.3.6
+ */
+@Configuration
+@Role(value = ROLE_INFRASTRUCTURE)
+public class Jsr310ConverterApplicationListener implements ApplicationListener<ApplicationEnvironmentPreparedEvent> {
+
+    private static final String DOUBLE_HYPHEN = "\\|\\|";
+    private static final AtomicBoolean PROCESSED = new AtomicBoolean(false);
+
+    @Override
+    public void onApplicationEvent(ApplicationEnvironmentPreparedEvent event) {
+        if (PROCESSED.compareAndSet(false, true)) {
+            ConfigurableEnvironment environment = event.getEnvironment();
+
+            String localDateTimeFormat = environment.resolvePlaceholders("${dubbo.generic.local-date-time-format:}");
+            if (StringUtils.isNotEmpty(localDateTimeFormat)) {
+                List<DateTimeFormatter> localDateTimeFormatterList = Arrays.stream(
+                                localDateTimeFormat.split(DOUBLE_HYPHEN))
+                        .map(DateTimeFormatter::ofPattern)
+                        .collect(Collectors.toList());
+                PojoUtils.registerJsr310Converter(
+                        LocalDateTime.class, new DefaultLocalDateTimeConverter(localDateTimeFormatterList));
+            }
+
+            String localDateFormat = environment.resolvePlaceholders("${dubbo.generic.local-date-format:}");
+            if (StringUtils.isNotEmpty(localDateFormat)) {
+                List<DateTimeFormatter> localDateFormatterList = Arrays.stream(localDateFormat.split(DOUBLE_HYPHEN))
+                        .map(DateTimeFormatter::ofPattern)
+                        .collect(Collectors.toList());
+                PojoUtils.registerJsr310Converter(
+                        LocalDate.class, new DefaultLocalDateConverter(localDateFormatterList));
+            }
+
+            String localTimeFormat = environment.resolvePlaceholders("${dubbo.generic.local-time-format:}");
+            if (StringUtils.isNotEmpty(localTimeFormat)) {
+                List<DateTimeFormatter> localTimeFormatterList = Arrays.stream(localTimeFormat.split(DOUBLE_HYPHEN))
+                        .map(DateTimeFormatter::ofPattern)
+                        .collect(Collectors.toList());
+                PojoUtils.registerJsr310Converter(
+                        LocalTime.class, new DefaultLocalTimeConverter(localTimeFormatterList));
+            }
+        }
+    }
+}

--- a/dubbo-spring-boot-project/dubbo-spring-boot-autoconfigure/src/main/resources/META-INF/spring-configuration-metadata.json
+++ b/dubbo-spring-boot-project/dubbo-spring-boot-autoconfigure/src/main/resources/META-INF/spring-configuration-metadata.json
@@ -1,0 +1,33 @@
+{
+    "groups":
+    [
+        {
+            "name": "Specify the time format based on the configuration when generic invoke",
+            "type": "org.apache.dubbo.spring.boot.context.event.Jsr310ConverterApplicationListener",
+            "sourceType": "org.apache.dubbo.spring.boot.context.event.Jsr310ConverterApplicationListener"
+        }
+    ],
+    "properties":
+    [
+        {
+            "name": "dubbo.generic.local-date-time-format",
+            "description": "LocalDateTime use this format when generic invoke",
+            "type": "java.lang.String",
+            "sourceType": "org.apache.dubbo.spring.boot.context.event.Jsr310ConverterApplicationListener"
+        },
+        {
+            "name": "dubbo.generic.local-date-format",
+            "description": "LocalDate use this format when generic invoke",
+            "type": "java.lang.String",
+            "sourceType": "org.apache.dubbo.spring.boot.context.event.Jsr310ConverterApplicationListener"
+        },
+        {
+            "name": "dubbo.generic.local-time-format",
+            "description": "LocalTime use this format when generic invoke",
+            "type": "java.lang.String",
+            "sourceType": "org.apache.dubbo.spring.boot.context.event.Jsr310ConverterApplicationListener"
+        }
+    ],
+    "hints":
+    []
+}

--- a/dubbo-spring-boot-project/dubbo-spring-boot-autoconfigure/src/main/resources/META-INF/spring.factories
+++ b/dubbo-spring-boot-project/dubbo-spring-boot-autoconfigure/src/main/resources/META-INF/spring.factories
@@ -8,4 +8,5 @@ org.apache.dubbo.spring.boot.autoconfigure.observability.DubboMicrometerTracingA
 org.apache.dubbo.spring.boot.autoconfigure.observability.DubboObservationAutoConfiguration,\
 org.apache.dubbo.spring.boot.autoconfigure.observability.brave.BraveAutoConfiguration,\
 org.apache.dubbo.spring.boot.autoconfigure.observability.zipkin.ZipkinAutoConfiguration,\
-org.apache.dubbo.spring.boot.autoconfigure.observability.otlp.OtlpAutoConfiguration
+org.apache.dubbo.spring.boot.autoconfigure.observability.otlp.OtlpAutoConfiguration,\
+org.apache.dubbo.spring.boot.autoconfigure.Jsr310ConverterApplicationListener

--- a/dubbo-spring-boot-project/dubbo-spring-boot-autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/dubbo-spring-boot-project/dubbo-spring-boot-autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -8,3 +8,4 @@ org.apache.dubbo.spring.boot.autoconfigure.observability.DubboObservationAutoCon
 org.apache.dubbo.spring.boot.autoconfigure.observability.brave.BraveAutoConfiguration
 org.apache.dubbo.spring.boot.autoconfigure.observability.zipkin.ZipkinAutoConfiguration
 org.apache.dubbo.spring.boot.autoconfigure.observability.otlp.OtlpAutoConfiguration
+org.apache.dubbo.spring.boot.autoconfigure.Jsr310ConverterApplicationListener

--- a/dubbo-spring-boot-project/dubbo-spring-boot-autoconfigure/src/test/java/org/apache/dubbo/spring/boot/autoconfigure/Jsr310ConverterApplicationListenerTest.java
+++ b/dubbo-spring-boot-project/dubbo-spring-boot-autoconfigure/src/test/java/org/apache/dubbo/spring/boot/autoconfigure/Jsr310ConverterApplicationListenerTest.java
@@ -39,8 +39,8 @@ import static org.junit.jupiter.api.Assertions.assertInstanceOf;
  */
 @TestPropertySource(
         properties = {
-                "dubbo.generic.local-date-time-format = yyyy-MM-dd HH:mm:ss.SSS",
-                "dubbo.generic.local-time-format = HH:mm:ss||HH:mm:ss.SSS"
+            "dubbo.generic.local-date-time-format = yyyy-MM-dd HH:mm:ss.SSS",
+            "dubbo.generic.local-time-format = HH:mm:ss||HH:mm:ss.SSS"
         })
 @SpringBootTest(classes = {Jsr310ConverterApplicationListener.class})
 @Disabled
@@ -74,5 +74,4 @@ public class Jsr310ConverterApplicationListenerTest {
         assertInstanceOf(LocalTime.class, localTime);
         assertEquals(12, localTime.toString().length());
     }
-
 }

--- a/dubbo-spring-boot-project/dubbo-spring-boot-autoconfigure/src/test/java/org/apache/dubbo/spring/boot/autoconfigure/Jsr310ConverterApplicationListenerTest.java
+++ b/dubbo-spring-boot-project/dubbo-spring-boot-autoconfigure/src/test/java/org/apache/dubbo/spring/boot/autoconfigure/Jsr310ConverterApplicationListenerTest.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.spring.boot.autoconfigure;
+
+import org.apache.dubbo.common.utils.PojoUtils;
+import org.apache.dubbo.rpc.model.ApplicationModel;
+
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+/**
+ * {@link Jsr310ConverterApplicationListener} Test
+ * @see Jsr310ConverterApplicationListener
+ * @since 3.3.6
+ */
+@TestPropertySource(
+        properties = {
+                "dubbo.generic.local-date-time-format = yyyy-MM-dd HH:mm:ss.SSS",
+                "dubbo.generic.local-time-format = HH:mm:ss||HH:mm:ss.SSS"
+        })
+@SpringBootTest(classes = {Jsr310ConverterApplicationListener.class})
+@Disabled
+public class Jsr310ConverterApplicationListenerTest {
+
+    @BeforeAll
+    public static void init() {
+        ApplicationModel.reset();
+    }
+
+    @AfterAll
+    public static void destroy() {
+        ApplicationModel.reset();
+    }
+
+    @Test
+    public void testOnApplicationEvent() {
+        LocalDateTime now = LocalDateTime.now();
+        Object localDateTimeGen = PojoUtils.generalize(now);
+        Object localDateTime = PojoUtils.realize(localDateTimeGen, LocalDateTime.class);
+        assertEquals(localDateTimeGen.toString().length(), "yyyy-MM-dd HH:mm:ss.SSS".length());
+        assertInstanceOf(LocalDateTime.class, localDateTime);
+
+        LocalTime nowTime = LocalTime.now();
+        Object localTimeGen = PojoUtils.generalize(nowTime);
+        Object localTime = PojoUtils.realize(localTimeGen, LocalTime.class);
+        assertInstanceOf(LocalTime.class, localTime);
+        assertEquals(8, localTimeGen.toString().length());
+
+        localTime = PojoUtils.realize(localTimeGen + ".001", LocalTime.class);
+        assertInstanceOf(LocalTime.class, localTime);
+        assertEquals(12, localTime.toString().length());
+    }
+
+}


### PR DESCRIPTION
## What is the purpose of the change?
Specify the jsr310 time format based on the configuration when generic invoke, the handling of jsr310 times (package names start with java.time) is opened to customize with dubbo's own spi implementation, which provides a default implementation in spring that allows you to configure date formats.

## Verifying this change
org.apache.dubbo.spring.boot.context.event.Jsr310ConverterApplicationListenerTest

## Old pull request
https://github.com/apache/dubbo/pull/13067https://github.com/apache/dubbo/pull/13067