### PR TITLE
Fix: Stabilize `ReferenceConfigTest` by Disabling Metrics Initialization and Ensuring Test Isolation

### DIFF
--- a/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/ReferenceConfigTest.java
+++ b/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/ReferenceConfigTest.java
@@ -141,6 +141,9 @@ class ReferenceConfigTest {
     public void setUp() throws Exception {
         DubboBootstrap.reset();
         FrameworkModel.destroyAll();
+        SysProps.clear();
+        SysProps.setProperty("dubbo.metrics.enabled", "false");
+        SysProps.setProperty("dubbo.metrics.protocol", "disabled");
         ApplicationModel.defaultModel().getApplicationConfigManager();
         DubboBootstrap.getInstance();
     }
@@ -149,6 +152,7 @@ class ReferenceConfigTest {
     public void tearDown() throws IOException {
         DubboBootstrap.reset();
         FrameworkModel.destroyAll();
+        SysProps.clear();
         Mockito.framework().clearInlineMocks();
     }
 


### PR DESCRIPTION
## What is the purpose of the change?

This PR stabilizes all `ReferenceConfig` tests that were intermittently failing under randomized execution orders (NonDex):

- `testCreateInvokerForLocalRefer`
- `testClassLoader`
- `testMultipleRegistryForRemoteRefer`
- `testCreateInvokerForRemoteRefer`
- `testCreateInvokerWithRemoteUrlForRemoteRefer`
- `testCreateInvokerWithRegistryUrlForRemoteRefer`
- `testGenericAndInterfaceConflicts`
- `testDifferentClassLoader`
- `testAppendConfig`
- `test1ReferenceRetry`
- `test2ReferenceRetry`

All of these tests were affected by nondeterministic behavior triggered by Micrometer’s composite meter registry during Dubbo bootstrap, even though the tests do not depend on metrics.

## Root Cause

These failures are identical to previously fixed issues in:
- https://github.com/apache/dubbo/pull/15778 
- https://github.com/apache/dubbo/pull/15782 
- https://github.com/apache/dubbo/pull/15785 

Those earlier PRs addressed flakiness caused by Micrometer’s `CompositeMeterRegistry` being initialized during `DubboBootstrap.initialize()`, leading to intermittent `ArrayIndexOutOfBoundsException` under NonDex seeds.

`ReferenceConfigTest` suffers from the exact same root cause, and the same fix (inline disabling of metrics + SysProps isolation) resolves the issue.

## Changes Made

- Disabled the metrics subsystem at the beginning of each test 
- Cleared all system properties using `SysProps.clear()` in both `@BeforeEach` and `@AfterEach`.
- Ensured consistent test isolation by resetting framework state

## Verification

You can try running the following snippet of code from the dubbo repo root, on both pre-fix and post-fix code

```bash
./mvnw -q -pl dubbo-config/dubbo-config-api \
  edu.illinois:nondex-maven-plugin:2.2.1:nondex \
  -DnondexRuns=20
```

The tests should fail intermittently on the pre-fix version, but pass consistently across all seeds on the post-fix version.
NonDex run logs will be available under the `dubbo-config/dubbo-config-api/.nondex` directory.

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Make sure gitHub actions can pass. [Why the workflow is failing and how to fix it?](../CONTRIBUTING.md)
