### PR TITLE
[3.3] Fixed hanging test cases when failed to download ZK image that due to timeout or other problems

### DIFF
--- a/dubbo-remoting/dubbo-remoting-zookeeper-curator5/src/main/java/org/apache/dubbo/remoting/zookeeper/curator5/Curator5ZookeeperClient.java
+++ b/dubbo-remoting/dubbo-remoting-zookeeper-curator5/src/main/java/org/apache/dubbo/remoting/zookeeper/curator5/Curator5ZookeeperClient.java
@@ -98,6 +98,8 @@ public class Curator5ZookeeperClient
             boolean connected = client.blockUntilConnected(timeout, TimeUnit.MILLISECONDS);
 
             if (!connected) {
+                // close CuratorFramework to stop re-connection.
+                client.close();
                 IllegalStateException illegalStateException =
                         new IllegalStateException("zookeeper not connected, the address is: " + url);
 

--- a/dubbo-test/dubbo-test-check/src/main/java/org/apache/dubbo/test/check/registrycenter/context/ZookeeperWindowsContext.java
+++ b/dubbo-test/dubbo-test-check/src/main/java/org/apache/dubbo/test/check/registrycenter/context/ZookeeperWindowsContext.java
@@ -50,6 +50,11 @@ public class ZookeeperWindowsContext extends ZookeeperContext {
     private final ExecuteWatchdog WATCHDOG = new ExecuteWatchdog(ExecuteWatchdog.INFINITE_TIMEOUT);
 
     /**
+     * Set it to TRUE when using WatchDog.
+     */
+    private boolean usedWatchDog = false;
+
+    /**
      * The map to store the pair of clientPort and PID.
      */
     private Map<Integer, Integer> processIds = new HashMap<>();
@@ -93,6 +98,7 @@ public class ZookeeperWindowsContext extends ZookeeperContext {
      * Returns the {@link ExecuteWatchdog}.
      */
     public ExecuteWatchdog getWatchdog() {
+        usedWatchDog = true;
         return WATCHDOG;
     }
 
@@ -101,7 +107,10 @@ public class ZookeeperWindowsContext extends ZookeeperContext {
      */
     public void destroy() {
         this.processIds.clear();
-        this.WATCHDOG.destroyProcess();
+        // check WatchDog used flag to avoid hanging at destroyProcess when WatchDog is not used.
+        if (usedWatchDog) {
+            this.WATCHDOG.destroyProcess();
+        }
         try {
             DEFAULT_EXECUTOR_SERVICE.shutdownNow();
         } catch (SecurityException | NullPointerException ex) {

--- a/dubbo-test/dubbo-test-check/src/main/java/org/apache/dubbo/test/check/registrycenter/processor/ResetZookeeperProcessor.java
+++ b/dubbo-test/dubbo-test-check/src/main/java/org/apache/dubbo/test/check/registrycenter/processor/ResetZookeeperProcessor.java
@@ -45,6 +45,8 @@ public class ResetZookeeperProcessor implements Processor {
                 client.start();
                 boolean connected = client.blockUntilConnected(1000, TimeUnit.MILLISECONDS);
                 if (!connected) {
+                    // close CuratorFramework to stop re-connection.
+                    client.close();
                     throw new IllegalStateException("zookeeper not connected");
                 }
                 client.delete().deletingChildrenIfNeeded().forPath("/dubbo");


### PR DESCRIPTION
## What is the purpose of the change?
There are unit tests which need to download Zookeeper image from archive.apache.org before runing test methods, but it might fail even the timeout parameter had been prolonged to 180s,  
```
2025-09-11T18:38:26.7288092Z Sep 11, 2025 6:38:26 PM org.junit.platform.launcher.core.CompositeTestExecutionListener lambda$notifyEach$21
2025-09-11T18:38:26.7291148Z 18:38:26.641 |-WARN  [AsyncHttpClient-timer-1-1] initializer.DownloadZookeeperInitializer:    -|  [DUBBO] Failed to download the file, download url: https://archive.apache.org/dist/zookeeper/zookeeper-3.6.0/apache-zookeeper-3.6.0-bin.tar.gz, dubbo version: 3.3.6-SNAPSHOT, current host: 172.31.192.1, error code: 81-3. This may be caused by , go to https://dubbo.apache.org/faq/81/3 to find instructions. 
2025-09-11T18:38:26.7295165Z WARNING: TestExecutionListener [org.apache.dubbo.test.check.RegistryCenterStarted] threw exception for method: testPlanExecutionStarted(org.junit.platform.launcher.TestPlan@60e67c06)
2025-09-11T18:38:26.7296970Z java.util.concurrent.TimeoutException: Request timeout to archive.apache.org/65.108.204.189:443 after 180000 ms
```
Junit just log warning message when exception was thrown at DownloadZookeeperInitializer because it is just a TestExecutionListener which does not block the testing process, the follow test methods will hang for ever because there are issues in the codes which will re-connect not-existed ZK server infinitely and  keep logging such error info,
```
2025-09-11T18:38:44.4431501Z 18:38:44.338 |-WARN  [main-SendThread(127.0.0.1:2181)]          org.apache.zookeeper.ClientCnxn:1300 -| Session 0x0 for server 127.0.0.1/127.0.0.1:2181, Closing socket connection. Attempting reconnect except it is a SessionExpiredException.
2025-09-11T18:38:44.4432323Z java.net.ConnectException: Connection refused: getsockopt
2025-09-11T18:38:44.4432692Z 	at java.base/sun.nio.ch.Net.pollConnect(Native Method) ~[?:?]
2025-09-11T18:38:44.4433061Z 	at java.base/sun.nio.ch.Net.pollConnectNow(Net.java:682) ~[?:?]
2025-09-11T18:38:44.4433517Z 	at java.base/sun.nio.ch.SocketChannelImpl.finishConnect(SocketChannelImpl.java:975) ~[?:?]
2025-09-11T18:38:44.4434185Z 	at org.apache.zookeeper.ClientCnxnSocketNIO.doTransport(ClientCnxnSocketNIO.java:344) ~[zookeeper-3.7.2.jar:3.7.2]
2025-09-11T18:38:44.4434865Z 	at org.apache.zookeeper.ClientCnxn$SendThread.run(ClientCnxn.java:1289) [zookeeper-3.7.2.jar:3.7.2]
```
The workflow will be terminated by github timeout action,
<img width="1710" height="445" alt="a0b3e96f-08f4-4196-bf8a-05bfbfcd6953" src="https://github.com/user-attachments/assets/238bd898-50aa-444b-85f4-1e676b44f65d" />

This pr will fix these issues.

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Make sure gitHub actions can pass. [Why the workflow is failing and how to fix it?](../CONTRIBUTING.md)
