### PR TITLE
Fix: Stabilize `DubboBootstrapTest` by Disabling Metrics Initialization and Ensuring Test Isolation      

### DIFF
--- a/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/bootstrap/DubboBootstrapTest.java
+++ b/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/bootstrap/DubboBootstrapTest.java
@@ -67,6 +67,7 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -107,6 +108,14 @@ class DubboBootstrapTest {
     @AfterAll
     public static void tearDown() {
         SystemPropertyConfigUtils.clearSystemProperty(CommonConstants.DubboProperty.DUBBO_PROPERTIES_KEY);
+    }
+
+    @BeforeEach
+    public void beforeEach() {
+        DubboBootstrap.reset();
+        SysProps.clear();
+        SysProps.setProperty("dubbo.metrics.enabled", "false");
+        SysProps.setProperty("dubbo.metrics.protocol", "disabled");
     }
 
     @AfterEach


### PR DESCRIPTION
## What is the purpose of the change?

This PR stabilizes several tests inside `DubboBootstrapTest` that were intermittently failing under randomized execution orders (NonDex):

- `testBootstrapStart`
- `testLocalMetadataServiceExporter`
- `testRemoteMetadataServiceExporter`
- `testRemoteMetadataServiceExporterCheckMetadataType`
- `testRegistryWithMetadataReport`
- `testLoadRegistries`
- `testDefaultTriple`

All of these tests indirectly trigger `DubboBootstrap.initialize()`, which cause the metrics subsystem to be initialized. Since these tests do not depend on metrics, metrics initialization introduces nondeterministic failures unrelated to bootstrap or metadata logic.

## Root Cause

These failures are identical to previously fixed issues in:

- https://github.com/apache/dubbo/pull/15778  
- https://github.com/apache/dubbo/pull/15782  
- https://github.com/apache/dubbo/pull/15785  

Those PRs addressed flakiness caused by Micrometer’s `CompositeMeterRegistry` being initialized during `DubboBootstrap.initialize()`, which, under certain NonDex randomized execution orders, can throw an `ArrayIndexOutOfBoundsException` from an internal `IdentityHashMap` iterator.

`DubboBootstrapTest` suffered from the same root cause:  
Stale Micrometer meter registries were leaking across test methods due to the lack of proper cleanup between bootstrap cycles.

## Changes Made

Added the following setup at the beginning of each test:

```java
@BeforeEach
public void beforeEach() {
    DubboBootstrap.reset();
    SysProps.clear();
    SysProps.setProperty("dubbo.metrics.enabled", "false");
    SysProps.setProperty("dubbo.metrics.protocol", "disabled");
}
```

These changes:

- Disable metrics for this test class to prevent registry initialization.
- Clear all Dubbo system properties between tests.
- Reset `DubboBootstrap` to ensure isolated and deterministic bootstraps.

## Verification

You can try running the following snippet of code from the dubbo repo root, on both pre-fix and post-fix code

```bash
./mvnw -q -pl dubbo-config/dubbo-config-api \
  edu.illinois:nondex-maven-plugin:2.2.1:nondex \
  -DnondexRuns=20
```

The tests should fail intermittently on the pre-fix version, but pass consistently across all seeds on the post-fix version.
NonDex run logs will be available under the `dubbo-config/dubbo-config-api/.nondex` directory.


## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Make sure gitHub actions can pass. [Why the workflow is failing and how to fix it?](../CONTRIBUTING.md)
