### PR TITLE
fix #15735 The configuration information logged by DefaultApplicationDeployer needs to be sanitized (masked) 

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/config/ConfigCenterConfig.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/config/ConfigCenterConfig.java
@@ -141,6 +141,29 @@ public class ConfigCenterConfig extends AbstractConfig {
     }
 
     @Override
+    public String toString() {
+        return "ConfigCenterConfig{" + "address='"
+                + address + '\'' + ", protocol='"
+                + protocol + '\'' + ", namespace='"
+                + namespace + '\'' + ", group='"
+                + group + '\'' + ", check="
+                + check + ", highestPriority="
+                + highestPriority + ", username='"
+                + username + '\'' + ", password='"
+                + mask(password) + '\'' + '}';
+    }
+
+    /**
+     * Masks the given value for security purposes, replacing it with asterisks.
+     */
+    private String mask(String value) {
+        if (value == null || value.isEmpty()) {
+            return value;
+        }
+        return "******";
+    }
+
+    @Override
     protected void checkDefault() {
         super.checkDefault();
 


### PR DESCRIPTION
## What is the purpose of the change?
This PR addresses issue #15735 by improving the handling of sensitive configuration properties in ConfigCenterConfig. It ensures that sensitive values like passwords are masked in logs and standardizes the approach for property safety checks, preventing accidental exposure of credentials.

