### PR TITLE
Tri backpressure support

### DIFF
--- a/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/h2/H2FlowController.java
+++ b/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/h2/H2FlowController.java
@@ -36,4 +36,3 @@ public interface H2FlowController {
      */
     void enableAutoFlowControl(int streamId);
 }
-

--- a/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/h2/H2FlowController.java
+++ b/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/h2/H2FlowController.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.remoting.http12.h2;
+
+import io.netty.util.AttributeKey;
+
+public interface H2FlowController {
+
+    /**
+     * Attribute key for storing the flow controller in the channel.
+     */
+    AttributeKey<H2FlowController> KEY = AttributeKey.valueOf("h2FlowController");
+
+    void consumeBytes(int streamId, int numBytes);
+
+    void disableAutoFlowControl(int streamId);
+
+    /**
+     * Enable automatic inbound flow control for a specific stream (default behavior).
+     *
+     * @param streamId the HTTP/2 stream ID
+     */
+    void enableAutoFlowControl(int streamId);
+}
+

--- a/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/h2/H2StreamChannel.java
+++ b/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/h2/H2StreamChannel.java
@@ -30,4 +30,24 @@ public interface H2StreamChannel extends HttpChannel {
     }
 
     Http2OutputMessage newOutputMessage(boolean endStream);
+
+    default void requestInboundData(int numBytes) {
+        throw new UnsupportedOperationException("requestInboundData Not implemented");
+    }
+
+    default void disableAutoInboundFlowControl() {
+        throw new UnsupportedOperationException("disableAutoInboundFlowControl Not implemented");
+    }
+
+    default void enableAutoInboundFlowControl() {
+        throw new UnsupportedOperationException("enableAutoInboundFlowControl Not implemented");
+    }
+
+    default boolean isWritable() {
+        return true;
+    }
+
+    default void setOnWritableHandler(Runnable handler) {
+        throw new UnsupportedOperationException("setOnWritableHandler Not implemented");
+    }
 }

--- a/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/h2/Http2ChannelDelegate.java
+++ b/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/h2/Http2ChannelDelegate.java
@@ -70,6 +70,31 @@ public class Http2ChannelDelegate implements H2StreamChannel {
     }
 
     @Override
+    public void requestInboundData(int numBytes) {
+        h2StreamChannel.requestInboundData(numBytes);
+    }
+
+    @Override
+    public void disableAutoInboundFlowControl() {
+        h2StreamChannel.disableAutoInboundFlowControl();
+    }
+
+    @Override
+    public void enableAutoInboundFlowControl() {
+        h2StreamChannel.enableAutoInboundFlowControl();
+    }
+
+    @Override
+    public boolean isWritable() {
+        return h2StreamChannel.isWritable();
+    }
+
+    @Override
+    public void setOnWritableHandler(Runnable handler) {
+        h2StreamChannel.setOnWritableHandler(handler);
+    }
+
+    @Override
     public String toString() {
         return "Http2ChannelDelegate{" + "h2StreamChannel=" + h2StreamChannel + '}';
     }

--- a/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/h2/Http2ServerChannelObserver.java
+++ b/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/h2/Http2ServerChannelObserver.java
@@ -89,11 +89,11 @@ public class Http2ServerChannelObserver extends AbstractServerHttpChannelObserve
     public void request(int count) {
         streamingDecoder.request(count);
 
-        // If manual flow control is enabled, trigger HTTP/2 WINDOW_UPDATE
-        // The actual bytes to send is tracked by TriHttp2LocalFlowController
-        if (!autoRequestN) {
-            getHttpChannel().requestInboundData(0); // 0 means use accumulated pending bytes
-        }
+        // Always trigger HTTP/2 WINDOW_UPDATE check when request() is called
+        // If autoRequestN=true, this is a no-op (Netty handles it automatically)
+        // If autoRequestN=false, this sends accumulated pending bytes as WINDOW_UPDATE
+        // This ensures request(n) always reaches the flow controller
+        getHttpChannel().requestInboundData(count);
     }
 
     @Override

--- a/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/h2/Http2ServerChannelObserver.java
+++ b/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/h2/Http2ServerChannelObserver.java
@@ -88,11 +88,19 @@ public class Http2ServerChannelObserver extends AbstractServerHttpChannelObserve
     @Override
     public void request(int count) {
         streamingDecoder.request(count);
+
+        // If manual flow control is enabled, trigger HTTP/2 WINDOW_UPDATE
+        // The actual bytes to send is tracked by TriHttp2LocalFlowController
+        if (!autoRequestN) {
+            getHttpChannel().requestInboundData(0); // 0 means use accumulated pending bytes
+        }
     }
 
     @Override
     public void disableAutoFlowControl() {
         autoRequestN = false;
+        // Also disable auto flow control at the HTTP/2 level
+        getHttpChannel().disableAutoInboundFlowControl();
     }
 
     @Override

--- a/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/netty4/h2/NettyH2StreamChannel.java
+++ b/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/netty4/h2/NettyH2StreamChannel.java
@@ -20,6 +20,7 @@ import org.apache.dubbo.config.nested.TripleConfig;
 import org.apache.dubbo.remoting.http12.HttpMetadata;
 import org.apache.dubbo.remoting.http12.HttpOutputMessage;
 import org.apache.dubbo.remoting.http12.LimitedByteBufOutputStream;
+import org.apache.dubbo.remoting.http12.h2.H2FlowController;
 import org.apache.dubbo.remoting.http12.h2.H2StreamChannel;
 import org.apache.dubbo.remoting.http12.h2.Http2OutputMessage;
 import org.apache.dubbo.remoting.http12.h2.Http2OutputMessageFrame;
@@ -30,6 +31,7 @@ import java.util.concurrent.CompletableFuture;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufOutputStream;
+import io.netty.channel.Channel;
 import io.netty.handler.codec.http2.DefaultHttp2ResetFrame;
 import io.netty.handler.codec.http2.Http2StreamChannel;
 
