### PR TITLE
[3.3] Optimize TriRpcStatus by adding http status code to its description

### DIFF
--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/TriRpcStatus.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/TriRpcStatus.java
@@ -135,7 +135,7 @@ public class TriRpcStatus implements Serializable {
                 code = Code.UNAVAILABLE;
                 break;
             case METHOD_NOT_FOUND:
-                code = Code.NOT_FOUND;
+                code = Code.UNIMPLEMENTED;
                 break;
             case SERIALIZATION_EXCEPTION:
                 code = Code.INTERNAL;

--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/stream/AbstractTripleClientStream.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/stream/AbstractTripleClientStream.java
@@ -244,7 +244,7 @@ public abstract class AbstractTripleClientStream extends AbstractStream implemen
             final CharSequence contentType = headers.get(HttpHeaderNames.CONTENT_TYPE.getKey());
             if (contentType == null || !GrpcUtils.isGrpcRequest(contentType.toString())) {
                 return TriRpcStatus.fromCode(TriRpcStatus.httpStatusToGrpcCode(httpStatus))
-                        .withDescription("invalid content-type: " + contentType);
+                        .withDescription("HTTP status: " + httpStatus + ", content-type: " + contentType);
             }
             return null;
         }

--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/stream/AbstractTripleClientStream.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/stream/AbstractTripleClientStream.java
@@ -244,7 +244,7 @@ public abstract class AbstractTripleClientStream extends AbstractStream implemen
             final CharSequence contentType = headers.get(HttpHeaderNames.CONTENT_TYPE.getKey());
             if (contentType == null || !GrpcUtils.isGrpcRequest(contentType.toString())) {
                 return TriRpcStatus.fromCode(TriRpcStatus.httpStatusToGrpcCode(httpStatus))
-                        .withDescription("HTTP status: " + httpStatus + ", content-type: " + contentType);
+                        .withDescription("HTTP status: " + httpStatus + ", invalid content-type: " + contentType);
             }
             return null;
         }


### PR DESCRIPTION
## What is the purpose of the change?
When the provider which try to enable servlet for triple at springboot3 but it doesn't import ```dubbo-spring-boot-3-autoconfigure``` into its pom.xml, the consumer will encounter RpcException like this,
```
2025-09-24T19:41:50.862+08:00 ERROR 25776 --- [dubbo-spring-consumer] [io-60052-exec-2] o.a.c.c.C.[.[.[/].[dispatcherServlet]    : Servlet.service() for servlet [dispatcherServlet] in context with path [] threw exception [Request processing failed: org.apache.dubbo.rpc.RpcException: java.util.concurrent.ExecutionException: org.apache.dubbo.rpc.StatusRpcException: UNIMPLEMENTED : invalid content-type: application/json]
```
however, ```UNIMPLEMENTED : invalid content-type: application/json``` is inaccurate, it might be better to say ```UNIMPLEMENTED : HTTP status 404, content-type: application/json```.

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Make sure gitHub actions can pass. [Why the workflow is failing and how to fix it?](../CONTRIBUTING.md)
