### PR TITLE
Fix AwaitingNonWebApplicationListener await with parent context

### DIFF
--- a/dubbo-spring-boot-project/dubbo-spring-boot/src/main/java/org/apache/dubbo/spring/boot/context/event/AwaitingNonWebApplicationListener.java
+++ b/dubbo-spring-boot-project/dubbo-spring-boot/src/main/java/org/apache/dubbo/spring/boot/context/event/AwaitingNonWebApplicationListener.java
@@ -112,7 +112,7 @@ public class AwaitingNonWebApplicationListener implements SmartApplicationListen
 
         final ConfigurableApplicationContext applicationContext = event.getApplicationContext();
 
-        if (!isRootApplicationContext(applicationContext) || isWebApplication(applicationContext)) {
+        if (isRootApplicationContext(applicationContext) || isWebApplication(applicationContext)) {
             return;
         }
 

--- a/dubbo-spring-boot-project/dubbo-spring-boot/src/test/java/org/apache/dubbo/spring/boot/context/event/AwaitingNonWebApplicationListenerTest.java
+++ b/dubbo-spring-boot-project/dubbo-spring-boot/src/test/java/org/apache/dubbo/spring/boot/context/event/AwaitingNonWebApplicationListenerTest.java
@@ -20,12 +20,23 @@ import org.apache.dubbo.config.bootstrap.DubboBootstrap;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.builder.SpringApplicationBuilder;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.springframework.boot.WebApplicationType;
+
+
+
+
+
 
 /**
  * {@link AwaitingNonWebApplicationListener} Test
  */
-@Disabled
+
 class AwaitingNonWebApplicationListenerTest {
 
     @BeforeEach
@@ -58,14 +69,15 @@ class AwaitingNonWebApplicationListenerTest {
     //        });
     //    }
     //
-    //    @Test
-    //    void testMultipleContextNonWebApplication() {
-    //        new SpringApplicationBuilder(Object.class)
-    //                .parent(Object.class)
-    //                .web(false)
-    //                .run().close();
-    //        AtomicBoolean awaited = AwaitingNonWebApplicationListener.getAwaited();
-    //        assertFalse(awaited.get());
-    //    }
+       @Test
+       void testMultipleContextNonWebApplication() {
+            new SpringApplicationBuilder(Object.class)
+                  .parent(Object.class)
+                    .properties("spring.main.web-application-type=none")
+                  .run().close();
+            AwaitingNonWebApplicationListener listener=new AwaitingNonWebApplicationListener();
+           AtomicBoolean awaited = listener.getAwaited();
+           assertFalse(awaited.get());
+       }
 
 }


### PR DESCRIPTION
Description

This PR fixes the await logic in AwaitingNonWebApplicationListener for
non-web Spring Boot applications using parent–child ApplicationContext
hierarchies.

Previously, the listener could incorrectly participate in the lifecycle when a
child context was present. The listener should only operate on the root,
non-web ApplicationContext, and must ignore child contexts.

Changes

Ensure onApplicationReadyEvent returns early for:

non-root ApplicationContexts

web ApplicationContexts

Add a regression test to verify correct behavior when a non-web application
has a parent–child context hierarchy

Testing

Added testMultipleContextNonWebApplication

Verified that the listener does not enter await state for child contexts

Fixes #13722