@@ -39,9 +41,29 @@ public class NettyH2StreamChannel implements H2StreamChannel {
 
     private final TripleConfig tripleConfig;
 
+    private volatile Runnable onWritableHandler;
+
     public NettyH2StreamChannel(Http2StreamChannel http2StreamChannel, TripleConfig tripleConfig) {
         this.http2StreamChannel = http2StreamChannel;
         this.tripleConfig = tripleConfig;
+    }
+
+    /**
+     * Get the stream ID of this HTTP/2 stream.
+     */
+    public int streamId() {
+        return http2StreamChannel.stream().id();
+    }
+
+    /**
+     * Get the H2FlowController from the parent channel.
+     */
+    private H2FlowController getFlowController() {
+        Channel parent = http2StreamChannel.parent();
+        if (parent != null) {
+            return parent.attr(H2FlowController.KEY).get();
+        }
+        return null;
     }
 
     @Override
@@ -88,5 +110,50 @@ public class NettyH2StreamChannel implements H2StreamChannel {
         NettyHttpChannelFutureListener nettyHttpChannelFutureListener = new NettyHttpChannelFutureListener();
         http2StreamChannel.write(resetFrame).addListener(nettyHttpChannelFutureListener);
         return nettyHttpChannelFutureListener;
+    }
+
+    @Override
+    public void requestInboundData(int numBytes) {
+        H2FlowController flowController = getFlowController();
+        if (flowController != null) {
+            flowController.consumeBytes(streamId(), numBytes);
+        }
+    }
+
+    @Override
+    public void disableAutoInboundFlowControl() {
+        H2FlowController flowController = getFlowController();
+        if (flowController != null) {
+            flowController.disableAutoFlowControl(streamId());
+        }
+    }
+
+    @Override
+    public void enableAutoInboundFlowControl() {
+        H2FlowController flowController = getFlowController();
+        if (flowController != null) {
+            flowController.enableAutoFlowControl(streamId());
+        }
+    }
+
+    @Override
+    public boolean isWritable() {
+        return http2StreamChannel.isWritable();
+    }
+
+    @Override
+    public void setOnWritableHandler(Runnable handler) {
+        this.onWritableHandler = handler;
+        // Register channel listener
+        http2StreamChannel.pipeline().addLast(new io.netty.channel.ChannelInboundHandlerAdapter() {
+            @Override
+            public void channelWritabilityChanged(io.netty.channel.ChannelHandlerContext ctx) throws Exception {
+                Runnable currentHandler = onWritableHandler;
+                if (currentHandler != null && ctx.channel().isWritable()) {
+                    currentHandler.run();
+                }
+                super.channelWritabilityChanged(ctx);
+            }
+        });
     }
 }

--- a/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/netty4/h2/NettyH2StreamChannel.java
+++ b/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/netty4/h2/NettyH2StreamChannel.java
@@ -16,8 +16,6 @@
  */
 package org.apache.dubbo.remoting.http12.netty4.h2;
 
-import org.apache.dubbo.common.logger.ErrorTypeAwareLogger;
-import org.apache.dubbo.common.logger.LoggerFactory;
 import org.apache.dubbo.config.nested.TripleConfig;
 import org.apache.dubbo.remoting.http12.HttpMetadata;
 import org.apache.dubbo.remoting.http12.HttpOutputMessage;
