### PR TITLE
Fix: Stabilize `URLParam.hashCode()` to prevent Non-Dex nondeterminism in `URLTest.testHashcode`

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/url/component/URLParam.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/url/component/URLParam.java
@@ -890,15 +890,17 @@ public class URLParam {
     @Override
     public int hashCode() {
         if (hashCodeCache == -1) {
+            int result = 1;
             for (Map.Entry<String, String> entry : EXTRA_PARAMS.entrySet()) {
                 if (!TIMESTAMP_KEY.equals(entry.getKey())) {
-                    hashCodeCache = hashCodeCache * 31 + Objects.hashCode(entry);
+                    result += entry.hashCode();
                 }
             }
-            for (Integer value : VALUE) {
-                hashCodeCache = hashCodeCache * 31 + value;
-            }
-            hashCodeCache = hashCodeCache * 31 + ((KEY == null) ? 0 : KEY.hashCode());
+
+            result = 31 * result + Arrays.hashCode(VALUE);
+            result = 31 * result + ((KEY == null) ? 0 : KEY.hashCode());
+
+            hashCodeCache = result;
         }
         return hashCodeCache;
     }


### PR DESCRIPTION
## What is the purpose of the change?

This PR stabilizes `URLParam.hashCode()` to eliminate Non-Dex flakiness in tests (notably `URLTest.hashCode`).

## Root Cause

The previous implementation multiplied `hashCodeCache` by 31 for each map entry.
Because iteration order over `EXTRA_PARAMS` (a `HashMap`) is nondeterministic, the resulting hash code varied between runs, breaking consistency with `equals()` and causing nondeterministic test failures.

## Changes Made

- Replaced the order-dependent multiplication-based accumulation with an **order-independent summation** of entry.hashCode() values.
- Kept the same handling for `VALUE`, `KEY`, and ignored `TIMESTAMP_KEY`.
- Preserved the existing structure and caching logic.

## Verification

You can try running the following snippet of code from the dubbo repo root, on both pre-fix and post-fix code

```bash
./mvnw -pl dubbo-common edu.illinois:nondex-maven-plugin:2.2.1:nondex \
  -DnondexRuns=20 \
  -Dtest=org.apache.dubbo.common.URLTest#testHashcode
```

The test should fail intermittently on the pre-fix version, but pass consistently across all seeds on the post-fix version.
NonDex run logs will be available under the `dubbo-common/.nondex` directory.

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Make sure gitHub actions can pass. [Why the workflow is failing and how to fix it?](../CONTRIBUTING.md)