### PR TITLE
Downgrade ubuntu testing system to 22.04 for ZK and nacos server

### DIFF
--- a/.github/workflows/build-and-test-pr.yml
+++ b/.github/workflows/build-and-test-pr.yml
@@ -35,7 +35,7 @@ env:
 jobs:
   check-format:
     name: "Check if code needs formatting"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: "Checkout"
         uses: actions/checkout@v4
@@ -76,7 +76,7 @@ jobs:
   license:
     name: "Check License"
     needs: check-format
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - name: "Check License"
@@ -102,7 +102,7 @@ jobs:
   build-source:
     name: "Build Dubbo"
     needs: check-format
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       version: ${{ steps.dubbo-version.outputs.version }}
     steps:
@@ -175,7 +175,7 @@ jobs:
   unit-test-prepare:
     name: "Preparation for Unit Test"
     needs: check-format
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
     env:
@@ -207,8 +207,8 @@ jobs:
 
   unit-test:
     needs: [check-format, unit-test-prepare]
-    name: "Unit Test On ubuntu-latest Java: ${{ matrix.java }}"
-    runs-on: ubuntu-latest
+    name: "Unit Test On ubuntu-22.04 Java: ${{ matrix.java }}"
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
@@ -276,7 +276,7 @@ jobs:
 
   samples-test-prepare:
     needs: check-format
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       JOB_COUNT: 3
     steps:
@@ -293,8 +293,8 @@ jobs:
           path: test/jobs
   samples-test-job:
     needs: [check-format, build-source, samples-test-prepare]
-    name: "Samples Test on ubuntu-latest (JobId: ${{matrix.job_id}} Java: ${{matrix.java}})"
-    runs-on: ubuntu-latest
+    name: "Samples Test on ubuntu-22.04 (JobId: ${{matrix.job_id}} Java: ${{matrix.java}})"
+    runs-on: ubuntu-22.04
     timeout-minutes: 90
     env:
       JAVA_VER: ${{matrix.java}}
