### PR TITLE
 #11157: Throw early type mismatch for List<T> deserialization

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/utils/PojoUtils.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/utils/PojoUtils.java
@@ -443,14 +443,14 @@ public class PojoUtils {
                     Class<?> keyClazz = obj == null ? null : obj.getClass();
                     if (keyType instanceof Class) {
                         keyClazz = (Class<?>) keyType;
+                    } else if (keyType instanceof ParameterizedType) {
+                        keyClazz = (Class<?>) ((ParameterizedType) keyType).getRawType();
                     }
-                    else if(keyType instanceof ParameterizedType){
-                        keyClazz=(Class<?>) ( (ParameterizedType) keyType).getRawType();
-                    }
-                     Object value = realize1(obj, keyClazz, keyType, mapGeneric, history);
-                    if(value!=null && !keyClazz.isAssignableFrom(value.getClass())){
-                        throw new IllegalArgumentException(String.format
-                            ("Cannot convert element of %s to %s",value.getClass().getName(),keyClazz.getName()));
+                    Object value = realize1(obj, keyClazz, keyType, mapGeneric, history);
+                    if (value != null && !keyClazz.isAssignableFrom(value.getClass())) {
+                        throw new IllegalArgumentException(String.format(
+                                "Cannot convert element of %s to %s",
+                                value.getClass().getName(), keyClazz.getName()));
                     }
                     dest.add(value);
                 }

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/utils/PojoUtils.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/utils/PojoUtils.java
@@ -444,7 +444,14 @@ public class PojoUtils {
                     if (keyType instanceof Class) {
                         keyClazz = (Class<?>) keyType;
                     }
-                    Object value = realize1(obj, keyClazz, keyType, mapGeneric, history);
+                    else if(keyType instanceof ParameterizedType){
+                        keyClazz=(Class<?>) ( (ParameterizedType) keyType).getRawType();
+                    }
+                     Object value = realize1(obj, keyClazz, keyType, mapGeneric, history);
+                    if(value!=null && !keyClazz.isAssignableFrom(value.getClass())){
+                        throw new IllegalArgumentException(String.format
+                            ("Cannot convert element of %s to %s",value.getClass().getName(),keyClazz.getName()));
+                    }
                     dest.add(value);
                 }
                 return dest;

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/utils/PojoUtilsTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/utils/PojoUtilsTest.java
@@ -52,7 +52,6 @@ import java.util.UUID;
 import com.alibaba.fastjson.JSON;
 import com.alibaba.fastjson.JSONObject;
 import com.alibaba.fastjson.TypeReference;
-
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -712,13 +711,13 @@ class PojoUtilsTest {
     @Test
     void testRealizeListGenericElementType() {
         List<Object> rawList = new ArrayList<>();
-        rawList.add(1); 
+        rawList.add(1);
         Type targetType = new TypeReference<List<String>>() {}.getType();
         Assertions.assertThrows(IllegalArgumentException.class, () -> {
             PojoUtils.realize(rawList, List.class, targetType);
         });
     }
-    
+
     @Test
     void testDateTimeTimestamp() throws Exception {
         String dateStr = "2018-09-12";

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/utils/PojoUtilsTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/utils/PojoUtilsTest.java
@@ -51,6 +51,8 @@ import java.util.UUID;
 
 import com.alibaba.fastjson.JSON;
 import com.alibaba.fastjson.JSONObject;
+import com.alibaba.fastjson.TypeReference;
+
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -707,6 +709,16 @@ class PojoUtilsTest {
         Assertions.assertEquals(parent.getAge(), realizeParent.getAge());
     }
 
+    @Test
+    void testRealizeListGenericElementType() {
+        List<Object> rawList = new ArrayList<>();
+        rawList.add(1); 
+        Type targetType = new TypeReference<List<String>>() {}.getType();
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+            PojoUtils.realize(rawList, List.class, targetType);
+        });
+    }
+    
     @Test
     void testDateTimeTimestamp() throws Exception {
         String dateStr = "2018-09-12";


### PR DESCRIPTION
## What is the purpose of the change?


## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Make sure gitHub actions can pass. [Why the workflow is failing and how to fix it?](../CONTRIBUTING.md

#11157

During generic invocation deserialization, when a request field is declared as a List<String> but the incoming payload contains numeric elements (e.g., [1]), Dubbo incorrectly realizes it as List<Integer>. This causes a late ClassCastException when iterating over the list inside user code. PojoUtils.realize() ignored the generic parameter when deserializing Collection fields. As a result, it always converted elements as Object instead of using the declared element type from ParameterizedType.

Fix proposed: 
-Added an else block to correct generic element type from ParameterizedType and realize elements using that type
-Throw an early IllegalArgumentException if type conversion fails (instead of deferring it to user code)
- Also added a test case testRealizeListGenericElementType() in PojoUtilsTest.java to verify that invalid element types trigger an early exception.

