### PR TITLE
Fix: Stabilize ExtensionLoaderTest.testInjectExtension 

### DIFF
--- a/dubbo-common/src/test/java/org/apache/dubbo/common/extension/ExtensionLoaderTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/extension/ExtensionLoaderTest.java
@@ -17,6 +17,7 @@
 package org.apache.dubbo.common.extension;
 
 import org.apache.dubbo.common.URL;
+import org.apache.dubbo.common.beans.factory.ScopeBeanFactory;
 import org.apache.dubbo.common.convert.Converter;
 import org.apache.dubbo.common.convert.StringToBooleanConverter;
 import org.apache.dubbo.common.convert.StringToDoubleConverter;
@@ -666,10 +667,16 @@ class ExtensionLoaderTest {
 
     @Test
     void testInjectExtension() {
-        // register bean for test ScopeBeanExtensionInjector
-        DemoImpl demoBean = new DemoImpl();
-        ApplicationModel.defaultModel().getBeanFactory().registerBean(demoBean);
-        // test default
+        // Work with the shared factory, but make registration idempotent.
+        ScopeBeanFactory beanFactory = ApplicationModel.defaultModel().getBeanFactory();
+        if (beanFactory.getBeansOfType(Demo.class).isEmpty()) {
+            beanFactory.registerBean("demo-test-singleton", new DemoImpl());
+        }
+        // After the (potential) registration, fetch the canonical DemoImpl(s).
+        List<DemoImpl> impls = beanFactory.getBeansOfType(DemoImpl.class);
+        DemoImpl demoBean = impls.get(0);
+
+        // Exercise injection path
         InjectExt injectExt = getExtensionLoader(InjectExt.class).getExtension("injection");
         InjectExtImpl injectExtImpl = (InjectExtImpl) injectExt;
         Assertions.assertNotNull(injectExtImpl.getSimpleExt());
@@ -691,6 +698,13 @@ class ExtensionLoaderTest {
 
     @Test
     void testGetOrDefaultExtension() {
+        // Ensure there is exactly one DemoImpl available to satisfy injection paths.
+        ScopeBeanFactory beanFactory = ApplicationModel.defaultModel().getBeanFactory();
+        List<DemoImpl> demos = beanFactory.getBeansOfType(DemoImpl.class);
+        if (demos == null || demos.isEmpty()) {
+            beanFactory.registerBean("test-demo-bean", new DemoImpl());
+        }
+
         ExtensionLoader<InjectExt> loader = getExtensionLoader(InjectExt.class);
         InjectExt injectExt = loader.getOrDefaultExtension("non-exists");
         assertEquals(InjectExtImpl.class, injectExt.getClass());


### PR DESCRIPTION
## What is the purpose of the change?

This PR fixes **order-dependent flakiness (OD-Vic)** in `ExtensionLoaderTest.testInjectExtension`

This test fails under randomized test execution orders due to multiple DemoImpl instances being registered in the shared ScopeBeanFactory of ApplicationModel.

## Root Cause

`testInjectExtension` and related tests (`testGetOrDefaultExtension`) both interacted with the same shared `ScopeBeanFactory`.
Because bean registration was not idempotent, repeated or parallel test execution sometimes resulted in duplicate `DemoImpl` entries, leading to inconsistent injection results or assertion failures.

## What's Changed
- Added defensive logic to check existing DemoImpl beans before registering a new one.
- Made registration idempotent by registering only one instance (demo-test-singleton) if none exists.
- Ensured subsequent tests reuse the same canonical bean reference.
- Updated testGetOrDefaultExtension to follow the same consistent setup.

These changes eliminate shared-state interference and make the test deterministic under any order or random seed.

## Verification

You can try running the loop below on pre-fix and post-fix code:
```bash
fail=0; total=0
for s in 7138 7351 7892 11170 15857 15869 17721 20421 21699 22631 24059 29905; do
  echo "SEED=$s"
  total=$((total+1))
  SEED=$s ./mvnw -pl dubbo-common -DfailIfNoTests=true -DforkCount=1 -DreuseForks=false \
    -Dsurefire.runOrder=random \
    -Djunit.jupiter.testclass.order.default=org.junit.jupiter.api.ClassOrderer\$Random \
    -Djunit.jupiter.testmethod.order.default=org.junit.jupiter.api.MethodOrderer\$Random \
    -Djunit.jupiter.testclass.order.random.seed="$s" \
    -Djunit.jupiter.testmethod.order.random.seed="$s" \
    -Dtest=org.apache.dubbo.common.extension.ExtensionLoaderTest test \
    >/dev/null || { echo "** FAILED on SEED=$s **"; fail=$((fail+1)); }
done
echo
echo "===== SUMMARY ====="
echo "Total seeds: $total"
echo "Failed:      $fail"
echo "Passed:      $((total - fail))"
echo "==================="
```

The seeds were found by using a script I developed locally. Sometimes not all seeds fail on execution, but some will always fail on pre-fix code. However, on post-fix code none of the seeds fail.

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Make sure gitHub actions can pass. [Why the workflow is failing and how to fix it?](../CONTRIBUTING.md)
