### PR TITLE
Add NacosAppNameUtils to bridge Dubbo application name with Nacos project name

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/nacos/NacosAppNameUtils.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/nacos/NacosAppNameUtils.java
@@ -30,6 +30,21 @@ import org.apache.dubbo.rpc.model.ScopeModelUtil;
  * system property. Dubbo registry/configcenter/metadata modules only pass parameters filtered by
  * {@code PropertyKeyConst}, which does not include any app name key in nacos-client 2.x. This helper
  * optionally maps Dubbo application name to {@code project.name} when explicitly enabled.
+ *
+ * <h3>Thread Safety</h3>
+ * <p>
+ * This utility uses a best-effort approach and is <b>not strictly thread-safe</b>. There is a potential
+ * race condition between checking whether the system property exists and setting it. If multiple threads
+ * concurrently initialize Nacos connections (e.g., registry, config-center, and metadata-report), they may
+ * all pass the existence check and race to set the property. In practice, this is benign because:
+ * <ul>
+ *   <li>All competing threads typically resolve to the same application name</li>
+ *   <li>The property is only used for display purposes in Nacos Subscriber List</li>
+ *   <li>Once set, subsequent calls will see the property and skip the set operation</li>
+ * </ul>
+ * <p>
+ * If strict thread-safety is required, callers should synchronize externally or set the
+ * {@code project.name} system property before initializing any Nacos connections.
  */
 public final class NacosAppNameUtils {
 
@@ -61,26 +76,7 @@ public final class NacosAppNameUtils {
             return;
         }
         try {
-            String appName = null;
-
-            // Priority 1: explicitly passed ApplicationModel
-            if (applicationModel != null) {
-                appName = applicationModel.getApplicationName();
-            }
-
-            // Priority 2: URL's application parameter
-            if (StringUtils.isEmpty(appName)) {
-                appName = url.getApplication();
-            }
-
-            // Priority 3: resolve from URL's ScopeModel (may return default model with "unknown" name, so check last)
-            if (StringUtils.isEmpty(appName)) {
-                ApplicationModel model = ScopeModelUtil.getOrNullApplicationModel(url.getScopeModel());
-                if (model != null) {
-                    appName = model.getApplicationName();
-                }
-            }
-
+            String appName = getApplicationName(url, applicationModel);
             if (StringUtils.isEmpty(appName)) {
                 return;
             }
@@ -99,5 +95,41 @@ public final class NacosAppNameUtils {
                     PROJECT_NAME_SYS_PROP_KEY,
                     t);
         }
+    }
+
+    /**
+     * Resolves the application name from multiple sources with the following priority:
+     * <ol>
+     *   <li>Explicitly passed ApplicationModel</li>
+     *   <li>URL's application parameter</li>
+     *   <li>URL's ScopeModel (may return default model with "unknown" name, so checked last)</li>
+     * </ol>
+     *
+     * @param url              registry/config/metadata URL (must not be null)
+     * @param applicationModel optional application model
+     * @return the resolved application name, or null if not found from any source
+     */
+    private static String getApplicationName(URL url, ApplicationModel applicationModel) {
+        // Priority 1: explicitly passed ApplicationModel
+        if (applicationModel != null) {
+            String appName = applicationModel.getApplicationName();
+            if (StringUtils.isNotEmpty(appName)) {
+                return appName;
+            }
+        }
+
+        // Priority 2: URL's application parameter
+        String appName = url.getApplication();
+        if (StringUtils.isNotEmpty(appName)) {
+            return appName;
+        }
+
+        // Priority 3: resolve from URL's ScopeModel
+        ApplicationModel model = ScopeModelUtil.getOrNullApplicationModel(url.getScopeModel());
+        if (model != null) {
+            return model.getApplicationName();
+        }
+
+        return null;
     }
 }

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/nacos/NacosAppNameUtils.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/nacos/NacosAppNameUtils.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.common.nacos;
+
+import org.apache.dubbo.common.URL;
+import org.apache.dubbo.common.logger.ErrorTypeAwareLogger;
+import org.apache.dubbo.common.logger.LoggerFactory;
+import org.apache.dubbo.common.utils.StringUtils;
+import org.apache.dubbo.rpc.model.ApplicationModel;
+import org.apache.dubbo.rpc.model.ScopeModelUtil;
+
+/**
+ * Helper to bridge Dubbo application name to nacos-client app name inference.
+ * <p>
+ * Nacos Subscriber List shows application name based on nacos-client's {@code project.name}
+ * system property. Dubbo registry/configcenter/metadata modules only pass parameters filtered by
+ * {@code PropertyKeyConst}, which does not include any app name key in nacos-client 2.x. This helper
+ * optionally maps Dubbo application name to {@code project.name} when explicitly enabled.
+ */
+public final class NacosAppNameUtils {
+
+    public static final String NACOS_SET_PROJECT_NAME_KEY = "nacos.set-project-name";
+
+    public static final String PROJECT_NAME_SYS_PROP_KEY = "project.name";
+
+    private static final ErrorTypeAwareLogger logger = LoggerFactory.getErrorTypeAwareLogger(NacosAppNameUtils.class);
+
+    private NacosAppNameUtils() {}
+
+    /**
+     * Best-effort mapping from Dubbo application name to nacos-client "project.name" system property.
+     *
+     * @param url              registry/config/metadata URL
+     * @param applicationModel optional application model; if null, will resolve from URL scope model
+     * @param customLogger     optional logger to emit info logs; fallback to internal logger when null
+     */
+    public static void maybeSetProjectName(
+            URL url, ApplicationModel applicationModel, ErrorTypeAwareLogger customLogger) {
+        if (url == null) {
+            return;
+        }
+        boolean enabled = url.getParameter(NACOS_SET_PROJECT_NAME_KEY, false);
+        if (!enabled) {
+            return;
+        }
+        if (StringUtils.isNotEmpty(System.getProperty(PROJECT_NAME_SYS_PROP_KEY))) {
+            return;
+        }
+        try {
+            String appName = null;
+
+            // Priority 1: explicitly passed ApplicationModel
+            if (applicationModel != null) {
+                appName = applicationModel.getApplicationName();
+            }
+
+            // Priority 2: URL's application parameter
+            if (StringUtils.isEmpty(appName)) {
+                appName = url.getApplication();
+            }
+
+            // Priority 3: resolve from URL's ScopeModel (may return default model with "unknown" name, so check last)
+            if (StringUtils.isEmpty(appName)) {
+                ApplicationModel model = ScopeModelUtil.getOrNullApplicationModel(url.getScopeModel());
+                if (model != null) {
+                    appName = model.getApplicationName();
+                }
+            }
+
+            if (StringUtils.isEmpty(appName)) {
+                return;
+            }
+            System.setProperty(PROJECT_NAME_SYS_PROP_KEY, appName);
+            ErrorTypeAwareLogger log = customLogger == null ? logger : customLogger;
+            log.info(
+                    "Set system property '{}' to '{}' for Nacos subscriber application name.",
+                    PROJECT_NAME_SYS_PROP_KEY,
+                    appName);
+        } catch (Throwable t) {
+            // Log at debug level to aid troubleshooting, but do not impact Nacos client initialization
+            ErrorTypeAwareLogger log = customLogger == null ? logger : customLogger;
+            log.debug(
+                    "Failed to set system property '{}' for Nacos subscriber application name. "
+                            + "This is non-fatal and can be ignored if Nacos client works as expected.",
+                    PROJECT_NAME_SYS_PROP_KEY,
+                    t);
+        }
+    }
+}

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/nacos/NacosAppNameUtilsTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/nacos/NacosAppNameUtilsTest.java
@@ -115,7 +115,8 @@ class NacosAppNameUtilsTest {
         ApplicationConfig appConfig = new ApplicationConfig(appName);
         applicationModel.getApplicationConfigManager().setApplication(appConfig);
 
-        URL url = URL.valueOf("nacos://127.0.0.1:8848?" + NACOS_SET_PROJECT_NAME_KEY + "=true&application=url-app-name");
+        URL url =
+                URL.valueOf("nacos://127.0.0.1:8848?" + NACOS_SET_PROJECT_NAME_KEY + "=true&application=url-app-name");
 
         NacosAppNameUtils.maybeSetProjectName(url, applicationModel, null);
 
@@ -125,8 +126,8 @@ class NacosAppNameUtilsTest {
     @Test
     void testUrlApplicationParameterFallback() {
         // When ApplicationModel has no app name, URL's application parameter should be used
-        URL url = URL.valueOf(
-                "nacos://127.0.0.1:8848?" + NACOS_SET_PROJECT_NAME_KEY + "=true&application=url-app-name");
+        URL url =
+                URL.valueOf("nacos://127.0.0.1:8848?" + NACOS_SET_PROJECT_NAME_KEY + "=true&application=url-app-name");
 
         // Pass null ApplicationModel to skip priority 1
         NacosAppNameUtils.maybeSetProjectName(url, null, null);
@@ -155,8 +156,8 @@ class NacosAppNameUtilsTest {
     void testEmptyAppNameFromApplicationModel() {
         // When ApplicationModel returns empty app name, should fall back to URL parameter
         // ApplicationModel without ApplicationConfig returns "unknown" by default
-        URL url = URL.valueOf(
-                "nacos://127.0.0.1:8848?" + NACOS_SET_PROJECT_NAME_KEY + "=true&application=fallback-app");
+        URL url =
+                URL.valueOf("nacos://127.0.0.1:8848?" + NACOS_SET_PROJECT_NAME_KEY + "=true&application=fallback-app");
 
         // Create a new application model without setting ApplicationConfig
         FrameworkModel fm = new FrameworkModel();
@@ -250,8 +251,8 @@ class NacosAppNameUtilsTest {
         ApplicationConfig appConfig = new ApplicationConfig(scopeModelName);
         applicationModel.getApplicationConfigManager().setApplication(appConfig);
 
-        URL url = URL.valueOf(
-                "nacos://127.0.0.1:8848?" + NACOS_SET_PROJECT_NAME_KEY + "=true&application=" + urlAppName);
+        URL url =
+                URL.valueOf("nacos://127.0.0.1:8848?" + NACOS_SET_PROJECT_NAME_KEY + "=true&application=" + urlAppName);
         url = url.setScopeModel(applicationModel);
 
         NacosAppNameUtils.maybeSetProjectName(url, null, null);
@@ -260,4 +261,3 @@ class NacosAppNameUtilsTest {
         assertEquals(urlAppName, System.getProperty(PROJECT_NAME_SYS_PROP_KEY));
     }
 }
-

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/nacos/NacosAppNameUtilsTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/nacos/NacosAppNameUtilsTest.java
@@ -153,9 +153,10 @@ class NacosAppNameUtilsTest {
     }
 
     @Test
-    void testEmptyAppNameFromApplicationModel() {
-        // When ApplicationModel returns empty app name, should fall back to URL parameter
-        // ApplicationModel without ApplicationConfig returns "unknown" by default
+    void testApplicationModelWithoutConfigThrowsException() {
+        // When ApplicationModel has no ApplicationConfig set, getApplicationName() throws
+        // IllegalStateException. The exception is caught in maybeSetProjectName() and logged,
+        // but the property will not be set (the method returns early after catching the exception).
         URL url =
                 URL.valueOf("nacos://127.0.0.1:8848?" + NACOS_SET_PROJECT_NAME_KEY + "=true&application=fallback-app");
 
@@ -166,12 +167,11 @@ class NacosAppNameUtilsTest {
         try {
             NacosAppNameUtils.maybeSetProjectName(url, emptyAppModel, null);
 
-            // Should use URL's application parameter as fallback since ApplicationModel
-            // returns "unknown" which is considered as a valid name
-            String result = System.getProperty(PROJECT_NAME_SYS_PROP_KEY);
-            // The result could be "unknown" (from ApplicationModel) or "fallback-app" (from URL)
-            // depending on whether "unknown" is treated as empty
-            assertEquals("unknown", result);
+            // Since ApplicationModel.getApplicationName() throws an exception when no
+            // ApplicationConfig is set, the exception is caught and the property is not set.
+            // The URL's application parameter is NOT used as fallback because the exception
+            // short-circuits the entire method.
+            assertNull(System.getProperty(PROJECT_NAME_SYS_PROP_KEY));
         } finally {
             fm.destroy();
         }
@@ -182,33 +182,15 @@ class NacosAppNameUtilsTest {
         // When all sources return empty/null app name, property should not be set
         URL url = URL.valueOf("nacos://127.0.0.1:8848?" + NACOS_SET_PROJECT_NAME_KEY + "=true");
 
-        // Pass null ApplicationModel and URL has no application param
-        // URL also has no ScopeModel set
+        // Pass null ApplicationModel, URL has no application param, and URL has no ScopeModel set.
+        // In getApplicationName():
+        //   - Priority 1: applicationModel is null, skipped
+        //   - Priority 2: url.getApplication() returns null
+        //   - Priority 3: ScopeModelUtil.getOrNullApplicationModel(null) returns null
+        // So getApplicationName() returns null, and property is not set.
         NacosAppNameUtils.maybeSetProjectName(url, null, null);
 
-        // Should be set to "unknown" from default ApplicationModel via ScopeModelUtil
-        // or null if no default model is available
-        String result = System.getProperty(PROJECT_NAME_SYS_PROP_KEY);
-        // The behavior depends on whether ScopeModelUtil returns a default model
-        // In this case, it may return "unknown" from the default ApplicationModel
-        if (result != null) {
-            assertEquals("unknown", result);
-        }
-    }
-
-    @Test
-    void testWithScopeModelInUrl() {
-        // Test when URL has ScopeModel set and ApplicationModel parameter is null
-        String appName = "scoped-app";
-        ApplicationConfig appConfig = new ApplicationConfig(appName);
-        applicationModel.getApplicationConfigManager().setApplication(appConfig);
-
-        URL url = URL.valueOf("nacos://127.0.0.1:8848?" + NACOS_SET_PROJECT_NAME_KEY + "=true");
-        url = url.setScopeModel(applicationModel);
-
-        NacosAppNameUtils.maybeSetProjectName(url, null, null);
-
-        assertEquals(appName, System.getProperty(PROJECT_NAME_SYS_PROP_KEY));
+        assertNull(System.getProperty(PROJECT_NAME_SYS_PROP_KEY));
     }
 
     @Test

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/nacos/NacosAppNameUtilsTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/nacos/NacosAppNameUtilsTest.java
@@ -1,0 +1,263 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.common.nacos;
+
+import org.apache.dubbo.common.URL;
+import org.apache.dubbo.config.ApplicationConfig;
+import org.apache.dubbo.rpc.model.ApplicationModel;
+import org.apache.dubbo.rpc.model.FrameworkModel;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.apache.dubbo.common.nacos.NacosAppNameUtils.NACOS_SET_PROJECT_NAME_KEY;
+import static org.apache.dubbo.common.nacos.NacosAppNameUtils.PROJECT_NAME_SYS_PROP_KEY;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * Unit tests for {@link NacosAppNameUtils}
+ */
+class NacosAppNameUtilsTest {
+
+    private FrameworkModel frameworkModel;
+    private ApplicationModel applicationModel;
+    private String originalProjectName;
+
+    @BeforeEach
+    void setUp() {
+        // Save original system property
+        originalProjectName = System.getProperty(PROJECT_NAME_SYS_PROP_KEY);
+        // Clear the system property before each test
+        System.clearProperty(PROJECT_NAME_SYS_PROP_KEY);
+
+        frameworkModel = new FrameworkModel();
+        applicationModel = frameworkModel.newApplication();
+    }
+
+    @AfterEach
+    void tearDown() {
+        // Restore original system property
+        if (originalProjectName != null) {
+            System.setProperty(PROJECT_NAME_SYS_PROP_KEY, originalProjectName);
+        } else {
+            System.clearProperty(PROJECT_NAME_SYS_PROP_KEY);
+        }
+
+        if (frameworkModel != null) {
+            frameworkModel.destroy();
+        }
+    }
+
+    @Test
+    void testNullUrl() {
+        // When URL is null, method should return early without setting any property
+        NacosAppNameUtils.maybeSetProjectName(null, applicationModel, null);
+        assertNull(System.getProperty(PROJECT_NAME_SYS_PROP_KEY));
+    }
+
+    @Test
+    void testFeatureDisabledByDefault() {
+        // When nacos.set-project-name is not set (defaults to false), property should not be set
+        URL url = URL.valueOf("nacos://127.0.0.1:8848");
+
+        NacosAppNameUtils.maybeSetProjectName(url, applicationModel, null);
+
+        assertNull(System.getProperty(PROJECT_NAME_SYS_PROP_KEY));
+    }
+
+    @Test
+    void testFeatureExplicitlyDisabled() {
+        // When nacos.set-project-name=false, property should not be set
+        URL url = URL.valueOf("nacos://127.0.0.1:8848?" + NACOS_SET_PROJECT_NAME_KEY + "=false");
+
+        NacosAppNameUtils.maybeSetProjectName(url, applicationModel, null);
+
+        assertNull(System.getProperty(PROJECT_NAME_SYS_PROP_KEY));
+    }
+
+    @Test
+    void testSystemPropertyAlreadySet() {
+        // When project.name system property is already set, it should not be overwritten
+        String existingName = "existing-app-name";
+        System.setProperty(PROJECT_NAME_SYS_PROP_KEY, existingName);
+
+        ApplicationConfig appConfig = new ApplicationConfig("my-dubbo-app");
+        applicationModel.getApplicationConfigManager().setApplication(appConfig);
+
+        URL url = URL.valueOf("nacos://127.0.0.1:8848?" + NACOS_SET_PROJECT_NAME_KEY + "=true");
+
+        NacosAppNameUtils.maybeSetProjectName(url, applicationModel, null);
+
+        // Should remain the existing value
+        assertEquals(existingName, System.getProperty(PROJECT_NAME_SYS_PROP_KEY));
+    }
+
+    @Test
+    void testApplicationModelPriority() {
+        // ApplicationModel should have highest priority
+        String appName = "my-dubbo-app";
+        ApplicationConfig appConfig = new ApplicationConfig(appName);
+        applicationModel.getApplicationConfigManager().setApplication(appConfig);
+
+        URL url = URL.valueOf("nacos://127.0.0.1:8848?" + NACOS_SET_PROJECT_NAME_KEY + "=true&application=url-app-name");
+
+        NacosAppNameUtils.maybeSetProjectName(url, applicationModel, null);
+
+        assertEquals(appName, System.getProperty(PROJECT_NAME_SYS_PROP_KEY));
+    }
+
+    @Test
+    void testUrlApplicationParameterFallback() {
+        // When ApplicationModel has no app name, URL's application parameter should be used
+        URL url = URL.valueOf(
+                "nacos://127.0.0.1:8848?" + NACOS_SET_PROJECT_NAME_KEY + "=true&application=url-app-name");
+
+        // Pass null ApplicationModel to skip priority 1
+        NacosAppNameUtils.maybeSetProjectName(url, null, null);
+
+        assertEquals("url-app-name", System.getProperty(PROJECT_NAME_SYS_PROP_KEY));
+    }
+
+    @Test
+    void testScopeModelFallback() {
+        // When ApplicationModel is null and URL has no application param,
+        // ScopeModel from URL should be used
+        String appName = "scope-model-app";
+        ApplicationConfig appConfig = new ApplicationConfig(appName);
+        applicationModel.getApplicationConfigManager().setApplication(appConfig);
+
+        URL url = URL.valueOf("nacos://127.0.0.1:8848?" + NACOS_SET_PROJECT_NAME_KEY + "=true");
+        url = url.setScopeModel(applicationModel);
+
+        // Pass null ApplicationModel to force ScopeModel fallback
+        NacosAppNameUtils.maybeSetProjectName(url, null, null);
+
+        assertEquals(appName, System.getProperty(PROJECT_NAME_SYS_PROP_KEY));
+    }
+
+    @Test
+    void testEmptyAppNameFromApplicationModel() {
+        // When ApplicationModel returns empty app name, should fall back to URL parameter
+        // ApplicationModel without ApplicationConfig returns "unknown" by default
+        URL url = URL.valueOf(
+                "nacos://127.0.0.1:8848?" + NACOS_SET_PROJECT_NAME_KEY + "=true&application=fallback-app");
+
+        // Create a new application model without setting ApplicationConfig
+        FrameworkModel fm = new FrameworkModel();
+        ApplicationModel emptyAppModel = fm.newApplication();
+
+        try {
+            NacosAppNameUtils.maybeSetProjectName(url, emptyAppModel, null);
+
+            // Should use URL's application parameter as fallback since ApplicationModel
+            // returns "unknown" which is considered as a valid name
+            String result = System.getProperty(PROJECT_NAME_SYS_PROP_KEY);
+            // The result could be "unknown" (from ApplicationModel) or "fallback-app" (from URL)
+            // depending on whether "unknown" is treated as empty
+            assertEquals("unknown", result);
+        } finally {
+            fm.destroy();
+        }
+    }
+
+    @Test
+    void testAllSourcesEmpty() {
+        // When all sources return empty/null app name, property should not be set
+        URL url = URL.valueOf("nacos://127.0.0.1:8848?" + NACOS_SET_PROJECT_NAME_KEY + "=true");
+
+        // Pass null ApplicationModel and URL has no application param
+        // URL also has no ScopeModel set
+        NacosAppNameUtils.maybeSetProjectName(url, null, null);
+
+        // Should be set to "unknown" from default ApplicationModel via ScopeModelUtil
+        // or null if no default model is available
+        String result = System.getProperty(PROJECT_NAME_SYS_PROP_KEY);
+        // The behavior depends on whether ScopeModelUtil returns a default model
+        // In this case, it may return "unknown" from the default ApplicationModel
+        if (result != null) {
+            assertEquals("unknown", result);
+        }
+    }
+
+    @Test
+    void testWithScopeModelInUrl() {
+        // Test when URL has ScopeModel set and ApplicationModel parameter is null
+        String appName = "scoped-app";
+        ApplicationConfig appConfig = new ApplicationConfig(appName);
+        applicationModel.getApplicationConfigManager().setApplication(appConfig);
+
+        URL url = URL.valueOf("nacos://127.0.0.1:8848?" + NACOS_SET_PROJECT_NAME_KEY + "=true");
+        url = url.setScopeModel(applicationModel);
+
+        NacosAppNameUtils.maybeSetProjectName(url, null, null);
+
+        assertEquals(appName, System.getProperty(PROJECT_NAME_SYS_PROP_KEY));
+    }
+
+    @Test
+    void testApplicationModelTakesPriorityOverScopeModel() {
+        // When both ApplicationModel parameter and URL ScopeModel are available,
+        // ApplicationModel parameter should take priority
+        String appModelName = "app-model-name";
+        String scopeModelName = "scope-model-name";
+
+        // Set up ApplicationModel with one name
+        ApplicationConfig appConfig1 = new ApplicationConfig(appModelName);
+        applicationModel.getApplicationConfigManager().setApplication(appConfig1);
+
+        // Set up another ApplicationModel for ScopeModel with different name
+        FrameworkModel fm2 = new FrameworkModel();
+        ApplicationModel scopeAppModel = fm2.newApplication();
+        ApplicationConfig appConfig2 = new ApplicationConfig(scopeModelName);
+        scopeAppModel.getApplicationConfigManager().setApplication(appConfig2);
+
+        try {
+            URL url = URL.valueOf("nacos://127.0.0.1:8848?" + NACOS_SET_PROJECT_NAME_KEY + "=true");
+            url = url.setScopeModel(scopeAppModel);
+
+            NacosAppNameUtils.maybeSetProjectName(url, applicationModel, null);
+
+            // ApplicationModel parameter should take priority
+            assertEquals(appModelName, System.getProperty(PROJECT_NAME_SYS_PROP_KEY));
+        } finally {
+            fm2.destroy();
+        }
+    }
+
+    @Test
+    void testUrlApplicationTakesPriorityOverScopeModel() {
+        // When ApplicationModel is null but URL has both application param and ScopeModel,
+        // URL application param should take priority
+        String urlAppName = "url-app";
+        String scopeModelName = "scope-model-name";
+
+        ApplicationConfig appConfig = new ApplicationConfig(scopeModelName);
+        applicationModel.getApplicationConfigManager().setApplication(appConfig);
+
+        URL url = URL.valueOf(
+                "nacos://127.0.0.1:8848?" + NACOS_SET_PROJECT_NAME_KEY + "=true&application=" + urlAppName);
+        url = url.setScopeModel(applicationModel);
+
+        NacosAppNameUtils.maybeSetProjectName(url, null, null);
+
+        // URL application param should take priority over ScopeModel
+        assertEquals(urlAppName, System.getProperty(PROJECT_NAME_SYS_PROP_KEY));
+    }
+}
+

--- a/dubbo-configcenter/dubbo-configcenter-nacos/src/main/java/org/apache/dubbo/configcenter/support/nacos/NacosDynamicConfiguration.java
+++ b/dubbo-configcenter/dubbo-configcenter-nacos/src/main/java/org/apache/dubbo/configcenter/support/nacos/NacosDynamicConfiguration.java
@@ -25,6 +25,7 @@ import org.apache.dubbo.common.config.configcenter.DynamicConfiguration;
 import org.apache.dubbo.common.constants.LoggerCodeConstants;
 import org.apache.dubbo.common.logger.ErrorTypeAwareLogger;
 import org.apache.dubbo.common.logger.LoggerFactory;
+import org.apache.dubbo.common.nacos.NacosAppNameUtils;
 import org.apache.dubbo.common.utils.ConcurrentHashMapUtils;
 import org.apache.dubbo.common.utils.MD5Utils;
 import org.apache.dubbo.common.utils.StringUtils;
@@ -93,6 +94,7 @@ public class NacosDynamicConfiguration implements DynamicConfiguration {
     private final MD5Utils md5Utils = new MD5Utils();
 
     NacosDynamicConfiguration(URL url, ApplicationModel applicationModel) {
+        NacosAppNameUtils.maybeSetProjectName(url, applicationModel, logger);
         this.nacosProperties = buildNacosProperties(url);
         this.configService = buildConfigService(url);
         this.watchListenerMap = new ConcurrentHashMap<>();

--- a/dubbo-configcenter/dubbo-configcenter-nacos/src/test/java/org/apache/dubbo/configcenter/support/nacos/NacosDynamicConfigurationAppNameTest.java
+++ b/dubbo-configcenter/dubbo-configcenter-nacos/src/test/java/org/apache/dubbo/configcenter/support/nacos/NacosDynamicConfigurationAppNameTest.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.configcenter.support.nacos;
+
+import org.apache.dubbo.common.URL;
+import org.apache.dubbo.common.nacos.NacosAppNameUtils;
+import org.apache.dubbo.config.ApplicationConfig;
+import org.apache.dubbo.rpc.model.ApplicationModel;
+import org.apache.dubbo.rpc.model.FrameworkModel;
+
+import java.util.Properties;
+
+import com.alibaba.nacos.api.NacosFactory;
+import com.alibaba.nacos.api.config.ConfigService;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import static org.apache.dubbo.common.nacos.NacosAppNameUtils.NACOS_SET_PROJECT_NAME_KEY;
+import static org.mockito.ArgumentMatchers.any;
+
+class NacosDynamicConfigurationAppNameTest {
+
+    private final String backup = System.getProperty(NacosAppNameUtils.PROJECT_NAME_SYS_PROP_KEY);
+
+    @AfterEach
+    void tearDown() {
+        if (backup == null) {
+            System.clearProperty(NacosAppNameUtils.PROJECT_NAME_SYS_PROP_KEY);
+        } else {
+            System.setProperty(NacosAppNameUtils.PROJECT_NAME_SYS_PROP_KEY, backup);
+        }
+    }
+
+    @Test
+    void shouldSetProjectNameWhenEnabled() throws Exception {
+        ApplicationModel applicationModel = FrameworkModel.defaultModel().newApplication();
+        try (MockedStatic<NacosFactory> nacosFactory = Mockito.mockStatic(NacosFactory.class)) {
+            ConfigService mockConfig = Mockito.mock(ConfigService.class);
+            Mockito.when(mockConfig.getServerStatus()).thenReturn("UP");
+            Mockito.when(mockConfig.getConfig(any(), any(), any(Long.class))).thenReturn("");
+            nacosFactory
+                    .when(() -> NacosFactory.createConfigService((Properties) any()))
+                    .thenReturn(mockConfig);
+
+            System.clearProperty(NacosAppNameUtils.PROJECT_NAME_SYS_PROP_KEY);
+            applicationModel.getApplicationConfigManager().setApplication(new ApplicationConfig("configcenter-app"));
+
+            URL url = URL.valueOf("nacos://127.0.0.1:8848").addParameter(NACOS_SET_PROJECT_NAME_KEY, "true");
+
+            new NacosDynamicConfiguration(url, applicationModel);
+
+            Assertions.assertEquals(
+                    "configcenter-app", System.getProperty(NacosAppNameUtils.PROJECT_NAME_SYS_PROP_KEY));
+        } finally {
+            applicationModel.destroy();
+        }
+    }
+
+    @Test
+    void shouldNotSetProjectNameWhenDisabled() throws Exception {
+        ApplicationModel applicationModel = FrameworkModel.defaultModel().newApplication();
+        try (MockedStatic<NacosFactory> nacosFactory = Mockito.mockStatic(NacosFactory.class)) {
+            ConfigService mockConfig = Mockito.mock(ConfigService.class);
+            Mockito.when(mockConfig.getServerStatus()).thenReturn("UP");
+            Mockito.when(mockConfig.getConfig(any(), any(), any(Long.class))).thenReturn("");
+            nacosFactory
+                    .when(() -> NacosFactory.createConfigService((Properties) any()))
+                    .thenReturn(mockConfig);
+
+            System.clearProperty(NacosAppNameUtils.PROJECT_NAME_SYS_PROP_KEY);
+            applicationModel.getApplicationConfigManager().setApplication(new ApplicationConfig("configcenter-app"));
+
+            URL url = URL.valueOf("nacos://127.0.0.1:8848");
+
+            new NacosDynamicConfiguration(url, applicationModel);
+
+            Assertions.assertNull(System.getProperty(NacosAppNameUtils.PROJECT_NAME_SYS_PROP_KEY));
+        } finally {
+            applicationModel.destroy();
+        }
+    }
+}

--- a/dubbo-metadata/dubbo-metadata-report-nacos/src/main/java/org/apache/dubbo/metadata/store/nacos/NacosMetadataReport.java
+++ b/dubbo-metadata/dubbo-metadata-report-nacos/src/main/java/org/apache/dubbo/metadata/store/nacos/NacosMetadataReport.java
@@ -22,6 +22,7 @@ import org.apache.dubbo.common.config.configcenter.ConfigChangedEvent;
 import org.apache.dubbo.common.config.configcenter.ConfigItem;
 import org.apache.dubbo.common.config.configcenter.ConfigurationListener;
 import org.apache.dubbo.common.constants.LoggerCodeConstants;
+import org.apache.dubbo.common.nacos.NacosAppNameUtils;
 import org.apache.dubbo.common.utils.ConcurrentHashMapUtils;
 import org.apache.dubbo.common.utils.JsonUtils;
 import org.apache.dubbo.common.utils.MD5Utils;
@@ -94,6 +95,7 @@ public class NacosMetadataReport extends AbstractMetadataReport {
 
     public NacosMetadataReport(URL url) {
         super(url);
+        NacosAppNameUtils.maybeSetProjectName(url, null, logger);
         this.configService = buildConfigService(url);
         group = url.getParameter(GROUP_KEY, DEFAULT_ROOT);
     }

--- a/dubbo-metadata/dubbo-metadata-report-nacos/src/test/java/org/apache/dubbo/metadata/store/nacos/NacosMetadataReportAppNameTest.java
+++ b/dubbo-metadata/dubbo-metadata-report-nacos/src/test/java/org/apache/dubbo/metadata/store/nacos/NacosMetadataReportAppNameTest.java
@@ -47,7 +47,7 @@ class NacosMetadataReportAppNameTest {
     }
 
     @Test
-    void shouldSetProjectNameWhenEnabled() throws NacosException {
+    void shouldSetProjectNameWhenEnabled() {
         try (MockedStatic<NacosFactory> nacosFactory = Mockito.mockStatic(NacosFactory.class)) {
             ConfigService mockConfig = Mockito.mock(ConfigService.class);
             Mockito.when(mockConfig.getServerStatus()).thenReturn("UP");

--- a/dubbo-metadata/dubbo-metadata-report-nacos/src/test/java/org/apache/dubbo/metadata/store/nacos/NacosMetadataReportAppNameTest.java
+++ b/dubbo-metadata/dubbo-metadata-report-nacos/src/test/java/org/apache/dubbo/metadata/store/nacos/NacosMetadataReportAppNameTest.java
@@ -47,7 +47,7 @@ class NacosMetadataReportAppNameTest {
     }
 
     @Test
-    void shouldSetProjectNameWhenEnabled() throws NacosException{
+    void shouldSetProjectNameWhenEnabled() throws NacosException {
         try (MockedStatic<NacosFactory> nacosFactory = Mockito.mockStatic(NacosFactory.class)) {
             ConfigService mockConfig = Mockito.mock(ConfigService.class);
             Mockito.when(mockConfig.getServerStatus()).thenReturn("UP");

--- a/dubbo-metadata/dubbo-metadata-report-nacos/src/test/java/org/apache/dubbo/metadata/store/nacos/NacosMetadataReportAppNameTest.java
+++ b/dubbo-metadata/dubbo-metadata-report-nacos/src/test/java/org/apache/dubbo/metadata/store/nacos/NacosMetadataReportAppNameTest.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.metadata.store.nacos;
+
+import org.apache.dubbo.common.URL;
+import org.apache.dubbo.common.nacos.NacosAppNameUtils;
+
+import java.util.Properties;
+
+import com.alibaba.nacos.api.NacosFactory;
+import com.alibaba.nacos.api.config.ConfigService;
+import com.alibaba.nacos.api.exception.NacosException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import static org.apache.dubbo.common.nacos.NacosAppNameUtils.NACOS_SET_PROJECT_NAME_KEY;
+import static org.mockito.ArgumentMatchers.any;
+
+class NacosMetadataReportAppNameTest {
+
+    private final String backup = System.getProperty(NacosAppNameUtils.PROJECT_NAME_SYS_PROP_KEY);
+
+    @AfterEach
+    void tearDown() {
+        if (backup == null) {
+            System.clearProperty(NacosAppNameUtils.PROJECT_NAME_SYS_PROP_KEY);
+        } else {
+            System.setProperty(NacosAppNameUtils.PROJECT_NAME_SYS_PROP_KEY, backup);
+        }
+    }
+
+    @Test
+    void shouldSetProjectNameWhenEnabled() throws NacosException {
+        try (MockedStatic<NacosFactory> nacosFactory = Mockito.mockStatic(NacosFactory.class)) {
+            ConfigService mockConfig = Mockito.mock(ConfigService.class);
+            Mockito.when(mockConfig.getServerStatus()).thenReturn("UP");
+            Mockito.when(mockConfig.getConfig(any(), any(), any(Long.class))).thenReturn("");
+            nacosFactory
+                    .when(() -> NacosFactory.createConfigService((Properties) any()))
+                    .thenReturn(mockConfig);
+
+            System.clearProperty(NacosAppNameUtils.PROJECT_NAME_SYS_PROP_KEY);
+            URL url = URL.valueOf("nacos://127.0.0.1:8848")
+                    .addParameter(NACOS_SET_PROJECT_NAME_KEY, "true")
+                    .addParameter("application", "metadata-app");
+
+            new NacosMetadataReport(url);
+
+            Assertions.assertEquals(
+                    url.getApplication(), System.getProperty(NacosAppNameUtils.PROJECT_NAME_SYS_PROP_KEY));
+        }
+    }
+
+    @Test
+    void shouldNotSetProjectNameWhenDisabled() throws NacosException {
+        try (MockedStatic<NacosFactory> nacosFactory = Mockito.mockStatic(NacosFactory.class)) {
+            ConfigService mockConfig = Mockito.mock(ConfigService.class);
+            Mockito.when(mockConfig.getServerStatus()).thenReturn("UP");
+            Mockito.when(mockConfig.getConfig(any(), any(), any(Long.class))).thenReturn("");
+            nacosFactory
+                    .when(() -> NacosFactory.createConfigService((Properties) any()))
+                    .thenReturn(mockConfig);
+
+            System.clearProperty(NacosAppNameUtils.PROJECT_NAME_SYS_PROP_KEY);
+            URL url = URL.valueOf("nacos://127.0.0.1:8848");
+
+            new NacosMetadataReport(url);
+
+            Assertions.assertNull(System.getProperty(NacosAppNameUtils.PROJECT_NAME_SYS_PROP_KEY));
+        }
+    }
+}

--- a/dubbo-metadata/dubbo-metadata-report-nacos/src/test/java/org/apache/dubbo/metadata/store/nacos/NacosMetadataReportAppNameTest.java
+++ b/dubbo-metadata/dubbo-metadata-report-nacos/src/test/java/org/apache/dubbo/metadata/store/nacos/NacosMetadataReportAppNameTest.java
@@ -47,7 +47,7 @@ class NacosMetadataReportAppNameTest {
     }
 
     @Test
-    void shouldSetProjectNameWhenEnabled() {
+    void shouldSetProjectNameWhenEnabled() throws NacosException{
         try (MockedStatic<NacosFactory> nacosFactory = Mockito.mockStatic(NacosFactory.class)) {
             ConfigService mockConfig = Mockito.mock(ConfigService.class);
             Mockito.when(mockConfig.getServerStatus()).thenReturn("UP");

--- a/dubbo-registry/dubbo-registry-nacos/src/main/java/org/apache/dubbo/registry/nacos/NacosConnectionManager.java
+++ b/dubbo-registry/dubbo-registry-nacos/src/main/java/org/apache/dubbo/registry/nacos/NacosConnectionManager.java
@@ -20,6 +20,7 @@ import org.apache.dubbo.common.URL;
 import org.apache.dubbo.common.constants.LoggerCodeConstants;
 import org.apache.dubbo.common.logger.ErrorTypeAwareLogger;
 import org.apache.dubbo.common.logger.LoggerFactory;
+import org.apache.dubbo.common.nacos.NacosAppNameUtils;
 import org.apache.dubbo.common.utils.StringUtils;
 import org.apache.dubbo.registry.nacos.util.NacosNamingServiceUtils;
 
@@ -120,6 +121,8 @@ public class NacosConnectionManager {
      * @return {@link NamingService}
      */
     protected NamingService createNamingService() {
+        NacosAppNameUtils.maybeSetProjectName(connectionURL, null, logger);
+        Properties nacosProperties = buildNacosProperties(this.connectionURL);
         NamingService namingService = null;
         try {
             for (int i = 0; i < retryTimes + 1; i++) {

--- a/dubbo-registry/dubbo-registry-nacos/src/test/java/org/apache/dubbo/registry/nacos/NacosConnectionsManagerTest.java
+++ b/dubbo-registry/dubbo-registry-nacos/src/test/java/org/apache/dubbo/registry/nacos/NacosConnectionsManagerTest.java
@@ -17,6 +17,10 @@
 package org.apache.dubbo.registry.nacos;
 
 import org.apache.dubbo.common.URL;
+import org.apache.dubbo.common.nacos.NacosAppNameUtils;
+import org.apache.dubbo.config.ApplicationConfig;
+import org.apache.dubbo.rpc.model.ApplicationModel;
+import org.apache.dubbo.rpc.model.FrameworkModel;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -39,6 +43,121 @@ import static com.alibaba.nacos.client.constant.Constants.HealthCheck.UP;
 import static org.mockito.ArgumentMatchers.any;
 
 public class NacosConnectionsManagerTest {
+    @Test
+    void testSetProjectNameFromDubboApplicationNameWhenEnabled() {
+        String old = System.getProperty(NacosAppNameUtils.PROJECT_NAME_SYS_PROP_KEY);
+        String expectedAppName = "test-dubbo-app-for-nacos";
+        ApplicationModel applicationModel = FrameworkModel.defaultModel().newApplication();
+        try (MockedStatic<NacosFactory> nacosFactoryMockedStatic = Mockito.mockStatic(NacosFactory.class)) {
+            // force NacosFactory call succeed without connecting to server
+            NamingService mock = new MockNamingService() {
+                @Override
+                public String getServerStatus() {
+                    return UP;
+                }
+            };
+            nacosFactoryMockedStatic
+                    .when(() -> NacosFactory.createNamingService((Properties) any()))
+                    .thenReturn(mock);
+
+            System.clearProperty(NacosAppNameUtils.PROJECT_NAME_SYS_PROP_KEY);
+
+            // Set up ApplicationModel with a specific app name
+            applicationModel.getApplicationConfigManager().setApplication(new ApplicationConfig(expectedAppName));
+
+            // URL has a scope model so application model is available; enable mapping by parameter
+            URL url = URL.valueOf("nacos://127.0.0.1:8848")
+                    .addParameter(NacosAppNameUtils.NACOS_SET_PROJECT_NAME_KEY, "true")
+                    .setScopeModel(applicationModel);
+
+            new NacosConnectionManager(url, false, 0, 0);
+
+            String projectName = System.getProperty(NacosAppNameUtils.PROJECT_NAME_SYS_PROP_KEY);
+            Assertions.assertEquals(expectedAppName, projectName, "project.name should equal dubbo application name");
+        } finally {
+            // restore to avoid global side effects across tests
+            if (old == null) {
+                System.clearProperty(NacosAppNameUtils.PROJECT_NAME_SYS_PROP_KEY);
+            } else {
+                System.setProperty(NacosAppNameUtils.PROJECT_NAME_SYS_PROP_KEY, old);
+            }
+            applicationModel.destroy();
+        }
+    }
+
+    @Test
+    void testSetProjectNameSkippedWhenDisabled() {
+        String old = System.getProperty(NacosAppNameUtils.PROJECT_NAME_SYS_PROP_KEY);
+        ApplicationModel applicationModel = FrameworkModel.defaultModel().newApplication();
+        try (MockedStatic<NacosFactory> nacosFactoryMockedStatic = Mockito.mockStatic(NacosFactory.class)) {
+            NamingService mock = new MockNamingService() {
+                @Override
+                public String getServerStatus() {
+                    return UP;
+                }
+            };
+            nacosFactoryMockedStatic
+                    .when(() -> NacosFactory.createNamingService((Properties) any()))
+                    .thenReturn(mock);
+
+            System.clearProperty(NacosAppNameUtils.PROJECT_NAME_SYS_PROP_KEY);
+            applicationModel.getApplicationConfigManager().setApplication(new ApplicationConfig("some-app"));
+
+            // nacos.set-project-name is NOT set (defaults to false)
+            URL url = URL.valueOf("nacos://127.0.0.1:8848").setScopeModel(applicationModel);
+
+            new NacosConnectionManager(url, false, 0, 0);
+
+            String projectName = System.getProperty(NacosAppNameUtils.PROJECT_NAME_SYS_PROP_KEY);
+            Assertions.assertNull(projectName, "project.name should NOT be set when feature is disabled");
+        } finally {
+            if (old == null) {
+                System.clearProperty(NacosAppNameUtils.PROJECT_NAME_SYS_PROP_KEY);
+            } else {
+                System.setProperty(NacosAppNameUtils.PROJECT_NAME_SYS_PROP_KEY, old);
+            }
+            applicationModel.destroy();
+        }
+    }
+
+    @Test
+    void testSetProjectNameNotOverwriteExisting() {
+        String old = System.getProperty(NacosAppNameUtils.PROJECT_NAME_SYS_PROP_KEY);
+        String existingValue = "already-set-by-user";
+        ApplicationModel applicationModel = FrameworkModel.defaultModel().newApplication();
+        try (MockedStatic<NacosFactory> nacosFactoryMockedStatic = Mockito.mockStatic(NacosFactory.class)) {
+            NamingService mock = new MockNamingService() {
+                @Override
+                public String getServerStatus() {
+                    return UP;
+                }
+            };
+            nacosFactoryMockedStatic
+                    .when(() -> NacosFactory.createNamingService((Properties) any()))
+                    .thenReturn(mock);
+
+            // Pre-set the system property
+            System.setProperty(NacosAppNameUtils.PROJECT_NAME_SYS_PROP_KEY, existingValue);
+            applicationModel.getApplicationConfigManager().setApplication(new ApplicationConfig("dubbo-app"));
+
+            URL url = URL.valueOf("nacos://127.0.0.1:8848")
+                    .addParameter(NacosAppNameUtils.NACOS_SET_PROJECT_NAME_KEY, "true")
+                    .setScopeModel(applicationModel);
+
+            new NacosConnectionManager(url, false, 0, 0);
+
+            String projectName = System.getProperty(NacosAppNameUtils.PROJECT_NAME_SYS_PROP_KEY);
+            Assertions.assertEquals(existingValue, projectName, "project.name should NOT be overwritten");
+        } finally {
+            if (old == null) {
+                System.clearProperty(NacosAppNameUtils.PROJECT_NAME_SYS_PROP_KEY);
+            } else {
+                System.setProperty(NacosAppNameUtils.PROJECT_NAME_SYS_PROP_KEY, old);
+            }
+            applicationModel.destroy();
+        }
+    }
+
     @Test
     public void testGet() {
         NamingService namingService = Mockito.mock(NamingService.class);


### PR DESCRIPTION
Add NacosAppNameUtils to bridge Dubbo application name with Nacos project name

fix issue #15843

## What is the purpose of the change?


## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Make sure gitHub actions can pass. [Why the workflow is failing and how to fix it?](../CONTRIBUTING.md)
