### PR TITLE
Fix: Stabilize `ServiceDefinitionBuilderTest.testBuilderComplexObject` to prevent Non-Dex nondeterminism 

### DIFF
--- a/dubbo-common/src/test/java/org/apache/dubbo/metadata/definition/ServiceDefinitionBuilderTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/metadata/definition/ServiceDefinitionBuilderTest.java
@@ -95,18 +95,22 @@ class ServiceDefinitionBuilderTest {
         Assertions.assertEquals(findComplexObject.getReturnType(), ComplexObject.class.getCanonicalName());
 
         Assertions.assertTrue(
-                testAnnotation
-                                .getAnnotations()
-                                .equals(
-                                        Arrays.asList(
-                                                "@org.apache.dubbo.metadata.definition.service.annotation.MockMethodAnnotation(value=777)",
+                (testAnnotation
+                                        .getAnnotations()
+                                        .contains(
+                                                "@org.apache.dubbo.metadata.definition.service.annotation.MockMethodAnnotation(value=777)")
+                                && testAnnotation
+                                        .getAnnotations()
+                                        .contains(
                                                 "@org.apache.dubbo.metadata.definition.service.annotation.MockMethodAnnotation2(value=888)"))
                         // JDK 17 style
-                        || testAnnotation
-                                .getAnnotations()
-                                .equals(
-                                        Arrays.asList(
-                                                "@org.apache.dubbo.metadata.definition.service.annotation.MockMethodAnnotation(777)",
+                        || (testAnnotation
+                                        .getAnnotations()
+                                        .contains(
+                                                "@org.apache.dubbo.metadata.definition.service.annotation.MockMethodAnnotation(777)")
+                                && testAnnotation
+                                        .getAnnotations()
+                                        .contains(
                                                 "@org.apache.dubbo.metadata.definition.service.annotation.MockMethodAnnotation2(888)")));
         Assertions.assertEquals(testAnnotation.getReturnType(), "void");
 


### PR DESCRIPTION
## What is the purpose of the change?

This PR stabilizes the test `ServiceDefinitionBuilderTest.testBuilderComplexObject`, which was exhibiting **order-dependent flakiness** in the annotation comparison logic.

## Root Cause

The test compared the list returned by `testAnnotation.getAnnotations()` using strict `equals()` checks against hard-coded ordered lists. However, the order of annotations retrieved via Java reflection is not **guaranteed**. The order may vary across JVM versions or execution orders. This caused intermittent assertion failures when the annotations were returned in a different order.

## Changes Made

- Replaced strict `equals()` checks with order-insensitive `contains()` assertions.
- Preserved the existing test structure, indentation, and style for consistency.
- Retained compatibility with both JDK 8 and JDK 17 annotation formats.

## Verification

You can try running the following snippet of code from the dubbo repo root, on both pre-fix and post-fix code

```bash
./mvnw -q -pl dubbo-common edu.illinois:nondex-maven-plugin:2.2.1:nondex \
  -DnondexRuns=50 \
  -Dtest=org.apache.dubbo.metadata.definition.ServiceDefinitionBuilderTest#testBuilderComplexObject
```

The test should fail intermittently on the pre-fix version, but pass consistently across all seeds on the post-fix version.
NonDex run logs will be available under the `dubbo-common/.nondex` directory.

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Make sure gitHub actions can pass. [Why the workflow is failing and how to fix it?](../CONTRIBUTING.md)