### PR TITLE
Fix: Upgrade Netty 4, Commons-Lang3 and Spring Security to remediate CVEs

### DIFF
--- a/dubbo-dependencies-bom/pom.xml
+++ b/dubbo-dependencies-bom/pom.xml
@@ -95,7 +95,7 @@
     <javassist_version>3.30.2-GA</javassist_version>
     <byte-buddy_version>1.17.5</byte-buddy_version>
     <netty_version>3.2.10.Final</netty_version>
-    <netty4_version>4.2.2.Final</netty4_version>
+    <netty4_version>4.2.7.Final</netty4_version>
     <httpclient_version>4.5.14</httpclient_version>
     <httpcore_version>4.4.16</httpcore_version>
     <fastjson_version>1.2.83_noneautotype</fastjson_version>
@@ -119,7 +119,7 @@
     <jcache_version>1.1.1</jcache_version>
     <apollo_client_version>2.4.0</apollo_client_version>
     <snakeyaml_version>2.4</snakeyaml_version>
-    <commons_lang3_version>3.17.0</commons_lang3_version>
+    <commons_lang3_version>3.18.0</commons_lang3_version>
     <envoy_api_version>0.1.35</envoy_api_version>
     <micrometer.version>1.15.1</micrometer.version>
     <opentelemetry.version>1.50.0</opentelemetry.version>
@@ -141,7 +141,7 @@
     <nacos_version>2.5.1</nacos_version>
     <sentinel.version>1.8.8</sentinel.version>
     <seata.version>1.8.0</seata.version>
-    <grpc.version>1.73.0</grpc.version>
+    <grpc.version>1.75.0</grpc.version>
     <grpc_contrib_verdion>0.8.1</grpc_contrib_verdion>
     <jprotoc_version>1.2.2</jprotoc_version>
     <mustache_version>0.9.14</mustache_version>

--- a/dubbo-test/dubbo-test-check/pom.xml
+++ b/dubbo-test/dubbo-test-check/pom.xml
@@ -55,6 +55,7 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
+      <version>3.18.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.zookeeper</groupId>

--- a/dubbo-test/dubbo-test-check/pom.xml
+++ b/dubbo-test/dubbo-test-check/pom.xml
@@ -34,6 +34,7 @@
     <commons.compress.version>1.27.1</commons.compress.version>
     <commons.exec.version>1.5.0</commons.exec.version>
     <async.http.client.version>2.12.4</async.http.client.version>
+    <commons_lang3_version>3.18.0</commons_lang3_version>
   </properties>
 
   <dependencies>
@@ -55,7 +56,7 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
-      <version>3.18.0</version>
+      <version>${commons_lang3_version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.zookeeper</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -165,12 +165,12 @@
 
     <!-- For unify spring boot 3 version -->
     <spring-6.version>6.2.11</spring-6.version>
-    <spring-security-6.version>6.5.1</spring-security-6.version>
+    <spring-security-6.version>6.5.4</spring-security-6.version>
     <spring-boot-3.version>3.5.0</spring-boot-3.version>
 
     <protobuf-protoc_version>3.22.3</protobuf-protoc_version>
     <!-- grpc_version should be same as grpc.version at dubbo-dependencies-bom -->
-    <grpc_version>1.73.0</grpc_version>
+    <grpc_version>1.75.0</grpc_version>
     <spotless-maven-plugin.version>2.45.0</spotless-maven-plugin.version>
     <dubbo-shared-resources.version>1.0.0</dubbo-shared-resources.version>
     <palantirJavaFormat.version>2.38.0</palantirJavaFormat.version>


### PR DESCRIPTION

## What is the purpose of the change?
This PR upgrades Netty 4, Apache Commons-Lang3, gRPC, and Spring Security 6 versions across the Dubbo build to remediate multiple security vulnerabilities detected by Trivy and OWASP Dependency-Check.

The new versions align Dubbo with the minimum fixed versions published in the CVE advisories and ensure the framework is not affected by reported DoS, Path Traversal, Recursion, and HTTP/2 attack vectors.

### Summary of CVEs remediated
**Netty / gRPC related**

- CVE-2025-55163 – Netty HTTP/2 “MadeYouReset” DDoS Vulnerability
- CVE-2025-58057 – Netty BrotliDecoder DoS (zip-bomb style)
- CVE-2025-58056 – Netty HTTP request smuggling
- CVE-2025-59419 – Netty SMTP Command Injection

**Apache Commons-Lang3**

- CVE-2025-48924 – Apache Commons-Lang3 uncontrolled recursion vulnerability

**Spring Security**

- CVE-2025-41248 – Spring Security authorization bypass

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Make sure gitHub actions can pass. [Why the workflow is failing and how to fix it?](../CONTRIBUTING.md)
