### PR TITLE
Fix: Stabilize `ReferenceConfigTest.testSearchReferences` to prevent Non-Dex nondeterminism in `ReferenceConfigTest.testLargeReferences` 

### DIFF
--- a/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/ReferenceConfigTest.java
+++ b/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/ReferenceConfigTest.java
@@ -58,6 +58,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -940,9 +941,10 @@ class ReferenceConfigTest {
                 .getDefaultModule()
                 .getConfigManager()
                 .getReferences();
-        List<ReferenceConfigBase<?>> results = references.stream()
-                .filter(rc -> rc.equals(references.iterator().next()))
-                .collect(Collectors.toList());
+        Iterator<ReferenceConfigBase<?>> it = references.iterator();
+        ReferenceConfigBase<?> first = it.next();
+        List<ReferenceConfigBase<?>> results =
+                references.stream().filter(first::equals).collect(Collectors.toList());
         long t2 = System.currentTimeMillis();
         long cost = t2 - t1;
         logger.info("Search large references cost: {}ms", cost);


### PR DESCRIPTION
## What is the purpose of the change?

This PR stabilizes `ReferenceConfigTest.testSearchReferences` to prevent Non-Dex nondeterministic failures in the method `ReferenceConfigTest.testLargeReferences` by making the equality check over the reference collection deterministic.

## Root Cause

The previous implementation was unstable because:
- `references` is backed by an unordered collection.
- `references.iterator().next()` was called inside the stream filter, so each element in the stream could be compared against a potentially different “first” element if the iteration order changed.
- Under NonDex, this led to `results.size()` sometimes being 0, sometimes > 1, causing intermittent failures in `testSearchReferences`, and therefore in `testLargeReferences`.

## Changes Made

Only testSearchReferences was modified:

- Capture the “first” element once, then reuse it throughout the stream
- No longer depend on calling `iterator().next()` repeatedly on an unordered collection inside the filter.
- The timing logic and assertions in both `testLargeReferences` and `testSearchReferences` are left unchanged
- Still asserting that exactly one reference in the large collection is equal to the first one (the intended behavior).


## Verification

You can try running the following snippet of code from the dubbo repo root, on both pre-fix and post-fix code

```bash
./mvnw -pl dubbo-config/dubbo-config-api \
  edu.illinois:nondex-maven-plugin:2.2.1:nondex \
  -DnondexRuns=50 \
  -Dtest=org.apache.dubbo.config.ReferenceConfigTest#testLargeReferences
```

The test should fail intermittently on the pre-fix version, but pass consistently across all seeds on the post-fix version.
NonDex run logs will be available under the `dubbo-config/dubbo-config-api/.nondex` directory.

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Make sure gitHub actions can pass. [Why the workflow is failing and how to fix it?](../CONTRIBUTING.md)