### PR TITLE
Stabilize `MethodConfigTest` by disabling metrics initialization to avoid Micrometer nondeterminism

### DIFF
--- a/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/MethodConfigTest.java
+++ b/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/MethodConfigTest.java
@@ -101,10 +101,14 @@ class MethodConfigTest {
     @BeforeEach
     public void beforeEach() {
         DubboBootstrap.reset();
+        SysProps.clear();
+        SysProps.setProperty("dubbo.metrics.enabled", "false");
+        SysProps.setProperty("dubbo.metrics.protocol", "disabled");
     }
 
     @AfterEach
     public void afterEach() {
+        DubboBootstrap.reset();
         SysProps.clear();
     }
 


### PR DESCRIPTION
## What is the purpose of the change?

This PR stabilizes the following tests in `MethodConfigTest`:
- `testOverrideMethodConfigOfService`
- `testAddMethodConfigOfService`
- `testOverrideMethodConfigOfReference`
- `testAddMethodConfigOfReference`
- `testIgnoreInvalidMethodConfigOfService`

These tests were intermittently failing under randomized execution orders (NonDex) due to nondeterministic behavior in Micrometer’s composite meter registry. The tests focus on method-level configuration overrides and do not intend to validate metrics behavior. Yet, the metrics subsystem was being initialized as part of the bootstrap process, introducing unnecessary nondeterminism.

## Root Cause

During application bootstrap, Dubbo initializes the metrics subsystem, which in turn configures Micrometer’s composite meter registry. Internally, Micrometer uses an `IdentityHashMap` whose iteration behavior is not deterministic under randomized JVM execution orders.

Under certain NonDex seeds, this produces:
```lua
java.lang.ArrayIndexOutOfBoundsException
  at java.util.IdentityHashMap$KeyIterator.next(...)
  at io.micrometer.core.instrument.composite.CompositeMeterRegistry.updateDescendants(...)
```

These failures occur before the tests exercise any method-configuration logic, so the flakiness is caused purely by nondeterministic metrics initialization and not by the `MethodConfig` functionality under test.

## Changes Made

- Added test-local configuration to explicitly disable the metrics subsystem for every test in `MethodConfigTest`.
- Ensured isolation by calling `SysProps.clear()` in `@BeforeEach` and `DubboBootstrap.reset()` in `@AfterEach`, so no metrics/config-related state leaks across tests.
- Kept all existing assertions and behavior intact.

## Verification

You can try running the following snippet of code from the dubbo repo root, on both pre-fix and post-fix code

```bash
./mvnw -q -pl dubbo-config/dubbo-config-api \
  edu.illinois:nondex-maven-plugin:2.2.1:nondex \
  -DnondexRuns=20
```

The tests should fail intermittently on the pre-fix version, but pass consistently across all seeds on the post-fix version.
NonDex run logs will be available under the `dubbo-config/dubbo-config-api/.nondex` directory.

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Make sure gitHub actions can pass. [Why the workflow is failing and how to fix it?](../CONTRIBUTING.md)
