### PR TITLE
Fix: Stabilize map-order assertions in REST protocol tests

### DIFF
--- a/dubbo-plugin/dubbo-rest-jaxrs/src/test/groovy/org/apache/dubbo/rpc/protocol/tri/rest/support/jaxrs/RestProtocolTest.groovy
+++ b/dubbo-plugin/dubbo-rest-jaxrs/src/test/groovy/org/apache/dubbo/rpc/protocol/tri/rest/support/jaxrs/RestProtocolTest.groovy
@@ -83,7 +83,8 @@ class RestProtocolTest extends BaseServiceTest {
                 contentType: MediaType.APPLICATION_FROM_URLENCODED,
                 body: body
             )
-            runner.post(request) == output
+            def actual = runner.post(request)
+            actual.contains('"name":[1,2]') && actual.contains('"age":[8]')
         where:
             path                  | body                  | output
             '/multivaluedMapTest' | 'name=1&name=2&age=8' | '{"name":[1,2],"age":[8]}'

--- a/dubbo-plugin/dubbo-rest-spring/src/test/groovy/org/apache/dubbo/rpc/protocol/tri/rest/support/spring/RestProtocolTest.groovy
+++ b/dubbo-plugin/dubbo-rest-spring/src/test/groovy/org/apache/dubbo/rpc/protocol/tri/rest/support/spring/RestProtocolTest.groovy
@@ -52,7 +52,8 @@ class RestProtocolTest extends BaseServiceTest {
 
     def "map argument body test"() {
         expect:
-            runner.post(path, body) contains output
+            def actual = runner.post(path, body)
+            actual.contains('1:[2,3]') && actual.contains('4:[5,6]')
         where:
             path                           | body                        | output
             '/spring/mapArgBodyTest?age=2' | '{"1":["2",3],"4":[5,"6"]}' | '{4:[5,6],1:[2,3]}'


### PR DESCRIPTION
## What is the purpose of the change?

This PR stabilizes map-related assertions in REST protocol tests that were intermittently failing under randomized execution orders (e.g., NonDex). Specifically, the following tests were affected:

- `RestProtocolTest.MultivaluedMap test` in `dubbo-plugin/dubbo-rest-jaxrs`
- `RestProtocolTest.map argument body test` in `dubbo-plugin/dubbo-rest-spring`

These tests failed when map entries were serialized in a different key order, despite the logical content being identical.

## Root Cause

The tests relied on strict string or substring comparisons that implicitly assumed a deterministic ordering of map keys in serialized responses. However, JSON object key ordering is not guaranteed, and internal map iteration order may vary due to JVM behavior or NonDex-induced reordering.

## Changes Made

- Updated the affected assertions to validate the presence of expected key–value fragments independently, rather than relying on a single ordered JSON substring.
- Preserved existing test structure, inputs, and expected semantics.

## Verification

You can try running the following snippet of code from the dubbo repo root, on both pre-fix and post-fix code

For `RestProtocolTest.MultivaluedMap test`:
```bash
./mvnw -q -pl dubbo-plugin/dubbo-rest-jaxrs edu.illinois:nondex-maven-plugin:2.2.1:nondex \
  -DnondexRuns=100 \
  -Dtest=org.apache.dubbo.rpc.protocol.tri.rest.support.jaxrs.RestProtocolTest
```

For `RestProtocolTest.map argument body test`:

```bash
./mvnw -q -pl dubbo-plugin/dubbo-rest-spring edu.illinois:nondex-maven-plugin:2.2.1:nondex \
  -DnondexRuns=100 \
  -Dtest=org.apache.dubbo.rpc.protocol.tri.rest.support.spring.RestProtocolTest
```

The tests should fail intermittently on the pre-fix version, but pass consistently across all seeds on the post-fix version.
NonDex run logs will be available under:
- `dubbo-plugin/dubbo-rest-jaxrs/.nondex` directory for `RestProtocolTest.MultivaluedMap test`
- `dubbo-plugin/dubbo-rest-spring/.nondex` directory for `RestProtocolTest.map argument body test`.

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Make sure gitHub actions can pass. [Why the workflow is failing and how to fix it?](../CONTRIBUTING.md)
