### PR TITLE
Fix: Stabilize `JsonUtilsTest.consistentTest` to prevent Non-Dex nondeterminism

### DIFF
--- a/dubbo-common/src/test/java/org/apache/dubbo/common/utils/JsonUtilsTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/utils/JsonUtilsTest.java
@@ -34,6 +34,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -165,7 +166,8 @@ class JsonUtilsTest {
     }
 
     @Test
-    void consistentTest() {
+    void consistentTest() throws Exception {
+        ObjectMapper om = new ObjectMapper();
         List<Object> objs = new LinkedList<>();
 
         {
@@ -261,11 +263,11 @@ class JsonUtilsTest {
 
             setJson(null);
 
-            Assertions.assertEquals(fromFastjson1, fromFastjson2);
-            Assertions.assertEquals(fromFastjson1, fromGson);
-            Assertions.assertEquals(fromFastjson2, fromGson);
-            Assertions.assertEquals(fromFastjson1, fromJackson);
-            Assertions.assertEquals(fromFastjson2, fromJackson);
+            Assertions.assertEquals(om.readTree(fromFastjson1), om.readTree(fromFastjson2));
+            Assertions.assertEquals(om.readTree(fromFastjson1), om.readTree(fromGson));
+            Assertions.assertEquals(om.readTree(fromFastjson2), om.readTree(fromGson));
+            Assertions.assertEquals(om.readTree(fromFastjson1), om.readTree(fromJackson));
+            Assertions.assertEquals(om.readTree(fromFastjson2), om.readTree(fromJackson));
         }
     }
 


### PR DESCRIPTION
## What is the purpose of the change?

This PR stabilizes `JsonUtilsTest.consistentTest`, which previously exhibited nondeterministic failures under random execution orders

## Root Cause

The issue stemmed from comparing raw JSON strings produced by different JSON frameworks (`fastjson2`, `fastjson`, `gson`, `jackson`). These frameworks may serialize map fields in different key orders, leading to order-dependent failures.

## Changes Made

- Updated assertions to compare JSON structures instead of raw strings using:

  ```java
  new ObjectMapper().readTree(json)
  ```
  This ensures comparisons are **semantically equivalent and order-insensitive.**
- Added `throws Exception` to the test method to handle Jackson’s checked exceptions.

## Verification

You can try running the following snippet of code from the dubbo repo root, on both pre-fix and post-fix code

```bash
./mvnw -pl dubbo-common edu.illinois:nondex-maven-plugin:2.2.1:nondex \
  -DnondexRuns=10 \
  -Dtest=org.apache.dubbo.common.utils.JsonUtilsTest#consistentTest
```

The test should fail intermittently on the pre-fix version, but pass consistently across all seeds on the post-fix version.
NonDex run logs will be available under the `dubbo-common/.nondex` directory.

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Make sure gitHub actions can pass. [Why the workflow is failing and how to fix it?](../CONTRIBUTING.md)
