### PR TITLE
Add unit test for PathUtils in dubbo-common

### DIFF
--- a/dubbo-common/src/test/java/org/apache/dubbo/common/utils/PathUtilsTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/utils/PathUtilsTest.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.common.utils;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class PathUtilsTest {
+    @Test
+    void testBuildPath() {
+        Assertions.assertEquals("a/b/c", PathUtils.buildPath("a", "b", "c"));
+        Assertions.assertEquals("root/sub", PathUtils.buildPath("root", "sub"));
+    }
+
+    @Test
+    void testNormalize() {
+        Assertions.assertEquals("/path", PathUtils.normalize("//path"));
+        Assertions.assertEquals("/api/v1", PathUtils.normalize("/api/v1?name=dubbo"));
+        Assertions.assertEquals("/", PathUtils.normalize(""));
+    }
+}

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/utils/PathUtilsTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/utils/PathUtilsTest.java
@@ -30,6 +30,10 @@ class PathUtilsTest {
     void testNormalize() {
         Assertions.assertEquals("/path", PathUtils.normalize("//path"));
         Assertions.assertEquals("/api/v1", PathUtils.normalize("/api/v1?name=dubbo"));
+        // Empty and Null handling (The "Edge Cases")
         Assertions.assertEquals("/", PathUtils.normalize(""));
+        Assertions.assertEquals("/", PathUtils.normalize(null));
+        // Multiple slashes
+        Assertions.assertEquals("/a/b/c", PathUtils.normalize("/a//b///c"));
     }
 }


### PR DESCRIPTION
## Documentation 
- [x] I have read the [contributing guidelines](https://github.com/apache/dubbo/blob/3.3/CONTRIBUTING.md).

## Purpose
This PR adds missing unit test coverage for the `PathUtils` interface in the `dubbo-common` module. 

## Key Changes
- Created `PathUtilsTest.java` to test path building and normalization logic.
- Verified that `normalize()` correctly handles multiple slashes and query strings.
- Verified that `buildPath()` correctly joins multiple path segments.

## Verification
I have verified these changes locally using Maven:
- **Command**: `mvn test -pl dubbo-common -Dtest=PathUtilsTest`
- **Result**: `BUILD SUCCESS`