### PR TITLE
fix(native): Resolve NullPointerException in ReferenceBeanManager

### DIFF
--- a/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/reference/ReferenceBeanManager.java
+++ b/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/reference/ReferenceBeanManager.java
@@ -154,6 +154,10 @@ public class ReferenceBeanManager implements ApplicationContextAware {
         for (ReferenceBean referenceBean : getReferences()) {
             initReferenceBean(referenceBean);
         }
+        // add a null check for moduleModel to be compatible with the native environment
+        if (moduleModel == null) {
+            setApplicationContext(applicationContext);
+        }
     }
 
     /**


### PR DESCRIPTION
## What is the purpose of the change?
This commit adds a defensive null-check for `moduleModel`. If it is null, it retrieves the model explicitly using `DubboBeanUtils.getModuleModel()` to prevent the `NullPointerException` and ensure stable initialization in native builds.

fixes: #15663

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Make sure gitHub actions can pass. [Why the workflow is failing and how to fix it?](../CONTRIBUTING.md)
