### PR TITLE
Fix: the interface-level timeout and retry configurations become invalid after the caller application is restarted

### DIFF
--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/integration/RegistryDirectory.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/integration/RegistryDirectory.java
@@ -145,6 +145,13 @@ public class RegistryDirectory<T> extends DynamicDirectory<T> {
         }
 
         ApplicationModel applicationModel = url.getApplicationModel();
+        if (moduleModel
+                .modelEnvironment()
+                .getConfiguration()
+                .convert(Boolean.class, org.apache.dubbo.registry.Constants.ENABLE_CONFIGURATION_LISTEN, true)) {
+            consumerConfigurationListener.addNotifyListener(this);
+            referenceConfigurationListener = new ReferenceConfigurationListener(moduleModel, this, url);
+        }
         String registryClusterName = registry.getUrl()
                 .getParameter(
                         RegistryConstants.REGISTRY_CLUSTER_KEY,
@@ -153,13 +160,6 @@ public class RegistryDirectory<T> extends DynamicDirectory<T> {
             super.subscribe(url);
             return null;
         });
-        if (moduleModel
-                .modelEnvironment()
-                .getConfiguration()
-                .convert(Boolean.class, org.apache.dubbo.registry.Constants.ENABLE_CONFIGURATION_LISTEN, true)) {
-            consumerConfigurationListener.addNotifyListener(this);
-            referenceConfigurationListener = new ReferenceConfigurationListener(moduleModel, this, url);
-        }
     }
 
     private ConsumerConfigurationListener getConsumerConfigurationListener(ModuleModel moduleModel) {


### PR DESCRIPTION
Details: By moving the subscription logic after initializing referenceConfigurationListener in the dynamic configuration
Addresses: #15783

## What is the purpose of the change?

### What's the problem

In Dubbo 3.2.11 and all latest Dubbo 3 versions, the interface-level timeout and retry configurations become invalid after the caller application is restarted

### Root cause

The investigation into why the referenceConfigurationListener was null points to a potential timing issue in the RegistryDirectory class's subscribe method: providers are being subscribed to before the referenceConfigurationListener is initialized.

### How to fix

I solve this problem by placing the referenceConfigurationListener initialization logic before the call to super.subscribe(url).

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Make sure gitHub actions can pass. [Why the workflow is failing and how to fix it?](../CONTRIBUTING.md)
