### PR TITLE
[3.3] Bump io.micrometer:micrometer-tracing-bom from 1.5.1 to 1.6.0 and rewrite DubboMicrometerTracingAutoConfigurationTests for jdk8 compatibility

### DIFF
--- a/dubbo-dependencies-bom/pom.xml
+++ b/dubbo-dependencies-bom/pom.xml
@@ -125,7 +125,7 @@
     <opentelemetry.version>1.54.1</opentelemetry.version>
     <zipkin-reporter.version>3.5.1</zipkin-reporter.version>
     <zipkin.version>3.5.1</zipkin.version>
-    <micrometer-tracing.version>1.5.1</micrometer-tracing.version>
+    <micrometer-tracing.version>1.6.0</micrometer-tracing.version>
     <t_digest.version>3.3</t_digest.version>
     <prometheus_client.version>0.16.0</prometheus_client.version>
     <reactive.version>1.0.4</reactive.version>

--- a/dubbo-spring-boot-project/dubbo-spring-boot-autoconfigure/src/test/java/org/apache/dubbo/spring/boot/autoconfigure/observability/DubboMicrometerTracingAutoConfigurationTests.java
+++ b/dubbo-spring-boot-project/dubbo-spring-boot-autoconfigure/src/test/java/org/apache/dubbo/spring/boot/autoconfigure/observability/DubboMicrometerTracingAutoConfigurationTests.java
@@ -16,9 +16,19 @@
  */
 package org.apache.dubbo.spring.boot.autoconfigure.observability;
 
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
+import io.micrometer.tracing.Baggage;
+import io.micrometer.tracing.BaggageManager;
+import io.micrometer.tracing.CurrentTraceContext;
+import io.micrometer.tracing.ScopedSpan;
+import io.micrometer.tracing.Span;
+import io.micrometer.tracing.Span.Builder;
+import io.micrometer.tracing.SpanCustomizer;
+import io.micrometer.tracing.TraceContext;
 import io.micrometer.tracing.Tracer;
 import io.micrometer.tracing.handler.DefaultTracingObservationHandler;
 import io.micrometer.tracing.handler.PropagatingReceiverTracingObservationHandler;
@@ -131,7 +141,63 @@ class DubboMicrometerTracingAutoConfigurationTests {
 
         @Bean
         Tracer tracer() {
-            return mock(Tracer.class);
+            return new Tracer() {
+                public Span nextSpan() {
+                    return Span.NOOP;
+                }
+
+                public Span nextSpan(Span parent) {
+                    return Span.NOOP;
+                }
+
+                public SpanInScope withSpan(Span span) {
+                    return () -> {};
+                }
+
+                public ScopedSpan startScopedSpan(String name) {
+                    return ScopedSpan.NOOP;
+                }
+
+                public Span.Builder spanBuilder() {
+                    return Builder.NOOP;
+                }
+
+                public TraceContext.Builder traceContextBuilder() {
+                    return io.micrometer.tracing.TraceContext.Builder.NOOP;
+                }
+
+                public CurrentTraceContext currentTraceContext() {
+                    return CurrentTraceContext.NOOP;
+                }
+
+                public SpanCustomizer currentSpanCustomizer() {
+                    return SpanCustomizer.NOOP;
+                }
+
+                public Span currentSpan() {
+                    return Span.NOOP;
+                }
+
+                public Map<String, String> getAllBaggage() {
+                    return BaggageManager.NOOP.getAllBaggage();
+                }
+
+                public Baggage getBaggage(String name) {
+                    return Baggage.NOOP;
+                }
+
+                public Baggage getBaggage(TraceContext traceContext, String name) {
+                    return Baggage.NOOP;
+                }
+
+                public Baggage createBaggage(String name) {
+                    return Baggage.NOOP;
+                }
+
+                public Baggage createBaggage(String name, String value) {
+                    return Baggage.NOOP;
+                }
+            };
         }
     }
 
@@ -140,7 +206,17 @@ class DubboMicrometerTracingAutoConfigurationTests {
 
         @Bean
         Propagator propagator() {
-            return mock(Propagator.class);
+            return new Propagator() {
+                public List<String> fields() {
+                    return Collections.emptyList();
+                }
+
+                public <C> void inject(TraceContext context, C carrier, Setter<C> setter) {}
+
+                public <C> Span.Builder extract(C carrier, Getter<C> getter) {
+                    return Builder.NOOP;
+                }
+            };
         }
     }
 


### PR DESCRIPTION
## What is the purpose of the change?
1. https://github.com/apache/dubbo/pull/15818 tested failed, the root cause is the new version classes ```Tracer``` and ```Propagator``` could not be mocked by ```mockito 4.x```
2. mockito 5 doesn't support jdk8 but dubbo still needs to support, so we could not bump mockito to 5 by now

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Make sure gitHub actions can pass. [Why the workflow is failing and how to fix it?](../CONTRIBUTING.md)
