### PR TITLE
[3.3] Add dubbo springboot3 dependency checker automatic configuration

### DIFF
--- a/dubbo-spring-boot-project/dubbo-spring-boot-autoconfigure/src/main/java/org/apache/dubbo/spring/boot/autoconfigure/DubboSpringBoot3DependencyCheckAutoConfiguration.java
+++ b/dubbo-spring-boot-project/dubbo-spring-boot-autoconfigure/src/main/java/org/apache/dubbo/spring/boot/autoconfigure/DubboSpringBoot3DependencyCheckAutoConfiguration.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.spring.boot.autoconfigure;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication.Type;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration(proxyBeanMethods = false)
+@Conditional(SpringBoot3Condition.class)
+public class DubboSpringBoot3DependencyCheckAutoConfiguration {
+
+    public static final String SERVLET_PREFIX = "dubbo.protocol.triple.servlet";
+
+    public static final String WEBSOCKET_PREFIX = "dubbo.protocol.triple.websocket";
+
+    public static final String JAKARATA_SERVLET_FILTER = "jakarta.servlet.Filter";
+
+    public static final String DUBBO_TRIPLE_3_AUTOCONFIGURATION =
+            "org.apache.dubbo.spring.boot.autoconfigure.DubboTriple3AutoConfiguration";
+
+    private static final String SPRING_BOOT_3_DEPENDENCY_CHECK_WARNING =
+            "Couldn't enable servlet support for triple at SpringBoot3: Missing dubbo-spring-boot-3-autoconfigure";
+
+    @Configuration(proxyBeanMethods = false)
+    @ConditionalOnClass(name = JAKARATA_SERVLET_FILTER)
+    @ConditionalOnWebApplication(type = Type.SERVLET)
+    @ConditionalOnProperty(prefix = SERVLET_PREFIX, name = "enabled", havingValue = "true")
+    @ConditionalOnMissingClass(DUBBO_TRIPLE_3_AUTOCONFIGURATION)
+    public static class tripleProtocolFilterDependencyCheckConfiguration {
+        @Bean
+        public Object tripleProtocolFilterDependencyCheck() {
+            throw new IllegalStateException(SPRING_BOOT_3_DEPENDENCY_CHECK_WARNING);
+        }
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    @ConditionalOnClass(name = JAKARATA_SERVLET_FILTER)
+    @ConditionalOnWebApplication(type = Type.SERVLET)
+    @ConditionalOnProperty(prefix = WEBSOCKET_PREFIX, name = "enabled", havingValue = "true")
+    @ConditionalOnMissingClass(DUBBO_TRIPLE_3_AUTOCONFIGURATION)
+    public static class tripleWebSocketFilterDependencyCheckConfiguration {
+        @Bean
+        public Object tripleWebSocketFilterDependencyCheck() {
+            throw new IllegalStateException(SPRING_BOOT_3_DEPENDENCY_CHECK_WARNING);
+        }
+    }
+}

--- a/dubbo-spring-boot-project/dubbo-spring-boot-autoconfigure/src/main/java/org/apache/dubbo/spring/boot/autoconfigure/SpringBoot3Condition.java
+++ b/dubbo-spring-boot-project/dubbo-spring-boot-autoconfigure/src/main/java/org/apache/dubbo/spring/boot/autoconfigure/SpringBoot3Condition.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.spring.boot.autoconfigure;
+
+import org.springframework.boot.SpringBootVersion;
+import org.springframework.context.annotation.Condition;
+import org.springframework.context.annotation.ConditionContext;
+import org.springframework.core.type.AnnotatedTypeMetadata;
+
+public class SpringBoot3Condition implements Condition {
+
+    public static boolean IS_SPRING_BOOT_3 = SpringBootVersion.getVersion().charAt(0) >= '3';
+
+    @Override
+    public boolean matches(ConditionContext context, AnnotatedTypeMetadata metadata) {
+        return IS_SPRING_BOOT_3;
+    }
+}

--- a/dubbo-spring-boot-project/dubbo-spring-boot-autoconfigure/src/main/resources/META-INF/spring.factories
+++ b/dubbo-spring-boot-project/dubbo-spring-boot-autoconfigure/src/main/resources/META-INF/spring.factories
@@ -8,4 +8,5 @@ org.apache.dubbo.spring.boot.autoconfigure.observability.DubboMicrometerTracingA
 org.apache.dubbo.spring.boot.autoconfigure.observability.DubboObservationAutoConfiguration,\
 org.apache.dubbo.spring.boot.autoconfigure.observability.brave.BraveAutoConfiguration,\
 org.apache.dubbo.spring.boot.autoconfigure.observability.zipkin.ZipkinAutoConfiguration,\
-org.apache.dubbo.spring.boot.autoconfigure.observability.otlp.OtlpAutoConfiguration
+org.apache.dubbo.spring.boot.autoconfigure.observability.otlp.OtlpAutoConfiguration,\
+org.apache.dubbo.spring.boot.autoconfigure.DubboSpringBoot3DependencyCheckAutoConfiguration

--- a/dubbo-spring-boot-project/dubbo-spring-boot-autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/dubbo-spring-boot-project/dubbo-spring-boot-autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -8,3 +8,4 @@ org.apache.dubbo.spring.boot.autoconfigure.observability.DubboObservationAutoCon
 org.apache.dubbo.spring.boot.autoconfigure.observability.brave.BraveAutoConfiguration
 org.apache.dubbo.spring.boot.autoconfigure.observability.zipkin.ZipkinAutoConfiguration
 org.apache.dubbo.spring.boot.autoconfigure.observability.otlp.OtlpAutoConfiguration
+org.apache.dubbo.spring.boot.autoconfigure.DubboSpringBoot3DependencyCheckAutoConfiguration


### PR DESCRIPTION
## What is the purpose of the change?
Since ```dubbo-spring-boot-autoconfigure-compatible``` was provided to support springboot 1.x,  maybe adding a dubbo springboot3 dependency checker is not redundant, especially for those customers who want enable servlet for triple but encounter with ```UNIMPLEMENTED : invalid content-type: application/json triple rpc protocol``` exception, not all customers are familiar with the url of Dubbo's FAQ.
 
## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Make sure gitHub actions can pass. [Why the workflow is failing and how to fix it?](../CONTRIBUTING.md)
