### PR TITLE
Import jackson 2.20.1 pom to simplify dependencies for bumping jackson components

### DIFF
--- a/dubbo-dependencies-bom/pom.xml
+++ b/dubbo-dependencies-bom/pom.xml
@@ -177,7 +177,7 @@
     <bouncycastle-bcprov_version>1.83</bouncycastle-bcprov_version>
     <metrics_version>2.0.6</metrics_version>
     <gson_version>2.13.2</gson_version>
-    <jackson_version>2.19.1</jackson_version>
+    <jackson_version>2.20.1</jackson_version>
     <mortbay_jetty_version>6.1.26</mortbay_jetty_version>
     <portlet_version>2.0</portlet_version>
     <maven_flatten_version>1.7.3</maven_flatten_version>
@@ -817,24 +817,11 @@
         <version>${gson_version}</version>
       </dependency>
       <dependency>
-        <groupId>com.fasterxml.jackson.core</groupId>
-        <artifactId>jackson-databind</artifactId>
+        <groupId>com.fasterxml.jackson</groupId>
+        <artifactId>jackson-bom</artifactId>
         <version>${jackson_version}</version>
-      </dependency>
-      <dependency>
-        <groupId>com.fasterxml.jackson.core</groupId>
-        <artifactId>jackson-annotations</artifactId>
-        <version>${jackson_version}</version>
-      </dependency>
-      <dependency>
-        <groupId>com.fasterxml.jackson.core</groupId>
-        <artifactId>jackson-core</artifactId>
-        <version>${jackson_version}</version>
-      </dependency>
-      <dependency>
-        <groupId>com.fasterxml.jackson.datatype</groupId>
-        <artifactId>jackson-datatype-jsr310</artifactId>
-        <version>${jackson_version}</version>
+        <type>pom</type>
+        <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>javax.portlet</groupId>


### PR DESCRIPTION
## What is the purpose of the change?

```Bump jackson_version from 2.19.1 to 2.20.1``` (https://github.com/apache/dubbo/pull/15952)  tested failed since the versioning scheme  of  ```jackson-annotations``` had been changed to 2.20 for jackson 3.x, we should import jackson pom to support this changing.
see details at https://github.com/FasterXML/jackson-annotations/issues/307

```jackson-annotations``` no longer uses patch number: so we have version 2.20 (instead of 2.19.0 and so on)
see details at https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.20

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Make sure gitHub actions can pass. [Why the workflow is failing and how to fix it?](../CONTRIBUTING.md)
