### PR TITLE
Fixes #15671: remove Future from FUTURES after timeout and add RejectedExecution test fix 

### DIFF
--- a/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/exchange/support/DefaultFuture.java
+++ b/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/exchange/support/DefaultFuture.java
@@ -38,6 +38,7 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 
 import static org.apache.dubbo.common.constants.CommonConstants.DEFAULT_TIMEOUT;
@@ -324,7 +325,12 @@ public class DefaultFuture extends CompletableFuture<Object> {
 
             ExecutorService executor = future.getExecutor();
             if (executor != null && !executor.isShutdown()) {
-                executor.execute(() -> notifyTimeout(future));
+                try {
+                    executor.execute(() -> notifyTimeout(future));
+                } catch (RejectedExecutionException e) {
+                    notifyTimeout(future);
+                    throw e;
+                }
             } else {
                 notifyTimeout(future);
             }

--- a/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/exchange/support/DefaultFuture.java
+++ b/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/exchange/support/DefaultFuture.java
@@ -38,7 +38,6 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 
 import static org.apache.dubbo.common.constants.CommonConstants.DEFAULT_TIMEOUT;
@@ -322,13 +321,10 @@ public class DefaultFuture extends CompletableFuture<Object> {
             if (future == null || future.isDone()) {
                 return;
             }
+
             ExecutorService executor = future.getExecutor();
             if (executor != null && !executor.isShutdown()) {
-                try {
-                    executor.execute(() -> notifyTimeout(future));
-                } catch (RejectedExecutionException e) {
-                    notifyTimeout(future);
-                }
+                executor.execute(() -> notifyTimeout(future));
             } else {
                 notifyTimeout(future);
             }

--- a/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/exchange/support/DefaultFuture.java
+++ b/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/exchange/support/DefaultFuture.java
@@ -38,6 +38,7 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 
 import static org.apache.dubbo.common.constants.CommonConstants.DEFAULT_TIMEOUT;
@@ -321,10 +322,13 @@ public class DefaultFuture extends CompletableFuture<Object> {
             if (future == null || future.isDone()) {
                 return;
             }
-
             ExecutorService executor = future.getExecutor();
             if (executor != null && !executor.isShutdown()) {
-                executor.execute(() -> notifyTimeout(future));
+                try {
+                    executor.execute(() -> notifyTimeout(future));
+                } catch (RejectedExecutionException e) {
+                    notifyTimeout(future);
+                }
             } else {
                 notifyTimeout(future);
             }

--- a/dubbo-remoting/dubbo-remoting-api/src/test/java/org/apache/dubbo/remoting/exchange/support/DefaultFutureTest.java
+++ b/dubbo-remoting/dubbo-remoting-api/src/test/java/org/apache/dubbo/remoting/exchange/support/DefaultFutureTest.java
@@ -227,6 +227,17 @@ class DefaultFutureTest {
         Assertions.assertFalse(executor.isTerminated());
     }
 
+    /**
+     * Test for timeout handling with a custom ThreadPoolExecutor that may reject tasks.
+     *
+     * <p>Note: The following assertion that checks FUTURES cleanup is commented out for now.
+     * This is because the timeout task runs in a background thread, so:
+     * - Any RejectedExecutionException is thrown in the timer worker thread, not this test thread.
+     * - The test thread cannot reliably verify whether the Future has been removed from FUTURES.
+     *
+     * Therefore, we do not assert that DefaultFuture.getFuture(...) is null at this point.
+     * Once the timeout handling logic is updated to allow testable behavior, this assertion can be restored.
+     */
     @Test
     void testTimeoutWithRejectedExecution() throws Exception {
         // Create a ThreadPoolExecutor with a queue capacity of 1
@@ -260,7 +271,8 @@ class DefaultFutureTest {
         DefaultFuture.sent(channel, request);
         // Wait for the timeout task to trigger
         Thread.sleep(300);
-        Assertions.assertNull(DefaultFuture.getFuture(999), "Future should be removed from FUTURES after timeout");
+        // TODO: The assertion below is temporarily disabled due to reasons explained above.
+        // Assertions.assertNull(DefaultFuture.getFuture(999), "Future should be removed from FUTURES after timeout");
         customExecutor.shutdown();
     }
 

--- a/dubbo-remoting/dubbo-remoting-api/src/test/java/org/apache/dubbo/remoting/exchange/support/DefaultFutureTest.java
+++ b/dubbo-remoting/dubbo-remoting-api/src/test/java/org/apache/dubbo/remoting/exchange/support/DefaultFutureTest.java
@@ -227,17 +227,6 @@ class DefaultFutureTest {
         Assertions.assertFalse(executor.isTerminated());
     }
 
-    /**
-     * Test for timeout handling with a custom ThreadPoolExecutor that may reject tasks.
-     *
-     * <p>Note: The following assertion that checks FUTURES cleanup is commented out for now.
-     * This is because the timeout task runs in a background thread, so:
-     * - Any RejectedExecutionException is thrown in the timer worker thread, not this test thread.
-     * - The test thread cannot reliably verify whether the Future has been removed from FUTURES.
-     *
-     * Therefore, we do not assert that DefaultFuture.getFuture(...) is null at this point.
-     * Once the timeout handling logic is updated to allow testable behavior, this assertion can be restored.
-     */
     @Test
     void testTimeoutWithRejectedExecution() throws Exception {
         // Create a ThreadPoolExecutor with a queue capacity of 1
@@ -271,8 +260,7 @@ class DefaultFutureTest {
         DefaultFuture.sent(channel, request);
         // Wait for the timeout task to trigger
         Thread.sleep(300);
-        // TODO: The assertion below is temporarily disabled due to reasons explained above.
-        // Assertions.assertNull(DefaultFuture.getFuture(999), "Future should be removed from FUTURES after timeout");
+        Assertions.assertNull(DefaultFuture.getFuture(999), "Future should be removed from FUTURES after timeout");
         customExecutor.shutdown();
     }
 


### PR DESCRIPTION
Fixes #15671
## What is the purpose of the change?
to fix:
When I set threadPool with my custom threadPool,
it may be executor reject exception when submit processTask in DefaultFuture.
The map of Futures cache may can not be clear for long time.
see #15671

## MySolution
Wrap the executor.execute call in a try-catch.
If the thread pool is full, notifyTimeout is called manually after a RejectedExecutionException to clean up and prevent memory leaks.
```java
@Override
public void run(Timeout timeout) {
    DefaultFuture future = DefaultFuture.getFuture(requestID);
    if (future == null || future.isDone()) {
        return;
    }
    ExecutorService executor = future.getExecutor();
    if (executor != null && !executor.isShutdown()) {
        try {
            executor.execute(() -> notifyTimeout(future));
        } catch (RejectedExecutionException e) {
            notifyTimeout(future);
        }
    } else {
        notifyTimeout(future);
    }
}
```

## Test
This unit test testTimeoutWithRejectedExecution verifies the behavior of DefaultFuture when using a custom ThreadPoolExecutor that may reject tasks due to full capacity.
```java
  @Test
  void testTimeoutWithRejectedExecution() throws Exception {
      // Create a ThreadPoolExecutor with a queue capacity of 1
      ThreadPoolExecutor customExecutor = new ThreadPoolExecutor(
              1, // corePoolSize
              1, // maxPoolSize
              60L,
              TimeUnit.SECONDS,
              new ArrayBlockingQueue<>(1), // queue capacity is 1
              new ThreadPoolExecutor.AbortPolicy() // default rejection policy: throws exception
              );
      // Submit two tasks to occupy the thread and the queue
      customExecutor.submit(() -> {
          try {
              Thread.sleep(500); // occupy the thread for a while
          } catch (InterruptedException ignored) {
          }
      });
      customExecutor.submit(() -> {
          try {
              Thread.sleep(500); // occupy the queue
          } catch (InterruptedException ignored) {
          }
      });
      // Create a Dubbo Mock Channel and a request
      Channel channel = new MockedChannel();
      Request request = new Request(999);
      // Use Dubbo's newFuture and pass in the custom thread pool
      DefaultFuture future = DefaultFuture.newFuture(channel, request, 100, customExecutor);
      // Mark the request as sent
      DefaultFuture.sent(channel, request);
      // Wait for the timeout task to trigger
      Thread.sleep(300);
      Assertions.assertNull(DefaultFuture.getFuture(999), "Future should be removed from FUTURES after timeout");
      customExecutor.shutdown();
  }
```
## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Make sure gitHub actions can pass. [Why the workflow is failing and how to fix it?](../CONTRIBUTING.md)
