### PR TITLE
Fix ReferenceBean type mismatch and add regression test

### DIFF
--- a/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/ReferenceBean.java
+++ b/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/ReferenceBean.java
@@ -217,7 +217,17 @@ public class ReferenceBean<T>
 
     @Override
     public Class<?> getObjectType() {
-        return getInterfaceClass();
+        if (this.interfaceClass != null) {
+            return this.interfaceClass;
+        }
+        if (this.interfaceName != null) {
+            try {
+                return ClassUtils.forName(this.interfaceName, this.beanClassLoader);
+            } catch (ClassNotFoundException ignored) {
+                // ignore
+            }
+        }
+        return Object.class;
     }
 
     @Override

--- a/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/ReferenceBeanTypeInjectionTest.java
+++ b/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/ReferenceBeanTypeInjectionTest.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.config.spring;
+
+import org.apache.dubbo.config.annotation.DubboReference;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+class ReferenceBeanTypeInjectionTest {
+
+    @Test
+    void testReferenceInjectionDoesNotThrowBeanNotOfRequiredTypeException() {
+        // Context startup itself is the assertion
+        new AnnotationConfigApplicationContext(TestConfig.class).close();
+    }
+
+    @Configuration
+    static class TestConfig {
+
+        @DubboReference
+        private DemoService demoService;
+
+        @Bean
+        ConsumerBean consumerBean() {
+            return new ConsumerBean(demoService);
+        }
+    }
+
+    interface DemoService {
+        String sayHello(String name);
+    }
+
+    static class ConsumerBean {
+
+        private final DemoService demoService;
+
+        ConsumerBean(DemoService demoService) {
+            this.demoService = demoService;
+        }
+    }
+}


### PR DESCRIPTION
What does this PR do?

This PR fixes a Spring type resolution issue where ReferenceBean#getObjectType() could return an incompatible or undefined type, which may lead to BeanNotOfRequiredTypeException during dependency injection.

A regression test is added to ensure that a Spring application context can start successfully when @DubboReference is injected into a constructor-managed bean.

Why is this needed?

Spring relies on FactoryBean#getObjectType() during bean type prediction and dependency matching.
Returning an incorrect or unresolved type at this stage can cause bean creation failures during application context initialization.

How was this tested?

Added ReferenceBeanTypeInjectionTest

All existing tests pass

Additional notes

No UI changes

No screenshots required

Fixes #12637

Kindly review this PR when you get time.
Thank you for your guidance.
@AlbumenJ @RainYuY