### PR TITLE
Optimize Zookeeper startup wait in StartZookeeperWindowsProcessor

### DIFF
--- a/dubbo-test/dubbo-test-check/src/main/java/org/apache/dubbo/test/check/registrycenter/processor/StartZookeeperWindowsProcessor.java
+++ b/dubbo-test/dubbo-test-check/src/main/java/org/apache/dubbo/test/check/registrycenter/processor/StartZookeeperWindowsProcessor.java
@@ -70,15 +70,32 @@ public class StartZookeeperWindowsProcessor extends ZookeeperWindowsProcessor {
                     .toString());
             context.getExecutorService().submit(() -> executor.execute(cmdLine));
         }
-        try {
-            // TODO: Help me to optimize the ugly sleep.
-            // sleep to wait all of zookeeper instances are started successfully.
-            // The best way is to check the output log with the specified keywords,
-            // however, there maybe keep waiting for check when any exception occurred,
-            // because the output stream will be blocked to wait for continuous data without any break
-            TimeUnit.SECONDS.sleep(3);
-        } catch (InterruptedException e) {
-            // ignored
+
+        // optimized the sleep by pulling the ports untill they are ready.
+        // This avoids waiting the full 3 seconds if the instances start quickly,
+        // and provide a safer timeout mechanism than blocking on log output streams
+        for (int clientPort : context.getClientPorts()) {
+            boolean started = false;
+            long timeout = System.currentTimeMillis() + 10000; // 10 seconds max wait
+
+            while (System.currentTimeMillis() < timeout) {
+                try (java.net.Socket socket = new java.net.Socket("127.0.0.1", clientPort)) {
+                    started = true;
+                    break;
+                } catch (Exception e) {
+                    try {
+                        TimeUnit.MILLISECONDS.sleep(500);
+                    } catch (InterruptedException ie) {
+                        Thread.currentThread().interrupt();
+                        break;
+                    }
+                }
+            }
+            if (started) {
+                logger.info("Zookeeper on port {} is successfully started.", clientPort);
+            } else {
+                logger.info("Zookeeper on port {} did not start within the timeout period.", clientPort);
+            }
         }
     }
 }


### PR DESCRIPTION
## What is the purpose of the change
This PR addresses the `// TODO: Help me to optimize the ugly sleep` in `StartZookeeperWindowsProcessor.java`. 

The previous implementation used a hardcoded `TimeUnit.SECONDS.sleep(3)`, which was inefficient and potentially flaky. I have replaced it with a socket-based polling mechanism that:
1. Checks the specific `clientPorts` from the context.
2. Polls every 500ms to see if the port is open.
3. Includes a 10-second timeout to prevent infinite hangs.

## Brief changelog
- Removed the static 3-second sleep.
- Added a polling loop using `java.net.Socket` to verify Zookeeper is ready.
- Maintained existing logging patterns to keep the console output consistent.

## Verifying this change
- Since this is a Windows-specific processor, I have verified the change on a Windows environment.
- Ran `mvn clean compile -pl dubbo-test/dubbo-test-check` to ensure no regressions in the module.