### PR TITLE
Optimize NettyBackedChannelBuffer for direct buffer transfer

### DIFF
--- a/dubbo-remoting/dubbo-remoting-netty4/src/main/java/org/apache/dubbo/remoting/transport/netty4/NettyBackedChannelBuffer.java
+++ b/dubbo-remoting/dubbo-remoting-netty4/src/main/java/org/apache/dubbo/remoting/transport/netty4/NettyBackedChannelBuffer.java
@@ -71,10 +71,15 @@ public class NettyBackedChannelBuffer implements ChannelBuffer {
 
     @Override
     public void getBytes(int index, ChannelBuffer dst, int dstIndex, int length) {
-        // careful
-        byte[] data = new byte[length];
-        buffer.getBytes(index, data, 0, length);
-        dst.setBytes(dstIndex, data, 0, length);
+        // use Netty ByteBuf
+        if (dst instanceof NettyBackedChannelBuffer) {
+            NettyBackedChannelBuffer nettyDst = (NettyBackedChannelBuffer) dst;
+            buffer.getBytes(index, nettyDst.buffer, dstIndex, length);
+        } else {
+            byte[] data = new byte[length];
+            buffer.getBytes(index, data, 0, length);
+            dst.setBytes(dstIndex, data, 0, length);
+        }
     }
 
     @Override
@@ -107,10 +112,15 @@ public class NettyBackedChannelBuffer implements ChannelBuffer {
         if (length > src.readableBytes()) {
             throw new IndexOutOfBoundsException();
         }
-        // careful
-        byte[] data = new byte[length];
-        src.getBytes(srcIndex, data, 0, length);
-        setBytes(index, data, 0, length);
+        // use Netty ByteBuf
+        if (src instanceof NettyBackedChannelBuffer) {
+            NettyBackedChannelBuffer nettySrc = (NettyBackedChannelBuffer) src;
+            buffer.setBytes(index, nettySrc.buffer, srcIndex, length);
+        } else {
+            byte[] data = new byte[length];
+            src.getBytes(srcIndex, data, 0, length);
+            setBytes(index, data, 0, length);
+        }
     }
 
     @Override
@@ -239,13 +249,18 @@ public class NettyBackedChannelBuffer implements ChannelBuffer {
 
     @Override
     public void readBytes(ChannelBuffer dst, int dstIndex, int length) {
-        // careful
         if (readableBytes() < length) {
             throw new IndexOutOfBoundsException();
         }
-        byte[] data = new byte[length];
-        buffer.readBytes(data, 0, length);
-        dst.setBytes(dstIndex, data, 0, length);
+        // use Netty ByteBuf
+        if (dst instanceof NettyBackedChannelBuffer) {
+            NettyBackedChannelBuffer nettyDst = (NettyBackedChannelBuffer) dst;
+            buffer.readBytes(nettyDst.buffer, dstIndex, length);
+        } else {
+            byte[] data = new byte[length];
+            buffer.readBytes(data, 0, length);
+            dst.setBytes(dstIndex, data, 0, length);
+        }
     }
 
     @Override
@@ -362,10 +377,15 @@ public class NettyBackedChannelBuffer implements ChannelBuffer {
 
     @Override
     public void writeBytes(ChannelBuffer src, int srcIndex, int length) {
-        // careful
-        byte[] data = new byte[length];
-        src.getBytes(srcIndex, data, 0, length);
-        writeBytes(data, 0, length);
+        // use Netty ByteBuf
+        if (src instanceof NettyBackedChannelBuffer) {
+            NettyBackedChannelBuffer nettySrc = (NettyBackedChannelBuffer) src;
+            buffer.writeBytes(nettySrc.buffer, srcIndex, length);
+        } else {
+            byte[] data = new byte[length];
+            src.getBytes(srcIndex, data, 0, length);
+            writeBytes(data, 0, length);
+        }
     }
 
     @Override

--- a/dubbo-remoting/dubbo-remoting-netty4/src/test/java/org/apache/dubbo/remoting/transport/netty4/NettyBackedChannelBufferTest.java
+++ b/dubbo-remoting/dubbo-remoting-netty4/src/test/java/org/apache/dubbo/remoting/transport/netty4/NettyBackedChannelBufferTest.java
@@ -18,11 +18,13 @@ package org.apache.dubbo.remoting.transport.netty4;
 
 import org.apache.dubbo.remoting.buffer.ChannelBuffer;
 
+import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class NettyBackedChannelBufferTest {
@@ -59,5 +61,53 @@ class NettyBackedChannelBufferTest {
         buffer.getBytes(0, actual);
         assertEquals(1, actual[0]);
         assertEquals(2, actual[1]);
+    }
+
+    @Test
+    void testBufferTransfer_directToDirect() {
+        ByteBuf srcDirect = Unpooled.directBuffer(4);
+        ByteBuf dstDirect = Unpooled.directBuffer(4);
+
+        ChannelBuffer source =
+                new NettyBackedChannelBuffer(srcDirect);
+        ChannelBuffer target =
+                new NettyBackedChannelBuffer(dstDirect);
+
+        byte[] data = {10, 20, 30, 40};
+        source.writeBytes(data);
+
+        target.setBytes(0, source, 0, 4);
+
+        byte[] actual = new byte[4];
+        target.getBytes(0, actual);
+
+        assertArrayEquals(data, actual);
+        assertEquals(0, target.readerIndex(),
+                "setBytes should not move readerIndex");
+    }
+
+    @Test
+    void testReadBytes_directBuffer() {
+        byte[] data = {1, 2, 3, 4};
+        buffer.writeBytes(data);
+
+        byte[] actual = new byte[4];
+        buffer.readBytes(actual);
+
+        assertArrayEquals(data, actual);
+        assertEquals(4, buffer.readerIndex());
+    }
+
+    @Test
+    void testGetBytes_directBuffer_shouldNotMoveIndex() {
+        buffer.writeBytes(new byte[]{5, 6, 7, 8});
+
+        int before = buffer.readerIndex();
+
+        byte[] actual = new byte[2];
+        buffer.getBytes(1, actual);
+
+        assertEquals(before, buffer.readerIndex());
+        assertArrayEquals(new byte[]{6, 7}, actual);
     }
 }

--- a/dubbo-remoting/dubbo-remoting-netty4/src/test/java/org/apache/dubbo/remoting/transport/netty4/NettyBackedChannelBufferTest.java
+++ b/dubbo-remoting/dubbo-remoting-netty4/src/test/java/org/apache/dubbo/remoting/transport/netty4/NettyBackedChannelBufferTest.java
@@ -68,19 +68,24 @@ class NettyBackedChannelBufferTest {
         ByteBuf srcDirect = Unpooled.directBuffer(4);
         ByteBuf dstDirect = Unpooled.directBuffer(4);
 
-        ChannelBuffer source = new NettyBackedChannelBuffer(srcDirect);
-        ChannelBuffer target = new NettyBackedChannelBuffer(dstDirect);
+        try {
+            ChannelBuffer source = new NettyBackedChannelBuffer(srcDirect);
+            ChannelBuffer target = new NettyBackedChannelBuffer(dstDirect);
 
-        byte[] data = {10, 20, 30, 40};
-        source.writeBytes(data);
+            byte[] data = {10, 20, 30, 40};
+            source.writeBytes(data);
 
-        target.setBytes(0, source, 0, 4);
+            target.setBytes(0, source, 0, 4);
 
-        byte[] actual = new byte[4];
-        target.getBytes(0, actual);
+            byte[] actual = new byte[4];
+            target.getBytes(0, actual);
 
-        assertArrayEquals(data, actual);
-        assertEquals(0, target.readerIndex(), "setBytes should not move readerIndex");
+            assertArrayEquals(data, actual);
+            assertEquals(0, target.readerIndex(), "setBytes should not move readerIndex");
+        } finally {
+            srcDirect.release();
+            dstDirect.release();
+        }
     }
 
     @Test

--- a/dubbo-remoting/dubbo-remoting-netty4/src/test/java/org/apache/dubbo/remoting/transport/netty4/NettyBackedChannelBufferTest.java
+++ b/dubbo-remoting/dubbo-remoting-netty4/src/test/java/org/apache/dubbo/remoting/transport/netty4/NettyBackedChannelBufferTest.java
@@ -68,10 +68,8 @@ class NettyBackedChannelBufferTest {
         ByteBuf srcDirect = Unpooled.directBuffer(4);
         ByteBuf dstDirect = Unpooled.directBuffer(4);
 
-        ChannelBuffer source =
-                new NettyBackedChannelBuffer(srcDirect);
-        ChannelBuffer target =
-                new NettyBackedChannelBuffer(dstDirect);
+        ChannelBuffer source = new NettyBackedChannelBuffer(srcDirect);
+        ChannelBuffer target = new NettyBackedChannelBuffer(dstDirect);
 
         byte[] data = {10, 20, 30, 40};
         source.writeBytes(data);
@@ -82,8 +80,7 @@ class NettyBackedChannelBufferTest {
         target.getBytes(0, actual);
 
         assertArrayEquals(data, actual);
-        assertEquals(0, target.readerIndex(),
-                "setBytes should not move readerIndex");
+        assertEquals(0, target.readerIndex(), "setBytes should not move readerIndex");
     }
 
     @Test
@@ -100,7 +97,7 @@ class NettyBackedChannelBufferTest {
 
     @Test
     void testGetBytes_directBuffer_shouldNotMoveIndex() {
-        buffer.writeBytes(new byte[]{5, 6, 7, 8});
+        buffer.writeBytes(new byte[] {5, 6, 7, 8});
 
         int before = buffer.readerIndex();
 
@@ -108,6 +105,6 @@ class NettyBackedChannelBufferTest {
         buffer.getBytes(1, actual);
 
         assertEquals(before, buffer.readerIndex());
-        assertArrayEquals(new byte[]{6, 7}, actual);
+        assertArrayEquals(new byte[] {6, 7}, actual);
     }
 }


### PR DESCRIPTION
- Optimize getBytes/setBytes/readBytes/writeBytes methods
- Avoid intermediate byte array copy when source/destination is NettyBackedChannelBuffer
- Directly use Netty's ByteBuf transfer capabilities
- Add fallback to intermediate array copy for other ChannelBuffer implementations
- Improve performance by 4-5x for Netty-to-Netty buffer transfers

Below are test code:
```java
import org.apache.dubbo.remoting.buffer.ByteBufferBackedChannelBuffer;
import org.apache.dubbo.remoting.buffer.ChannelBuffer;
import org.apache.dubbo.remoting.transport.netty4.NettyBackedChannelBuffer;
import org.apache.dubbo.remoting.transport.netty4.NettyBackedChannelBufferOld;

import java.nio.ByteBuffer;

import io.netty.buffer.ByteBuf;
import io.netty.buffer.PooledByteBufAllocator;
import org.junit.jupiter.api.Test;

public class NettyBackedChannelBufferBenchmarkTest {

    private static final int BUFFER_SIZE = 1024 * 1024; // 1MB
    private static final int TEST_ITERATIONS = 1000;

    @Test
    public void testPerformance() {
        byte[] data = new byte[BUFFER_SIZE];
        for (int i = 0; i < data.length; i++) {
            data[i] = (byte) (i % 256);
        }

        ByteBuf nettyBuffer = PooledByteBufAllocator.DEFAULT.buffer(BUFFER_SIZE);
        nettyBuffer.writeBytes(data);
        ChannelBuffer nettySource = new NettyBackedChannelBuffer(nettyBuffer);

        // Netty->Netty vs Netty->Other (getBytes)
        double nettyToNettyGet = testGetBytes(
                nettySource, new NettyBackedChannelBuffer(PooledByteBufAllocator.DEFAULT.buffer(BUFFER_SIZE)));
        double nettyToOtherGet = testGetBytes(
                nettySource, new NettyBackedChannelBufferOld(PooledByteBufAllocator.DEFAULT.buffer(BUFFER_SIZE)));
        System.out.printf(
                "getBytes: Netty->Netty %.2f MB/s, Netty->Other %.2f MB/s, ratio %.2f\n",
                nettyToNettyGet, nettyToOtherGet, (nettyToOtherGet > 0 ? nettyToNettyGet / nettyToOtherGet : 0.0));

        // Netty->Netty vs Netty->Other (setBytes)
        double nettyToNettySet = testSetBytes(
                nettySource, new NettyBackedChannelBuffer(PooledByteBufAllocator.DEFAULT.buffer(BUFFER_SIZE)));
        double nettyToOtherSet = testSetBytes(
                nettySource, new NettyBackedChannelBufferOld(PooledByteBufAllocator.DEFAULT.buffer(BUFFER_SIZE)));
        System.out.printf(
                "setBytes: Netty->Netty %.2f MB/s, Netty->Other %.2f MB/s, ratio %.2f\n",
                nettyToNettySet, nettyToOtherSet, (nettyToOtherSet > 0 ? nettyToNettySet / nettyToOtherSet : 0.0));

        System.out.println("-----------------------------------");

        ByteBufferBackedChannelBuffer byteBufferSource =
                new ByteBufferBackedChannelBuffer(ByteBuffer.allocate(BUFFER_SIZE));
        
        if (byteBufferSource.readableBytes() < BUFFER_SIZE) {
            byteBufferSource.clear();
            byteBufferSource.writeBytes(data);
        }

        double otherToNettyGet = testGetBytes(
                byteBufferSource, new NettyBackedChannelBuffer(PooledByteBufAllocator.DEFAULT.buffer(BUFFER_SIZE)));
        double otherToOtherGet = testGetBytes(
                byteBufferSource, new NettyBackedChannelBufferOld(PooledByteBufAllocator.DEFAULT.buffer(BUFFER_SIZE)));
        System.out.printf(
                "getBytes: Other->Netty %.2f MB/s, Other->Other %.2f MB/s, ratio %.2f\n",
                otherToNettyGet, otherToOtherGet, (otherToOtherGet > 0 ? otherToNettyGet / otherToOtherGet : 0.0));

        double otherToNettySet = testSetBytes(
                byteBufferSource, new NettyBackedChannelBuffer(PooledByteBufAllocator.DEFAULT.buffer(BUFFER_SIZE)));
        double otherToOtherSet = testSetBytes(
                byteBufferSource, new NettyBackedChannelBufferOld(PooledByteBufAllocator.DEFAULT.buffer(BUFFER_SIZE)));
        System.out.printf(
                "setBytes: Other->Netty %.2f MB/s, Other->Other %.2f MB/s, ratio %.2f\n",
                otherToNettySet, otherToOtherSet, (otherToOtherSet > 0 ? otherToNettySet / otherToOtherSet : 0.0));

        nettyBuffer.release();
    }

    private static double testGetBytes(ChannelBuffer src, ChannelBuffer dest) {
        if (src.readableBytes() < BUFFER_SIZE) {
            byte[] fill = new byte[BUFFER_SIZE];
            for (int i = 0; i < fill.length; i++) {
                fill[i] = (byte) (i % 256);
            }
            src.clear();
            src.writeBytes(fill);
        }

        for (int i = 0; i < TEST_ITERATIONS / 10; i++) {
            dest.clear(); 
            src.getBytes(0, dest, 0, BUFFER_SIZE);
        }

        long startTime = System.nanoTime();
        for (int i = 0; i < TEST_ITERATIONS; i++) {
            dest.clear();
            src.getBytes(0, dest, 0, BUFFER_SIZE);
        }
        long endTime = System.nanoTime();
        long totalTime = endTime - startTime;
        
        dest.release();

        return TEST_ITERATIONS / (totalTime / 1_000_000_000.0);
    }

    private static double testSetBytes(ChannelBuffer src, ChannelBuffer dest) {
        if (src.readableBytes() < BUFFER_SIZE) {
            byte[] fill = new byte[BUFFER_SIZE];
            for (int i = 0; i < fill.length; i++) {
                fill[i] = (byte) (i % 256);
            }
            src.clear();
            src.writeBytes(fill);
        }

        for (int i = 0; i < TEST_ITERATIONS / 10; i++) {
            dest.clear();
            dest.setBytes(0, src, 0, BUFFER_SIZE);
        }

        long startTime = System.nanoTime();
        for (int i = 0; i < TEST_ITERATIONS; i++) {
            dest.clear();
            dest.setBytes(0, src, 0, BUFFER_SIZE);
        }
        long endTime = System.nanoTime();
        long totalTime = endTime - startTime;
        
        dest.release();

        return TEST_ITERATIONS / (totalTime / 1_000_000_000.0);
    }
}

```

Test output:
```plain text
getBytes: Netty->Netty 36047.87 MB/s, Netty->Other 6926.83 MB/s, ratio 5.20
setBytes: Netty->Netty 49730.58 MB/s, Netty->Other 13129.59 MB/s, ratio 3.79
-----------------------------------
getBytes: Other->Netty 53048.21 MB/s, Other->Other 46807.54 MB/s, ratio 1.13
setBytes: Other->Netty 11765.61 MB/s, Other->Other 11816.55 MB/s, ratio 1.00
```