### PR TITLE
Fix: Stabilize `ConfigManagerTest.testGetConfigByIdOrName` to prevent Non-Dex nondeterminism 

### DIFF
--- a/dubbo-common/src/test/java/org/apache/dubbo/config/context/ConfigManagerTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/config/context/ConfigManagerTest.java
@@ -410,11 +410,20 @@ class ConfigManagerTest {
             Assertions.fail();
         } catch (Exception e) {
             Assertions.assertTrue(e instanceof IllegalStateException);
-            Assertions.assertEquals(
-                    e.getMessage(),
-                    "Found more than one config by name: dubbo, instances: "
-                            + "[<dubbo:protocol port=\"9103\" name=\"dubbo\" />, <dubbo:protocol name=\"dubbo\" />]. "
-                            + "Please remove redundant configs or get config by id.");
+            String msg = e.getMessage();
+
+            Assertions.assertTrue(
+                    msg.startsWith("Found more than one config by name: dubbo, instances: "),
+                    "Unexpected message prefix: " + msg);
+            Assertions.assertTrue(
+                    msg.contains("<dubbo:protocol port=\"9103\" name=\"dubbo\" />"),
+                    "Message should mention protocol with port 9103: " + msg);
+            Assertions.assertTrue(
+                    msg.contains("<dubbo:protocol name=\"dubbo\" />"),
+                    "Message should mention protocol with default port: " + msg);
+            Assertions.assertTrue(
+                    msg.endsWith("Please remove redundant configs or get config by id."),
+                    "Unexpected message suffix: " + msg);
         }
 
         ModuleConfig moduleConfig = new ModuleConfig();


### PR DESCRIPTION
## What is the purpose of the change?

This PR stabilizes `testGetConfigByIdOrName` by fixing an order-dependent assertion that caused flakiness under randomized execution orders.

## Root Cause

When multiple `ProtocolConfig` objects share the same name, `ConfigManager.getConfig()` throws an `IllegalStateException` whose message lists all matching configs. The order of these instances in the message depends on the iteration order of internal collections, which is non-deterministic. The previous test compared the entire exception message with a hard-coded string, making it fail intermittently when the order of entries changed.

## Changes Made

- Replaced strict `assertEquals` on the exception message with **content-based checks** (`startsWith`, `contains`, `endsWith`).
- Verified that both protocol entries appear in the message, regardless of their order.
- Kept the rest of the test logic unchanged.

## Verification

You can try running the following snippet of code from the dubbo repo root, on both pre-fix and post-fix code

```bash
./mvnw -q -pl dubbo-common edu.illinois:nondex-maven-plugin:2.2.1:nondex \
  -DnondexRuns=50 \
  -Dtest=org.apache.dubbo.config.context.ConfigManagerTest#testGetConfigByIdOrName
```

The test should fail intermittently on the pre-fix version, but pass consistently across all seeds on the post-fix version.
NonDex run logs will be available under the `dubbo-common/.nondex` directory.

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Make sure gitHub actions can pass. [Why the workflow is failing and how to fix it?](../CONTRIBUTING.md)