### PR TITLE
Fix duplicate 'the' typos in common-utils and README

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/utils/AnnotationUtils.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/utils/AnnotationUtils.java
@@ -201,7 +201,7 @@ public interface AnnotationUtils {
     }
 
     /**
-     * Get all directly declared annotations of the the annotated element, not including
+     * Get all directly declared annotations of  the annotated element, not including
      * meta annotations.
      *
      * @param annotatedElement    the annotated element
@@ -321,7 +321,7 @@ public interface AnnotationUtils {
     }
 
     /**
-     * Find the meta annotations from the the {@link Annotation annotation} type by meta annotation type
+     * Find the meta annotations from  the {@link Annotation annotation} type by meta annotation type
      *
      * @param annotationType     the {@link Annotation annotation} type
      * @param metaAnnotationType the meta annotation type
@@ -335,7 +335,7 @@ public interface AnnotationUtils {
     }
 
     /**
-     * Find the meta annotations from the the the annotated element by meta annotation type
+     * Find the meta annotations from  the annotated element by meta annotation type
      *
      * @param annotatedElement   the annotated element
      * @param metaAnnotationType the meta annotation type

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/utils/MethodUtils.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/utils/MethodUtils.java
@@ -6,7 +6,7 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -138,10 +138,10 @@ public interface MethodUtils {
     /**
      * Get all {@link Method methods} of the declared class
      *
-     * @param declaringClass        the declared class
+     * @param declaringClass         the declared class
      * @param includeInheritedTypes include the inherited types, e,g. super classes or interfaces
-     * @param publicOnly            only public method
-     * @param methodsToFilter       (optional) the methods to be filtered
+     * @param publicOnly             only public method
+     * @param methodsToFilter        (optional) the methods to be filtered
      * @return non-null read-only {@link List}
      * @since 2.7.6
      */
@@ -230,14 +230,8 @@ public interface MethodUtils {
         return getMethods(declaringClass, true, true, methodsToFilter);
     }
 
-    //    static List<Method> getOverriderMethods(Class<?> implementationClass, Class<?>... superTypes) {
-
-    //
-
-    //    }
-
     /**
-     * Find the {@link Method} by the the specified type and method name without the parameter types
+     * Find the {@link Method} by the specified type and method name without the parameter types
      *
      * @param type       the target type
      * @param methodName the specified method name
@@ -249,7 +243,7 @@ public interface MethodUtils {
     }
 
     /**
-     * Find the {@link Method} by the the specified type, method name and parameter types
+     * Find the {@link Method} by the specified type, method name and parameter types
      *
      * @param type           the target type
      * @param methodName     the method name
@@ -274,7 +268,7 @@ public interface MethodUtils {
      * @param object           the target object
      * @param methodName       the method name
      * @param methodParameters the method parameters
-     * @param <T>              the return type
+     * @param <T>               the return type
      * @return the target method's execution result
      * @since 2.7.6
      */

--- a/dubbo-spring-boot-project/dubbo-spring-boot-autoconfigure/README.md
+++ b/dubbo-spring-boot-project/dubbo-spring-boot-autoconfigure/README.md
@@ -1,6 +1,6 @@
 # Dubbo Spring Boot Auto-Configure
 
-`dubbo-spring-boot-autoconfigure` uses Spring Boot's `@EnableAutoConfiguration` which helps core Dubbo's components to be auto-configured by `DubboAutoConfiguration`. It reduces code, eliminates XML configuration. 
+`dubbo-spring-boot-autoconfigure` uses Spring Boot's `@EnableAutoConfiguration` which helps core Dubbo's components to be auto-configured by `DubboAutoConfiguration`. It reduces code, eliminates XML configuration.
 
 
 
@@ -54,7 +54,7 @@ Since  `2.5.7`  , Dubbo totally supports Annotation-Driven , core Dubbo's compon
 
 
 
-`dubbo-spring-boot-autoconfigure` uses Spring Boot's `@EnableAutoConfiguration` which helps core Dubbo's components to be auto-configured by `DubboAutoConfiguration`. It reduces code, eliminates XML configuration. 
+`dubbo-spring-boot-autoconfigure` uses Spring Boot's `@EnableAutoConfiguration` which helps core Dubbo's components to be auto-configured by `DubboAutoConfiguration`. It reduces code, eliminates XML configuration.
 
 
 
@@ -85,7 +85,7 @@ There are two Spring Beans will be initialized when Spring `ApplicationContext` 
  If application requires current `ApplicationConfig` Bean in somewhere , you can get it from Spring `BeanFactory` as those code :
 
 ```java
-BeanFactory beanFactory = .... 
+BeanFactory beanFactory = ....
 ApplicationConfig applicationConfig = beanFactory.getBean(ApplicationConfig.class)
 ```
 
@@ -181,9 +181,9 @@ The whole Properties Mapping of "Multiple Dubbo Config Bean Bindings" lists belo
 
 There is a  different way to identify Multiple Dubbo Config Bean , the configuration pattern is like this :
 
-`${config-property-prefix}.${config-bean-id}.${property-name} = some value` , let's explain those placeholders : 
+`${config-property-prefix}.${config-bean-id}.${property-name} = some value` , let's explain those placeholders :
 
-- `${config-property-prefix}` : The The prefix of property name for Multiple Bindings , e.g. `dubbo.protocols`, `dubbo.applications` and so on.
+- `${config-property-prefix}` : The  prefix of property name for Multiple Bindings , e.g. `dubbo.protocols`, `dubbo.applications` and so on.
 - `${config-bean-id}` : The bean id of Dubbo's `*Config`
 - `${property-name}`: The property name of  `*Config`
 
@@ -207,7 +207,7 @@ dubbo.consumers.consumer1.client = netty
 
 
 
-If you used advanced IDE tools , for instance [Jetbrains IDEA Ultimate](https://www.jetbrains.com/idea/) develops Dubbo Spring Boot application, it will popup the tips of Dubbo Configuration Bindings in `application.properties` : 
+If you used advanced IDE tools , for instance [Jetbrains IDEA Ultimate](https://www.jetbrains.com/idea/) develops Dubbo Spring Boot application, it will popup the tips of Dubbo Configuration Bindings in `application.properties` :
 
 
 


### PR DESCRIPTION
Removed duplicate 'the' words in Javadoc comments within AnnotationUtils and MethodUtils, and fixed a typo in the Spring Boot autoconfigure README.
