### PR TITLE
Bump protobuf-java from 3.25.8 to 4.33.4 and remove guava dependency by rewriting CodecTest with java.nio.charset.StandardCharsets

### DIFF
--- a/dubbo-dependencies-bom/pom.xml
+++ b/dubbo-dependencies-bom/pom.xml
@@ -104,7 +104,7 @@
     <curator_version>5.9.0</curator_version>
     <curator_test_version>2.12.0</curator_test_version>
     <hessian_version>4.0.66</hessian_version>
-    <protobuf-java_version>3.25.8</protobuf-java_version>
+    <protobuf-java_version>4.33.4</protobuf-java_version>
     <jsr305_version>3.0.2</jsr305_version>
     <javax_annotation-api_version>1.3.2</javax_annotation-api_version>
     <servlet_version>3.1.0</servlet_version>

--- a/dubbo-maven-plugin/pom.xml
+++ b/dubbo-maven-plugin/pom.xml
@@ -29,8 +29,8 @@
 
   <properties>
     <dubbo.version>${revision}</dubbo.version>
-    <protobuf-java.version>3.25.5</protobuf-java.version>
-    <!--<protobuf-java.version>3.24.3</protobuf-java.version>-->
+    <!-- the protobuf-java version should be same with the version defined at dubbo-dependencies-bom -->
+    <protobuf-java.version>4.33.4</protobuf-java.version>
   </properties>
 
   <dependencies>

--- a/dubbo-remoting/dubbo-remoting-http12/src/test/java/org/apache/dubbo/remoting/http12/message/codec/CodecTest.java
+++ b/dubbo-remoting/dubbo-remoting-http12/src/test/java/org/apache/dubbo/remoting/http12/message/codec/CodecTest.java
@@ -22,8 +22,8 @@ import org.apache.dubbo.rpc.model.FrameworkModel;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 
-import com.google.common.base.Charsets;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -76,11 +76,11 @@ public class CodecTest {
 
         in = new ByteArrayInputStream(utf8Bytes);
         codec = PlainTextCodec.INSTANCE;
-        res = (String) codec.decode(in, String.class, Charsets.UTF_8);
+        res = (String) codec.decode(in, String.class, StandardCharsets.UTF_8);
         Assertions.assertEquals("你好，世界", res);
 
         in = new ByteArrayInputStream(utf16Bytes);
-        res = (String) codec.decode(in, String.class, Charsets.UTF_16);
+        res = (String) codec.decode(in, String.class, StandardCharsets.UTF_16);
         Assertions.assertEquals("你好，世界", res);
     }
 }


### PR DESCRIPTION
## What is the purpose of the change?

guava dependency had been removed from protobuf-java-util 4.x, according to https://github.com/protocolbuffers/protobuf/issues/21173 

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Make sure gitHub actions can pass. [Why the workflow is failing and how to fix it?](../CONTRIBUTING.md)
