### PR TITLE
[PR] #15988 Fix: Clear SecurityContext in finally block to prevent thread pollution

### DIFF
--- a/dubbo-plugin/dubbo-spring-security/src/main/java/org/apache/dubbo/spring/security/filter/ContextHolderAuthenticationResolverFilter.java
+++ b/dubbo-plugin/dubbo-spring-security/src/main/java/org/apache/dubbo/spring/security/filter/ContextHolderAuthenticationResolverFilter.java
@@ -61,7 +61,13 @@ public class ContextHolderAuthenticationResolverFilter implements Filter {
             getSecurityContext(invocation);
         }
 
-        return invoker.invoke(invocation);
+        try {
+            return invoker.invoke(invocation);
+        } finally {
+            if (this.mapper != null) {
+                SecurityContextHolder.clearContext();
+            }
+        }
     }
 
     private void getSecurityContext(Invocation invocation) {

--- a/dubbo-plugin/dubbo-spring-security/src/test/java/org/apache/dubbo/spring/security/filter/ContextHolderAuthenticationResolverFilterTest.java
+++ b/dubbo-plugin/dubbo-spring-security/src/test/java/org/apache/dubbo/spring/security/filter/ContextHolderAuthenticationResolverFilterTest.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.spring.security.filter;
+
+import org.apache.dubbo.common.beans.factory.ScopeBeanFactory;
+import org.apache.dubbo.rpc.AppResponse;
+import org.apache.dubbo.rpc.Invocation;
+import org.apache.dubbo.rpc.Invoker;
+import org.apache.dubbo.rpc.model.ApplicationModel;
+import org.apache.dubbo.spring.security.jackson.ObjectMapperCodec;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class ContextHolderAuthenticationResolverFilterTest {
+
+    @AfterEach
+    public void cleanup() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    void testSecurityContextIsClearedAfterInvoke() {
+        ApplicationModel applicationModel = mock(ApplicationModel.class);
+        ScopeBeanFactory beanFactory = mock(ScopeBeanFactory.class);
+        ObjectMapperCodec codec = mock(ObjectMapperCodec.class);
+
+        when(applicationModel.getBeanFactory()).thenReturn(beanFactory);
+        when(beanFactory.getBean(ObjectMapperCodec.class)).thenReturn(codec);
+
+        ContextHolderAuthenticationResolverFilter filter =
+                new ContextHolderAuthenticationResolverFilter(applicationModel);
+
+        Invocation invocation = mock(Invocation.class);
+        Invoker<?> invoker = mock(Invoker.class);
+
+        when(invoker.invoke(any(Invocation.class))).thenReturn(new AppResponse());
+        SecurityContextHolder.getContext()
+                .setAuthentication(new UsernamePasswordAuthenticationToken("user", "password"));
+        filter.invoke(invoker, invocation);
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+
+        assertNull(
+                auth, "SecurityContext must be cleared after the filter chain completes to prevent thread pollution.");
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

This PR addresses [#15988](https://github.com/apache/dubbo/issues/15988) a security context pollution issue in `ContextHolderAuthenticationResolverFilter`.

The filter sets authentication data into the `SecurityContextHolder` (ThreadLocal) but fails to clear it. Since Dubbo uses thread pools, this causes thread pollution where subsequent requests may inherit stale credentials. This fix ensures `clearContext()` is always called in a `finally` block.

## Brief changelog

* **Fix:** Wrapped invocation in a `try-finally` block to ensure `SecurityContextHolder.clearContext()` is always called.
* **Test:** Added `ContextHolderAuthenticationResolverFilterTest` to verify thread cleanup.

## Verifying this change

* Added a new unit test `ContextHolderAuthenticationResolverFilterTest`.
* The test simulates thread pollution by setting a dirty `SecurityContext` and asserts that the context is successfully cleared (`null`) after filter execution.

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Make sure gitHub actions can pass. [Why the workflow is failing and how to fix it?](../CONTRIBUTING.md)