### PR TITLE
feat: implement isReady and setOnReadyHandler for Triple protocol #15827

### DIFF
--- a/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/AbstractServerHttpChannelObserver.java
+++ b/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/AbstractServerHttpChannelObserver.java
@@ -356,4 +356,8 @@ public abstract class AbstractServerHttpChannelObserver<H extends HttpChannel> i
     protected final void closed() {
         closed = true;
     }
+
+    public void onWritabilityChanged() {
+        // default no-op
+    }
 }

--- a/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/FlowControlStreamObserver.java
+++ b/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/FlowControlStreamObserver.java
@@ -39,4 +39,20 @@ public interface FlowControlStreamObserver<T> extends StreamObserver<T> {
      * specified.
      */
     void disableAutoFlowControl();
+
+    /**
+     * Returns true if the stream is ready to receive more messages.
+     * @return ready status
+     */
+    default boolean isReady() {
+        return true;
+    }
+
+    /**
+     * Sets the handler to be called when the stream is ready to receive more messages.
+     * @param handler the on-ready handler
+     */
+    default void setOnReadyHandler(Runnable handler) {
+        // default no-op
+    }
 }

--- a/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/HttpChannel.java
+++ b/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/HttpChannel.java
@@ -32,4 +32,10 @@ public interface HttpChannel {
     SocketAddress localAddress();
 
     void flush();
+
+    /**
+     * Determine if the channel is writable.
+     * @return true if writable
+     */
+    boolean isWritable();
 }

--- a/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/HttpChannel.java
+++ b/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/HttpChannel.java
@@ -37,5 +37,7 @@ public interface HttpChannel {
      * Determine if the channel is writable.
      * @return true if writable
      */
-    boolean isWritable();
+    default boolean isWritable() {
+        return true;
+    }
 }

--- a/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/h2/Http2ChannelDelegate.java
+++ b/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/h2/Http2ChannelDelegate.java
@@ -73,4 +73,9 @@ public class Http2ChannelDelegate implements H2StreamChannel {
     public String toString() {
         return "Http2ChannelDelegate{" + "h2StreamChannel=" + h2StreamChannel + '}';
     }
+
+    @Override
+    public boolean isWritable() {
+        return h2StreamChannel.isWritable();
+    }
 }

--- a/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/h2/Http2ServerChannelObserver.java
+++ b/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/h2/Http2ServerChannelObserver.java
@@ -36,6 +36,8 @@ public class Http2ServerChannelObserver extends AbstractServerHttpChannelObserve
 
     private StreamingDecoder streamingDecoder;
 
+    private Runnable onReadyHandler;
+
     private boolean autoRequestN = true;
 
     public Http2ServerChannelObserver(H2StreamChannel h2StreamChannel) {
@@ -96,6 +98,16 @@ public class Http2ServerChannelObserver extends AbstractServerHttpChannelObserve
     }
 
     @Override
+    public boolean isReady() {
+        return getHttpChannel().isWritable();
+    }
+
+    @Override
+    public void setOnReadyHandler(Runnable handler) {
+        this.onReadyHandler = handler;
+    }
+
+    @Override
     public boolean isAutoRequestN() {
         return autoRequestN;
     }
@@ -104,5 +116,12 @@ public class Http2ServerChannelObserver extends AbstractServerHttpChannelObserve
     public void close() {
         super.close();
         streamingDecoder.onStreamClosed();
+    }
+
+    @Override
+    public void onWritabilityChanged() {
+        if (isReady() && onReadyHandler != null) {
+            onReadyHandler.run();
+        }
     }
 }

--- a/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/netty4/h1/NettyHttp1Channel.java
+++ b/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/netty4/h1/NettyHttp1Channel.java
@@ -78,4 +78,9 @@ public class NettyHttp1Channel implements HttpChannel {
 
     @Override
     public void flush() {}
+
+    @Override
+    public boolean isWritable() {
+        return this.channel.isWritable();
+    }
 }

--- a/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/netty4/h2/NettyH2StreamChannel.java
+++ b/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/netty4/h2/NettyH2StreamChannel.java
@@ -89,4 +89,9 @@ public class NettyH2StreamChannel implements H2StreamChannel {
         http2StreamChannel.write(resetFrame).addListener(nettyHttpChannelFutureListener);
         return nettyHttpChannelFutureListener;
     }
