### PR TITLE
[3.3] Add dubbo package to serialize allow list for SpringXmlConfigTest to avoid IllegalArgumentException

### DIFF
--- a/dubbo-test/dubbo-test-spring/src/main/resources/security/serialize.allowlist
+++ b/dubbo-test/dubbo-test-spring/src/main/resources/security/serialize.allowlist
@@ -1,0 +1,20 @@
+#
+#
+#   Licensed to the Apache Software Foundation (ASF) under one or more
+#   contributor license agreements.  See the NOTICE file distributed with
+#   this work for additional information regarding copyright ownership.
+#   The ASF licenses this file to You under the Apache License, Version 2.0
+#   (the "License"); you may not use this file except in compliance with
+#   the License.  You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+#
+
+org.apache.dubbo


### PR DESCRIPTION
## What is the purpose of the change?
IllegalArgumentException with ```Serialized class org.apache.dubbo.metadata.MetadataRequest is not in allow list``` might be thrown during running SpringXmlConfigTest,
```
2025-10-02T01:02:16.0058528Z 01:02:15.896 |-ERROR [main] o.registry.client.metadata.MetadataUtils:    -|  [DUBBO] Failed to get app metadata for revision 312a6703996643a97229a89ab14e0ebf for type local from instance 172.22.144.1:20880, dubbo version: 3.3.6-SNAPSHOT, current host: 172.22.144.1, error code: 1-39. This may be caused by , go to https://dubbo.apache.org/faq/1/39 to find instructions. 
2025-10-02T01:02:16.0060367Z java.lang.IllegalArgumentException: [Serialization Security] Serialized class org.apache.dubbo.metadata.MetadataRequest is not in allow list. Current mode is `STRICT`, will disallow to deserialize it by default. Please add it into security/serialize.allowlist or follow FAQ to configure it.
2025-10-02T01:02:16.0061777Z 	at org.apache.dubbo.common.utils.DefaultSerializeClassChecker.loadClass0(DefaultSerializeClassChecker.java:153)
...
2025-10-02T01:02:16.0206172Z 	at org.apache.dubbo.test.spring.SpringXmlConfigTest.test(SpringXmlConfigTest.java:64) ~[dubbo-test-spring-3.3.6-SNAPSHOT.jar:3.3.6-SNAPSHOT]
```
see details at the raw logs of https://github.com/apache/dubbo/actions/runs/18179422286/job/51752831259


## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Make sure gitHub actions can pass. [Why the workflow is failing and how to fix it?](../CONTRIBUTING.md)
