### PR TITLE
Fix reference cache key collision for different registries

### DIFF
--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/utils/SimpleReferenceCache.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/utils/SimpleReferenceCache.java
@@ -51,7 +51,7 @@ public class SimpleReferenceCache implements ReferenceCache {
     /**
      * Create the key with the <b>Group</b>, <b>Interface</b> and <b>version</b> attribute of {@link ReferenceConfigBase}.
      * <p>
-     * key example: <code>group1/org.apache.dubbo.foo.FooService:1.0.0</code>.
+     * key example: <code>group1/org.apache.dubbo.foo.FooService:1.0.0@registry=registry1</code>
      */
     public static final KeyGenerator DEFAULT_KEY_GENERATOR = referenceConfig -> {
         String iName = referenceConfig.getInterface();
@@ -63,7 +63,15 @@ public class SimpleReferenceCache implements ReferenceCache {
             throw new IllegalArgumentException("No interface info in ReferenceConfig" + referenceConfig);
         }
 
-        return BaseServiceMetadata.buildServiceKey(iName, referenceConfig.getGroup(), referenceConfig.getVersion());
+        String key =
+                BaseServiceMetadata.buildServiceKey(iName, referenceConfig.getGroup(), referenceConfig.getVersion());
+
+        String registryIds = referenceConfig.getRegistryIds();
+        if (StringUtils.isNotEmpty(registryIds)) {
+            key += "@registry=" + registryIds;
+        }
+
+        return key;
     };
 
     private static final AtomicInteger nameIndex = new AtomicInteger();
@@ -74,7 +82,6 @@ public class SimpleReferenceCache implements ReferenceCache {
 
     private final ConcurrentMap<String, List<ReferenceConfigBase<?>>> referenceKeyMap = new ConcurrentHashMap<>();
     private final ConcurrentMap<Class<?>, List<ReferenceConfigBase<?>>> referenceTypeMap = new ConcurrentHashMap<>();
-    private final Map<ReferenceConfigBase<?>, Object> references = new ConcurrentHashMap<>();
 
     protected SimpleReferenceCache(String name, KeyGenerator generator) {
         this.name = name;
@@ -133,9 +140,11 @@ public class SimpleReferenceCache implements ReferenceCache {
         if (proxy == null) {
             List<ReferenceConfigBase<?>> referencesOfType = ConcurrentHashMapUtils.computeIfAbsent(
                     referenceTypeMap, type, _t -> Collections.synchronizedList(new ArrayList<>()));
+            assert referencesOfType != null;
             referencesOfType.add(rc);
             List<ReferenceConfigBase<?>> referenceConfigList = ConcurrentHashMapUtils.computeIfAbsent(
                     referenceKeyMap, key, _k -> Collections.synchronizedList(new ArrayList<>()));
+            assert referenceConfigList != null;
             referenceConfigList.add(rc);
             proxy = rc.get(check);
         }
@@ -300,10 +309,6 @@ public class SimpleReferenceCache implements ReferenceCache {
 
     public Map<String, List<ReferenceConfigBase<?>>> getReferenceMap() {
         return referenceKeyMap;
-    }
-
-    public Map<Class<?>, List<ReferenceConfigBase<?>>> getReferenceTypeMap() {
-        return referenceTypeMap;
     }
 
     @Override

--- a/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/utils/ReferenceCacheTest.java
+++ b/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/utils/ReferenceCacheTest.java
@@ -18,6 +18,7 @@ package org.apache.dubbo.config.utils;
 
 import org.apache.dubbo.common.config.ReferenceCache;
 import org.apache.dubbo.config.ApplicationConfig;
+import org.apache.dubbo.config.ReferenceConfigBase;
 import org.apache.dubbo.config.RegistryConfig;
 import org.apache.dubbo.config.SysProps;
 import org.apache.dubbo.config.bootstrap.DubboBootstrap;
@@ -26,9 +27,11 @@ import org.apache.dubbo.config.utils.service.FooService;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class ReferenceCacheTest {
@@ -52,17 +55,15 @@ class ReferenceCacheTest {
     }
 
     @Test
-    void testGetCacheSameReference() throws Exception {
+    void testGetCacheSameReference() {
         ReferenceCache cache = SimpleReferenceCache.getCache();
-        MockReferenceConfig config =
-                buildMockReferenceConfig("org.apache.dubbo.config.utils.service.FooService", "group1", "1.0.0");
+        MockReferenceConfig config = buildMockReferenceConfig();
         assertEquals(0L, config.getCounter());
         Object proxy = cache.get(config);
         assertTrue(config.isGetMethodRun());
 
         // singleton reference config by default
-        MockReferenceConfig configCopy =
-                buildMockReferenceConfig("org.apache.dubbo.config.utils.service.FooService", "group1", "1.0.0");
+        MockReferenceConfig configCopy = buildMockReferenceConfig();
         assertEquals(1L, configCopy.getCounter());
         Object proxyOfCopyConfig = cache.get(configCopy);
         assertFalse(configCopy.isGetMethodRun());
@@ -73,10 +74,9 @@ class ReferenceCacheTest {
     }
 
     @Test
-    void testGetCacheDiffReference() throws Exception {
+    void testGetCacheDiffReference() {
         ReferenceCache cache = SimpleReferenceCache.getCache();
-        MockReferenceConfig config =
-                buildMockReferenceConfig("org.apache.dubbo.config.utils.service.FooService", "group1", "1.0.0");
+        MockReferenceConfig config = buildMockReferenceConfig();
         assertEquals(0L, config.getCounter());
         cache.get(config);
         assertEquals(1L, config.getCounter());
@@ -84,8 +84,7 @@ class ReferenceCacheTest {
         cache.get(config);
         assertEquals(1L, config.getCounter());
 
-        XxxMockReferenceConfig configCopy =
-                buildXxxMockReferenceConfig("org.apache.dubbo.config.utils.service.XxxService", "group1", "1.0.0");
+        XxxMockReferenceConfig configCopy = buildXxxMockReferenceConfig();
         assertEquals(0L, configCopy.getCounter());
         cache.get(configCopy);
         assertTrue(configCopy.isGetMethodRun());
@@ -93,27 +92,25 @@ class ReferenceCacheTest {
     }
 
     @Test
-    void testGetCacheWithKey() throws Exception {
+    void testGetCacheWithKey() {
         ReferenceCache cache = SimpleReferenceCache.getCache();
-        MockReferenceConfig config =
-                buildMockReferenceConfig("org.apache.dubbo.config.utils.service.FooService", "group1", "1.0.0");
+        MockReferenceConfig config = buildMockReferenceConfig();
         FooService value = cache.get(config);
         assertEquals(
                 value, cache.get("group1/org.apache.dubbo.config.utils.service.FooService:1.0.0", FooService.class));
     }
 
     @Test
-    void testGetCacheDiffName() throws Exception {
+    void testGetCacheDiffName() {
         SimpleReferenceCache cache = SimpleReferenceCache.getCache();
-        MockReferenceConfig config =
-                buildMockReferenceConfig("org.apache.dubbo.config.utils.service.FooService", "group1", "1.0.0");
+        MockReferenceConfig config = buildMockReferenceConfig();
         assertEquals(0L, config.getCounter());
         cache.get(config);
         assertTrue(config.isGetMethodRun());
         assertEquals(1L, config.getCounter());
 
         cache = SimpleReferenceCache.getCache("foo");
-        config = buildMockReferenceConfig("org.apache.dubbo.config.utils.service.FooService", "group1", "1.0.0");
+        config = buildMockReferenceConfig();
         assertEquals(1L, config.getCounter());
         cache.get(config);
         // still init for the same ReferenceConfig if the cache is different
@@ -122,13 +119,11 @@ class ReferenceCacheTest {
     }
 
     @Test
-    void testDestroy() throws Exception {
+    void testDestroy() {
         SimpleReferenceCache cache = SimpleReferenceCache.getCache();
-        MockReferenceConfig config =
-                buildMockReferenceConfig("org.apache.dubbo.config.utils.service.FooService", "group1", "1.0.0");
+        MockReferenceConfig config = buildMockReferenceConfig();
         cache.get(config);
-        XxxMockReferenceConfig configCopy =
-                buildXxxMockReferenceConfig("org.apache.dubbo.config.utils.service.XxxService", "group1", "1.0.0");
+        XxxMockReferenceConfig configCopy = buildXxxMockReferenceConfig();
         cache.get(configCopy);
         assertEquals(2, cache.getReferenceMap().size());
         cache.destroy(config);
@@ -140,13 +135,11 @@ class ReferenceCacheTest {
     }
 
     @Test
-    void testDestroyAll() throws Exception {
+    void testDestroyAll() {
         SimpleReferenceCache cache = SimpleReferenceCache.getCache();
-        MockReferenceConfig config =
-                buildMockReferenceConfig("org.apache.dubbo.config.utils.service.FooService", "group1", "1.0.0");
+        MockReferenceConfig config = buildMockReferenceConfig();
         cache.get(config);
-        XxxMockReferenceConfig configCopy =
-                buildXxxMockReferenceConfig("org.apache.dubbo.config.utils.service.XxxService", "group1", "1.0.0");
+        XxxMockReferenceConfig configCopy = buildXxxMockReferenceConfig();
         cache.get(configCopy);
         assertEquals(2, cache.getReferenceMap().size());
         cache.destroyAll();
@@ -155,25 +148,51 @@ class ReferenceCacheTest {
         assertEquals(0, cache.getReferenceMap().size());
     }
 
-    private MockReferenceConfig buildMockReferenceConfig(String service, String group, String version) {
+    private MockReferenceConfig buildMockReferenceConfig() {
         MockReferenceConfig config = new MockReferenceConfig();
         config.setApplication(new ApplicationConfig("cache"));
         config.setRegistry(new RegistryConfig("multicast://224.5.6.7:1234"));
         config.setCheck(false);
-        config.setInterface(service);
-        config.setGroup(group);
-        config.setVersion(version);
+        config.setInterface("org.apache.dubbo.config.utils.service.FooService");
+        config.setGroup("group1");
+        config.setVersion("1.0.0");
         return config;
     }
 
-    private XxxMockReferenceConfig buildXxxMockReferenceConfig(String service, String group, String version) {
+    private XxxMockReferenceConfig buildXxxMockReferenceConfig() {
         XxxMockReferenceConfig config = new XxxMockReferenceConfig();
         config.setApplication(new ApplicationConfig("cache"));
         config.setRegistry(new RegistryConfig("multicast://224.5.6.7:1234"));
-        config.setInterface(service);
+        config.setInterface("org.apache.dubbo.config.utils.service.XxxService");
         config.setCheck(false);
-        config.setGroup(group);
-        config.setVersion(version);
+        config.setGroup("group1");
+        config.setVersion("1.0.0");
         return config;
+    }
+
+    @Test
+    void testKeyGenerationWithRegistry() {
+        // Mock two ReferenceConfigs with same Interface/Group/Version
+        ReferenceConfigBase<?> rc1 = Mockito.mock(ReferenceConfigBase.class);
+        ReferenceConfigBase<?> rc2 = Mockito.mock(ReferenceConfigBase.class);
+
+        Mockito.when(rc1.getInterface()).thenReturn("org.apache.dubbo.config.utils.service.FooService");
+        Mockito.when(rc1.getGroup()).thenReturn("group1");
+        Mockito.when(rc1.getVersion()).thenReturn("1.0.0");
+
+        Mockito.when(rc2.getInterface()).thenReturn("org.apache.dubbo.config.utils.service.FooService");
+        Mockito.when(rc2.getGroup()).thenReturn("group1");
+        Mockito.when(rc2.getVersion()).thenReturn("1.0.0");
+
+        Mockito.when(rc1.getRegistryIds()).thenReturn("registry-A");
+        Mockito.when(rc2.getRegistryIds()).thenReturn("registry-B");
+
+        String key1 = SimpleReferenceCache.DEFAULT_KEY_GENERATOR.generateKey(rc1);
+        String key2 = SimpleReferenceCache.DEFAULT_KEY_GENERATOR.generateKey(rc2);
+
+        assertNotEquals(key1, key2, "Keys should be different for different registries!");
+
+        assertTrue(key1.contains("@registry=registry-A"));
+        assertTrue(key2.contains("@registry=registry-B"));
     }
 }


### PR DESCRIPTION
## What is the purpose of the change?
This change appends the registry ID to the reference cache key, preventing cache collisions between references with the same interface, group, and version but different registry configurations, and ensuring requests are routed to the intended registry.

Fixes #15761 

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit tests to verify your logic correction. If the new feature or significant change is committed, please remember to adda sample in the [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Make sure GitHub actions can pass. [Why the workflow is failing and how to fix it?](../CONTRIBUTING.md)
