### PR TITLE
Preventing spring mvc from mapping dubbo service beans, Fixes #15274

### DIFF
--- a/dubbo-spring-boot-project/dubbo-spring-boot-3-autoconfigure/pom.xml
+++ b/dubbo-spring-boot-project/dubbo-spring-boot-3-autoconfigure/pom.xml
@@ -75,6 +75,7 @@
       <artifactId>jakarta.servlet-api</artifactId>
       <scope>provided</scope>
     </dependency>
+
     <dependency>
       <groupId>org.apache.tomcat.embed</groupId>
       <artifactId>tomcat-embed-core</artifactId>
@@ -91,6 +92,12 @@
       <groupId>jakarta.websocket</groupId>
       <artifactId>jakarta.websocket-client-api</artifactId>
       <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-webmvc</artifactId>
+      <optional>true</optional>
     </dependency>
   </dependencies>
 </project>

--- a/dubbo-spring-boot-project/dubbo-spring-boot-3-autoconfigure/src/main/java/org/apache/dubbo/spring/boot/autoconfigure/DubboTripleWebMvcConfiguration.java
+++ b/dubbo-spring-boot-project/dubbo-spring-boot-3-autoconfigure/src/main/java/org/apache/dubbo/spring/boot/autoconfigure/DubboTripleWebMvcConfiguration.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.spring.boot.autoconfigure;
+
+import org.apache.dubbo.config.annotation.DubboService;
+import org.apache.dubbo.rpc.service.EchoService;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
+import org.springframework.boot.autoconfigure.web.servlet.WebMvcRegistrations;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.AnnotatedElementUtils;
+import org.springframework.lang.NonNull;
+import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping;
+
+/**
+ * Spring MVC autoconfiguration for Dubbo Triple REST integration.
+ * This configuration registers a custom RequestMappingHandlerMapping to prevent
+ * Dubbo service beans and Reference proxies from being mistakenly scanned as
+ * Spring MVC controllers.
+ */
+@Configuration(proxyBeanMethods = false)
+@ConditionalOnWebApplication(type = ConditionalOnWebApplication.Type.SERVLET)
+@ConditionalOnClass({WebMvcRegistrations.class, RequestMappingHandlerMapping.class})
+public class DubboTripleWebMvcConfiguration {
+
+    @Bean
+    public WebMvcRegistrations dubboMvcRegistrations() {
+        return new WebMvcRegistrations() {
+            @Override
+            public RequestMappingHandlerMapping getRequestMappingHandlerMapping() {
+                return new DubboExcludedRequestMappingHandlerMapping();
+            }
+        };
+    }
+
+    static class DubboExcludedRequestMappingHandlerMapping extends RequestMappingHandlerMapping {
+
+        @Override
+        protected boolean isHandler(@NonNull Class<?> beanType) {
+
+            if (AnnotatedElementUtils.hasAnnotation(beanType, DubboService.class)) {
+                return false;
+            }
+
+            if (EchoService.class.isAssignableFrom(beanType)) {
+                return false;
+            }
+
+            return super.isHandler(beanType);
+        }
+    }
+}

--- a/dubbo-spring-boot-project/dubbo-spring-boot-3-autoconfigure/src/main/java/org/apache/dubbo/spring/boot/autoconfigure/DubboTripleWebMvcConfiguration.java
+++ b/dubbo-spring-boot-project/dubbo-spring-boot-3-autoconfigure/src/main/java/org/apache/dubbo/spring/boot/autoconfigure/DubboTripleWebMvcConfiguration.java
@@ -18,6 +18,7 @@ package org.apache.dubbo.spring.boot.autoconfigure;
 
 import org.apache.dubbo.config.annotation.DubboService;
 import org.apache.dubbo.rpc.service.EchoService;
+
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
 import org.springframework.boot.autoconfigure.web.servlet.WebMvcRegistrations;

--- a/dubbo-spring-boot-project/dubbo-spring-boot-3-autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/dubbo-spring-boot-project/dubbo-spring-boot-3-autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,1 +1,2 @@
 org.apache.dubbo.spring.boot.autoconfigure.DubboTriple3AutoConfiguration
+org.apache.dubbo.spring.boot.autoconfigure.DubboTripleWebMvcConfiguration


### PR DESCRIPTION
## What is the purpose of the change?
It is to prevent application startup failures caused by Spring MVC incorrectly identifying Dubbo service components as web controllers. By registering a custom RequestMappingHandlerMapping that excludes beans annotated with DubboService and beans implementing EchoService, the configuration ensures that Spring MVC does not attempt to map duplicate or ambiguous endpoints, which resolves AmbiguousMappingException errors.

Fixes #15274

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit tests to verify your logic correction. If the new feature or significant change is committed, please remember to add a sample to the [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Make sure GitHub actions can pass. [Why the workflow is failing and how to fix it?](../CONTRIBUTING.md)
