### PR TITLE
Fix issue 15678 Key no longer appear in exception messages

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/URL.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/URL.java
@@ -17,6 +17,7 @@
 package org.apache.dubbo.common;
 
 import org.apache.dubbo.common.config.Configuration;
+import org.apache.dubbo.common.config.ConfigurationUtils;
 import org.apache.dubbo.common.config.InmemoryConfiguration;
 import org.apache.dubbo.common.constants.CommonConstants;
 import org.apache.dubbo.common.constants.RemotingConstants;
@@ -1204,7 +1205,10 @@ public /*final**/ class URL implements Serializable {
             List<String> includes = (ArrayUtils.isEmpty(parameters) ? null : Arrays.asList(parameters));
             boolean first = true;
             for (Map.Entry<String, String> entry : new TreeMap<>(getParameters()).entrySet()) {
-                if (StringUtils.isNotEmpty(entry.getKey()) && (includes == null || includes.contains(entry.getKey()))) {
+                String key = entry.getKey();
+                if (StringUtils.isNotEmpty(key)
+                        && (includes == null || includes.contains(entry.getKey()))
+                        && !ConfigurationUtils.isSensitiveParameter(this, key)) {
                     if (first) {
                         if (concat) {
                             buf.append('?');

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/config/ConfigurationUtils.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/config/ConfigurationUtils.java
@@ -16,7 +16,9 @@
  */
 package org.apache.dubbo.common.config;
 
+import org.apache.dubbo.common.URL;
 import org.apache.dubbo.common.config.configcenter.DynamicConfigurationFactory;
+import org.apache.dubbo.common.constants.CommonConstants;
 import org.apache.dubbo.common.extension.ExtensionAccessor;
 import org.apache.dubbo.common.extension.ExtensionLoader;
 import org.apache.dubbo.common.logger.ErrorTypeAwareLogger;
@@ -60,6 +62,7 @@ public final class ConfigurationUtils {
     private static final Set<String> securityKey;
 
     private static volatile long expectedShutdownTime = Long.MAX_VALUE;
+    private static volatile Set<String> SensitiveParameterNames;
 
     static {
         Set<String> keys = new HashSet<>();
@@ -397,6 +400,34 @@ public final class ConfigurationUtils {
         ExtensionLoader<DynamicConfigurationFactory> loader =
                 extensionAccessor.getExtensionLoader(DynamicConfigurationFactory.class);
         return loader.getOrDefaultExtension(name);
+    }
+    /**
+     * Checks whether a parameter name is considered sensitive.
+     * <p>
+     * The set of sensitive parameter names is lazily initialized from configuration
+     * defined by {@link CommonConstants#SENSITIVE_PARAMETER_NAMES}. Initialization
+     * is thread-safe using double-checked locking.
+     *
+     * @param url  the {@link URL} to get the application model from
+     * @param name the parameter name to check
+     * @return true if the parameter is sensitive, false otherwise
+     */
+    public static boolean isSensitiveParameter(URL url, String name) {
+        if (SensitiveParameterNames == null) {
+            synchronized (ConfigurationUtils.class) {
+                if (SensitiveParameterNames == null) {
+                    Set<String> names = new HashSet<>();
+                    String value = ConfigurationUtils.getProperty(
+                            url.getOrDefaultApplicationModel(), CommonConstants.SENSITIVE_PARAMETER_NAMES);
+                    if (value != null) {
+                        String[] customNames = StringUtils.tokenize(value);
+                        Collections.addAll(names, customNames);
+                    }
+                    SensitiveParameterNames = Collections.unmodifiableSet(names);
+                }
+            }
+        }
+        return SensitiveParameterNames.contains(name);
     }
 
     /**

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/constants/CommonConstants.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/constants/CommonConstants.java
@@ -293,6 +293,8 @@ public interface CommonConstants {
 
     String PASSWORD_KEY = "password";
 
+    String SENSITIVE_PARAMETER_NAMES = "dubbo.url.sensitive-parameter-names";
+
     String HOST_KEY = "host";
 
     String PORT_KEY = "port";

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/config/ConfigurationUtilsTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/config/ConfigurationUtilsTest.java
@@ -21,6 +21,7 @@ import org.apache.dubbo.rpc.model.ApplicationModel;
 import org.apache.dubbo.rpc.model.FrameworkModel;
 import org.apache.dubbo.rpc.model.ModuleModel;
 
+import java.lang.reflect.Field;
 import java.util.Map;
 
 import org.junit.jupiter.api.Assertions;
@@ -111,7 +112,11 @@ class ConfigurationUtilsTest {
     }
 
     @Test
-    void testSensitiveParameterFromConfig() {
+    void testSensitiveParameterFromConfig() throws NoSuchFieldException, IllegalAccessException {
+        // Clear the static cache to ensure fresh load
+        Field field = ConfigurationUtils.class.getDeclaredField("SensitiveParameterNames");
+        field.setAccessible(true);
+        field.set(null, null);
         // Set a system property to simulate a custom sensitive parameter for testing
         System.setProperty("dubbo.url.sensitive-parameter-names", "token");
         // Construct a URL; the default ApplicationModel will read the configuration

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/config/ConfigurationUtilsTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/config/ConfigurationUtilsTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.dubbo.common.config;
 
+import org.apache.dubbo.common.URL;
 import org.apache.dubbo.rpc.model.ApplicationModel;
 import org.apache.dubbo.rpc.model.FrameworkModel;
 import org.apache.dubbo.rpc.model.ModuleModel;
@@ -107,5 +108,17 @@ class ConfigurationUtilsTest {
         Assertions.assertEquals(1, result.size());
         Assertions.assertEquals(
                 "zookeeper://127.0.0.1:2181\\ndubbo.protocol.port=20880", result.get("dubbo.registry.address"));
+    }
+
+    @Test
+    void testSensitiveParameterFromConfig() {
+        // Set a system property to simulate a custom sensitive parameter for testing
+        System.setProperty("dubbo.url.sensitive-parameter-names", "token");
+        // Construct a URL; the default ApplicationModel will read the configuration
+        URL url = URL.valueOf("nacos://127.0.0.1:8848/registry?password=secret&secretKey=mysecret&timeout=5000");
+        // Assert that the custom sensitive parameter is recognized
+        Assertions.assertTrue(ConfigurationUtils.isSensitiveParameter(url, "token"));
+        // Assert that a non-sensitive parameter is not recognized
+        Assertions.assertFalse(ConfigurationUtils.isSensitiveParameter(url, "username"));
     }
 }

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/url/URLParamTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/url/URLParamTest.java
@@ -16,9 +16,12 @@
  */
 package org.apache.dubbo.common.url;
 
+import org.apache.dubbo.common.URL;
+import org.apache.dubbo.common.config.ConfigurationUtils;
 import org.apache.dubbo.common.url.component.URLParam;
 import org.apache.dubbo.common.utils.CollectionUtils;
 
+import java.lang.reflect.Field;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -307,5 +310,26 @@ class URLParamTest {
         URLParam urlParam2 = URLParam.parse("methods=aaa&aaa.method1=aaa&bbb.method2=bbb");
         Assertions.assertEquals("aaa", urlParam2.getAnyMethodParameter("method1"));
         Assertions.assertNull(urlParam2.getAnyMethodParameter("method2"));
+    }
+
+    @Test
+    void testBuildParametersFiltersSensitiveFields() throws Exception {
+        // Reset the static cache to ensure test isolation
+        Field field = ConfigurationUtils.class.getDeclaredField("SensitiveParameterNames");
+        field.setAccessible(true);
+        field.set(null, null);
+        // Set a system property to simulate custom sensitive parameters
+        System.setProperty("dubbo.url.sensitive-parameter-names", "token,password");
+        // Construct a URL
+        URL url = URL.valueOf(
+                "nacos://127.0.0.1:8848/registry?password=secret&secretKey=mysecret&token=mytoken&timeout=5000");
+        // Get the parameter string from the URL
+        String paramStr = url.toString();
+        // Verify that sensitive parameters are filtered out
+        Assertions.assertFalse(paramStr.contains("token="));
+        Assertions.assertFalse(paramStr.contains("password="));
+        // Verify that non-sensitive parameters are retained
+        Assertions.assertTrue(paramStr.contains("secretKey=mysecret"));
+        Assertions.assertTrue(paramStr.contains("timeout=5000"));
     }
 }

--- a/dubbo-common/src/test/resources/dubbo.properties
+++ b/dubbo-common/src/test/resources/dubbo.properties
@@ -18,3 +18,4 @@
 dubbo=properties
 dubbo.application.enable-file-cache=false
 dubbo.service.shutdown.wait=200
+

--- a/dubbo-common/src/test/resources/dubbo.properties
+++ b/dubbo-common/src/test/resources/dubbo.properties
@@ -18,4 +18,3 @@
 dubbo=properties
 dubbo.application.enable-file-cache=false
 dubbo.service.shutdown.wait=200
-


### PR DESCRIPTION
## What is the purpose of the change?
see #15678 
This change introduces support for masking sensitive parameters when building URL strings in Dubbo.
Previously, parameters such as password, secretKey, or other user-defined sensitive fields could be exposed in logs or configuration outputs.
The update ensures that:
	1.	Sensitive parameter names can be configured through
dubbo.url.sensitive-parameter-names.
	2.	Any parameter matching the sensitive list is automatically excluded when the URL string is generated.
	3.	The behavior is covered by unit tests, ensuring consistent functionality and preventing regressions.


## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Make sure gitHub actions can pass. [Why the workflow is failing and how to fix it?](../CONTRIBUTING.md)
