### PR TITLE
Reuse Nacos NamingService connections across registry groups

### DIFF
--- a/dubbo-registry/dubbo-registry-nacos/src/main/java/org/apache/dubbo/registry/nacos/NacosRegistry.java
+++ b/dubbo-registry/dubbo-registry-nacos/src/main/java/org/apache/dubbo/registry/nacos/NacosRegistry.java
@@ -196,6 +196,13 @@ public class NacosRegistry extends FailbackRegistry {
                     serviceNames.add(compatibleServiceName);
                 }
 
+                /**
+                 *  namingService.registerInstance with
+                 *  {@link org.apache.dubbo.registry.support.AbstractRegistry#registryUrl}
+                 *  default {@link DEFAULT_GROUP}
+                 *
+                 * in https://github.com/apache/dubbo/issues/5978
+                 */
                 for (String service : serviceNames) {
                     namingService.registerInstance(service, getUrl().getGroup(Constants.DEFAULT_GROUP), instance);
                 }
@@ -256,6 +263,16 @@ public class NacosRegistry extends FailbackRegistry {
         try {
             if (isServiceNamesWithCompatibleMode(url)) {
 
+                /**
+                 * Get all instances with serviceNames to avoid instance overwrite and but with empty instance mentioned
+                 * in https://github.com/apache/dubbo/issues/5885 and https://github.com/apache/dubbo/issues/5899
+                 *
+                 * namingService.getAllInstances with
+                 * {@link org.apache.dubbo.registry.support.AbstractRegistry#registryUrl}
+                 * default {@link DEFAULT_GROUP}
+                 *
+                 * in https://github.com/apache/dubbo/issues/5978
+                 */
                 for (String serviceName : serviceNames) {
                     List<Instance> instances = namingService.getAllInstancesWithoutSubscription(
                             serviceName, getUrl().getGroup(Constants.DEFAULT_GROUP));

--- a/dubbo-registry/dubbo-registry-nacos/src/main/java/org/apache/dubbo/registry/nacos/NacosRegistry.java
+++ b/dubbo-registry/dubbo-registry-nacos/src/main/java/org/apache/dubbo/registry/nacos/NacosRegistry.java
@@ -38,6 +38,7 @@ import org.apache.dubbo.rpc.RpcException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
@@ -195,13 +196,6 @@ public class NacosRegistry extends FailbackRegistry {
                     serviceNames.add(compatibleServiceName);
                 }
 
-                /**
-                 *  namingService.registerInstance with
-                 *  {@link org.apache.dubbo.registry.support.AbstractRegistry#registryUrl}
-                 *  default {@link DEFAULT_GROUP}
-                 *
-                 * in https://github.com/apache/dubbo/issues/5978
-                 */
                 for (String service : serviceNames) {
                     namingService.registerInstance(service, getUrl().getGroup(Constants.DEFAULT_GROUP), instance);
                 }
@@ -262,16 +256,6 @@ public class NacosRegistry extends FailbackRegistry {
         try {
             if (isServiceNamesWithCompatibleMode(url)) {
 
-                /**
-                 * Get all instances with serviceNames to avoid instance overwrite and but with empty instance mentioned
-                 * in https://github.com/apache/dubbo/issues/5885 and https://github.com/apache/dubbo/issues/5899
-                 *
-                 * namingService.getAllInstances with
-                 * {@link org.apache.dubbo.registry.support.AbstractRegistry#registryUrl}
-                 * default {@link DEFAULT_GROUP}
-                 *
-                 * in https://github.com/apache/dubbo/issues/5978
-                 */
                 for (String serviceName : serviceNames) {
                     List<Instance> instances = namingService.getAllInstancesWithoutSubscription(
                             serviceName, getUrl().getGroup(Constants.DEFAULT_GROUP));
@@ -282,8 +266,7 @@ public class NacosRegistry extends FailbackRegistry {
                 }
             } else {
                 for (String serviceName : serviceNames) {
-                    List<Instance> instances = new LinkedList<>();
-                    instances.addAll(namingService.getAllInstancesWithoutSubscription(
+                    List<Instance> instances = new LinkedList<>(namingService.getAllInstancesWithoutSubscription(
                             serviceName, getUrl().getGroup(Constants.DEFAULT_GROUP)));
                     String serviceInterface = serviceName;
                     String[] segments = serviceName.split(SERVICE_NAME_SEPARATOR, -1);
@@ -312,10 +295,8 @@ public class NacosRegistry extends FailbackRegistry {
 
     /**
      * Since 2.7.6 the legacy service name will be added to serviceNames to fix bug with
-     * https://github.com/apache/dubbo/issues/5442
+     * <a href="https://github.com/apache/dubbo/issues/5442">...</a>
      *
-     * @param url
-     * @return
      */
     private boolean isServiceNamesWithCompatibleMode(final URL url) {
         return !isAdminProtocol(url) && createServiceName(url).isConcrete();
@@ -413,18 +394,15 @@ public class NacosRegistry extends FailbackRegistry {
 
     private Set<String> filterServiceNames(NacosServiceName serviceName) {
         try {
-            Set<String> serviceNames = new LinkedHashSet<>();
-            serviceNames.addAll(
-                    namingService
-                            .getServicesOfServer(1, Integer.MAX_VALUE, getUrl().getGroup(Constants.DEFAULT_GROUP))
-                            .getData()
-                            .stream()
-                            .filter(this::isConformRules)
-                            .map(NacosServiceName::new)
-                            .filter(serviceName::isCompatible)
-                            .map(NacosServiceName::toString)
-                            .collect(Collectors.toList()));
-            return serviceNames;
+            return namingService
+                    .getServicesOfServer(1, Integer.MAX_VALUE, getUrl().getGroup(Constants.DEFAULT_GROUP))
+                    .getData()
+                    .stream()
+                    .filter(this::isConformRules)
+                    .map(NacosServiceName::new)
+                    .filter(serviceName::isCompatible)
+                    .map(NacosServiceName::toString)
+                    .collect(Collectors.toCollection(LinkedHashSet::new));
         } catch (SkipFailbackWrapperException exception) {
             throw exception;
         } catch (Throwable cause) {
@@ -438,8 +416,6 @@ public class NacosRegistry extends FailbackRegistry {
     /**
      * Verify whether it is a dubbo service
      *
-     * @param serviceName
-     * @return
      * @since 2.7.12
      */
     private boolean isConformRules(String serviceName) {
@@ -511,14 +487,13 @@ public class NacosRegistry extends FailbackRegistry {
 
     private Set<String> getAllServiceNames() {
         try {
-            final Set<String> serviceNames = new LinkedHashSet<>();
             int pageIndex = 1;
             ListView<String> listView = namingService.getServicesOfServer(
                     pageIndex, PAGINATION_SIZE, getUrl().getGroup(Constants.DEFAULT_GROUP));
             // First page data
             List<String> firstPageData = listView.getData();
             // Append first page into list
-            serviceNames.addAll(firstPageData);
+            final Set<String> serviceNames = new LinkedHashSet<>(firstPageData);
             // the total count
             int count = listView.getCount();
             // the number of pages
@@ -622,7 +597,7 @@ public class NacosRegistry extends FailbackRegistry {
         consumerURL = removeParamsFromConsumer(consumerURL);
         List<URL> urls = buildURLs(consumerURL, instances);
         // Nacos does not support configurators and routers from registry, so all notifications are of providers type.
-        if (urls.size() == 0 && !getUrl().getParameter(ENABLE_EMPTY_PROTECTION_KEY, DEFAULT_ENABLE_EMPTY_PROTECTION)) {
+        if (urls.isEmpty() && !getUrl().getParameter(ENABLE_EMPTY_PROTECTION_KEY, DEFAULT_ENABLE_EMPTY_PROTECTION)) {
             logger.warn(
                     REGISTRY_NACOS_EXCEPTION,
                     "",
@@ -700,7 +675,7 @@ public class NacosRegistry extends FailbackRegistry {
     private void notifySubscriber(
             URL url, String serviceName, NacosAggregateListener listener, Collection<Instance> instances) {
         List<Instance> enabledInstances = new LinkedList<>(instances);
-        if (enabledInstances.size() > 0) {
+        if (!enabledInstances.isEmpty()) {
             //  Instances
             filterEnabledInstances(enabledInstances);
         }
@@ -716,7 +691,9 @@ public class NacosRegistry extends FailbackRegistry {
      * @return non-null array
      */
     private List<String> getCategories(URL url) {
-        return ANY_VALUE.equals(url.getServiceInterface()) ? ALL_SUPPORTED_CATEGORIES : Arrays.asList(DEFAULT_CATEGORY);
+        return ANY_VALUE.equals(url.getServiceInterface())
+                ? ALL_SUPPORTED_CATEGORIES
+                : Collections.singletonList(DEFAULT_CATEGORY);
     }
 
     private URL buildURL(URL consumerURL, Instance instance) {
@@ -773,7 +750,7 @@ public class NacosRegistry extends FailbackRegistry {
     private interface NacosDataFilter<T> {
 
         /**
-         * Tests whether or not the specified data should be accepted.
+         * Tests whether the specified data should be accepted.
          *
          * @param data The data to be tested
          * @return <code>true</code> if and only if <code>data</code>

--- a/dubbo-registry/dubbo-registry-nacos/src/main/java/org/apache/dubbo/registry/nacos/NacosRegistry.java
+++ b/dubbo-registry/dubbo-registry-nacos/src/main/java/org/apache/dubbo/registry/nacos/NacosRegistry.java
@@ -30,6 +30,7 @@ import org.apache.dubbo.common.utils.UrlUtils;
 import org.apache.dubbo.registry.NotifyListener;
 import org.apache.dubbo.registry.Registry;
 import org.apache.dubbo.registry.RegistryNotifier;
+import org.apache.dubbo.registry.nacos.util.NacosNamingServiceUtils;
 import org.apache.dubbo.registry.support.FailbackRegistry;
 import org.apache.dubbo.registry.support.SkipFailbackWrapperException;
 import org.apache.dubbo.rpc.RpcException;
@@ -608,9 +609,11 @@ public class NacosRegistry extends FailbackRegistry {
     public void destroy() {
         super.destroy();
         try {
-            this.namingService.shutdown();
-        } catch (NacosException e) {
-            logger.warn(REGISTRY_NACOS_EXCEPTION, "", "", "Unable to shutdown nacos naming service", e);
+            // Release the reference to the shared Nacos connection.
+            NacosNamingServiceUtils.releaseNamingService(getUrl());
+        } catch (Exception e) {
+            logger.warn(REGISTRY_NACOS_EXCEPTION, "", "",
+                    "Unable to release nacos naming service", e);
         }
         this.nacosListeners.clear();
     }

--- a/dubbo-registry/dubbo-registry-nacos/src/main/java/org/apache/dubbo/registry/nacos/NacosRegistry.java
+++ b/dubbo-registry/dubbo-registry-nacos/src/main/java/org/apache/dubbo/registry/nacos/NacosRegistry.java
@@ -612,8 +612,7 @@ public class NacosRegistry extends FailbackRegistry {
             // Release the reference to the shared Nacos connection.
             NacosNamingServiceUtils.releaseNamingService(getUrl());
         } catch (Exception e) {
-            logger.warn(REGISTRY_NACOS_EXCEPTION, "", "",
-                    "Unable to release nacos naming service", e);
+            logger.warn(REGISTRY_NACOS_EXCEPTION, "", "", "Unable to release nacos naming service", e);
         }
         this.nacosListeners.clear();
     }

--- a/dubbo-registry/dubbo-registry-nacos/src/main/java/org/apache/dubbo/registry/nacos/NacosRegistry.java
+++ b/dubbo-registry/dubbo-registry-nacos/src/main/java/org/apache/dubbo/registry/nacos/NacosRegistry.java
@@ -615,6 +615,7 @@ public class NacosRegistry extends FailbackRegistry {
             logger.warn(REGISTRY_NACOS_EXCEPTION, "", "", "Unable to release nacos naming service", e);
         }
         this.nacosListeners.clear();
+        this.originToAggregateListener.clear();
     }
 
     private List<URL> toUrlWithEmpty(URL consumerURL, Collection<Instance> instances) {

--- a/dubbo-registry/dubbo-registry-nacos/src/main/java/org/apache/dubbo/registry/nacos/NacosServiceDiscovery.java
+++ b/dubbo-registry/dubbo-registry-nacos/src/main/java/org/apache/dubbo/registry/nacos/NacosServiceDiscovery.java
@@ -134,7 +134,7 @@ public class NacosServiceDiscovery extends AbstractServiceDiscovery {
                 service.updateInstance(instance.getServiceName(), group, oldInstance, newInstance);
             });
         } catch (Exception e) {
-            throw new RpcException(REGISTRY_EXCEPTION, "Failed register instance " + newServiceInstance.toString(), e);
+            throw new RpcException(REGISTRY_EXCEPTION, "Failed register instance " + newServiceInstance, e);
         }
     }
 
@@ -230,11 +230,6 @@ public class NacosServiceDiscovery extends AbstractServiceDiscovery {
         public boolean isEmpty() {
             return listeners.isEmpty();
         }
-    }
-
-    @Override
-    public URL getUrl() {
-        return registryURL;
     }
 
     private void handleEvent(NamingEvent event, ServiceInstancesChangedListener listener) {

--- a/dubbo-registry/dubbo-registry-nacos/src/main/java/org/apache/dubbo/registry/nacos/util/NacosNamingServiceUtils.java
+++ b/dubbo-registry/dubbo-registry-nacos/src/main/java/org/apache/dubbo/registry/nacos/util/NacosNamingServiceUtils.java
@@ -170,7 +170,7 @@ public class NacosNamingServiceUtils {
                     logger.info("Destroying shared NacosNamingService for key: {}", key);
                     v.wrapper.shutdown();
                 } catch (Exception e) {
-                    logger.warn("Failed to destroy naming service for key: {}", key, e);
+                    logger.warn("Failed to destroy naming service for key: " + key, e);
                 }
                 return null;
             }

--- a/dubbo-registry/dubbo-registry-nacos/src/main/java/org/apache/dubbo/registry/nacos/util/NacosNamingServiceUtils.java
+++ b/dubbo-registry/dubbo-registry-nacos/src/main/java/org/apache/dubbo/registry/nacos/util/NacosNamingServiceUtils.java
@@ -198,10 +198,9 @@ public class NacosNamingServiceUtils {
                         REGISTRY_NACOS_EXCEPTION,
                         "",
                         "",
-                        "releaseNamingService called more times than createNamingService for key: {} (refCount={}). "
-                                + "This indicates a bug in caller lifecycle management.",
-                        key,
-                        left);
+                        "releaseNamingService called more times than createNamingService for key: "
+                                + key + " (refCount=" + left + "). "
+                                + "This indicates a bug in caller lifecycle management.");
                 try {
                     v.wrapper.shutdown();
                 } catch (Exception e) {

--- a/dubbo-registry/dubbo-registry-nacos/src/main/java/org/apache/dubbo/registry/nacos/util/NacosNamingServiceUtils.java
+++ b/dubbo-registry/dubbo-registry-nacos/src/main/java/org/apache/dubbo/registry/nacos/util/NacosNamingServiceUtils.java
@@ -62,10 +62,11 @@ public class NacosNamingServiceUtils {
         final NacosNamingServiceWrapper wrapper;
 
         // Atomic counter to track usage.
-        final AtomicInteger refCount = new AtomicInteger(0);
+        final AtomicInteger refCount;
 
         NacosNamingServiceHolder(NacosNamingServiceWrapper wrapper) {
             this.wrapper = wrapper;
+            this.refCount = new AtomicInteger(1);
         }
     }
 
@@ -147,7 +148,7 @@ public class NacosNamingServiceUtils {
             if (v == null) {
                 logger.info("Creating shared NacosNamingService for key: {}", key);
                 NacosNamingServiceWrapper newWrapper = createWrapperInternal(connectionURL);
-                v = new NacosNamingServiceHolder(newWrapper);
+                return new NacosNamingServiceHolder(newWrapper);
             }
             v.refCount.incrementAndGet();
             return v;
@@ -156,17 +157,31 @@ public class NacosNamingServiceUtils {
         return holder.wrapper;
     }
 
-    // Release a previously acquired naming service reference.
+    /**
+     * Release a previously acquired {@link NacosNamingServiceWrapper} reference.
+     *
+     * <p>This method decrements the reference count associated with the normalized
+     * Nacos connection key. When the reference count reaches zero, the underlying
+     * {@link NacosNamingServiceWrapper} is shut down and removed from the cache.</p>
+     *
+     * <p>If the reference count becomes negative, it indicates a lifecycle bug
+     * (i.e. {@code releaseNamingService} was called more times than
+     * {@code createNamingService}).</p>
+     *
+     * @param connectionURL the registry connection URL used to identify the shared naming service
+     */
     public static void releaseNamingService(URL connectionURL) {
         String key = createNamingServiceCacheKey(connectionURL);
 
-        // Decrement the reference count and close the connection if it reaches zero.
         SERVICE_CACHE.compute(key, (k, v) -> {
             if (v == null) {
                 return null;
             }
 
-            if (v.refCount.decrementAndGet() <= 0) {
+            int left = v.refCount.decrementAndGet();
+
+            // If the count hits zero, this is the last user so we close the physical connection.
+            if (left == 0) {
                 try {
                     logger.info("Destroying shared NacosNamingService for key: {}", key);
                     v.wrapper.shutdown();
@@ -176,6 +191,24 @@ public class NacosNamingServiceUtils {
                 }
                 return null;
             }
+
+            // Error case: more releases than creates (unbalanced lifecycle)
+            if (left < 0) {
+                logger.warn(
+                        "releaseNamingService called more times than createNamingService for key: {} (refCount={})."
+                                + " This indicates a bug in caller lifecycle management.",
+                        key,
+                        left);
+                try {
+                    v.wrapper.shutdown();
+                } catch (Exception e) {
+                    logger.warn(
+                            REGISTRY_NACOS_EXCEPTION, "", "", "Failed to destroy naming service for key: " + key, e);
+                }
+                v.refCount.set(0);
+                return null;
+            }
+
             return v;
         });
     }
@@ -185,8 +218,13 @@ public class NacosNamingServiceUtils {
      * connection URL and configured retry options.
      */
     private static NacosNamingServiceWrapper createWrapperInternal(URL connectionURL) {
+
+        // Use of normalized URL for connection identity / cache key. This ensures
+        // registry.group differences don't create separate physical connections.
         URL normalized = normalizeConnectionURL(connectionURL);
 
+        // We do NOT embed them into the cache key because they represent per-creation behavior,
+        // not part of the identity of the physical Nacos server/namespace.
         boolean check = connectionURL.getParameter(NACOS_CHECK_KEY, true);
         int retryTimes = connectionURL.getPositiveParameter(NACOS_RETRY_KEY, 10);
         int sleepMsBetweenRetries = connectionURL.getPositiveParameter(NACOS_RETRY_WAIT_KEY, 10);
@@ -201,14 +239,26 @@ public class NacosNamingServiceUtils {
     }
 
     /**
-     * Normalizes the URL by removing group parameters and sorting the server address list.
-     * This method removes grouping parameters and standardizes the server address list
+     * Normalize a Nacos registry connection URL for connection reuse.
+     *
+     * <p>This method produces a standard form of the connection URL that is
+     * suitable for use as a cache key. It performs the following normalization steps:</p>
+     *
+     * <p>Removes group-related parameters, since grouping affects only service
+     * registration semantics and not the underlying physical Nacos connection.</p>
+     *
+     * <p>Standardizes the server address list by trimming, sorting, and rejoining
+     * addresses, ensuring that different address orders map to the same connection.</p>
+     *
+     * @param connectionURL the original registry connection URL
+     * @return a normalized URL representing the unique physical Nacos connection
      */
     private static URL normalizeConnectionURL(URL connectionURL) {
-        URL normalized = URL.valueOf(connectionURL.toServiceStringWithoutResolving())
-                .removeParameter(GROUP_KEY)
-                .removeParameter(NACOS_GROUP_KEY);
 
+        // Start from the original URL to preserve all parameters
+        URL normalized = connectionURL.removeParameter(GROUP_KEY).removeParameter(NACOS_GROUP_KEY);
+
+        // Standardize server addresses for stable cache keys
         String serverAddr = normalized.getParameter("serverAddr", normalized.getAddress());
         if (serverAddr != null) {
             String canonical = Arrays.stream(serverAddr.split(","))
@@ -223,5 +273,9 @@ public class NacosNamingServiceUtils {
 
     static void clearCacheForTest() {
         SERVICE_CACHE.clear();
+    }
+
+    static int getCacheSizeForTest() {
+        return SERVICE_CACHE.size();
     }
 }

--- a/dubbo-registry/dubbo-registry-nacos/src/main/java/org/apache/dubbo/registry/nacos/util/NacosNamingServiceUtils.java
+++ b/dubbo-registry/dubbo-registry-nacos/src/main/java/org/apache/dubbo/registry/nacos/util/NacosNamingServiceUtils.java
@@ -172,13 +172,7 @@ public class NacosNamingServiceUtils {
                     v.wrapper.shutdown();
                 } catch (Exception e) {
                     logger.warn(
-                            REGISTRY_NACOS_EXCEPTION,
-                            "",
-                            "",
-                            "Failed to destroy naming service for key: " + key,
-                            e
-                    );
-
+                            REGISTRY_NACOS_EXCEPTION, "", "", "Failed to destroy naming service for key: " + key, e);
                 }
                 return null;
             }

--- a/dubbo-registry/dubbo-registry-nacos/src/main/java/org/apache/dubbo/registry/nacos/util/NacosNamingServiceUtils.java
+++ b/dubbo-registry/dubbo-registry-nacos/src/main/java/org/apache/dubbo/registry/nacos/util/NacosNamingServiceUtils.java
@@ -167,7 +167,7 @@ public class NacosNamingServiceUtils {
 
             if (v.refCount.decrementAndGet() <= 0) {
                 try {
-                    logger.info("Destroying shared NacosNamingService for key: " + key);
+                    logger.info("Destroying shared NacosNamingService for key: {}", key);
                     v.wrapper.shutdown();
                 } catch (Exception e) {
                     logger.warn("Failed to destroy naming service for key: {}", key, e);

--- a/dubbo-registry/dubbo-registry-nacos/src/main/java/org/apache/dubbo/registry/nacos/util/NacosNamingServiceUtils.java
+++ b/dubbo-registry/dubbo-registry-nacos/src/main/java/org/apache/dubbo/registry/nacos/util/NacosNamingServiceUtils.java
@@ -144,7 +144,7 @@ public class NacosNamingServiceUtils {
         // Create or retrieve the shared service holder.
         NacosNamingServiceHolder holder = SERVICE_CACHE.compute(key, (k, v) -> {
             if (v == null) {
-                logger.info("Creating shared NacosNamingService for key: " + key);
+                logger.info("Creating shared NacosNamingService for key: {}", key);
                 NacosNamingServiceWrapper newWrapper = createWrapperInternal(connectionURL);
                 v = new NacosNamingServiceHolder(newWrapper);
             }
@@ -170,7 +170,7 @@ public class NacosNamingServiceUtils {
                     logger.info("Destroying shared NacosNamingService for key: " + key);
                     v.wrapper.shutdown();
                 } catch (Exception e) {
-                    logger.warn("Failed to destroy naming service for key: " + key, e);
+                    logger.warn("Failed to destroy naming service for key: {}", key, e);
                 }
                 return null;
             }

--- a/dubbo-registry/dubbo-registry-nacos/src/main/java/org/apache/dubbo/registry/nacos/util/NacosNamingServiceUtils.java
+++ b/dubbo-registry/dubbo-registry-nacos/src/main/java/org/apache/dubbo/registry/nacos/util/NacosNamingServiceUtils.java
@@ -195,7 +195,11 @@ public class NacosNamingServiceUtils {
             // Error case: more releases than creates (unbalanced lifecycle)
             if (left < 0) {
                 logger.warn(
-                        "releaseNamingService called more times than createNamingService for key: {} (refCount={}). This indicates a bug in caller lifecycle management.",
+                        REGISTRY_NACOS_EXCEPTION,
+                        "",
+                        "",
+                        "releaseNamingService called more times than createNamingService for key: {} (refCount={}). "
+                                + "This indicates a bug in caller lifecycle management.",
                         key,
                         left);
                 try {

--- a/dubbo-registry/dubbo-registry-nacos/src/main/java/org/apache/dubbo/registry/nacos/util/NacosNamingServiceUtils.java
+++ b/dubbo-registry/dubbo-registry-nacos/src/main/java/org/apache/dubbo/registry/nacos/util/NacosNamingServiceUtils.java
@@ -26,6 +26,12 @@ import org.apache.dubbo.registry.nacos.NacosConnectionManager;
 import org.apache.dubbo.registry.nacos.NacosNamingServiceWrapper;
 import org.apache.dubbo.rpc.model.ScopeModelUtil;
 
+import java.util.Arrays;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+
 import com.alibaba.nacos.api.naming.NamingService;
 import com.alibaba.nacos.api.naming.pojo.Instance;
 import com.alibaba.nacos.api.naming.utils.NamingUtils;
@@ -49,6 +55,20 @@ public class NacosNamingServiceUtils {
     private static final String NACOS_RETRY_WAIT_KEY = "nacos.retry-wait";
 
     private static final String NACOS_CHECK_KEY = "nacos.check";
+
+    // Keeps track of the shared wrapper instance and how many registries are using it.
+    private static final class NacosNamingServiceHolder {
+        final NacosNamingServiceWrapper wrapper;
+
+        // Atomic counter to track usage.
+        final AtomicInteger refCount = new AtomicInteger(0);
+
+        NacosNamingServiceHolder(NacosNamingServiceWrapper wrapper) {
+            this.wrapper = wrapper;
+        }
+    }
+
+    private static final ConcurrentMap<String, NacosNamingServiceHolder> SERVICE_CACHE = new ConcurrentHashMap<>();
 
     private NacosNamingServiceUtils() {
         throw new IllegalStateException("NacosNamingServiceUtils should not be instantiated");
@@ -104,22 +124,102 @@ public class NacosNamingServiceUtils {
         return connectionURL.getParameter(NACOS_GROUP_KEY, group);
     }
 
+    // This ensures that different registry groups sharing the same Nacos server and namespace reuse a single
+    // physical connection.
+    private static String createNamingServiceCacheKey(URL connectionURL) {
+        URL normalized = normalizeConnectionURL(connectionURL);
+        return normalized.toFullString();
+    }
+
     /**
-     * Create an instance of {@link NamingService} from specified {@link URL connection url}
+     * Create or obtain a shared {@link NacosNamingServiceWrapper} for the given connection URL.
      *
-     * @param connectionURL {@link URL connection url}
-     * @return {@link NamingService}
+     * @param connectionURL the registry connection URL
+     * @return a shared {@link NacosNamingServiceWrapper}
      * @since 2.7.5
      */
     public static NacosNamingServiceWrapper createNamingService(URL connectionURL) {
+        String key = createNamingServiceCacheKey(connectionURL);
+
+        // Create or retrieve the shared service holder.
+        NacosNamingServiceHolder holder = SERVICE_CACHE.compute(key, (k, v) -> {
+            if (v == null) {
+                logger.info("Creating shared NacosNamingService for key: " + key);
+                NacosNamingServiceWrapper newWrapper = createWrapperInternal(connectionURL);
+                v = new NacosNamingServiceHolder(newWrapper);
+            }
+            v.refCount.incrementAndGet();
+            return v;
+        });
+
+        return holder.wrapper;
+    }
+
+    // Release a previously acquired naming service reference.
+    public static void releaseNamingService(URL connectionURL) {
+        String key = createNamingServiceCacheKey(connectionURL);
+
+        // Decrement the reference count and close the connection if it reaches zero.
+        SERVICE_CACHE.compute(key, (k, v) -> {
+            if (v == null) {
+                return null;
+            }
+
+            if (v.refCount.decrementAndGet() <= 0) {
+                try {
+                    logger.info("Destroying shared NacosNamingService for key: " + key);
+                    v.wrapper.shutdown();
+                } catch (Exception e) {
+                    logger.warn("Failed to destroy naming service for key: " + key, e);
+                }
+                return null;
+            }
+            return v;
+        });
+    }
+
+    /**
+     * Create a new {@link NacosNamingServiceWrapper} using the normalized
+     * connection URL and configured retry options.
+     */
+    private static NacosNamingServiceWrapper createWrapperInternal(URL connectionURL) {
+        URL normalized = normalizeConnectionURL(connectionURL);
+
         boolean check = connectionURL.getParameter(NACOS_CHECK_KEY, true);
         int retryTimes = connectionURL.getPositiveParameter(NACOS_RETRY_KEY, 10);
         int sleepMsBetweenRetries = connectionURL.getPositiveParameter(NACOS_RETRY_WAIT_KEY, 10);
+
         if (check && !UrlUtils.isCheck(connectionURL)) {
             check = false;
         }
+
         NacosConnectionManager nacosConnectionManager =
-                new NacosConnectionManager(connectionURL, check, retryTimes, sleepMsBetweenRetries);
+                new NacosConnectionManager(normalized, check, retryTimes, sleepMsBetweenRetries);
         return new NacosNamingServiceWrapper(nacosConnectionManager, retryTimes, sleepMsBetweenRetries);
+    }
+
+    /**
+     * Normalizes the URL by removing group parameters and sorting the server address list.
+     * This method removes grouping parameters and standardizes the server address list
+     */
+    private static URL normalizeConnectionURL(URL connectionURL) {
+        URL normalized = URL.valueOf(connectionURL.toServiceStringWithoutResolving())
+                .removeParameter(GROUP_KEY)
+                .removeParameter(NACOS_GROUP_KEY);
+
+        String serverAddr = normalized.getParameter("serverAddr", normalized.getAddress());
+        if (serverAddr != null) {
+            String canonical = Arrays.stream(serverAddr.split(","))
+                    .map(String::trim)
+                    .filter(s -> !s.isEmpty())
+                    .sorted()
+                    .collect(Collectors.joining(","));
+            normalized = normalized.addParameter("serverAddr", canonical);
+        }
+        return normalized;
+    }
+
+    static void clearCacheForTest() {
+        SERVICE_CACHE.clear();
     }
 }

--- a/dubbo-registry/dubbo-registry-nacos/src/main/java/org/apache/dubbo/registry/nacos/util/NacosNamingServiceUtils.java
+++ b/dubbo-registry/dubbo-registry-nacos/src/main/java/org/apache/dubbo/registry/nacos/util/NacosNamingServiceUtils.java
@@ -38,6 +38,7 @@ import com.alibaba.nacos.api.naming.utils.NamingUtils;
 
 import static com.alibaba.nacos.api.common.Constants.DEFAULT_GROUP;
 import static org.apache.dubbo.common.constants.CommonConstants.GROUP_KEY;
+import static org.apache.dubbo.common.constants.LoggerCodeConstants.REGISTRY_NACOS_EXCEPTION;
 
 /**
  * The utilities class for {@link NamingService}
@@ -170,7 +171,14 @@ public class NacosNamingServiceUtils {
                     logger.info("Destroying shared NacosNamingService for key: {}", key);
                     v.wrapper.shutdown();
                 } catch (Exception e) {
-                    logger.warn("Failed to destroy naming service for key: " + key, e);
+                    logger.warn(
+                            REGISTRY_NACOS_EXCEPTION,
+                            "",
+                            "",
+                            "Failed to destroy naming service for key: " + key,
+                            e
+                    );
+
                 }
                 return null;
             }

--- a/dubbo-registry/dubbo-registry-nacos/src/main/java/org/apache/dubbo/registry/nacos/util/NacosNamingServiceUtils.java
+++ b/dubbo-registry/dubbo-registry-nacos/src/main/java/org/apache/dubbo/registry/nacos/util/NacosNamingServiceUtils.java
@@ -195,8 +195,7 @@ public class NacosNamingServiceUtils {
             // Error case: more releases than creates (unbalanced lifecycle)
             if (left < 0) {
                 logger.warn(
-                        "releaseNamingService called more times than createNamingService for key: {} (refCount={})."
-                                + " This indicates a bug in caller lifecycle management.",
+                        "releaseNamingService called more times than createNamingService for key: {} (refCount={}). This indicates a bug in caller lifecycle management.",
                         key,
                         left);
                 try {

--- a/dubbo-registry/dubbo-registry-nacos/src/test/java/org/apache/dubbo/registry/nacos/util/NacosNamingServiceUtilsTest.java
+++ b/dubbo-registry/dubbo-registry-nacos/src/test/java/org/apache/dubbo/registry/nacos/util/NacosNamingServiceUtilsTest.java
@@ -32,6 +32,7 @@ import com.alibaba.nacos.api.NacosFactory;
 import com.alibaba.nacos.api.exception.NacosException;
 import com.alibaba.nacos.api.naming.NamingService;
 import com.alibaba.nacos.api.naming.pojo.Instance;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
@@ -84,7 +85,7 @@ class NacosNamingServiceUtilsTest {
     }
 
     @Test
-    void testRetryCreate() throws NacosException {
+    void testRetryCreate() {
         try (MockedStatic<NacosFactory> nacosFactoryMockedStatic = Mockito.mockStatic(NacosFactory.class)) {
             AtomicInteger atomicInteger = new AtomicInteger(0);
             NamingService mock = new MockNamingService() {
@@ -102,6 +103,8 @@ class NacosNamingServiceUtilsTest {
                     .addParameter("nacos.retry-wait", 10);
             Assertions.assertThrows(
                     IllegalStateException.class, () -> NacosNamingServiceUtils.createNamingService(url));
+
+            NacosNamingServiceUtils.clearCacheForTest();
 
             try {
                 NacosNamingServiceUtils.createNamingService(url);
@@ -171,5 +174,10 @@ class NacosNamingServiceUtilsTest {
                 Assertions.fail(t);
             }
         }
+    }
+
+    @AfterEach
+    void tearDown() {
+        NacosNamingServiceUtils.clearCacheForTest();
     }
 }

--- a/dubbo-registry/dubbo-registry-nacos/src/test/java/org/apache/dubbo/registry/nacos/util/NacosNamingServiceUtilsTest.java
+++ b/dubbo-registry/dubbo-registry-nacos/src/test/java/org/apache/dubbo/registry/nacos/util/NacosNamingServiceUtilsTest.java
@@ -17,7 +17,6 @@
 package org.apache.dubbo.registry.nacos.util;
 
 import org.apache.dubbo.common.URL;
-import org.apache.dubbo.metadata.report.MetadataReport;
 import org.apache.dubbo.registry.client.ServiceInstance;
 import org.apache.dubbo.registry.nacos.MockNamingService;
 import org.apache.dubbo.registry.nacos.NacosNamingServiceWrapper;
@@ -47,7 +46,6 @@ import static org.mockito.Mockito.mock;
  * Test for NacosNamingServiceUtils
  */
 class NacosNamingServiceUtilsTest {
-    private static MetadataReport metadataReport = Mockito.mock(MetadataReport.class);
 
     @Test
     void testToInstance() {
@@ -66,15 +64,15 @@ class NacosNamingServiceUtilsTest {
         instance.setWeight(2);
         instance.setHealthy(Boolean.TRUE);
         instance.setEnabled(Boolean.TRUE);
-        Map<String, String> map = new HashMap<String, String>();
+        Map<String, String> map = new HashMap<>();
         map.put("netType", "external");
         map.put("version", "2.0");
         instance.setMetadata(map);
 
         ServiceInstance serviceInstance = NacosNamingServiceUtils.toServiceInstance(registryUrl, instance);
         Assertions.assertNotNull(serviceInstance);
-        Assertions.assertEquals(serviceInstance.isEnabled(), Boolean.TRUE);
-        Assertions.assertEquals(serviceInstance.getServiceName(), "serviceName");
+        Assertions.assertEquals(Boolean.TRUE, serviceInstance.isEnabled());
+        Assertions.assertEquals("serviceName", serviceInstance.getServiceName());
     }
 
     @Test
@@ -179,5 +177,39 @@ class NacosNamingServiceUtilsTest {
     @AfterEach
     void tearDown() {
         NacosNamingServiceUtils.clearCacheForTest();
+    }
+
+    @Test
+    void testConnectionReuseAndRefCounting() {
+        try (MockedStatic<NacosFactory> nacosFactoryMockedStatic = Mockito.mockStatic(NacosFactory.class)) {
+
+            NamingService mockNamingService = Mockito.spy(new MockNamingService() {
+                @Override
+                public String getServerStatus() {
+                    return UP;
+                }
+            });
+
+            nacosFactoryMockedStatic
+                    .when(() -> NacosFactory.createNamingService((Properties) any()))
+                    .thenReturn(mockNamingService);
+
+            URL urlGroupA = URL.valueOf("nacos://127.0.0.1:8848?serverAddr=127.0.0.1:8848&nacos.check=false")
+                    .addParameter("group", "group-A");
+            URL urlGroupB = URL.valueOf("nacos://127.0.0.1:8848?serverAddr=127.0.0.1:8848&nacos.check=false")
+                    .addParameter("group", "group-B");
+
+            NacosNamingServiceWrapper wrapperA = NacosNamingServiceUtils.createNamingService(urlGroupA);
+            NacosNamingServiceWrapper wrapperB = NacosNamingServiceUtils.createNamingService(urlGroupB);
+
+            Assertions.assertSame(wrapperA, wrapperB);
+            Assertions.assertEquals(1, NacosNamingServiceUtils.getCacheSizeForTest());
+
+            NacosNamingServiceUtils.releaseNamingService(urlGroupA);
+            Assertions.assertEquals(1, NacosNamingServiceUtils.getCacheSizeForTest());
+
+            NacosNamingServiceUtils.releaseNamingService(urlGroupB);
+            Assertions.assertEquals(0, NacosNamingServiceUtils.getCacheSizeForTest());
+        }
     }
 }


### PR DESCRIPTION
## What is the purpose of the change?
This change prevents the creation of multiple physical Nacos NamingService connections when a single Dubbo application uses multiple registry groups pointing to the same Nacos server. It introduces a reference-counted cache that reuses a single NamingService instance per unique Nacos connection identity, ensuring connections are only closed when no registries remain.

Fixes #15624 

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit tests to verify your logic correction. If the new feature or significant change is committed, please remember to add a sample in the [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Make sure GitHub actions can pass. [Why the workflow is failing and how to fix it?](../CONTRIBUTING.md)
