### PR TITLE
Fix: Override Guava to 32.0.0-jre in parent POM to remediate CVE-2020-8908 and CVE-2023-2976

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -186,6 +186,12 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
+
+      <dependency>
+        <groupId>com.google.guava</groupId>
+        <artifactId>guava</artifactId>
+        <version>32.0.0-jre</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 


### PR DESCRIPTION


## What is the purpose of the change?
This PR overrides **com.google.guava:guava** to 32.0.0-jre in the parent dependencyManagement section.
The goal is to remediate the following reported CVEs:

CVE-2020-8908 – Temporary directory creation vulnerability

CVE-2023-2976 – Insecure temporary directory handling

These CVEs were detected via security scanners in multiple Dubbo modules.
Overriding Guava in the parent POM ensures a consistent, safe version is applied across the entire multi-module build without altering individual submodules.


## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Make sure gitHub actions can pass. [Why the workflow is failing and how to fix it?](../CONTRIBUTING.md)
