### PR TITLE
Fix: Stabilize `dubbo-config-spring` issues-related tests by Disabling Metrics Initialization and Ensuring Test Isolation

### DIFF
--- a/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/issues/issue6000/Issue6000Test.java
+++ b/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/issues/issue6000/Issue6000Test.java
@@ -17,6 +17,7 @@
 package org.apache.dubbo.config.spring.issues.issue6000;
 
 import org.apache.dubbo.config.bootstrap.DubboBootstrap;
+import org.apache.dubbo.config.spring.SysProps;
 import org.apache.dubbo.config.spring.context.annotation.EnableDubbo;
 import org.apache.dubbo.config.spring.issues.issue6000.adubbo.HelloDubbo;
 
@@ -45,11 +46,15 @@ class Issue6000Test {
     @BeforeAll
     public static void beforeAll() {
         DubboBootstrap.reset();
+        SysProps.clear();
+        SysProps.setProperty("dubbo.metrics.enabled", "false");
+        SysProps.setProperty("dubbo.metrics.protocol", "disabled");
     }
 
     @AfterAll
     public static void afterAll() {
         DubboBootstrap.reset();
+        SysProps.clear();
     }
 
     @Test

--- a/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/issues/issue6252/Issue6252Test.java
+++ b/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/issues/issue6252/Issue6252Test.java
@@ -18,6 +18,7 @@ package org.apache.dubbo.config.spring.issues.issue6252;
 
 import org.apache.dubbo.config.annotation.DubboReference;
 import org.apache.dubbo.config.bootstrap.DubboBootstrap;
+import org.apache.dubbo.config.spring.SysProps;
 import org.apache.dubbo.config.spring.api.DemoService;
 import org.apache.dubbo.config.spring.context.annotation.EnableDubboConfig;
 
@@ -41,11 +42,15 @@ class Issue6252Test {
     @BeforeAll
     public static void beforeAll() {
         DubboBootstrap.reset();
+        SysProps.clear();
+        SysProps.setProperty("dubbo.metrics.enabled", "false");
+        SysProps.setProperty("dubbo.metrics.protocol", "disabled");
     }
 
     @AfterAll
     public static void afterAll() {
         DubboBootstrap.reset();
+        SysProps.clear();
     }
 
     @DubboReference

--- a/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/issues/issue7003/Issue7003Test.java
+++ b/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/issues/issue7003/Issue7003Test.java
@@ -20,6 +20,7 @@ import org.apache.dubbo.config.ReferenceConfigBase;
 import org.apache.dubbo.config.annotation.DubboReference;
 import org.apache.dubbo.config.bootstrap.DubboBootstrap;
 import org.apache.dubbo.config.spring.ReferenceBean;
+import org.apache.dubbo.config.spring.SysProps;
 import org.apache.dubbo.config.spring.api.HelloService;
 import org.apache.dubbo.config.spring.context.annotation.EnableDubbo;
 import org.apache.dubbo.rpc.model.ApplicationModel;
@@ -51,11 +52,15 @@ class Issue7003Test {
     @BeforeAll
     public static void beforeAll() {
         DubboBootstrap.reset();
+        SysProps.clear();
+        SysProps.setProperty("dubbo.metrics.enabled", "false");
+        SysProps.setProperty("dubbo.metrics.protocol", "disabled");
     }
 
     @AfterAll
     public static void afterAll() {
         DubboBootstrap.reset();
+        SysProps.clear();
     }
 
     @Test

--- a/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/issues/issue9172/MultipleConsumerAndProviderTest.java
+++ b/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/issues/issue9172/MultipleConsumerAndProviderTest.java
@@ -19,7 +19,9 @@ package org.apache.dubbo.config.spring.issues.issue9172;
 import org.apache.dubbo.config.ReferenceConfigBase;
 import org.apache.dubbo.config.annotation.DubboReference;
 import org.apache.dubbo.config.annotation.DubboService;
+import org.apache.dubbo.config.bootstrap.DubboBootstrap;
 import org.apache.dubbo.config.context.ModuleConfigManager;
+import org.apache.dubbo.config.spring.SysProps;
 import org.apache.dubbo.config.spring.api.DemoService;
 import org.apache.dubbo.config.spring.api.HelloService;
 import org.apache.dubbo.config.spring.context.annotation.EnableDubbo;
@@ -28,7 +30,9 @@ import org.apache.dubbo.config.spring.impl.HelloServiceImpl;
 import org.apache.dubbo.config.spring.util.DubboBeanUtils;
 import org.apache.dubbo.rpc.model.ModuleModel;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
@@ -38,6 +42,20 @@ import org.springframework.context.annotation.PropertySource;
  * Test for issue 9172
  */
 class MultipleConsumerAndProviderTest {
+
+    @BeforeEach
+    void setUp() {
+        DubboBootstrap.reset();
+        SysProps.clear();
+        SysProps.setProperty("dubbo.metrics.enabled", "false");
+        SysProps.setProperty("dubbo.metrics.protocol", "disabled");
+    }
+
+    @AfterEach
+    void tearDown() {
+        DubboBootstrap.reset();
+        SysProps.clear();
+    }
 
     @Test
     void test() {

--- a/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/issues/issue9207/ConfigCenterBeanTest.java
+++ b/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/issues/issue9207/ConfigCenterBeanTest.java
@@ -17,6 +17,7 @@
 package org.apache.dubbo.config.spring.issues.issue9207;
 
 import org.apache.dubbo.config.ConfigCenterConfig;
+import org.apache.dubbo.config.bootstrap.DubboBootstrap;
 import org.apache.dubbo.config.context.ConfigManager;
 import org.apache.dubbo.config.spring.ConfigCenterBean;
 import org.apache.dubbo.config.spring.SysProps;
@@ -33,7 +34,9 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.stream.Collectors;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.config.BeanFactoryPostProcessor;
@@ -49,6 +52,20 @@ class ConfigCenterBeanTest {
     private static final String DUBBO_PROPERTIES_FILE =
             "/META-INF/issues/issue9207/dubbo-properties-in-configcenter.properties";
     private static final String DUBBO_EXTERNAL_CONFIG_KEY = "my-dubbo.properties";
+
+    @BeforeEach
+    void setUp() {
+        DubboBootstrap.reset();
+        SysProps.clear();
+        SysProps.setProperty("dubbo.metrics.enabled", "false");
+        SysProps.setProperty("dubbo.metrics.protocol", "disabled");
+    }
+
+    @AfterEach
+    void tearDown() {
+        DubboBootstrap.reset();
+        SysProps.clear();
+    }
 
     @Test
     void testConfigCenterBeanFromProps() throws IOException {


### PR DESCRIPTION
## What is the purpose of the change?

This PR stabilizes issues-related tests inside `dubbo-config-spring` that were intermittently failing under randomized execution orders (NonDex) due to shared Dubbo/Spring framework state leaking across test boundaries. The following tests were consistently among the flaky failures before this fix, but now pass reliably across all NonDex seeds:

- **Issue6000Test:** `test`
- **Issue6252Test:** `test`
- **Issue7003Test:** `test`
- **MultipleConsumerAndProviderTest:** `test`
- **ConfigCenterBeanTest:** `testConfigCenterBeanFromProps`

## Root Cause

These failures are identical to previously fixed issues in:

- https://github.com/apache/dubbo/pull/15778  
- https://github.com/apache/dubbo/pull/15782  
- https://github.com/apache/dubbo/pull/15785  

Each of those PRs addressed flakiness caused by Micrometer’s `CompositeMeterRegistry`, which can throw an `ArrayIndexOutOfBoundsException` when it iterates over internal `IdentityHashMap` structures under randomized execution orders (NonDex).

The tests mentioned above suffered from the same underlying issue:  
Dubbo framework state was leaking between test methods. This meant that the behavior of reference creation in one test could affect subsequent tests, causing nondeterministic failures.

## Changes Made

To fully isolate each test method and eliminate shared state, the following changes were applied:

- Disabled the metrics subsystem at the beginning of each test.
- Cleared all system properties via `SysProps.clear()` in the lifecycle hooks to avoid cross-test pollution.
- Reset framework state using `DubboBootstrap.reset()` to ensure isolation between tests.

## Verification

You can try running the following snippet of code from the dubbo repo root, on both pre-fix and post-fix code

```bash
./mvnw -q -pl dubbo-config/dubbo-config-spring \
  edu.illinois:nondex-maven-plugin:2.2.1:nondex \
  -DnondexRuns=50
```

The tests should fail intermittently on the pre-fix version, but pass consistently across all seeds on the post-fix version.
NonDex run logs will be available under the `dubbo-config/dubbo-config-spring/.nondex` directory.

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Make sure gitHub actions can pass. [Why the workflow is failing and how to fix it?](../CONTRIBUTING.md)
