### PR TITLE
[PR] #15969 Fix: Add warning log when using unbounded queue in FixedThreadPool

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/threadpool/support/fixed/FixedThreadPool.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/threadpool/support/fixed/FixedThreadPool.java
@@ -17,6 +17,8 @@
 package org.apache.dubbo.common.threadpool.support.fixed;
 
 import org.apache.dubbo.common.URL;
+import org.apache.dubbo.common.logger.ErrorTypeAwareLogger;
+import org.apache.dubbo.common.logger.LoggerFactory;
 import org.apache.dubbo.common.threadlocal.NamedInternalThreadFactory;
 import org.apache.dubbo.common.threadpool.MemorySafeLinkedBlockingQueue;
 import org.apache.dubbo.common.threadpool.ThreadPool;
@@ -35,6 +37,7 @@ import static org.apache.dubbo.common.constants.CommonConstants.DEFAULT_THREAD_N
 import static org.apache.dubbo.common.constants.CommonConstants.QUEUES_KEY;
 import static org.apache.dubbo.common.constants.CommonConstants.THREADS_KEY;
 import static org.apache.dubbo.common.constants.CommonConstants.THREAD_NAME_KEY;
+import static org.apache.dubbo.common.constants.LoggerCodeConstants.COMMON_UNEXPECTED_EXCEPTION;
 
 /**
  * Creates a thread pool that reuses a fixed number of threads
@@ -42,6 +45,8 @@ import static org.apache.dubbo.common.constants.CommonConstants.THREAD_NAME_KEY;
  * @see java.util.concurrent.Executors#newFixedThreadPool(int)
  */
 public class FixedThreadPool implements ThreadPool {
+
+    private static final ErrorTypeAwareLogger logger = LoggerFactory.getErrorTypeAwareLogger(FixedThreadPool.class);
 
     @Override
     public Executor getExecutor(URL url) {
@@ -56,6 +61,13 @@ public class FixedThreadPool implements ThreadPool {
             blockingQueue = new SynchronousQueue<>();
         } else if (queues < 0) {
             blockingQueue = new MemorySafeLinkedBlockingQueue<>();
+            logger.warn(
+                    COMMON_UNEXPECTED_EXCEPTION,
+                    "",
+                    "",
+                    "FixedThreadPool created with an unbounded queue (queues < 0). "
+                            + "This may lead to OutOfMemoryError under high load. "
+                            + "Consider configuring a positive integer for 'queues'.");
         } else {
             blockingQueue = new LinkedBlockingQueue<>(queues);
         }

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/threadpool/support/fixed/FixedThreadPoolTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/threadpool/support/fixed/FixedThreadPoolTest.java
@@ -18,6 +18,7 @@ package org.apache.dubbo.common.threadpool.support.fixed;
 
 import org.apache.dubbo.common.URL;
 import org.apache.dubbo.common.threadlocal.InternalThread;
+import org.apache.dubbo.common.threadpool.MemorySafeLinkedBlockingQueue;
 import org.apache.dubbo.common.threadpool.ThreadPool;
 import org.apache.dubbo.common.threadpool.support.AbortPolicyWithReport;
 
@@ -80,5 +81,15 @@ class FixedThreadPoolTest {
         ThreadPool threadPool = new FixedThreadPool();
         ThreadPoolExecutor executor = (ThreadPoolExecutor) threadPool.getExecutor(url);
         assertThat(executor.getQueue(), Matchers.<BlockingQueue<Runnable>>instanceOf(LinkedBlockingQueue.class));
+    }
+
+    @Test
+    void testNegativeQueuesCreateUnboundedQueue() {
+        URL url = URL.valueOf("dubbo://10.20.130.230:20880/context/path?" + QUEUES_KEY + "=-1");
+        ThreadPool threadPool = new FixedThreadPool();
+        ThreadPoolExecutor executor = (ThreadPoolExecutor) threadPool.getExecutor(url);
+        assertThat(
+                executor.getQueue(), Matchers.<BlockingQueue<Runnable>>instanceOf(MemorySafeLinkedBlockingQueue.class));
+        assertThat(executor.getQueue().remainingCapacity(), is(Integer.MAX_VALUE));
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

This PR addresses **[Issue #15969](https://github.com/apache/dubbo/issues/15969)**.

Currently, `FixedThreadPool` silently creates an unbounded `MemorySafeLinkedBlockingQueue` (capacity `Integer.MAX_VALUE`) when `queues` is configured to a negative value (e.g., `-1`). This poses a stability risk (OutOfMemoryError) without the user being aware of the danger.

This PR improves observability by logging a **WARN** message when this configuration is detected.

**Note to Reviewers:**
I implemented **Option 1** (Warning Log) from the issue description because it is safer and preserves backward compatibility for users currently relying on negative values. 

## Brief changelog

* **FixedThreadPool.java:** Added a `WARN` log when `queues < 0` is detected, explicitly warning the user about the unbounded queue risk.
* **FixedThreadPoolTest.java:** Added `testNegativeQueuesCreatesUnboundedQueue` to verify that negative configuration correctly instantiates the `MemorySafeLinkedBlockingQueue` (preserving backward compatibility) while triggering the new warning path.