### PR TITLE
[PR] #15935 Enhance NetUtils IPv6 handling and test coverage

### DIFF
--- a/dubbo-common/src/test/java/org/apache/dubbo/common/utils/NetUtilsTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/utils/NetUtilsTest.java
@@ -225,6 +225,23 @@ class NetUtilsTest {
         assertThat(normalized.getHostAddress(), equalTo("fe80:0:0:0:894:aeec:f37d:23e1%5"));
     }
 
+    // ================================
+    // IPv6 normalization and testcases
+    // ================================
+
+    @Test
+    void testNormalizeIpv6WithoutScope() throws UnknownHostException {
+        Inet6Address input = (Inet6Address) InetAddress.getByName("2001:db8::1");
+
+        InetAddress result = NetUtils.normalizeV6Address(input);
+
+        assertEquals(input.getHostAddress(), result.getHostAddress());
+    }
+    // NOTE:
+    // Scope-name normalization logic is covered by testNormalizeV6Address,
+    // which is currently @Disabled due to Mockito final-class limitations.
+    // These tests focus on CI-safe behavior over hacky way around.
+
     @Test
     void testMatchIpExpressionWithIpv6Pattern() throws UnknownHostException {
         String pattern = "2001:db8::/64";
@@ -248,12 +265,19 @@ class NetUtilsTest {
     }
 
     @Test
-    public void testMatchIPv6CIDRUnsupported() {
-        String pattern = "2001:db8::/64";
-        String host = "2001:db8::1";
+    void testValidIpv6EdgeCases() {
+        assertDoesNotThrow(() -> InetAddress.getByName("::"));
+        assertDoesNotThrow(() -> InetAddress.getByName("::1"));
+        assertDoesNotThrow(() -> InetAddress.getByName("2001:db8::"));
+    }
 
-        // Current behavior: no exception, result is implementation-defined
-        assertDoesNotThrow(() -> NetUtils.matchIpExpression(pattern, host, 90));
+    @Test
+    void testInvalidIpv6EdgeCases() {
+        assertThrows(UnknownHostException.class, () -> InetAddress.getByName("1:2:3:4:5:6:7:8:9"));
+
+        assertThrows(UnknownHostException.class, () -> InetAddress.getByName("2001:db8::zzzz"));
+
+        assertThrows(UnknownHostException.class, () -> InetAddress.getByName("2001:db8::192.168.1"));
     }
 
     @Test

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/utils/NetUtilsTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/utils/NetUtilsTest.java
@@ -32,6 +32,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -222,6 +223,37 @@ class NetUtilsTest {
         when(address.getScopeId()).thenReturn(5);
         InetAddress normalized = NetUtils.normalizeV6Address(address);
         assertThat(normalized.getHostAddress(), equalTo("fe80:0:0:0:894:aeec:f37d:23e1%5"));
+    }
+
+    @Test
+    void testMatchIpExpressionWithIpv6Pattern() throws UnknownHostException {
+        String pattern = "2001:db8::/64";
+        String host = "2001:db8::1";
+        assertTrue(NetUtils.matchIpExpression(pattern, host, 90));
+    }
+
+    @Test
+    void testMatchIPv6WildcardUnsupported() throws UnknownHostException {
+        String pattern = "2001:db8::*";
+        String host = "2001:db8::1";
+        assertThrows(IllegalArgumentException.class, () -> NetUtils.matchIpExpression(pattern, host, 90));
+    }
+
+    @Test
+    void testMatchIPv4PatternIPv6Host() throws IllegalArgumentException {
+        String pattern = "127.0.0.1";
+        String host = "::1";
+
+        assertThrows(IllegalArgumentException.class, () -> NetUtils.matchIpExpression(pattern, host, 90));
+    }
+
+    @Test
+    public void testMatchIPv6CIDRUnsupported() {
+        String pattern = "2001:db8::/64";
+        String host = "2001:db8::1";
+
+        // Current behavior: no exception, result is implementation-defined
+        assertDoesNotThrow(() -> NetUtils.matchIpExpression(pattern, host, 90));
     }
 
     @Test


### PR DESCRIPTION
## What is the purpose of the change?

This PR addresses issue #15935 by improving IPv6-related test coverage in `NetUtils`.

Specifically, it:
- Adds unit tests for IPv6 address normalization without scope.
- Verifies IPv6 CIDR matching behavior in `matchIpExpression`.
- Ensures unsupported IPv6 wildcard patterns fail fast with clear exceptions.
- Validates mismatched IPv4 pattern and IPv6 host scenarios.
- Documents current implementation-defined behavior via tests, without modifying runtime logic.

No functional behavior is changed; this PR focuses on correctness, clarity, and maintainability through testing.

## Brief changelog

- **NetUtilsTest.java**
  - Added IPv6 normalization tests.
  - Added IPv6 CIDR and invalid pattern matching tests.
  - Added validation for IPv4/IPv6 mismatch cases.
  - Documented unsupported IPv6 wildcard behavior.

## Verifying this change

Validated locally by running:

```bash
mvn test -Dtest=NetUtilsTest -pl dubbo-common
```

And verify build by running: 
```bash 
./mvnw -e --batch-mode --no-snapshot-updates --no-transfer-progress --fail-fast clean install -Psources,skip-spotless,checkstyle -Dmaven.test.skip=true
```

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify behavior. No production logic is changed.
- [x] Make sure GitHub Actions can pass.
