### PR TITLE
patch for case mismatch error

### DIFF
--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/rest/mapping/DefaultRequestMappingRegistry.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/rest/mapping/DefaultRequestMappingRegistry.java
@@ -139,6 +139,10 @@ public final class DefaultRequestMappingRegistry implements RequestMappingRegist
                         if (len > 0 && StreamObserver.class.isAssignableFrom(paramTypes[len - 1])) {
                             md = sd.getMethod(method.getName(), Arrays.copyOf(paramTypes, len - 1));
                         }
+                        if(md==null){
+                            String altname=Character.toUpperCase(method.getName().charAt(0))+method.getName().substring(1);
+                            md=sd.getMethod(altname,paramTypes);
+                        }
                     }
                     MethodMeta methodMeta = new MethodMeta(methods, md, serviceMeta);
                     if (!resolver.accept(methodMeta)) {

--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/rest/mapping/DefaultRequestMappingRegistry.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/rest/mapping/DefaultRequestMappingRegistry.java
@@ -139,9 +139,11 @@ public final class DefaultRequestMappingRegistry implements RequestMappingRegist
                         if (len > 0 && StreamObserver.class.isAssignableFrom(paramTypes[len - 1])) {
                             md = sd.getMethod(method.getName(), Arrays.copyOf(paramTypes, len - 1));
                         }
-                        if(md==null){
-                            String altname=Character.toUpperCase(method.getName().charAt(0))+method.getName().substring(1);
-                            md=sd.getMethod(altname,paramTypes);
+                        if (md == null) {
+                            String altname =
+                                    Character.toUpperCase(method.getName().charAt(0))
+                                            + method.getName().substring(1);
+                            md = sd.getMethod(altname, paramTypes);
                         }
                     }
                     MethodMeta methodMeta = new MethodMeta(methods, md, serviceMeta);


### PR DESCRIPTION
#15484 

When a Dubbo Triple service extends the generated stub base class, HTTP-based requests could return 404 if the service method name uses lowerCamelCase (sayHello) while the generated StubServiceDescriptor stores method keys in UpperCamelCase (SayHello) because StubServiceDescriptor stores entries using method names in UpperCamelCase while DefaultRequestMappingRegistry  returns method names in lowerCamelCase.
As a result, lookups like getMethod("sayHello", ...) returned null, and no HTTP route was registered.

Fix:
Added a fallback lookup to try the name with the first letter capitalized when the initial lookup fails: