### PR TITLE
Fix: Stabilize multiple tests in `ServiceConfigTest` by isolating system properties and cached state

### DIFF
--- a/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/ServiceConfigTest.java
+++ b/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/ServiceConfigTest.java
@@ -100,6 +100,9 @@ class ServiceConfigTest {
     public void setUp() throws Exception {
         DubboBootstrap.reset();
 
+        SysProps.setProperty("dubbo.metrics.enabled", "false");
+        SysProps.setProperty("dubbo.metrics.protocol", "disabled");
+
         service = new ServiceConfig<>();
         service2 = new ServiceConfig<>();
         serviceWithoutRegistryConfig = new ServiceConfig<>();
@@ -165,7 +168,10 @@ class ServiceConfigTest {
     }
 
     @AfterEach
-    public void tearDown() {}
+    public void tearDown() {
+        SysProps.clear();
+        DubboBootstrap.reset();
+    }
 
     @Test
     void testExport() throws Exception {


### PR DESCRIPTION
## What is the purpose of the change?

This PR stabilizes several tests inside `ServiceConfigTest`:

- `testMethodConfigWithInvalidArgumentIndex`
- `testExport`
- `testVersionAndGroupConfigFromProvider`
- `testUnexport`
- `testMethodConfigWithUnmatchedArgument`
- `testMethodConfigWithUnknownArgumentType`
- `testMethodConfigWithInvalidArgumentConfig`
- `testMethodConfigWithConfiguredArgumentTypeAndIndex`
- `testMethodConfigWithConfiguredArgumentType`
- `testExportWithoutRegistryConfig`
- `testDelayExport`
- `testApplicationInUrl`
- `testServiceListener`
- `testProxy`
- `testMethodConfigWithConfiguredArgumentIndex`

These tests were intermittently failing under randomized execution orders (NonDex). All of them involve the service export/unexport lifecycle and indirectly trigger application bootstrap logic, including the initialization of the metrics subsystem.

When metrics are enabled, Micrometer’s composite meter registry is created during bootstrap. Its internal data structures (such as `IdentityHashMap`) exhibit nondeterministic iteration behavior under random JVM execution orders, which leads to unpredictable test failures.

Additionally, `ServiceConfig` interacts with the global `DubboBootstrap` singleton, so any leftover state from one test can leak into the next one under random execution order.

## Root Cause

Two independent sources of nondeterminism were affecting the tests:

### 1. Metrics subsystem initialization

Even though `ServiceConfigTest` does not test metrics functionality, the metrics subsystem is still initialized by default as part of the service export flow.

Micrometer uses an `IdentityHashMap` internally, and under certain NonDex seeds this leads to exceptions such as:

```lua
java.lang.ArrayIndexOutOfBoundsException
  at java.util.IdentityHashMap$KeyIterator.next(...)
  at io.micrometer.core.instrument.composite.CompositeMeterRegistry.updateDescendants(...)
```

This happens _before_ the test reaches any `ServiceConfig` assertions.

### 2. Shared `DubboBootstrap` singleton

`DubboBootstrap` stores global state such as exported services, protocol configuration, and application metadata.

Without cleanup between tests, the bootstrap instance from a previous test can leak into the next one, creating nondeterministic behavior under reordered execution.

## Changes Made

The fix is as follows:

- Metrics are explicitly disabled at the beginning of each test so that the metrics subsystem never initializes, removing one major source of nondeterminism.
- All system properties introduced during testing are cleared afterward to prevent them from leaking across test boundaries.
- The global Dubbo bootstrap instance is reset after every test to ensure complete isolation and eliminate interference caused by shared internal state.
- No test logic, assertions, or mocks were modified.

## Verification

You can try running the following snippet of code from the dubbo repo root, on both pre-fix and post-fix code

```bash
./mvnw -q -pl dubbo-config/dubbo-config-api \
  edu.illinois:nondex-maven-plugin:2.2.1:nondex \
  -DnondexRuns=20
```

The tests should fail intermittently on the pre-fix version, but pass consistently across all seeds on the post-fix version.
NonDex run logs will be available under the `dubbo-config/dubbo-config-api/.nondex` directory.

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Make sure gitHub actions can pass. [Why the workflow is failing and how to fix it?](../CONTRIBUTING.md)
