### PR TITLE
[3.3] Bump validation-api to 2.0.1.Final and use ParameterMessageInterpolator as default ValidatorFactory's message interpolator

### DIFF
--- a/dubbo-dependencies-bom/pom.xml
+++ b/dubbo-dependencies-bom/pom.xml
@@ -112,7 +112,7 @@
     <jakarta_servlet_version>6.1.0</jakarta_servlet_version>
     <jetty_version>9.4.57.v20241219</jetty_version>
     <validation_new_version>3.1.1</validation_new_version>
-    <validation_version>1.1.0.Final</validation_version>
+    <validation_version>2.0.1.Final</validation_version>
     <hibernate_validator_version>6.2.0.Final</hibernate_validator_version>
     <hibernate_validator_new_version>7.0.5.Final</hibernate_validator_new_version>
     <jel_version>3.0.1-b12</jel_version>

--- a/dubbo-plugin/dubbo-filter-validation/pom.xml
+++ b/dubbo-plugin/dubbo-filter-validation/pom.xml
@@ -29,9 +29,7 @@
   <description>The validation module of dubbo project</description>
   <properties>
     <skip_maven_deploy>false</skip_maven_deploy>
-    <hibernate_validator_version>5.2.4.Final</hibernate_validator_version>
     <el_api_version>2.2.5</el_api_version>
-    <jaxb_api_version>2.2.7</jaxb_api_version>
   </properties>
   <dependencies>
     <dependency>
@@ -50,8 +48,6 @@
     <dependency>
       <groupId>org.hibernate</groupId>
       <artifactId>hibernate-validator</artifactId>
-      <version>${hibernate_validator_version}</version>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>javax.el</groupId>
@@ -62,19 +58,16 @@
     <dependency>
       <groupId>javax.xml.bind</groupId>
       <artifactId>jaxb-api</artifactId>
-      <version>${jaxb_api_version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.sun.xml.bind</groupId>
       <artifactId>jaxb-impl</artifactId>
-      <version>${jaxb_api_version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.sun.xml.bind</groupId>
       <artifactId>jaxb-core</artifactId>
-      <version>${jaxb_api_version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/dubbo-plugin/dubbo-filter-validation/src/main/java/org/apache/dubbo/validation/support/jvalidation/JValidator.java
+++ b/dubbo-plugin/dubbo-filter-validation/src/main/java/org/apache/dubbo/validation/support/jvalidation/JValidator.java
@@ -28,6 +28,7 @@ import org.apache.dubbo.validation.Validator;
 import javax.validation.Constraint;
 import javax.validation.ConstraintViolation;
 import javax.validation.ConstraintViolationException;
+import javax.validation.MessageInterpolator;
 import javax.validation.Validation;
 import javax.validation.ValidatorFactory;
 import javax.validation.groups.Default;
@@ -98,9 +99,10 @@ public class JValidator implements Validator {
                     .configure()
                     .buildValidatorFactory();
         } else {
+            MessageInterpolator messageInterpolator = new ParameterMessageInterpolator();
             factory = Validation.byDefaultProvider()
                     .configure()
-                    .messageInterpolator(new ParameterMessageInterpolator())
+                    .messageInterpolator(messageInterpolator)
                     .buildValidatorFactory();
         }
         this.validator = factory.getValidator();

--- a/dubbo-plugin/dubbo-filter-validation/src/main/java/org/apache/dubbo/validation/support/jvalidation/JValidator.java
+++ b/dubbo-plugin/dubbo-filter-validation/src/main/java/org/apache/dubbo/validation/support/jvalidation/JValidator.java
@@ -68,6 +68,8 @@ import javassist.bytecode.annotation.MemberValue;
 import javassist.bytecode.annotation.ShortMemberValue;
 import javassist.bytecode.annotation.StringMemberValue;
 
+import org.hibernate.validator.messageinterpolation.ParameterMessageInterpolator;
+
 import static org.apache.dubbo.common.constants.LoggerCodeConstants.CONFIG_FILTER_VALIDATION_EXCEPTION;
 
 /**
@@ -96,7 +98,10 @@ public class JValidator implements Validator {
                     .configure()
                     .buildValidatorFactory();
         } else {
-            factory = Validation.buildDefaultValidatorFactory();
+            factory = Validation.byDefaultProvider()
+                    .configure()
+                    .messageInterpolator(new ParameterMessageInterpolator())
+                    .buildValidatorFactory();
         }
         this.validator = factory.getValidator();
         this.methodClassMap = new ConcurrentHashMap<>();


### PR DESCRIPTION
## What is the purpose of the change?
1. https://github.com/apache/dubbo/pull/15687 (Bump org.hibernate:hibernate-validator from 5.2.4.Final to 6.2.0.Final in /dubbo-plugin/dubbo-filter-validation) tested failed, the root cause is ```hibernate-validator``` 6.2.0.Final depends on ```validation-api``` 2.x
2. https://github.com/apache/dubbo/pull/15728 (Bump org.hibernate:hibernate-validator from 5.2.4.Final to 5.4.3.Final) tested failed, the root cause is ```Unable to initialize 'javax.el.ExpressionFactory'. Check that you have the EL dependencies on the classpath, or use ParameterMessageInterpolator instead```.
<img width="1754" height="654" alt="image" src="https://github.com/user-attachments/assets/5c593162-8ae1-4864-9281-ec8b8ff0122e" />

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Make sure gitHub actions can pass. [Why the workflow is failing and how to fix it?](../CONTRIBUTING.md)
