### PR TITLE
Fix: Stabilize `ConsumerConfigTest` by Disabling Metrics Initialization and Ensuring Test Isolation

### DIFF
--- a/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/ConsumerConfigTest.java
+++ b/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/ConsumerConfigTest.java
@@ -41,11 +41,15 @@ class ConsumerConfigTest {
     @BeforeEach
     public void setUp() {
         DubboBootstrap.reset();
+        SysProps.clear();
+        SysProps.setProperty("dubbo.metrics.enabled", "false");
+        SysProps.setProperty("dubbo.metrics.protocol", "disabled");
     }
 
     @AfterEach
     public void afterEach() {
         SysProps.clear();
+        DubboBootstrap.reset();
     }
 
     @Test


### PR DESCRIPTION
## What is the purpose of the change?

This PR stabilizes several tests in `ConsumerConfigTest` that were intermittently failing under randomized execution orders (NonDex):

- `testOverrideConfigSingle`
- `testOverrideConfigByPluralityId`
- `testOverrideConfigBySingularId`
- `testOverrideConfigByDubboProps`
- `testReferenceAndConsumerConfigOverlay`

All of these tests trigger `DubboBootstrap.initialize()`, which unintentionally initializes the metrics subsystem. Since these tests do not depend on metrics, metrics initialization introduces nondeterministic failures unrelated to consumer configuration logic.

## Root Cause

These failures are identical to previously fixed issues in:

- https://github.com/apache/dubbo/pull/15778
- https://github.com/apache/dubbo/pull/15782
- https://github.com/apache/dubbo/pull/15785

Those PRs addressed flakiness caused by Micrometer’s `CompositeMeterRegistry` being initialized during `DubboBootstrap.initialize()`, which, under certain NonDex randomized execution orders, can throw an `ArrayIndexOutOfBoundsException` from an internal `IdentityHashMap` iterator.

`ConsumerConfigTest` suffers from the same root cause, and the same fix (inline disabling of metrics + SysProps isolation) resolves the issue.

## Changes Made

- Disabled the metrics subsystem at the beginning of each test.
- Cleared all system properties via `SysProps.clear()` in the lifecycle hooks to avoid cross-test pollution.
- Reset framework state using `DubboBootstrap.reset()` to ensure isolation between tests.

## Verification

You can try running the following snippet of code from the dubbo repo root, on both pre-fix and post-fix code

```bash
./mvnw -q -pl dubbo-config/dubbo-config-api \
  edu.illinois:nondex-maven-plugin:2.2.1:nondex \
  -DnondexRuns=20
```

The tests should fail intermittently on the pre-fix version, but pass consistently across all seeds on the post-fix version.
NonDex run logs will be available under the `dubbo-config/dubbo-config-api/.nondex` directory.

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Make sure gitHub actions can pass. [Why the workflow is failing and how to fix it?](../CONTRIBUTING.md)
