### PR TITLE
Fix: Stabilize `ExporterSideConfigUrlTest` by disabling metrics initialization during URL export

### DIFF
--- a/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/url/ExporterSideConfigUrlTest.java
+++ b/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/url/ExporterSideConfigUrlTest.java
@@ -18,6 +18,7 @@ package org.apache.dubbo.config.url;
 
 import org.apache.dubbo.common.logger.Logger;
 import org.apache.dubbo.common.logger.LoggerFactory;
+import org.apache.dubbo.config.SysProps;
 import org.apache.dubbo.config.bootstrap.DubboBootstrap;
 
 import java.io.UnsupportedEncodingException;
@@ -41,12 +42,16 @@ class ExporterSideConfigUrlTest extends UrlTestBase {
     @BeforeEach
     public void setUp() {
         DubboBootstrap.reset();
+        SysProps.clear();
+        SysProps.setProperty("dubbo.metrics.enabled", "false");
+        SysProps.setProperty("dubbo.metrics.protocol", "disabled");
         initServConf();
     }
 
     @AfterEach()
     public void teardown() {
         DubboBootstrap.reset();
+        SysProps.clear();
     }
 
     @Test


### PR DESCRIPTION
## What is the purpose of the change?

This PR stabilizes the following three tests in `ExporterSideConfigUrlTest`:
- `exporterMethodConfigUrlTest`
- `exporterServiceConfigUrlTest`
- `exporterProviderConfigUrlTest`

These tests were intermittently failing under randomized execution orders due to nondeterministic behavior in Micrometer’s composite meter registry, which was being initialized during Dubbo’s metrics setup, even though these URL-related tests do not depend on metrics.

## Root Cause

When `servConf.export()` is invoked inside `verifyExporterUrlGeneration`, Dubbo triggers `DefaultApplicationDeployer.initialize()`, which initializes metrics reporters (Prometheus by default).
During this initialization, Micrometer’s `CompositeMeterRegistry` iterates through an internal `IdentityHashMap` whose iteration order is not deterministic under randomized JVM execution orders.

Under certain NonDex seeds, this produces:
```lua
java.lang.ArrayIndexOutOfBoundsException
  at java.util.IdentityHashMap$KeyIterator.next(...)
  at io.micrometer.core.instrument.composite.CompositeMeterRegistry.updateDescendants(...)
```

This exception happens before the test even begins validating URL parameters, making the failure unrelated to URL behavior.
The test suite never intended to validate metrics behavior here, so metrics initialization adds unnecessary non-determinism.

## Changes Made

- Added explicit test-local configuration to disable the metrics subsystem for every test execution in this class
- Ensured cleanup via `SysProps.clear()` in both `@BeforeEach` and `@AfterEach` to preserve isolation.
- Preserved the existing test structure and behavior.

## Verification

You can try running the following snippet of code from the dubbo repo root, on both pre-fix and post-fix code

```bash
./mvnw -q -pl dubbo-config/dubbo-config-api \
  edu.illinois:nondex-maven-plugin:2.2.1:nondex \
  -DnondexRuns=20
```

The tests should fail intermittently on the pre-fix version, but pass consistently across all seeds on the post-fix version.
NonDex run logs will be available under the `dubbo-config/dubbo-config-api/.nondex` directory.

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Make sure gitHub actions can pass. [Why the workflow is failing and how to fix it?](../CONTRIBUTING.md)
