### PR TITLE
Fix: Stabilize `dubbo-config-spring` propertyconfigurer-related tests by Disabling Metrics Initialization and Ensuring Test Isolation

### DIFF
--- a/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/propertyconfigurer/consumer/PropertyConfigurerTest.java
+++ b/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/propertyconfigurer/consumer/PropertyConfigurerTest.java
@@ -17,6 +17,7 @@
 package org.apache.dubbo.config.spring.propertyconfigurer.consumer;
 
 import org.apache.dubbo.config.bootstrap.DubboBootstrap;
+import org.apache.dubbo.config.spring.SysProps;
 import org.apache.dubbo.config.spring.api.HelloService;
 import org.apache.dubbo.config.spring.context.annotation.EnableDubbo;
 
@@ -38,11 +39,15 @@ class PropertyConfigurerTest {
     @BeforeAll
     public static void beforeAll() {
         DubboBootstrap.reset();
+        SysProps.clear();
+        SysProps.setProperty("dubbo.metrics.enabled", "false");
+        SysProps.setProperty("dubbo.metrics.protocol", "disabled");
     }
 
     @AfterAll
     public static void afterAll() {
         DubboBootstrap.reset();
+        SysProps.clear();
     }
 
     @Test

--- a/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/propertyconfigurer/consumer2/PropertySourcesConfigurerTest.java
+++ b/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/propertyconfigurer/consumer2/PropertySourcesConfigurerTest.java
@@ -17,6 +17,7 @@
 package org.apache.dubbo.config.spring.propertyconfigurer.consumer2;
 
 import org.apache.dubbo.config.bootstrap.DubboBootstrap;
+import org.apache.dubbo.config.spring.SysProps;
 import org.apache.dubbo.config.spring.api.HelloService;
 import org.apache.dubbo.config.spring.context.annotation.EnableDubbo;
 import org.apache.dubbo.config.spring.propertyconfigurer.consumer.DemoBeanFactoryPostProcessor;
@@ -39,11 +40,15 @@ class PropertySourcesConfigurerTest {
     @BeforeAll
     public static void beforeAll() {
         DubboBootstrap.reset();
+        SysProps.clear();
+        SysProps.setProperty("dubbo.metrics.enabled", "false");
+        SysProps.setProperty("dubbo.metrics.protocol", "disabled");
     }
 
     @AfterAll
     public static void afterAll() {
         DubboBootstrap.reset();
+        SysProps.clear();
     }
 
     @Test

--- a/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/propertyconfigurer/consumer3/PropertySourcesInJavaConfigTest.java
+++ b/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/propertyconfigurer/consumer3/PropertySourcesInJavaConfigTest.java
@@ -17,6 +17,7 @@
 package org.apache.dubbo.config.spring.propertyconfigurer.consumer3;
 
 import org.apache.dubbo.config.bootstrap.DubboBootstrap;
+import org.apache.dubbo.config.spring.SysProps;
 import org.apache.dubbo.config.spring.api.HelloService;
 import org.apache.dubbo.config.spring.context.annotation.EnableDubbo;
 import org.apache.dubbo.config.spring.propertyconfigurer.consumer.DemoBeanFactoryPostProcessor;
@@ -49,16 +50,15 @@ class PropertySourcesInJavaConfigTest {
     @BeforeEach
     public void setUp() throws Exception {
         DubboBootstrap.reset();
+        SysProps.clear();
+        SysProps.setProperty("dubbo.metrics.enabled", "false");
+        SysProps.setProperty("dubbo.metrics.protocol", "disabled");
     }
 
     @AfterEach
     public void tearDown() throws IOException {
         DubboBootstrap.reset();
-    }
-
-    @BeforeEach
-    public void beforeTest() {
-        DubboBootstrap.reset();
+        SysProps.clear();
     }
 
     @Test


### PR DESCRIPTION
## What is the purpose of the change?

This PR stabilizes propertyconfigurer-related tests inside `dubbo-config-spring` that were intermittently failing under randomized execution orders (NonDex) due to shared Dubbo/Spring framework state leaking across test boundaries. The following tests were consistently among the flaky failures before this fix, but now pass reliably across all NonDex seeds:

- **PropertyConfigurerTest:** `testEarlyInit`
- **PropertySourcesConfigurerTest:** `testEarlyInit`
- **PropertySourcesInJavaConfigTest:** `testImportPropertySource`, `testCustomPropertySourceBean`

## Root Cause

These failures are identical to previously fixed issues in:

- https://github.com/apache/dubbo/pull/15778  
- https://github.com/apache/dubbo/pull/15782  
- https://github.com/apache/dubbo/pull/15785  

Each of those PRs addressed flakiness caused by Micrometer’s `CompositeMeterRegistry`, which can throw an `ArrayIndexOutOfBoundsException` when it iterates over internal `IdentityHashMap` structures under randomized execution orders (NonDex).

The tests mentioned above suffered from the same underlying issue:  
Dubbo framework state was leaking between test methods. This meant that the behavior of reference creation in one test could affect subsequent tests, causing nondeterministic failures.

## Changes Made

To fully isolate each test method and eliminate shared state, the following changes were applied:

- Disabled the metrics subsystem at the beginning of each test.
- Cleared all system properties via `SysProps.clear()` in the lifecycle hooks to avoid cross-test pollution.
- Reset framework state using `DubboBootstrap.reset()` to ensure isolation between tests.

## Verification

You can try running the following snippet of code from the dubbo repo root, on both pre-fix and post-fix code

```bash
./mvnw -q -pl dubbo-config/dubbo-config-spring \
  edu.illinois:nondex-maven-plugin:2.2.1:nondex \
  -DnondexRuns=50
```

The tests should fail intermittently on the pre-fix version, but pass consistently across all seeds on the post-fix version.
NonDex run logs will be available under the `dubbo-config/dubbo-config-spring/.nondex` directory.

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Make sure gitHub actions can pass. [Why the workflow is failing and how to fix it?](../CONTRIBUTING.md)
