### PR TITLE
fix(nacos): Add application key to consumer subscribe URL

### DIFF
--- a/dubbo-registry/dubbo-registry-nacos/src/main/java/org/apache/dubbo/registry/nacos/NacosRegistry.java
+++ b/dubbo-registry/dubbo-registry-nacos/src/main/java/org/apache/dubbo/registry/nacos/NacosRegistry.java
@@ -290,7 +290,13 @@ public class NacosRegistry extends FailbackRegistry {
                         serviceInterface = segments[SERVICE_INTERFACE_INDEX];
                     }
                     URL subscriberURL = url.setPath(serviceInterface)
-                            .addParameters(INTERFACE_KEY, serviceInterface, CHECK_KEY, String.valueOf(false));
+                            .addParameters(
+                                    INTERFACE_KEY,
+                                    serviceInterface,
+                                    CommonConstants.APPLICATION_KEY,
+                                    url.getApplication(), // <-- Your actual fix
+                                    CHECK_KEY,
+                                    String.valueOf(false));
                     notifySubscriber(subscriberURL, serviceName, listener, instances);
                     subscribeEventListener(serviceName, subscriberURL, listener);
                 }

--- a/dubbo-registry/dubbo-registry-nacos/src/main/java/org/apache/dubbo/registry/nacos/NacosRegistry.java
+++ b/dubbo-registry/dubbo-registry-nacos/src/main/java/org/apache/dubbo/registry/nacos/NacosRegistry.java
@@ -294,7 +294,7 @@ public class NacosRegistry extends FailbackRegistry {
                                     INTERFACE_KEY,
                                     serviceInterface,
                                     CommonConstants.APPLICATION_KEY,
-                                    url.getApplication(), // <-- Your actual fix
+                                    url.getApplication(),
                                     CHECK_KEY,
                                     String.valueOf(false));
                     notifySubscriber(subscriberURL, serviceName, listener, instances);


### PR DESCRIPTION
Fixes #15843

The subscriber URL constructed in NacosRegistry for the non-compatible mode was missing the application key, causing the application name to default to "unknown" in the Nacos client metadata. This commit adds the CommonConstants.APPLICATION_KEY parameter using the consumer URL's application name.

## What is the purpose of the change?


## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Make sure gitHub actions can pass. [Why the workflow is failing and how to fix it?](../CONTRIBUTING.md)