+
+    @Override
+    public boolean isWritable() {
+        return this.http2StreamChannel.isWritable();
+    }
 }

--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/observer/CallStreamObserver.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/observer/CallStreamObserver.java
@@ -48,4 +48,22 @@ public interface CallStreamObserver<T> extends StreamObserver<T> {
      * specified.
      */
     void disableAutoFlowControl();
+
+    /**
+     * Returns true if the stream is ready to receive more messages.
+     *
+     * @return ready status
+     */
+    default boolean isReady() {
+        return true;
+    }
+
+    /**
+     * Sets the handler to be called when the stream is ready to receive more messages.
+     *
+     * @param handler the on-ready handler
+     */
+    default void setOnReadyHandler(Runnable handler) {
+        // default no-op
+    }
 }

--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/observer/CallStreamObserver.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/observer/CallStreamObserver.java
@@ -17,9 +17,10 @@
 package org.apache.dubbo.rpc.protocol.tri.observer;
 
 import org.apache.dubbo.common.stream.StreamObserver;
+import org.apache.dubbo.remoting.http12.FlowControlStreamObserver;
 import org.apache.dubbo.rpc.protocol.tri.compressor.Compressor;
 
-public interface CallStreamObserver<T> extends StreamObserver<T> {
+public interface CallStreamObserver<T> extends StreamObserver<T>, FlowControlStreamObserver {
 
     /**
      * Requests the peer to produce {@code count} more messages to be delivered to the 'inbound'
@@ -54,6 +55,7 @@ public interface CallStreamObserver<T> extends StreamObserver<T> {
      *
      * @return ready status
      */
+    @Override
     default boolean isReady() {
         return true;
     }
@@ -63,6 +65,7 @@ public interface CallStreamObserver<T> extends StreamObserver<T> {
      *
      * @param handler the on-ready handler
      */
+    @Override
     default void setOnReadyHandler(Runnable handler) {
         // default no-op
     }

--- a/dubbo-rpc/dubbo-rpc-triple/src/test/java/org/apache/dubbo/rpc/protocol/tri/TripleProtocolTest.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/test/java/org/apache/dubbo/rpc/protocol/tri/TripleProtocolTest.java
@@ -31,6 +31,7 @@ import org.apache.dubbo.rpc.model.ModuleServiceRepository;
 import org.apache.dubbo.rpc.model.ProviderModel;
 import org.apache.dubbo.rpc.model.ServiceDescriptor;
 import org.apache.dubbo.rpc.model.ServiceMetadata;
+import org.apache.dubbo.rpc.protocol.tri.observer.CallStreamObserver;
 import org.apache.dubbo.rpc.protocol.tri.support.IGreeter;
 import org.apache.dubbo.rpc.protocol.tri.support.IGreeterImpl;
 import org.apache.dubbo.rpc.protocol.tri.support.MockStreamObserver;
@@ -98,6 +99,16 @@ class TripleProtocolTest {
         // 3. test bidirectionalStream
         MockStreamObserver outboundMessageSubscriber2 = new MockStreamObserver();
         StreamObserver<String> inboundMessageObserver = greeterProxy.bidirectionalStream(outboundMessageSubscriber2);
+
+        // verify isReady and setOnReadyHandler
+        if (inboundMessageObserver instanceof CallStreamObserver) {
+            CallStreamObserver<String> callObserver = (CallStreamObserver<String>) inboundMessageObserver;
+            Assertions.assertTrue(callObserver.isReady());
+            callObserver.setOnReadyHandler(() -> {
+                // logic to be executed when ready
+            });
+        }
+
         inboundMessageObserver.onNext(REQUEST_MSG);
         inboundMessageObserver.onCompleted();
         outboundMessageSubscriber2.getLatch().await(3000, TimeUnit.MILLISECONDS);


### PR DESCRIPTION
Fixes #15827.

Implemented backpressure support by adding isReady() and setOnReadyHandler() to the Triple protocol stream observers and wiring them to the Netty channel writability events.