@@ -38,9 +36,6 @@ import io.netty.handler.codec.http2.DefaultHttp2ResetFrame;
 import io.netty.handler.codec.http2.Http2StreamChannel;
 
 public class NettyH2StreamChannel implements H2StreamChannel {
-
-    private static final ErrorTypeAwareLogger LOGGER =
-            LoggerFactory.getErrorTypeAwareLogger(NettyH2StreamChannel.class);
 
     private final Http2StreamChannel http2StreamChannel;
 
@@ -121,13 +116,15 @@ public class NettyH2StreamChannel implements H2StreamChannel {
     public void requestInboundData(int numBytes) {
         H2FlowController flowController = getFlowController();
         if (flowController != null) {
-            LOGGER.info("Stream {} requestInboundData({}), calling flowController.consumeBytes", streamId(), numBytes);
-            flowController.consumeBytes(streamId(), numBytes);
-        } else {
-            LOGGER.warn(
-                    "Stream {} requestInboundData({}) failed: H2FlowController not found on parent channel",
-                    streamId(),
-                    numBytes);
+            Channel parent = http2StreamChannel.parent();
+            if (parent != null && parent.eventLoop() != null) {
+                if (parent.eventLoop().inEventLoop()) {
+                    flowController.consumeBytes(streamId(), numBytes);
+                } else {
+                    int streamId = streamId();
+                    parent.eventLoop().execute(() -> flowController.consumeBytes(streamId, numBytes));
+                }
+            }
         }
     }
 
@@ -135,14 +132,15 @@ public class NettyH2StreamChannel implements H2StreamChannel {
     public void disableAutoInboundFlowControl() {
         H2FlowController flowController = getFlowController();
         if (flowController != null) {
-            LOGGER.info(
-                    "Stream {} disableAutoInboundFlowControl, calling flowController.disableAutoFlowControl",
-                    streamId());
-            flowController.disableAutoFlowControl(streamId());
-        } else {
-            LOGGER.warn(
-                    "Stream {} disableAutoInboundFlowControl failed: H2FlowController not found on parent channel",
-                    streamId());
+            Channel parent = http2StreamChannel.parent();
+            if (parent != null && parent.eventLoop() != null) {
+                if (parent.eventLoop().inEventLoop()) {
+                    flowController.disableAutoFlowControl(streamId());
+                } else {
+                    int streamId = streamId();
+                    parent.eventLoop().execute(() -> flowController.disableAutoFlowControl(streamId));
+                }
+            }
         }
     }
 
@@ -150,7 +148,15 @@ public class NettyH2StreamChannel implements H2StreamChannel {
     public void enableAutoInboundFlowControl() {
         H2FlowController flowController = getFlowController();
         if (flowController != null) {
-            flowController.enableAutoFlowControl(streamId());
+            Channel parent = http2StreamChannel.parent();
+            if (parent != null && parent.eventLoop() != null) {
+                if (parent.eventLoop().inEventLoop()) {
+                    flowController.enableAutoFlowControl(streamId());
+                } else {
+                    int streamId = streamId();
+                    parent.eventLoop().execute(() -> flowController.enableAutoFlowControl(streamId));
+                }
+            }
         }
     }
 

--- a/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/netty4/h2/NettyH2StreamChannel.java
+++ b/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/netty4/h2/NettyH2StreamChannel.java
@@ -16,6 +16,8 @@
  */
 package org.apache.dubbo.remoting.http12.netty4.h2;
 
+import org.apache.dubbo.common.logger.ErrorTypeAwareLogger;
+import org.apache.dubbo.common.logger.LoggerFactory;
 import org.apache.dubbo.config.nested.TripleConfig;
 import org.apache.dubbo.remoting.http12.HttpMetadata;
 import org.apache.dubbo.remoting.http12.HttpOutputMessage;
@@ -36,6 +38,9 @@ import io.netty.handler.codec.http2.DefaultHttp2ResetFrame;
 import io.netty.handler.codec.http2.Http2StreamChannel;
 
 public class NettyH2StreamChannel implements H2StreamChannel {
+
+    private static final ErrorTypeAwareLogger LOGGER =
+            LoggerFactory.getErrorTypeAwareLogger(NettyH2StreamChannel.class);
 
     private final Http2StreamChannel http2StreamChannel;
 
@@ -116,7 +121,13 @@ public class NettyH2StreamChannel implements H2StreamChannel {
     public void requestInboundData(int numBytes) {
         H2FlowController flowController = getFlowController();
         if (flowController != null) {
+            LOGGER.info("Stream {} requestInboundData({}), calling flowController.consumeBytes", streamId(), numBytes);
             flowController.consumeBytes(streamId(), numBytes);
+        } else {
+            LOGGER.warn(
+                    "Stream {} requestInboundData({}) failed: H2FlowController not found on parent channel",
+                    streamId(),
+                    numBytes);
         }
     }
 
@@ -124,7 +135,14 @@ public class NettyH2StreamChannel implements H2StreamChannel {
     public void disableAutoInboundFlowControl() {
         H2FlowController flowController = getFlowController();
         if (flowController != null) {
+            LOGGER.info(
+                    "Stream {} disableAutoInboundFlowControl, calling flowController.disableAutoFlowControl",
+                    streamId());
             flowController.disableAutoFlowControl(streamId());
+        } else {
+            LOGGER.warn(
+                    "Stream {} disableAutoInboundFlowControl failed: H2FlowController not found on parent channel",
+                    streamId());
         }
     }
 

--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/ClientStreamObserver.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/ClientStreamObserver.java
@@ -30,4 +30,6 @@ public interface ClientStreamObserver<T> extends CallStreamObserver<T> {
     default void disableAutoRequest() {
         disableAutoFlowControl();
     }
+
+    void disableAutoRequestWithInitial(int request);
 }

--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/TriHttp2LocalFlowController.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/TriHttp2LocalFlowController.java
@@ -16,17 +16,17 @@
  */
 package org.apache.dubbo.rpc.protocol.tri;
 
+import org.apache.dubbo.common.logger.Logger;
+import org.apache.dubbo.common.logger.LoggerFactory;
 import org.apache.dubbo.remoting.http12.h2.H2FlowController;
 
 import io.netty.handler.codec.http2.DefaultHttp2LocalFlowController;
 import io.netty.handler.codec.http2.Http2Connection;
 import io.netty.handler.codec.http2.Http2Exception;
 import io.netty.handler.codec.http2.Http2Stream;
-import io.netty.util.internal.logging.InternalLogger;
-import io.netty.util.internal.logging.InternalLoggerFactory;
 
 public class TriHttp2LocalFlowController extends DefaultHttp2LocalFlowController implements H2FlowController {
-    private static final InternalLogger LOGGER = InternalLoggerFactory.getInstance(TriHttp2LocalFlowController.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(TriHttp2LocalFlowController.class);
     private final Http2Connection connection;
     private final Http2Connection.PropertyKey autoFlowControlKey;
     private final Http2Connection.PropertyKey pendingBytesKey;
@@ -46,7 +46,9 @@ public class TriHttp2LocalFlowController extends DefaultHttp2LocalFlowController
         stream.setProperty(autoFlowControlKey, Boolean.FALSE);
         // Initialize pending bytes counter
         stream.setProperty(pendingBytesKey, 0);
-        LOGGER.info("Disabled auto flow control for stream {}", stream.id());
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("Disabled auto flow control for stream {}", stream.id());
+        }
     }
 
     /**
@@ -60,7 +62,7 @@ public class TriHttp2LocalFlowController extends DefaultHttp2LocalFlowController
             try {
                 super.consumeBytes(stream, pendingBytes);
             } catch (Http2Exception e) {
-                LOGGER.warn("", "", "", "Failed to flush pending bytes for stream " + stream.id(), e);
+                LOGGER.warn("Failed to flush pending bytes for stream " + stream.id(), e);
             }
             stream.setProperty(pendingBytesKey, 0);
         }
@@ -97,11 +99,13 @@ public class TriHttp2LocalFlowController extends DefaultHttp2LocalFlowController
             // - Track the consumed bytes but don't send WINDOW_UPDATE
             // - Application will call consumeBytes(streamId, numBytes) to send WINDOW_UPDATE
             addPendingBytes(stream, numBytes);
-            LOGGER.info(
-                    "Stream {} auto flow control disabled, accumulated {} bytes, total pending: {}",
-                    stream.id(),
-                    numBytes,
-                    getPendingBytes(stream));
+            if (LOGGER.isDebugEnabled()) {
+                LOGGER.debug(
+                        "Stream {} auto flow control disabled, accumulated {} bytes, total pending: {}",
+                        stream.id(),
+                        numBytes,
+                        getPendingBytes(stream));
+            }
             return false;
         }
         // Default behavior: send WINDOW_UPDATE when appropriate
@@ -113,27 +117,32 @@ public class TriHttp2LocalFlowController extends DefaultHttp2LocalFlowController
         try {
             Http2Stream stream = connection.stream(streamId);
             if (stream == null) {
-                LOGGER.info("Stream {} not found, skip consumeBytes", streamId);
                 return;
             }
 
-            // Calculate actual bytes to send
+            // Get current pending bytes
             int pendingBytes = getPendingBytes(stream);
-            int bytesToSend = pendingBytes > 0 ? pendingBytes : numBytes;
 
-            // Clear pending bytes
+            // If auto flow control is enabled and no pending bytes,
+            // Netty is already handling WINDOW_UPDATE automatically
+            if (isAutoFlowControlEnabled(stream) && pendingBytes == 0) {
+                return;
+            }
+
+            // No pending bytes to send
+            if (pendingBytes <= 0) {
+                return;
+            }
+
+            // Send all pending bytes as WINDOW_UPDATE
+            // Note: numBytes parameter is the message count from request(n), not byte count
+            // We always send all accumulated bytes to ensure the sender has enough window
             stream.setProperty(pendingBytesKey, 0);
 
-            // Send WINDOW_UPDATE via parent implementation
-            if (bytesToSend > 0) {
-                LOGGER.info(
-                        "Stream {} sending WINDOW_UPDATE for {} bytes (pending: {}, requested: {})",
-                        streamId,
-                        bytesToSend,
-                        pendingBytes,
-                        numBytes);
-                super.consumeBytes(stream, bytesToSend);
+            if (LOGGER.isDebugEnabled()) {
+                LOGGER.debug("Stream {} sending WINDOW_UPDATE for {} bytes", streamId, pendingBytes);
             }
+            super.consumeBytes(stream, pendingBytes);
         } catch (Http2Exception e) {
             LOGGER.warn("Failed to consume bytes for stream " + streamId, e);
         }

--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/TriHttp2LocalFlowController.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/TriHttp2LocalFlowController.java
@@ -16,8 +16,11 @@
  */
 package org.apache.dubbo.rpc.protocol.tri;
 
-import org.apache.dubbo.common.logger.Logger;
-import org.apache.dubbo.common.logger.LoggerFactory;
+import io.netty.util.internal.UnstableApi;
+
+import io.netty.util.internal.logging.InternalLogger;
+import io.netty.util.internal.logging.InternalLoggerFactory;
+
 import org.apache.dubbo.remoting.http12.h2.H2FlowController;
 
 import io.netty.handler.codec.http2.DefaultHttp2LocalFlowController;
@@ -25,8 +28,9 @@ import io.netty.handler.codec.http2.Http2Connection;
 import io.netty.handler.codec.http2.Http2Exception;
 import io.netty.handler.codec.http2.Http2Stream;
 
+@UnstableApi
 public class TriHttp2LocalFlowController extends DefaultHttp2LocalFlowController implements H2FlowController {
-    private static final Logger LOGGER = LoggerFactory.getLogger(TriHttp2LocalFlowController.class);
+    private static final InternalLogger LOGGER = InternalLoggerFactory.getInstance(TriHttp2RemoteFlowController.class);
     private final Http2Connection connection;
     private final Http2Connection.PropertyKey autoFlowControlKey;
     private final Http2Connection.PropertyKey pendingBytesKey;

--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/TriHttp2LocalFlowController.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/TriHttp2LocalFlowController.java
@@ -19,8 +19,6 @@ package org.apache.dubbo.rpc.protocol.tri;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 
-import org.apache.dubbo.common.logger.ErrorTypeAwareLogger;
-import org.apache.dubbo.common.logger.LoggerFactory;
 import org.apache.dubbo.remoting.http12.h2.H2FlowController;
 
 import io.netty.handler.codec.http2.DefaultHttp2LocalFlowController;
@@ -49,6 +47,7 @@ public class TriHttp2LocalFlowController extends DefaultHttp2LocalFlowController
         stream.setProperty(autoFlowControlKey, Boolean.FALSE);
         // Initialize pending bytes counter
         stream.setProperty(pendingBytesKey, 0);
+        LOGGER.info("Disabled auto flow control for stream {}", stream.id());
     }
 
     /**
@@ -99,6 +98,8 @@ public class TriHttp2LocalFlowController extends DefaultHttp2LocalFlowController
             // - Track the consumed bytes but don't send WINDOW_UPDATE
             // - Application will call consumeBytes(streamId, numBytes) to send WINDOW_UPDATE
             addPendingBytes(stream, numBytes);
+            LOGGER.info("Stream {} auto flow control disabled, accumulated {} bytes, total pending: {}",
+                    stream.id(), numBytes, getPendingBytes(stream));
             return false;
         }
         // Default behavior: send WINDOW_UPDATE when appropriate
@@ -110,6 +111,7 @@ public class TriHttp2LocalFlowController extends DefaultHttp2LocalFlowController
         try {
             Http2Stream stream = connection.stream(streamId);
             if (stream == null) {
+                LOGGER.info("Stream {} not found, skip consumeBytes", streamId);
                 return;
             }
 
@@ -122,10 +124,12 @@ public class TriHttp2LocalFlowController extends DefaultHttp2LocalFlowController
 
             // Send WINDOW_UPDATE via parent implementation
             if (bytesToSend > 0) {
+                LOGGER.info("Stream {} sending WINDOW_UPDATE for {} bytes (pending: {}, requested: {})",
+                        streamId, bytesToSend, pendingBytes, numBytes);
                 super.consumeBytes(stream, bytesToSend);
             }
         } catch (Http2Exception e) {
-            LOGGER.warn("", "", "", "Failed to consume bytes for stream " + streamId, e);
+            LOGGER.warn("Failed to consume bytes for stream " + streamId, e);
         }
     }
 

--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/TriHttp2LocalFlowController.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/TriHttp2LocalFlowController.java
@@ -16,21 +16,23 @@
  */
 package org.apache.dubbo.rpc.protocol.tri;
 
-import io.netty.util.internal.UnstableApi;
-
-import io.netty.util.internal.logging.InternalLogger;
-import io.netty.util.internal.logging.InternalLoggerFactory;
-
+import org.apache.dubbo.common.logger.ErrorTypeAwareLogger;
+import org.apache.dubbo.common.logger.LoggerFactory;
+import org.apache.dubbo.common.threadpool.support.AbortPolicyWithReport;
 import org.apache.dubbo.remoting.http12.h2.H2FlowController;
 
 import io.netty.handler.codec.http2.DefaultHttp2LocalFlowController;
 import io.netty.handler.codec.http2.Http2Connection;
 import io.netty.handler.codec.http2.Http2Exception;
 import io.netty.handler.codec.http2.Http2Stream;
+import io.netty.util.internal.UnstableApi;
+
+import static org.apache.dubbo.common.constants.LoggerCodeConstants.PROTOCOL_FAILED_RESPONSE;
 
 @UnstableApi
 public class TriHttp2LocalFlowController extends DefaultHttp2LocalFlowController implements H2FlowController {
-    private static final InternalLogger LOGGER = InternalLoggerFactory.getInstance(TriHttp2RemoteFlowController.class);
+    protected static final ErrorTypeAwareLogger LOGGER =
+            LoggerFactory.getErrorTypeAwareLogger(AbortPolicyWithReport.class);
     private final Http2Connection connection;
     private final Http2Connection.PropertyKey autoFlowControlKey;
     private final Http2Connection.PropertyKey pendingBytesKey;
@@ -66,7 +68,8 @@ public class TriHttp2LocalFlowController extends DefaultHttp2LocalFlowController
             try {
                 super.consumeBytes(stream, pendingBytes);
             } catch (Http2Exception e) {
-                LOGGER.warn("Failed to flush pending bytes for stream " + stream.id(), e);
+                LOGGER.warn(
+                        PROTOCOL_FAILED_RESPONSE, "", "", "Failed to flush pending bytes for stream " + stream.id(), e);
             }
             stream.setProperty(pendingBytesKey, 0);
         }
@@ -148,7 +151,7 @@ public class TriHttp2LocalFlowController extends DefaultHttp2LocalFlowController
             }
             super.consumeBytes(stream, pendingBytes);
         } catch (Http2Exception e) {
-            LOGGER.warn("Failed to consume bytes for stream " + streamId, e);
+            LOGGER.warn(PROTOCOL_FAILED_RESPONSE, "", "", "Failed to consume bytes for stream " + streamId, e);
         }
     }
 

--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/TriHttp2LocalFlowController.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/TriHttp2LocalFlowController.java
@@ -1,0 +1,155 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.rpc.protocol.tri;
+
+import io.netty.util.internal.logging.InternalLogger;
+import io.netty.util.internal.logging.InternalLoggerFactory;
+
+import org.apache.dubbo.common.logger.ErrorTypeAwareLogger;
+import org.apache.dubbo.common.logger.LoggerFactory;
+import org.apache.dubbo.remoting.http12.h2.H2FlowController;
+
+import io.netty.handler.codec.http2.DefaultHttp2LocalFlowController;
+import io.netty.handler.codec.http2.Http2Connection;
+import io.netty.handler.codec.http2.Http2Exception;
+import io.netty.handler.codec.http2.Http2Stream;
+
+public class TriHttp2LocalFlowController extends DefaultHttp2LocalFlowController implements H2FlowController {
+    private static final InternalLogger LOGGER = InternalLoggerFactory.getInstance(TriHttp2LocalFlowController.class);
+    private final Http2Connection connection;
+    private final Http2Connection.PropertyKey autoFlowControlKey;
+    private final Http2Connection.PropertyKey pendingBytesKey;
+
+    public TriHttp2LocalFlowController(Http2Connection connection) {
+        super(connection);
+        this.connection = connection;
+        this.autoFlowControlKey = connection.newKey();
+        this.pendingBytesKey = connection.newKey();
+    }
+
+    /**
+     * Disable automatic flow control for a specific stream.
+     * When disabled, WINDOW_UPDATE frames will not be sent automatically.
+     */
+    public void disableAutoFlowControlForStream(Http2Stream stream) {
+        stream.setProperty(autoFlowControlKey, Boolean.FALSE);
+        // Initialize pending bytes counter
+        stream.setProperty(pendingBytesKey, 0);
+    }
+
+    /**
+     * Enable automatic flow control for a specific stream (default behavior).
+     */
+    public void enableAutoFlowControlForStream(Http2Stream stream) {
+        stream.setProperty(autoFlowControlKey, Boolean.TRUE);
+        // Flush any pending bytes
+        Integer pendingBytes = stream.getProperty(pendingBytesKey);
+        if (pendingBytes != null && pendingBytes > 0) {
+            try {
+                super.consumeBytes(stream, pendingBytes);
+            } catch (Http2Exception e) {
+                LOGGER.warn("", "", "", "Failed to flush pending bytes for stream " + stream.id(), e);
+            }
+            stream.setProperty(pendingBytesKey, 0);
+        }
+    }
+
+    /**
+     * Check if automatic flow control is enabled for a stream.
+     */
+    public boolean isAutoFlowControlEnabled(Http2Stream stream) {
+        Boolean autoFlowControl = stream.getProperty(autoFlowControlKey);
+        return autoFlowControl == null || autoFlowControl;
+    }
+
+    /**
+     * Get pending bytes for a stream (bytes consumed but not yet sent as WINDOW_UPDATE).
+     */
+    private int getPendingBytes(Http2Stream stream) {
+        Integer pending = stream.getProperty(pendingBytesKey);
+        return pending != null ? pending : 0;
+    }
+
+    /**
+     * Add pending bytes for a stream.
+     */
+    private void addPendingBytes(Http2Stream stream, int bytes) {
+        int current = getPendingBytes(stream);
+        stream.setProperty(pendingBytesKey, current + bytes);
+    }
+
+    @Override
+    public boolean consumeBytes(Http2Stream stream, int numBytes) throws Http2Exception {
+        if (!isAutoFlowControlEnabled(stream)) {
+            // When auto flow control is disabled:
+            // - Track the consumed bytes but don't send WINDOW_UPDATE
+            // - Application will call consumeBytes(streamId, numBytes) to send WINDOW_UPDATE
+            addPendingBytes(stream, numBytes);
+            return false;
+        }
+        // Default behavior: send WINDOW_UPDATE when appropriate
+        return super.consumeBytes(stream, numBytes);
+    }
+
+    @Override
+    public void consumeBytes(int streamId, int numBytes) {
+        try {
+            Http2Stream stream = connection.stream(streamId);
+            if (stream == null) {
+                return;
+            }
+
+            // Calculate actual bytes to send
+            int pendingBytes = getPendingBytes(stream);
+            int bytesToSend = pendingBytes > 0 ? pendingBytes : numBytes;
+
+            // Clear pending bytes
+            stream.setProperty(pendingBytesKey, 0);
+
+            // Send WINDOW_UPDATE via parent implementation
+            if (bytesToSend > 0) {
+                super.consumeBytes(stream, bytesToSend);
+            }
+        } catch (Http2Exception e) {
+            LOGGER.warn("", "", "", "Failed to consume bytes for stream " + streamId, e);
+        }
+    }
+
+    @Override
+    public void disableAutoFlowControl(int streamId) {
+        Http2Stream stream = connection.stream(streamId);
+        if (stream != null) {
+            disableAutoFlowControlForStream(stream);
+        }
+    }
+
+    @Override
+    public void enableAutoFlowControl(int streamId) {
+        Http2Stream stream = connection.stream(streamId);
+        if (stream != null) {
+            enableAutoFlowControlForStream(stream);
+        }
+    }
+
+    /**
+     * Get the HTTP/2 connection.
+     */
+    public Http2Connection connection() {
+        return connection;
+    }
+}
+

--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/TriHttp2LocalFlowController.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/TriHttp2LocalFlowController.java
@@ -16,15 +16,14 @@
  */
 package org.apache.dubbo.rpc.protocol.tri;
 
-import io.netty.util.internal.logging.InternalLogger;
-import io.netty.util.internal.logging.InternalLoggerFactory;
-
 import org.apache.dubbo.remoting.http12.h2.H2FlowController;
 
 import io.netty.handler.codec.http2.DefaultHttp2LocalFlowController;
 import io.netty.handler.codec.http2.Http2Connection;
 import io.netty.handler.codec.http2.Http2Exception;
 import io.netty.handler.codec.http2.Http2Stream;
+import io.netty.util.internal.logging.InternalLogger;
+import io.netty.util.internal.logging.InternalLoggerFactory;
 
 public class TriHttp2LocalFlowController extends DefaultHttp2LocalFlowController implements H2FlowController {
     private static final InternalLogger LOGGER = InternalLoggerFactory.getInstance(TriHttp2LocalFlowController.class);
@@ -98,8 +97,11 @@ public class TriHttp2LocalFlowController extends DefaultHttp2LocalFlowController
             // - Track the consumed bytes but don't send WINDOW_UPDATE
             // - Application will call consumeBytes(streamId, numBytes) to send WINDOW_UPDATE
             addPendingBytes(stream, numBytes);
-            LOGGER.info("Stream {} auto flow control disabled, accumulated {} bytes, total pending: {}",
-                    stream.id(), numBytes, getPendingBytes(stream));
+            LOGGER.info(
+                    "Stream {} auto flow control disabled, accumulated {} bytes, total pending: {}",
+                    stream.id(),
+                    numBytes,
+                    getPendingBytes(stream));
             return false;
         }
         // Default behavior: send WINDOW_UPDATE when appropriate
@@ -124,8 +126,12 @@ public class TriHttp2LocalFlowController extends DefaultHttp2LocalFlowController
 
             // Send WINDOW_UPDATE via parent implementation
             if (bytesToSend > 0) {
-                LOGGER.info("Stream {} sending WINDOW_UPDATE for {} bytes (pending: {}, requested: {})",
-                        streamId, bytesToSend, pendingBytes, numBytes);
+                LOGGER.info(
+                        "Stream {} sending WINDOW_UPDATE for {} bytes (pending: {}, requested: {})",
+                        streamId,
+                        bytesToSend,
+                        pendingBytes,
+                        numBytes);
                 super.consumeBytes(stream, bytesToSend);
             }
         } catch (Http2Exception e) {
@@ -156,4 +162,3 @@ public class TriHttp2LocalFlowController extends DefaultHttp2LocalFlowController
         return connection;
     }
 }
-

--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/TripleHttp2Protocol.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/TripleHttp2Protocol.java
@@ -26,6 +26,7 @@ import org.apache.dubbo.remoting.api.pu.ChannelHandlerPretender;
 import org.apache.dubbo.remoting.api.pu.ChannelOperator;
 import org.apache.dubbo.remoting.api.ssl.ContextOperator;
 import org.apache.dubbo.remoting.http12.HttpVersion;
+import org.apache.dubbo.remoting.http12.h2.H2FlowController;
 import org.apache.dubbo.remoting.http12.netty4.HttpWriteQueueHandler;
 import org.apache.dubbo.remoting.http12.netty4.h1.NettyHttp1Codec;
 import org.apache.dubbo.remoting.http12.netty4.h1.NettyHttp1ConnectionHandler;
@@ -157,8 +158,10 @@ public class TripleHttp2Protocol extends AbstractWireProtocol implements ScopeMo
                 protocol -> {
                     if (AsciiString.contentEquals(Http2CodecUtil.HTTP_UPGRADE_PROTOCOL_NAME, protocol)) {
                         NettyHttp2SettingsHandler nettyHttp2SettingsHandler = new NettyHttp2SettingsHandler();
+                        TriHttp2LocalFlowController[] localFlowControllerHolder = new TriHttp2LocalFlowController[1];
                         return new Http2ServerUpgradeCodec(
-                                buildHttp2FrameCodec(tripleConfig),
+                                buildHttp2FrameCodec(tripleConfig, localFlowControllerHolder),
+                                new TripleFlowControlAttributeHandler(localFlowControllerHolder),
                                 nettyHttp2SettingsHandler,
                                 new HttpWriteQueueHandler(),
                                 new FlushConsolidationHandler(64, true),
@@ -210,10 +213,16 @@ public class TripleHttp2Protocol extends AbstractWireProtocol implements ScopeMo
     private void configurerHttp2Handlers(URL url, List<ChannelHandler> handlers) {
         NettyHttp2SettingsHandler nettyHttp2SettingsHandler = new NettyHttp2SettingsHandler();
         TripleConfig tripleConfig = ConfigManager.getProtocolOrDefault(url).getTripleOrDefault();
-        Http2FrameCodec codec = buildHttp2FrameCodec(tripleConfig);
+
+        // Create local flow controller for backpressure support
+        TriHttp2LocalFlowController[] localFlowControllerHolder = new TriHttp2LocalFlowController[1];
+        Http2FrameCodec codec = buildHttp2FrameCodec(tripleConfig, localFlowControllerHolder);
         Http2MultiplexHandler handler = buildHttp2MultiplexHandler(nettyHttp2SettingsHandler, url, tripleConfig);
+
         handlers.add(new ChannelHandlerPretender(new HttpWriteQueueHandler()));
         handlers.add(new ChannelHandlerPretender(codec));
+        // Add handler to set flow controller attribute on the channel
+        handlers.add(new ChannelHandlerPretender(new TripleFlowControlAttributeHandler(localFlowControllerHolder)));
         handlers.add(new ChannelHandlerPretender(nettyHttp2SettingsHandler));
         handlers.add(new ChannelHandlerPretender(new FlushConsolidationHandler(64, true)));
         handlers.add(new ChannelHandlerPretender(new TripleServerConnectionHandler()));
@@ -221,10 +230,18 @@ public class TripleHttp2Protocol extends AbstractWireProtocol implements ScopeMo
         handlers.add(new ChannelHandlerPretender(new TripleTailHandler()));
     }
 
-    private Http2FrameCodec buildHttp2FrameCodec(TripleConfig tripleConfig) {
+    private Http2FrameCodec buildHttp2FrameCodec(TripleConfig tripleConfig, TriHttp2LocalFlowController[] localFlowControllerHolder) {
         return TripleHttp2FrameCodecBuilder.forServer()
-                .customizeConnection((connection) ->
-                        connection.remote().flowController(new TriHttp2RemoteFlowController(connection, tripleConfig)))
+                .customizeConnection((connection) -> {
+                    connection.remote().flowController(new TriHttp2RemoteFlowController(connection, tripleConfig));
+                    // Set custom local flow controller for inbound flow control (backpressure support)
+                    TriHttp2LocalFlowController localFlowController = new TriHttp2LocalFlowController(connection);
+                    connection.local().flowController(localFlowController);
+                    // Store reference for later use
+                    if (localFlowControllerHolder != null) {
+                        localFlowControllerHolder[0] = localFlowController;
+                    }
+                })
                 .gracefulShutdownTimeoutMillis(10000)
                 .initialSettings(new Http2Settings()
                         .headerTableSize(tripleConfig.getHeaderTableSizeOrDefault())
@@ -235,6 +252,25 @@ public class TripleHttp2Protocol extends AbstractWireProtocol implements ScopeMo
                 .frameLogger(SERVER_LOGGER)
                 .validateHeaders(false)
                 .build();
+    }
+
+    /**
+     * Handler to set the flow controller attribute on the channel.
+     */
+    private static class TripleFlowControlAttributeHandler extends io.netty.channel.ChannelInboundHandlerAdapter {
+        private final TriHttp2LocalFlowController[] localFlowControllerHolder;
+
+        TripleFlowControlAttributeHandler(TriHttp2LocalFlowController[] localFlowControllerHolder) {
+            this.localFlowControllerHolder = localFlowControllerHolder;
+        }
+
+        @Override
+        public void handlerAdded(io.netty.channel.ChannelHandlerContext ctx) throws Exception {
+            if (localFlowControllerHolder != null && localFlowControllerHolder[0] != null) {
+                ctx.channel().attr(H2FlowController.KEY).set(localFlowControllerHolder[0]);
+            }
+            super.handlerAdded(ctx);
+        }
     }
 
     private WebSocketServerProtocolHandler buildWebSocketServerProtocolHandler(TripleConfig tripleConfig) {

--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/TripleHttp2Protocol.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/TripleHttp2Protocol.java
@@ -230,7 +230,8 @@ public class TripleHttp2Protocol extends AbstractWireProtocol implements ScopeMo
         handlers.add(new ChannelHandlerPretender(new TripleTailHandler()));
     }
 
-    private Http2FrameCodec buildHttp2FrameCodec(TripleConfig tripleConfig, TriHttp2LocalFlowController[] localFlowControllerHolder) {
+    private Http2FrameCodec buildHttp2FrameCodec(
+            TripleConfig tripleConfig, TriHttp2LocalFlowController[] localFlowControllerHolder) {
         return TripleHttp2FrameCodecBuilder.forServer()
                 .customizeConnection((connection) -> {
                     connection.remote().flowController(new TriHttp2RemoteFlowController(connection, tripleConfig));

--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/call/ClientCall.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/call/ClientCall.java
@@ -33,6 +33,13 @@ public interface ClientCall {
     interface Listener {
 
         /**
+         * Whether the response is streaming response.
+         *
+         * @return
+         */
+        boolean streamingResponse();
+
+        /**
          * Called when the call is started, user can use this to set some configurations.
          *
          * @param call call implementation
@@ -42,7 +49,7 @@ public interface ClientCall {
         /**
          * Callback when message received.
          *
-         * @param message message received
+         * @param message             message received
          * @param actualContentLength actual content length from body
          */
         void onMessage(Object message, int actualContentLength);
@@ -88,6 +95,9 @@ public interface ClientCall {
      * @return true if this call is auto request
      */
     boolean isAutoRequest();
+
+
+    void setAutoRequestWithInitial(int initialRequest);
 
     /**
      * Set auto request for this call

--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/call/ObserverToClientCallListenerAdapter.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/call/ObserverToClientCallListenerAdapter.java
@@ -54,12 +54,13 @@ public class ObserverToClientCallListenerAdapter implements ClientCall.Listener 
     }
 
     @Override
+    public boolean streamingResponse() {
+        return true;
+    }
+
+    @Override
     public void onStart(ClientCall call) {
         this.call = call;
-        if (call.isAutoRequest()) {
-            call.request(1);
-        }
-
         onStartConsumer.accept(call);
     }
 }

--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/call/TripleClientCall.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/call/TripleClientCall.java
@@ -42,6 +42,7 @@ import static org.apache.dubbo.common.constants.LoggerCodeConstants.PROTOCOL_FAI
 import static org.apache.dubbo.common.constants.LoggerCodeConstants.PROTOCOL_STREAM_LISTENER;
 
 public class TripleClientCall implements ClientCall, ClientStream.Listener {
+
     private static final ErrorTypeAwareLogger LOGGER = LoggerFactory.getErrorTypeAwareLogger(TripleClientCall.class);
     private final AbstractConnectionClient connectionClient;
     private final Executor executor;
@@ -53,7 +54,9 @@ public class TripleClientCall implements ClientCall, ClientStream.Listener {
     private boolean canceled;
     private boolean headerSent;
     private boolean autoRequest = true;
+    private int initialRequest = 1;
     private boolean done;
+    private boolean streamingResponse;
     private StreamException streamException;
 
     public TripleClientCall(
@@ -71,32 +74,19 @@ public class TripleClientCall implements ClientCall, ClientStream.Listener {
     @Override
     public void onMessage(byte[] message, boolean isReturnTriException) {
         if (done) {
-            LOGGER.warn(
-                    PROTOCOL_STREAM_LISTENER,
-                    "",
-                    "",
+            LOGGER.warn(PROTOCOL_STREAM_LISTENER, "", "",
                     "Received message from closed stream,connection=" + connectionClient + " service="
-                            + requestMetadata.service + " method="
-                            + requestMetadata.method.getMethodName());
+                            + requestMetadata.service + " method=" + requestMetadata.method.getMethodName());
             return;
         }
         try {
             Object unpacked = requestMetadata.packableMethod.parseResponse(message, isReturnTriException);
             listener.onMessage(unpacked, message.length);
         } catch (Throwable t) {
-            TriRpcStatus status = TriRpcStatus.INTERNAL
-                    .withDescription("Deserialize response failed")
-                    .withCause(t);
+            TriRpcStatus status = TriRpcStatus.INTERNAL.withDescription("Deserialize response failed").withCause(t);
             cancelByLocal(status.asException());
             listener.onClose(status, null, false);
-            LOGGER.error(
-                    PROTOCOL_FAILED_RESPONSE,
-                    "",
-                    "",
-                    String.format(
-                            "Failed to deserialize triple response, service=%s, method=%s,connection=%s",
-                            requestMetadata.service, requestMetadata.service, requestMetadata.method.getMethodName()),
-                    t);
+            LOGGER.error(PROTOCOL_FAILED_RESPONSE, "", "", String.format("Failed to deserialize triple response, service=%s, method=%s,connection=%s", requestMetadata.service, requestMetadata.service, requestMetadata.method.getMethodName()), t);
         }
     }
 
@@ -125,10 +115,7 @@ public class TripleClientCall implements ClientCall, ClientStream.Listener {
         try {
             listener.onClose(status, StreamUtils.toAttachments(attachments), isReturnTriException);
         } catch (Throwable t) {
-            cancelByLocal(TriRpcStatus.INTERNAL
-                    .withDescription("Close stream error")
-                    .withCause(t)
-                    .asException());
+            cancelByLocal(TriRpcStatus.INTERNAL.withDescription("Close stream error").withCause(t).asException());
         }
         if (requestMetadata.cancellationContext != null) {
             requestMetadata.cancellationContext.cancel(null);
@@ -145,6 +132,11 @@ public class TripleClientCall implements ClientCall, ClientStream.Listener {
 
     @Override
     public void onStart() {
+        if (streamingResponse) {
+            request(initialRequest);
+        } else {
+            request(2);
+        }
         listener.onStart(this);
     }
 
@@ -162,8 +154,7 @@ public class TripleClientCall implements ClientCall, ClientStream.Listener {
             return;
         }
         if (t instanceof StreamException && ((StreamException) t).error().equals(FLOW_CONTROL_ERROR)) {
-            TriRpcStatus status = TriRpcStatus.CANCELLED
-                    .withCause(t)
+            TriRpcStatus status = TriRpcStatus.CANCELLED.withCause(t)
                     .withDescription("Due flowcontrol over pendingbytes, Cancelled by client");
             stream.cancelByLocal(status);
             streamException = (StreamException) t;
@@ -205,21 +196,10 @@ public class TripleClientCall implements ClientCall, ClientStream.Listener {
                 }
             });
         } catch (Throwable t) {
-            LOGGER.error(
-                    PROTOCOL_FAILED_SERIALIZE_TRIPLE,
-                    "",
-                    "",
-                    String.format(
-                            "Serialize triple request failed, service=%s method=%s",
-                            requestMetadata.service, requestMetadata.method.getMethodName()),
-                    t);
+            LOGGER.error(PROTOCOL_FAILED_SERIALIZE_TRIPLE, "", "", String.format("Serialize triple request failed, service=%s method=%s", requestMetadata.service, requestMetadata.method.getMethodName()), t);
             cancelByLocal(t);
-            listener.onClose(
-                    TriRpcStatus.INTERNAL
-                            .withDescription("Serialize request failed")
-                            .withCause(t),
-                    null,
-                    false);
+            listener.onClose(TriRpcStatus.INTERNAL.withDescription("Serialize request failed")
+                    .withCause(t), null, false);
         }
     }
     // stream listener end
@@ -253,7 +233,8 @@ public class TripleClientCall implements ClientCall, ClientStream.Listener {
                 this.requestMetadata = metadata;
                 this.listener = responseListener;
                 this.stream = stream;
-                return new ClientCallToObserverAdapter<>(this);
+                this.streamingResponse = responseListener.streamingResponse();
+                return new ClientCallToObserverAdapter<>(this, responseListener.streamingResponse());
             }
         }
         throw new IllegalStateException("No available ClientStreamFactory");
@@ -262,6 +243,12 @@ public class TripleClientCall implements ClientCall, ClientStream.Listener {
     @Override
     public boolean isAutoRequest() {
         return autoRequest;
+    }
+
+    @Override
+    public void setAutoRequestWithInitial(int initialRequest) {
+        setAutoRequest(false);
+        this.initialRequest = initialRequest;
     }
 
     @Override

--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/call/UnaryClientCallListener.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/call/UnaryClientCallListener.java
@@ -57,8 +57,12 @@ public class UnaryClientCallListener implements ClientCall.Listener {
     }
 
     @Override
+    public boolean streamingResponse() {
+        return false;
+    }
+
+    @Override
     public void onStart(ClientCall call) {
         future.addTimeoutListener(() -> call.cancelByLocal(new IllegalStateException("client timeout")));
-        call.request(2);
     }
 }

--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/observer/CallStreamObserver.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/observer/CallStreamObserver.java
@@ -48,4 +48,11 @@ public interface CallStreamObserver<T> extends StreamObserver<T> {
      * specified.
      */
     void disableAutoFlowControl();
+
+    /**
+     * compatible method for gRPC
+     */
+    default void disableAutoInboundFlowControl() {
+        disableAutoFlowControl();
+    }
 }

--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/observer/ClientCallToObserverAdapter.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/observer/ClientCallToObserverAdapter.java
@@ -20,13 +20,17 @@ import org.apache.dubbo.rpc.protocol.tri.CancelableStreamObserver;
 import org.apache.dubbo.rpc.protocol.tri.ClientStreamObserver;
 import org.apache.dubbo.rpc.protocol.tri.call.ClientCall;
 
+import java.sql.Timestamp;
+
 public class ClientCallToObserverAdapter<T> extends CancelableStreamObserver<T> implements ClientStreamObserver<T> {
 
     private final ClientCall call;
+    private final boolean streamingResponse;
     private boolean terminated;
 
-    public ClientCallToObserverAdapter(ClientCall call) {
+    public ClientCallToObserverAdapter(ClientCall call, boolean streamingResponse) {
         this.call = call;
+        this.streamingResponse = streamingResponse;
     }
 
     public boolean isAutoRequestEnabled() {
@@ -75,5 +79,10 @@ public class ClientCallToObserverAdapter<T> extends CancelableStreamObserver<T> 
     @Override
     public void disableAutoFlowControl() {
         call.setAutoRequest(false);
+    }
+
+    @Override
+    public void disableAutoRequestWithInitial(int request) {
+        call.setAutoRequestWithInitial(request);
     }
 }


### PR DESCRIPTION
## 问题背景
gRPC 原生支持背压机制，但 Dubbo Triple 协议在 HTTP/2 层面缺少对 WINDOW_UPDATE 帧的手动控制，导致无法实现真正的 HTTP/2 级别背压

## 优化思路
拦截 Netty 默认的自动 WINDOW_UPDATE 发送行为，改为由应用层通过 request(n) 手动触发