### PR TITLE
Fix: Stabilize `dubbo-config-spring` boot-related tests by Disabling Metrics Initialization and Ensuring Test Isolation

### DIFF
--- a/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/boot/conditional1/XmlReferenceBeanConditionalTest.java
+++ b/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/boot/conditional1/XmlReferenceBeanConditionalTest.java
@@ -38,7 +38,7 @@ import org.springframework.core.annotation.Order;
  * issue: https://github.com/apache/dubbo-spring-boot-project/issues/779
  */
 @SpringBootTest(
-        properties = {"dubbo.registry.address=N/A"},
+        properties = {"dubbo.registry.address=N/A", "dubbo.metrics.enabled=false", "dubbo.metrics.protocol=disabled"},
         classes = {XmlReferenceBeanConditionalTest.class})
 @Configuration
 // @ComponentScan

--- a/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/boot/conditional2/JavaConfigAnnotationReferenceBeanConditionalTest.java
+++ b/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/boot/conditional2/JavaConfigAnnotationReferenceBeanConditionalTest.java
@@ -41,7 +41,13 @@ import org.springframework.core.annotation.Order;
  * issue: https://github.com/apache/dubbo-spring-boot-project/issues/779
  */
 @SpringBootTest(
-        properties = {"dubbo.application.name=consumer-app", "dubbo.registry.address=N/A", "myapp.group=demo"},
+        properties = {
+            "dubbo.application.name=consumer-app",
+            "dubbo.registry.address=N/A",
+            "myapp.group=demo",
+            "dubbo.metrics.enabled=false",
+            "dubbo.metrics.protocol=disabled"
+        },
         classes = {JavaConfigAnnotationReferenceBeanConditionalTest.class})
 @Configuration
 // @ComponentScan

--- a/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/boot/conditional3/JavaConfigRawReferenceBeanConditionalTest.java
+++ b/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/boot/conditional3/JavaConfigRawReferenceBeanConditionalTest.java
@@ -41,7 +41,13 @@ import org.springframework.core.annotation.Order;
  * issue: https://github.com/apache/dubbo-spring-boot-project/issues/779
  */
 @SpringBootTest(
-        properties = {"dubbo.application.name=consumer-app", "dubbo.registry.address=N/A", "myapp.group=demo"},
+        properties = {
+            "dubbo.application.name=consumer-app",
+            "dubbo.registry.address=N/A",
+            "myapp.group=demo",
+            "dubbo.metrics.enabled=false",
+            "dubbo.metrics.protocol=disabled"
+        },
         classes = {JavaConfigRawReferenceBeanConditionalTest.class})
 @Configuration
 // @ComponentScan

--- a/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/boot/importxml/SpringBootImportDubboXmlTest.java
+++ b/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/boot/importxml/SpringBootImportDubboXmlTest.java
@@ -30,7 +30,12 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.ImportResource;
 
 @SpringBootTest(
-        properties = {"dubbo.registry.protocol=zookeeper", "dubbo.registry.address=localhost:2181"},
+        properties = {
+            "dubbo.registry.protocol=zookeeper",
+            "dubbo.registry.address=localhost:2181",
+            "dubbo.metrics.enabled=false",
+            "dubbo.metrics.protocol=disabled"
+        },
         classes = {SpringBootImportDubboXmlTest.class})
 @Configuration
 @ComponentScan

--- a/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/boot/importxml2/SpringBootImportAndScanTest.java
+++ b/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/boot/importxml2/SpringBootImportAndScanTest.java
@@ -44,7 +44,9 @@ import org.springframework.context.annotation.ImportResource;
             "dubbo.registry.address=N/A",
             "myapp.dubbo.port=20881",
             "myapp.name=dubbo-provider",
-            "myapp.group=test"
+            "myapp.group=test",
+            "dubbo.metrics.enabled=false",
+            "dubbo.metrics.protocol=disabled"
         },
         classes = SpringBootImportAndScanTest.class)
 @Configuration


### PR DESCRIPTION
## What is the purpose of the change?

This PR stabilizes boot-related tests inside `dubbo-config-spring` that were intermittently failing under randomized execution orders (NonDex) due to shared Dubbo/Spring framework state leaking across test boundaries. The following tests were consistently among the flaky failures before this fix, but now pass reliably across all NonDex seeds:

- **XmlReferenceBeanConditionalTest:** `testConsumer`
- **JavaConfigAnnotationReferenceBeanConditionalTest:** `testConsumer`
- **JavaConfigRawReferenceBeanConditionalTest:** `testConsumer`
- **SpringBootImportDubboXmlTest:** `testConsumer`
- **SpringBootImportAndScanTest:** `testProvider`

## Root Cause

These failures are identical to previously fixed issues in:

- https://github.com/apache/dubbo/pull/15778  
- https://github.com/apache/dubbo/pull/15782  
- https://github.com/apache/dubbo/pull/15785  

Each of those PRs addressed flakiness caused by Micrometer’s `CompositeMeterRegistry`, which can throw an `ArrayIndexOutOfBoundsException` when it iterates over internal `IdentityHashMap` structures under randomized execution orders (NonDex).

The tests mentioned above suffered from the same underlying issue:  
Dubbo framework state was leaking between test methods. This meant that the behavior of reference creation in one test could affect subsequent tests, causing nondeterministic failures.

## Changes Made

To fully isolate each test method and eliminate shared state, the following changes were applied:

- Disabled the metrics subsystem at the beginning of each test.
- Cleared all system properties via `SysProps.clear()` in the lifecycle hooks to avoid cross-test pollution.
- Reset framework state using `DubboBootstrap.reset()` to ensure isolation between tests.

## Verification

You can try running the following snippet of code from the dubbo repo root, on both pre-fix and post-fix code

```bash
./mvnw -q -pl dubbo-config/dubbo-config-spring \
  edu.illinois:nondex-maven-plugin:2.2.1:nondex \
  -DnondexRuns=50
```

The tests should fail intermittently on the pre-fix version, but pass consistently across all seeds on the post-fix version.
NonDex run logs will be available under the `dubbo-config/dubbo-config-spring/.nondex` directory.

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Make sure gitHub actions can pass. [Why the workflow is failing and how to fix it?](../CONTRIBUTING.md)