@@ -367,9 +367,9 @@ jobs:
           path: test/logs/*
   samples-test-result:
     needs: [check-format, samples-test-job]
-    name: "Samples Test Result on ubuntu-latest (JobId: ${{matrix.job_id}} Java: ${{matrix.java}})"
+    name: "Samples Test Result on ubuntu-22.04 (JobId: ${{matrix.job_id}} Java: ${{matrix.java}})"
     if: always()
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       JAVA_VER: ${{matrix.java}}
     strategy:
@@ -391,7 +391,7 @@ jobs:
 
   integration-test-prepare:
     needs: check-format
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       JOB_COUNT: 3
     steps:
@@ -408,8 +408,8 @@ jobs:
           path: test/jobs
   integration-test-job:
     needs: [check-format, build-source, integration-test-prepare]
-    name: "Integration Test on ubuntu-latest (JobId: ${{matrix.job_id}} Java: ${{matrix.java}})"
-    runs-on: ubuntu-latest
+    name: "Integration Test on ubuntu-22.04 (JobId: ${{matrix.job_id}} Java: ${{matrix.java}})"
+    runs-on: ubuntu-22.04
     timeout-minutes: 90
     env:
       JAVA_VER: ${{matrix.java}}
@@ -481,10 +481,10 @@ jobs:
           name: integration-test-logs-${{matrix.job_id}}-java${{matrix.java}}
           path: test/logs/*
   integration-test-result:
-    name: "Integration Test Result on ubuntu-latest (JobId: ${{matrix.job_id}} Java: ${{matrix.java}})"
+    name: "Integration Test Result on ubuntu-22.04 (JobId: ${{matrix.job_id}} Java: ${{matrix.java}})"
     needs: [check-format, integration-test-job]
     if: always()
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       JAVA_VER: ${{matrix.java}}
     strategy:
@@ -505,8 +505,8 @@ jobs:
         run: ./test/scripts/merge-test-results.sh
 
   samples-jacoco-result-merge:
-    name: "Samples Jacoco Result on ubuntu-latest (JobId: ${{matrix.job_id}} Java: ${{matrix.java}})"
-    runs-on: ubuntu-latest
+    name: "Samples Jacoco Result on ubuntu-22.04 (JobId: ${{matrix.job_id}} Java: ${{matrix.java}})"
+    runs-on: ubuntu-22.04
     needs: [check-format, samples-test-result]
     strategy:
       matrix:
@@ -555,8 +555,8 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   integration-jacoco-result-merge:
-    name: "Integration Jacoco Result on ubuntu-latest (JobId: ${{matrix.job_id}} Java: ${{matrix.java}})"
-    runs-on: ubuntu-latest
+    name: "Integration Jacoco Result on ubuntu-22.04 (JobId: ${{matrix.job_id}} Java: ${{matrix.java}})"
+    runs-on: ubuntu-22.04
     needs: [check-format, integration-test-result, samples-test-result]
     strategy:
       matrix:
@@ -607,7 +607,7 @@ jobs:
 
   error-code-inspecting:
     needs: check-format
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
         with:
@@ -651,7 +651,7 @@ jobs:
 
   native-image-inspecting:
     needs: check-format
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/build-and-test-scheduled-3.1.yml
+++ b/.github/workflows/build-and-test-scheduled-3.1.yml
@@ -22,7 +22,7 @@ env:
 
 jobs:
   license:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
         with:
@@ -32,7 +32,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   build-source:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       version: ${{ steps.dubbo-version.outputs.version }}
     steps:
@@ -83,7 +83,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, windows-latest ]
+        os: [ ubuntu-22.04, windows-latest ]
     env:
       ZOOKEEPER_VERSION: 3.7.2
     steps:
@@ -131,7 +131,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, windows-latest ]
+        os: [ ubuntu-22.04, windows-latest ]
         jdk: [ 8, 11, 17, 21 ]
     env:
       DISABLE_FILE_SYSTEM_TEST: true
@@ -175,7 +175,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, windows-latest ]
+        os: [ ubuntu-22.04, windows-latest ]
         jdk: [ 8, 11, 17, 21 ]
     env:
       DISABLE_FILE_SYSTEM_TEST: true
@@ -222,7 +222,7 @@ jobs:
         run: ./mvnw --batch-mode --no-snapshot-updates -e --no-transfer-progress --fail-fast clean test verify -P"jacoco,'!jdk15ge'" -D"http.keepAlive=false" -D"maven.wagon.http.pool=false" -D"maven.wagon.httpconnectionManager.ttlSeconds=120" -D"maven.wagon.http.retryHandler.count=5" -DskipTests=false -DskipIntegrationTests=true -D"checkstyle.skip=false" -D"checkstyle_unix.skip=true" -D"rat.skip=false" -D"maven.javadoc.skip=true" -D"embeddedZookeeperPath=${{ github.workspace }}/.tmp/zookeeper"
 
   samples-test-prepare:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       JOB_COUNT: 5
     steps:
@@ -240,8 +240,8 @@ jobs:
           path: test/jobs
   samples-test-job:
     needs: [build-source, samples-test-prepare]
-    name: "Samples Test on ubuntu-latest (JobId: ${{matrix.job_id}} JavaVer: ${{matrix.jdk}})"
-    runs-on: ubuntu-latest
+    name: "Samples Test on ubuntu-22.04 (JobId: ${{matrix.job_id}} JavaVer: ${{matrix.jdk}})"
+    runs-on: ubuntu-22.04
     timeout-minutes: 90
     env:
       JAVA_VER: ${{matrix.jdk}}
@@ -306,7 +306,7 @@ jobs:
   samples-test-result:
     needs: [samples-test-job]
     if: always()
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       JAVA_VER: ${{matrix.jdk}}
     strategy:
@@ -328,7 +328,7 @@ jobs:
         run: ./test/scripts/merge-test-results.sh
 
   integration-test-prepare:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       JOB_COUNT: 5
     steps:
@@ -346,8 +346,8 @@ jobs:
           path: test/jobs
   integration-test-job:
     needs: [build-source, integration-test-prepare]
-    name: "Integration Test on ubuntu-latest (JobId: ${{matrix.job_id}} JavaVer: ${{matrix.jdk}})"
-    runs-on: ubuntu-latest
+    name: "Integration Test on ubuntu-22.04 (JobId: ${{matrix.job_id}} JavaVer: ${{matrix.jdk}})"
+    runs-on: ubuntu-22.04
     timeout-minutes: 90
     env:
       JAVA_VER: ${{matrix.jdk}}
@@ -412,7 +412,7 @@ jobs:
   integration-test-result:
     needs: [integration-test-job]
     if: always()
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       JAVA_VER: ${{matrix.jdk}}
     strategy:
@@ -434,7 +434,7 @@ jobs:
         run: ./test/scripts/merge-test-results.sh
 
   error-code-inspecting:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
         with:
@@ -473,7 +473,7 @@ jobs:
           path: ${{ github.workspace }}/dubbo-test-tools/dubbo-error-code-inspector/error-inspection-result.txt
 
   native-image-inspecting:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/build-and-test-scheduled-3.2.yml
+++ b/.github/workflows/build-and-test-scheduled-3.2.yml
@@ -22,7 +22,7 @@ env:
 
 jobs:
   license:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
         with:
@@ -32,7 +32,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   build-source:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       version: ${{ steps.dubbo-version.outputs.version }}
     steps:
@@ -83,7 +83,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, windows-latest ]
+        os: [ ubuntu-22.04, windows-latest ]
     env:
       ZOOKEEPER_VERSION: 3.7.2
     steps:
@@ -131,7 +131,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, windows-latest ]
+        os: [ ubuntu-22.04, windows-latest ]
         jdk: [ 8, 11, 17, 21 ]
     env:
       DISABLE_FILE_SYSTEM_TEST: true
@@ -175,7 +175,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, windows-latest ]
+        os: [ ubuntu-22.04, windows-latest ]
         jdk: [ 8, 11, 17, 21 ]
     env:
       DISABLE_FILE_SYSTEM_TEST: true
@@ -222,7 +222,7 @@ jobs:
         run: ./mvnw --batch-mode --no-snapshot-updates -e --no-transfer-progress --fail-fast clean test verify -P"jacoco,jdk15ge-simple,'!jdk15ge-add-open'" -D"http.keepAlive=false" -D"maven.wagon.http.pool=false" -D"maven.wagon.httpconnectionManager.ttlSeconds=120" -D"maven.wagon.http.retryHandler.count=5" -DskipTests=false -DskipIntegrationTests=true -D"checkstyle.skip=false" -D"checkstyle_unix.skip=true" -D"rat.skip=false" -D"maven.javadoc.skip=true" -D"embeddedZookeeperPath=${{ github.workspace }}/.tmp/zookeeper"
 
   samples-test-prepare:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       JOB_COUNT: 5
     steps:
@@ -240,8 +240,8 @@ jobs:
           path: test/jobs
   samples-test-job:
     needs: [build-source, samples-test-prepare]
-    name: "Samples Test on ubuntu-latest (JobId: ${{matrix.job_id}} JavaVer: ${{matrix.jdk}})"
-    runs-on: ubuntu-latest
+    name: "Samples Test on ubuntu-22.04 (JobId: ${{matrix.job_id}} JavaVer: ${{matrix.jdk}})"
+    runs-on: ubuntu-22.04
     timeout-minutes: 90
     env:
       JAVA_VER: ${{matrix.jdk}}
@@ -306,7 +306,7 @@ jobs:
   samples-test-result:
     needs: [samples-test-job]
     if: always()
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       JAVA_VER: ${{matrix.jdk}}
     strategy:
@@ -328,7 +328,7 @@ jobs:
         run: ./test/scripts/merge-test-results.sh
 
   integration-test-prepare:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       JOB_COUNT: 5
     steps:
@@ -346,8 +346,8 @@ jobs:
           path: test/jobs
   integration-test-job:
     needs: [build-source, integration-test-prepare]
-    name: "Integration Test on ubuntu-latest (JobId: ${{matrix.job_id}} JavaVer: ${{matrix.jdk}})"
-    runs-on: ubuntu-latest
+    name: "Integration Test on ubuntu-22.04 (JobId: ${{matrix.job_id}} JavaVer: ${{matrix.jdk}})"
+    runs-on: ubuntu-22.04
     timeout-minutes: 90
     env:
       JAVA_VER: ${{matrix.jdk}}
@@ -412,7 +412,7 @@ jobs:
   integration-test-result:
     needs: [integration-test-job]
     if: always()
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       JAVA_VER: ${{matrix.jdk}}
     strategy:
@@ -434,7 +434,7 @@ jobs:
         run: ./test/scripts/merge-test-results.sh
 
   error-code-inspecting:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
         with:
@@ -473,7 +473,7 @@ jobs:
           path: ${{ github.workspace }}/dubbo-test-tools/dubbo-error-code-inspector/error-inspection-result.txt
 
   native-image-inspecting:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/build-and-test-scheduled-3.3.yml
+++ b/.github/workflows/build-and-test-scheduled-3.3.yml
@@ -22,7 +22,7 @@ env:
 
 jobs:
   license:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
         with:
@@ -32,7 +32,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   build-source:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       version: ${{ steps.dubbo-version.outputs.version }}
     steps:
@@ -83,7 +83,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, windows-latest ]
+        os: [ ubuntu-22.04, windows-latest ]
     env:
       ZOOKEEPER_VERSION: 3.7.2
     steps:
@@ -131,7 +131,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, windows-latest ]
+        os: [ ubuntu-22.04, windows-latest ]
         jdk: [ 8, 11, 17, 21 ]
     env:
       DISABLE_FILE_SYSTEM_TEST: true
@@ -175,7 +175,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, windows-latest ]
+        os: [ ubuntu-22.04, windows-latest ]
         jdk: [ 8, 11, 17, 21 ]
     env:
       DISABLE_FILE_SYSTEM_TEST: true
@@ -222,7 +222,7 @@ jobs:
         run: ./mvnw --batch-mode --no-snapshot-updates -e --no-transfer-progress --fail-fast clean test verify -P"jacoco,jdk15ge-simple,'!jdk15ge-add-open'" -D"http.keepAlive=false" -D"maven.wagon.http.pool=false" -D"maven.wagon.httpconnectionManager.ttlSeconds=120" -D"maven.wagon.http.retryHandler.count=5" -DskipTests=false -DskipIntegrationTests=true -D"checkstyle.skip=false" -D"checkstyle_unix.skip=true" -D"rat.skip=false" -D"maven.javadoc.skip=true" -D"embeddedZookeeperPath=${{ github.workspace }}/.tmp/zookeeper"
 
   samples-test-prepare:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       JOB_COUNT: 5
     steps:
@@ -240,8 +240,8 @@ jobs:
           path: test/jobs
   samples-test-job:
     needs: [build-source, samples-test-prepare]
-    name: "Samples Test on ubuntu-latest (JobId: ${{matrix.job_id}} JavaVer: ${{matrix.jdk}})"
-    runs-on: ubuntu-latest
+    name: "Samples Test on ubuntu-22.04 (JobId: ${{matrix.job_id}} JavaVer: ${{matrix.jdk}})"
+    runs-on: ubuntu-22.04
     timeout-minutes: 90
     env:
       JAVA_VER: ${{matrix.jdk}}
@@ -306,7 +306,7 @@ jobs:
   samples-test-result:
     needs: [samples-test-job]
     if: always()
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       JAVA_VER: ${{matrix.jdk}}
     strategy:
@@ -328,7 +328,7 @@ jobs:
         run: ./test/scripts/merge-test-results.sh
 
   integration-test-prepare:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       JOB_COUNT: 5
     steps:
@@ -346,8 +346,8 @@ jobs:
           path: test/jobs
   integration-test-job:
     needs: [build-source, integration-test-prepare]
-    name: "Integration Test on ubuntu-latest (JobId: ${{matrix.job_id}} JavaVer: ${{matrix.jdk}})"
-    runs-on: ubuntu-latest
+    name: "Integration Test on ubuntu-22.04 (JobId: ${{matrix.job_id}} JavaVer: ${{matrix.jdk}})"
+    runs-on: ubuntu-22.04
     timeout-minutes: 90
     env:
       JAVA_VER: ${{matrix.jdk}}
@@ -412,7 +412,7 @@ jobs:
   integration-test-result:
     needs: [integration-test-job]
     if: always()
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       JAVA_VER: ${{matrix.jdk}}
     strategy:
@@ -434,7 +434,7 @@ jobs:
         run: ./test/scripts/merge-test-results.sh
 
   error-code-inspecting:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
         with:
@@ -473,7 +473,7 @@ jobs:
           path: ${{ github.workspace }}/dubbo-test-tools/dubbo-error-code-inspector/error-inspection-result.txt
 
   native-image-inspecting:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/release-test.yml
+++ b/.github/workflows/release-test.yml
@@ -23,7 +23,7 @@ env:
 
 jobs:
   license:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - name: Check License
@@ -31,7 +31,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   build-source:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       version: ${{ steps.dubbo-version.outputs.version }}
     steps:
@@ -80,7 +80,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, windows-latest ]
+        os: [ ubuntu-22.04, windows-latest ]
     env:
       ZOOKEEPER_VERSION: 3.7.2
     steps:
@@ -127,7 +127,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, windows-latest ]
+        os: [ ubuntu-22.04, windows-latest ]
         jdk: [ 8, 11, 17, 21 ]
     env:
       DISABLE_FILE_SYSTEM_TEST: true
@@ -170,7 +170,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, windows-latest ]
+        os: [ ubuntu-22.04, windows-latest ]
         jdk: [ 8, 11, 17, 21 ]
     env:
       DISABLE_FILE_SYSTEM_TEST: true
@@ -217,7 +217,7 @@ jobs:
         run: ./mvnw --batch-mode --no-snapshot-updates -e --no-transfer-progress --fail-fast clean test verify -P"jacoco,jdk15ge-simple,'!jdk15ge-add-open'" -D"http.keepAlive=false" -D"maven.wagon.http.pool=false" -D"maven.wagon.httpconnectionManager.ttlSeconds=120" -D"maven.wagon.http.retryHandler.count=5" -DskipTests=false -DskipIntegrationTests=true -D"checkstyle.skip=false" -D"checkstyle_unix.skip=true" -D"rat.skip=false" -D"maven.javadoc.skip=true" -D"embeddedZookeeperPath=${{ github.workspace }}/.tmp/zookeeper"
 
   samples-test-prepare:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       JOB_COUNT: 5
     steps:
@@ -235,8 +235,8 @@ jobs:
           path: test/jobs
   samples-test-job:
     needs: [build-source, samples-test-prepare]
-    name: "Samples Test on ubuntu-latest (JobId: ${{matrix.job_id}} JavaVer: ${{matrix.jdk}})"
-    runs-on: ubuntu-latest
+    name: "Samples Test on ubuntu-22.04 (JobId: ${{matrix.job_id}} JavaVer: ${{matrix.jdk}})"
+    runs-on: ubuntu-22.04
     timeout-minutes: 90
     env:
       JAVA_VER: ${{matrix.jdk}}
@@ -295,7 +295,7 @@ jobs:
   samples-test-result:
     needs: [samples-test-job]
     if: always()
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       JAVA_VER: ${{matrix.jdk}}
     strategy:
@@ -317,7 +317,7 @@ jobs:
         run: ./test/scripts/merge-test-results.sh
 
   integration-test-prepare:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       JOB_COUNT: 5
     steps:
@@ -335,8 +335,8 @@ jobs:
           path: test/jobs
   integration-test-job:
     needs: [build-source, integration-test-prepare]
-    name: "Integration Test on ubuntu-latest (JobId: ${{matrix.job_id}} JavaVer: ${{matrix.jdk}})"
-    runs-on: ubuntu-latest
+    name: "Integration Test on ubuntu-22.04 (JobId: ${{matrix.job_id}} JavaVer: ${{matrix.jdk}})"
+    runs-on: ubuntu-22.04
     timeout-minutes: 90
     env:
       JAVA_VER: ${{matrix.jdk}}
@@ -395,7 +395,7 @@ jobs:
   integration-test-result:
     needs: [integration-test-job]
     if: always()
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       JAVA_VER: ${{matrix.jdk}}
     strategy:
@@ -417,7 +417,7 @@ jobs:
         run: ./test/scripts/merge-test-results.sh
 
   error-code-inspecting:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
         with:
@@ -454,7 +454,7 @@ jobs:
           path: ${{ github.workspace }}/dubbo-test-tools/dubbo-error-code-inspector/error-inspection-result.txt
 
   native-image-inspecting:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## What is the purpose of the change?
Downgrade ubuntu testing system to 22.04 for ZK and nacos server which need legacy cgroup v1 that was disabled at latest github hosted ubuntu system (its os.version had been upgraded to 6.14 which will disable legacy cgroup v1 by default),
<img width="2364" height="1118" alt="image" src="https://github.com/user-attachments/assets/b3aab6f9-484a-4f04-ad80-13162268b74e" />

The exception will be thrown during starting ZK or nacos server if runs on latest github hosted ubuntu system:
<img width="1381" height="786" alt="image" src="https://github.com/user-attachments/assets/c074e07e-7398-4511-ab58-3cd8b6920d54" />


## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Make sure gitHub actions can pass. [Why the workflow is failing and how to fix it?](../CONTRIBUTING.md)
