### PR TITLE
[3.3] Fix thread safety issue of ConsumerConfigurationListener

### DIFF
--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/ServiceDiscoveryRegistryDirectory.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/ServiceDiscoveryRegistryDirectory.java
@@ -65,6 +65,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.stream.Collectors;
 
 import static org.apache.dubbo.common.constants.CommonConstants.APPLICATION_KEY;
@@ -711,7 +712,7 @@ public class ServiceDiscoveryRegistryDirectory<T> extends DynamicDirectory<T> {
     }
 
     private static class ConsumerConfigurationListener extends AbstractConfiguratorListener {
-        private final List<ServiceDiscoveryRegistryDirectory<?>> listeners = new ArrayList<>();
+        private final List<ServiceDiscoveryRegistryDirectory<?>> listeners = new CopyOnWriteArrayList<>();
 
         ConsumerConfigurationListener(ModuleModel moduleModel) {
             super(moduleModel);


### PR DESCRIPTION
## What is the purpose of the change?
ArrayIndexOutOfBoundsException might be thrown due to the listener array list at ConsumerConfigurationListener in ServiceDiscoveryRegistryDirectory has thread safety issue.
```
java.lang.ArrayIndexOutOfBoundsException: Index 1 out of bounds for length 0
	at java.base/java.util.ArrayList.add(ArrayList.java:484) ~[?:?]
	at java.base/java.util.ArrayList.add(ArrayList.java:496) ~[?:?]
	at org.apache.dubbo.registry.client.ServiceDiscoveryRegistryDirectory$ConsumerConfigurationListener.addNotifyListener(ServiceDiscoveryRegistryDirectory.java:724) ~[dubbo-3.3.6-SNAPSHOT.jar:3.3.6-SNAPSHOT]
	at org.apache.dubbo.registry.client.ServiceDiscoveryRegistryDirectory.subscribe(ServiceDiscoveryRegistryDirectory.java:149) ~[dubbo-3.3.6-SNAPSHOT.jar:3.3.6-SNAPSHOT]
```
see details at https://github.com/apache/dubbo/actions/runs/17985444797/job/51163241388

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Make sure gitHub actions can pass. [Why the workflow is failing and how to fix it?](../CONTRIBUTING.md)
