### PR TITLE
providing local cache support for service discovery when registry is unavailable #13856

### DIFF
--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/support/AbstractRegistry.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/support/AbstractRegistry.java
@@ -463,7 +463,7 @@ public abstract class AbstractRegistry implements Registry {
         Set<NotifyListener> listeners =
                 ConcurrentHashMapUtils.computeIfAbsent(subscribed, url, n -> new ConcurrentHashSet<>());
         listeners.add(listener);
-        if(localCacheEnabled){
+        if(localCacheEnabled && !isAvailable()){
             try{
                 List<URL> cached=getCacheUrls(url);
                 if(CollectionUtils.isNotEmpty(cached)){

--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/support/AbstractRegistry.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/support/AbstractRegistry.java
@@ -463,21 +463,17 @@ public abstract class AbstractRegistry implements Registry {
         Set<NotifyListener> listeners =
                 ConcurrentHashMapUtils.computeIfAbsent(subscribed, url, n -> new ConcurrentHashSet<>());
         listeners.add(listener);
-        if(localCacheEnabled && !isAvailable()){
-            try{
-                List<URL> cached=getCacheUrls(url);
-                if(CollectionUtils.isNotEmpty(cached)){
+        if (localCacheEnabled && !isAvailable()) {
+            try {
+                List<URL> cached = getCacheUrls(url);
+                if (CollectionUtils.isNotEmpty(cached)) {
                     listener.notify(cached);
                     logger.info("Registry unavailable or not yet ready. Loaded cached URLs for " + url.getServiceKey()
                             + " : " + cached.size());
                 }
             } catch (Throwable t) {
                 logger.warn(
-                        INTERNAL_ERROR,
-                        "failed to load cached URLs",
-                        "",
-                        "Failed to load cached URLs for " + url,
-                        t);
+                        INTERNAL_ERROR, "failed to load cached URLs", "", "Failed to load cached URLs for " + url, t);
                 throw t;
             }
         }

--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/support/AbstractRegistry.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/support/AbstractRegistry.java
@@ -413,10 +413,10 @@ public abstract class AbstractRegistry implements Registry {
                 }
             }
         }
-        if(result.isEmpty() && localCacheEnabled){
-            List<URL> cached=getCacheUrls(url);
-            if(CollectionUtils.isNotEmpty(cached)){
-                logger.info("Using local cache URLs for lookup of "+url.getServiceKey());
+        if (result.isEmpty() && localCacheEnabled) {
+            List<URL> cached = getCacheUrls(url);
+            if (CollectionUtils.isNotEmpty(cached)) {
+                logger.info("Using local cache URLs for lookup of " + url.getServiceKey());
                 result.addAll(cached);
             }
         }
@@ -463,15 +463,21 @@ public abstract class AbstractRegistry implements Registry {
         Set<NotifyListener> listeners =
                 ConcurrentHashMapUtils.computeIfAbsent(subscribed, url, n -> new ConcurrentHashSet<>());
         listeners.add(listener);
-        if(localCacheEnabled){
-            try{
-                List<URL> cached=getCacheUrls(url);
-                if(CollectionUtils.isNotEmpty(cached)){
+        if (localCacheEnabled && !isAvailable()) {
+            try {
+                List<URL> cached = getCacheUrls(url);
+                if (CollectionUtils.isNotEmpty(cached)) {
                     listener.notify(cached);
-                    logger.info("Registry unavailable or not yet ready. Loaded cached URLs for "+url.getServiceKey()+" : "+cached.size());
+                    logger.info("Registry unavailable or not yet ready. Loaded cached URLs for " + url.getServiceKey()
+                            + " : " + cached.size());
                 }
-            }catch(Throwable t){
-                logger.warn(INTERNAL_ERROR,"failed to load local cache","","Failed to load chached registry data for "+url,t);
+            } catch (Throwable t) {
+                logger.warn(
+                        INTERNAL_ERROR,
+                        "failed to load cached URLs",
+                        "",
+                        "Failed to load cached URLs for " + url,
+                        t);
                 throw t;
             }
         }

--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/support/AbstractRegistry.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/support/AbstractRegistry.java
@@ -413,10 +413,10 @@ public abstract class AbstractRegistry implements Registry {
                 }
             }
         }
-        if(result.isEmpty() && localCacheEnabled){
-            List<URL> cached=getCacheUrls(url);
-            if(CollectionUtils.isNotEmpty(cached)){
-                logger.info("Using local cache URLs for lookup of "+url.getServiceKey());
+        if (result.isEmpty() && localCacheEnabled) {
+            List<URL> cached = getCacheUrls(url);
+            if (CollectionUtils.isNotEmpty(cached)) {
+                logger.info("Using local cache URLs for lookup of " + url.getServiceKey());
                 result.addAll(cached);
             }
         }
@@ -463,15 +463,21 @@ public abstract class AbstractRegistry implements Registry {
         Set<NotifyListener> listeners =
                 ConcurrentHashMapUtils.computeIfAbsent(subscribed, url, n -> new ConcurrentHashSet<>());
         listeners.add(listener);
-        if(localCacheEnabled){
-            try{
-                List<URL> cached=getCacheUrls(url);
-                if(CollectionUtils.isNotEmpty(cached)){
+        if (localCacheEnabled) {
+            try {
+                List<URL> cached = getCacheUrls(url);
+                if (CollectionUtils.isNotEmpty(cached)) {
                     listener.notify(cached);
-                    logger.info("Registry unavailable or not yet ready. Loaded cached URLs for "+url.getServiceKey()+" : "+cached.size());
+                    logger.info("Registry unavailable or not yet ready. Loaded cached URLs for " + url.getServiceKey()
+                            + " : " + cached.size());
                 }
-            }catch(Throwable t){
-                logger.warn(INTERNAL_ERROR,"failed to load local cache","","Failed to load chached registry data for "+url,t);
+            } catch (Throwable t) {
+                logger.warn(
+                        INTERNAL_ERROR,
+                        "failed to load local cache",
+                        "",
+                        "Failed to load chached registry data for " + url,
+                        t);
                 throw t;
             }
         }

--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/support/AbstractRegistry.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/support/AbstractRegistry.java
@@ -474,9 +474,9 @@ public abstract class AbstractRegistry implements Registry {
             } catch (Throwable t) {
                 logger.warn(
                         INTERNAL_ERROR,
-                        "failed to load local cache",
+                        "failed to load cached URLs",
                         "",
-                        "Failed to load chached registry data for " + url,
+                        "Failed to load cached URLs for " + url,
                         t);
                 throw t;
             }

--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/support/AbstractRegistry.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/support/AbstractRegistry.java
@@ -413,6 +413,13 @@ public abstract class AbstractRegistry implements Registry {
                 }
             }
         }
+        if(result.isEmpty() && localCacheEnabled){
+            List<URL> cached=getCacheUrls(url);
+            if(CollectionUtils.isNotEmpty(cached)){
+                logger.info("Using local cache URLs for lookup of "+url.getServiceKey());
+                result.addAll(cached);
+            }
+        }
         return result;
     }
 
@@ -456,6 +463,18 @@ public abstract class AbstractRegistry implements Registry {
         Set<NotifyListener> listeners =
                 ConcurrentHashMapUtils.computeIfAbsent(subscribed, url, n -> new ConcurrentHashSet<>());
         listeners.add(listener);
+        if(localCacheEnabled){
+            try{
+                List<URL> cached=getCacheUrls(url);
+                if(CollectionUtils.isNotEmpty(cached)){
+                    listener.notify(cached);
+                    logger.info("Registry unavailable or not yet ready. Loaded cached URLs for "+url.getServiceKey()+" : "+cached.size());
+                }
+            }catch(Throwable t){
+                logger.warn(INTERNAL_ERROR,"failed to load local cache","","Failed to load chached registry data for "+url,t);
+                throw t;
+            }
+        }
     }
 
     @Override


### PR DESCRIPTION
try to fix https://github.com/apache/dubbo/issues/13856

Currently, Dubbo’s registry layer writes provider information to a local cache file, but it does not read that cache when the registry center becomes unavailable. So, consumers fail to discover providers during temporary registry outages, even though the information already exists locally.
This PR introduces a fallback mechanism so that consumers can still find providers using the last known data in the local cache.

Added some code in org.apache.dubbo.registry.support.AbstractRegistry to:
   Load provider URLs from the local cache file when the registry cannot be reached.
    Immediately notify registered listeners with cached data so consumers remain functional.

The fallback is triggered only when the registry is unavailable or not yet ready.