### PR TITLE
Fix: Stabilize `dubbo-config-spring` reference-related tests by Disabling Metrics Initialization and Ensuring Test Isolation

### DIFF
--- a/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/reference/ReferenceKeyTest.java
+++ b/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/reference/ReferenceKeyTest.java
@@ -21,6 +21,7 @@ import org.apache.dubbo.config.annotation.DubboReference;
 import org.apache.dubbo.config.annotation.Method;
 import org.apache.dubbo.config.bootstrap.DubboBootstrap;
 import org.apache.dubbo.config.spring.ReferenceBean;
+import org.apache.dubbo.config.spring.SysProps;
 import org.apache.dubbo.config.spring.api.DemoService;
 import org.apache.dubbo.config.spring.api.HelloService;
 import org.apache.dubbo.config.spring.api.ProvidedByDemoService1;
@@ -37,6 +38,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
@@ -54,6 +56,15 @@ class ReferenceKeyTest {
     @BeforeEach
     protected void setUp() {
         DubboBootstrap.reset();
+        SysProps.clear();
+        SysProps.setProperty("dubbo.metrics.enabled", "false");
+        SysProps.setProperty("dubbo.metrics.protocol", "disabled");
+    }
+
+    @AfterEach
+    void tearDown() {
+        DubboBootstrap.reset();
+        SysProps.clear();
     }
 
     @Test

--- a/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/reference/registryNA/provider/DubboXmlProviderTest.java
+++ b/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/reference/registryNA/provider/DubboXmlProviderTest.java
@@ -16,14 +16,32 @@
  */
 package org.apache.dubbo.config.spring.reference.registryNA.provider;
 
+import org.apache.dubbo.config.bootstrap.DubboBootstrap;
+import org.apache.dubbo.config.spring.SysProps;
 import org.apache.dubbo.config.spring.api.HelloService;
 import org.apache.dubbo.rpc.RpcException;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 
 public class DubboXmlProviderTest {
+
+    @BeforeEach
+    void setUp() {
+        DubboBootstrap.reset();
+        SysProps.clear();
+        SysProps.setProperty("dubbo.metrics.enabled", "false");
+        SysProps.setProperty("dubbo.metrics.protocol", "disabled");
+    }
+
+    @AfterEach
+    void tearDown() {
+        DubboBootstrap.reset();
+        SysProps.clear();
+    }
 
     @Test
     void testProvider() {


### PR DESCRIPTION
## What is the purpose of the change?

This PR stabilizes reference-related tests inside `dubbo-config-spring` that were intermittently failing under randomized execution orders (NonDex) due to shared Dubbo/Spring framework state leaking across test boundaries. The following tests were consistently among the flaky failures before this fix, but now pass reliably across all NonDex seeds:

- **ReferenceKeyTest:** `testConfig`, `testConfig3`
- **DubboXmlProviderTest:** `testProvider`, `testProvider2`

## Root Cause

These failures are identical to previously fixed issues in:

- https://github.com/apache/dubbo/pull/15778  
- https://github.com/apache/dubbo/pull/15782  
- https://github.com/apache/dubbo/pull/15785  

Each of those PRs addressed flakiness caused by Micrometer’s `CompositeMeterRegistry`, which can throw an `ArrayIndexOutOfBoundsException` when it iterates over internal `IdentityHashMap` structures under randomized execution orders (NonDex).

`ReferenceKeyTest`, `PropertySourcesInJavaConfigTest`, `DubboXmlProviderTest` suffered from the same underlying issue:  
Dubbo framework state was leaking between test methods. This meant that the behavior of reference creation in one test could affect subsequent tests, causing nondeterministic failures.

## Changes Made

To fully isolate each test method and eliminate shared state, the following changes were applied:

- Disabled the metrics subsystem at the beginning of each test.
- Cleared all system properties via `SysProps.clear()` in the lifecycle hooks to avoid cross-test pollution.
- Reset framework state using `DubboBootstrap.reset()` to ensure isolation between tests.

## Verification

You can try running the following snippet of code from the dubbo repo root, on both pre-fix and post-fix code

```bash
./mvnw -q -pl dubbo-config/dubbo-config-spring \
  edu.illinois:nondex-maven-plugin:2.2.1:nondex \
  -DnondexRuns=50
```

The tests should fail intermittently on the pre-fix version, but pass consistently across all seeds on the post-fix version.
NonDex run logs will be available under the `dubbo-config/dubbo-config-spring/.nondex` directory.

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Make sure gitHub actions can pass. [Why the workflow is failing and how to fix it?](../CONTRIBUTING.md)
