### PR TITLE
Fix: Stabilize `ReferenceCacheTest` by Disabling Metrics Initialization and Ensuring Test Isolation 

### DIFF
--- a/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/utils/ReferenceCacheTest.java
+++ b/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/utils/ReferenceCacheTest.java
@@ -19,9 +19,11 @@ package org.apache.dubbo.config.utils;
 import org.apache.dubbo.common.config.ReferenceCache;
 import org.apache.dubbo.config.ApplicationConfig;
 import org.apache.dubbo.config.RegistryConfig;
+import org.apache.dubbo.config.SysProps;
 import org.apache.dubbo.config.bootstrap.DubboBootstrap;
 import org.apache.dubbo.config.utils.service.FooService;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -34,8 +36,18 @@ class ReferenceCacheTest {
     @BeforeEach
     public void setUp() throws Exception {
         DubboBootstrap.reset();
+        SysProps.clear();
+        SysProps.setProperty("dubbo.metrics.enabled", "false");
+        SysProps.setProperty("dubbo.metrics.protocol", "disabled");
         MockReferenceConfig.setCounter(0);
         XxxMockReferenceConfig.setCounter(0);
+        SimpleReferenceCache.CACHE_HOLDER.clear();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        DubboBootstrap.reset();
+        SysProps.clear();
         SimpleReferenceCache.CACHE_HOLDER.clear();
     }
 


### PR DESCRIPTION
## What is the purpose of the change?

This PR stabilizes several tests inside `ReferenceCacheTest` that were intermittently failing under randomized execution orders (NonDex):

- `testGetCacheSameReference`
- `testGetCacheDiffReference`
- `testGetCacheWithKey`
- `testGetCacheDiffName`
- `testDestroy`
- `testDestroyAll`

All of these tests invoke reference creation through `ReferenceConfig.get()`, which cause the metrics subsystem to be initialized. This introduces nondeterministic behavior that causes intermittent test failures unrelated to the core reference-caching logic.

## Root Cause

These failures are identical to previously fixed issues in:

- https://github.com/apache/dubbo/pull/15778  
- https://github.com/apache/dubbo/pull/15782  
- https://github.com/apache/dubbo/pull/15785  

Each of those PRs addressed flakiness caused by Micrometer’s `CompositeMeterRegistry`, which can throw an `ArrayIndexOutOfBoundsException` when it iterates over internal `IdentityHashMap` structures under randomized execution orders (NonDex).

`ReferenceCacheTest` suffered from the same underlying issue:  
Dubbo framework state was leaking between test methods. This meant that the behavior of reference creation in one test could affect subsequent tests, causing nondeterministic failures.

## Changes Made

To fully isolate each test method and eliminate shared state, the following changes were applied:

- All Dubbo-related system properties were cleared at the beginning of each test so that no stale configuration could influence behavior.
- Metrics were explicitly disabled for the entire test class by setting the appropriate system properties. 
- After each test, Dubbo was reset again, system properties were cleared, and the reference cache was emptied to guarantee that no state persisted into the next test.

Together, these changes ensure that every test in `ReferenceCacheTest` starts from a completely clean, predictable environment, eliminating flaky behavior caused by shared or leaked state.

## Verification

You can try running the following snippet of code from the dubbo repo root, on both pre-fix and post-fix code

```bash
./mvnw -q -pl dubbo-config/dubbo-config-api \
  edu.illinois:nondex-maven-plugin:2.2.1:nondex \
  -DnondexRuns=20
```

The tests should fail intermittently on the pre-fix version, but pass consistently across all seeds on the post-fix version.
NonDex run logs will be available under the `dubbo-config/dubbo-config-api/.nondex` directory.

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Make sure gitHub actions can pass. [Why the workflow is failing and how to fix it?](../CONTRIBUTING.md)
