### PR TITLE
Fix timestamp filtering in ZooKeeper registry causing pre-warmup failure

### DIFF
--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/support/CacheableFailbackRegistry.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/support/CacheableFailbackRegistry.java
@@ -37,6 +37,7 @@ import org.apache.dubbo.rpc.model.ScopeModel;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -323,29 +324,76 @@ public abstract class CacheableFailbackRegistry extends FailbackRegistry {
             return rawProvider;
         }
 
+        int encodedIdx = rawProvider.indexOf(ENCODED_QUESTION_MARK);
+        int plainIdx = rawProvider.indexOf('?');
+        boolean encoded;
+        int questionIdx;
+        if (encodedIdx >= 0 && (plainIdx < 0 || encodedIdx < plainIdx)) {
+            encoded = true;
+            questionIdx = encodedIdx;
+        } else if (plainIdx >= 0) {
+            encoded = false;
+            questionIdx = plainIdx;
+        } else {
+            return rawProvider;
+        }
+
+        String prefix = rawProvider.substring(0, questionIdx);
+        String params = rawProvider.substring(questionIdx + (encoded ? ENCODED_QUESTION_MARK.length() : 1));
+        if (params.isEmpty()) {
+            return rawProvider;
+        }
+
+        String andMark = encoded ? ENCODED_AND_MARK : "&";
+        String eqMark = encoded ? "%3D" : "=";
+
+        HashSet<String> variableNames = new HashSet<>(keys.length);
         for (String key : keys) {
-            int idxStart = rawProvider.indexOf(key);
-            if (idxStart == -1) {
+            if (key != null) {
+                variableNames.add(normalizeVariableName(key));
+            }
+        }
+
+        List<String> remaining = new ArrayList<>();
+        boolean removed = false;
+        for (String param : params.split(andMark)) {
+            if (param.isEmpty()) {
                 continue;
             }
-            int idxEnd = rawProvider.indexOf(ENCODED_AND_MARK, idxStart);
-            String part1 = rawProvider.substring(0, idxStart);
-            if (idxEnd == -1) {
-                rawProvider = part1;
-            } else {
-                String part2 = rawProvider.substring(idxEnd + ENCODED_AND_MARK.length());
-                rawProvider = part1 + part2;
+            int eqIdx = param.indexOf(eqMark);
+            if (eqIdx < 0) {
+                remaining.add(param);
+                continue;
             }
+            String name = param.substring(0, eqIdx);
+            if (variableNames.contains(normalizeVariableName(name))) {
+                removed = true;
+                continue;
+            }
+            remaining.add(param);
         }
 
-        if (rawProvider.endsWith(ENCODED_AND_MARK)) {
-            rawProvider = rawProvider.substring(0, rawProvider.length() - ENCODED_AND_MARK.length());
+        if (!removed) {
+            return rawProvider;
         }
-        if (rawProvider.endsWith(ENCODED_QUESTION_MARK)) {
-            rawProvider = rawProvider.substring(0, rawProvider.length() - ENCODED_QUESTION_MARK.length());
+        if (remaining.isEmpty()) {
+            return prefix;
         }
 
-        return rawProvider;
+        return prefix + (encoded ? ENCODED_QUESTION_MARK : "?") + String.join(andMark, remaining);
+    }
+
+    private String normalizeVariableName(String key) {
+        if (key == null) {
+            return null;
+        }
+        if (key.endsWith("%3D")) {
+            return key.substring(0, key.length() - 3);
+        }
+        if (key.endsWith("=")) {
+            return key.substring(0, key.length() - 1);
+        }
+        return key;
     }
 
     private List<URL> toConfiguratorsWithoutEmpty(URL consumer, Collection<String> configurators) {

--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/support/CacheableFailbackRegistry.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/support/CacheableFailbackRegistry.java
@@ -212,13 +212,14 @@ public abstract class CacheableFailbackRegistry extends FailbackRegistry {
             for (String rawProvider : providers) {
                 // Normalize the rawProvider for cache key matching and deduplication.
                 String normalizedKey = stripOffVariableKeys(rawProvider);
-
-                // Create new URL using the original rawProvider (all parameters preserved including timestamp).
-                ServiceAddressURL cachedURL = createURL(rawProvider, copyOfConsumer, getExtraParameters());
+                ServiceAddressURL cachedURL = oldURLs.remove(normalizedKey);
                 if (cachedURL == null) {
-                    continue;
+                    // Create new URL using the original rawProvider (all parameters preserved including timestamp).
+                    cachedURL = createURL(rawProvider, copyOfConsumer, getExtraParameters());
+                    if (cachedURL == null) {
+                        continue;
+                    }
                 }
-
                 // Use normalized key for storage: if multiple providers normalize to the same key,
                 // the last one will be kept, ensuring no duplicate instances with outdated timestamps.
                 newURLs.put(normalizedKey, cachedURL);

--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/support/CacheableFailbackRegistry.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/support/CacheableFailbackRegistry.java
@@ -177,6 +177,8 @@ public abstract class CacheableFailbackRegistry extends FailbackRegistry {
         Map<String, ServiceAddressURL> oldURLs = stringUrls.get(consumer);
 
         // create new urls
+        // The key of newURLs is the normalized rawProvider (variable keys removed for deduplication),
+        // but the cached ServiceAddressURL is built from the original rawProvider (with all parameters preserved).
         Map<String, ServiceAddressURL> newURLs = new HashMap<>((int) (providers.size() / 0.75f + 1));
 
         // remove 'release', 'dubbo', 'methods', timestamp, 'dubbo.tag' parameter
@@ -185,28 +187,41 @@ public abstract class CacheableFailbackRegistry extends FailbackRegistry {
 
         if (oldURLs == null) {
             for (String rawProvider : providers) {
-                // remove VARIABLE_KEYS(timestamp,pid..) in provider url.
-                rawProvider = stripOffVariableKeys(rawProvider);
+                // Normalize the rawProvider by removing VARIABLE_KEYS(timestamp, pid..) for deduplication purposes.
+                // The normalized key is used to avoid duplicate instances of the same provider.
+                String normalizedKey = stripOffVariableKeys(rawProvider);
 
-                // create DubboServiceAddress object using provider url, consumer url, and extra parameters.
+                // Create DubboServiceAddress object using the ORIGINAL rawProvider (with all parameters intact),
+                // so that timestamp and other parameters are preserved for correct parameter parsing.
+                // This ensures that when multiple providers normalize to the same key (e.g., different timestamps),
+                // the latest one's timestamp will be used.
                 ServiceAddressURL cachedURL = createURL(rawProvider, copyOfConsumer, getExtraParameters());
                 if (cachedURL == null) {
                     continue;
                 }
-                newURLs.put(rawProvider, cachedURL);
+
+                // Use normalized key for deduplication: if multiple providers normalize to the same key,
+                // the last one (with the latest timestamp) will be kept.
+                newURLs.put(normalizedKey, cachedURL);
             }
         } else {
-            // maybe only default, or "env" + default
+            // Reuse or create URLs based on both normalized key and original rawProvider.
+            // The normalized key is used to find potential cache entries for reuse (deduplication),
+            // but we always create a new ServiceAddressURL from the original rawProvider to ensure
+            // the timestamp and other parameters are up-to-date.
             for (String rawProvider : providers) {
-                rawProvider = stripOffVariableKeys(rawProvider);
-                ServiceAddressURL cachedURL = oldURLs.remove(rawProvider);
+                // Normalize the rawProvider for cache key matching and deduplication.
+                String normalizedKey = stripOffVariableKeys(rawProvider);
+
+                // Create new URL using the original rawProvider (all parameters preserved including timestamp).
+                ServiceAddressURL cachedURL = createURL(rawProvider, copyOfConsumer, getExtraParameters());
                 if (cachedURL == null) {
-                    cachedURL = createURL(rawProvider, copyOfConsumer, getExtraParameters());
-                    if (cachedURL == null) {
-                        continue;
-                    }
+                    continue;
                 }
-                newURLs.put(rawProvider, cachedURL);
+
+                // Use normalized key for storage: if multiple providers normalize to the same key,
+                // the last one will be kept, ensuring no duplicate instances with outdated timestamps.
+                newURLs.put(normalizedKey, cachedURL);
             }
         }
 
@@ -347,6 +362,7 @@ public abstract class CacheableFailbackRegistry extends FailbackRegistry {
         String andMark = encoded ? ENCODED_AND_MARK : "&";
         String eqMark = encoded ? "%3D" : "=";
 
+        // Build a set of normalized variable names for efficient matching.
         HashSet<String> variableNames = new HashSet<>(keys.length);
         for (String key : keys) {
             if (key != null) {
@@ -366,7 +382,20 @@ public abstract class CacheableFailbackRegistry extends FailbackRegistry {
                 continue;
             }
             String name = param.substring(0, eqIdx);
-            if (variableNames.contains(normalizeVariableName(name))) {
+            String normalizedName = normalizeVariableName(name);
+
+            // Check if this parameter name is a variable key that should be removed.
+            // Support both exact match (e.g., "timestamp") and suffix match with dot separator (e.g.,
+            // "remote.timestamp").
+            boolean isVariable = false;
+            for (String var : variableNames) {
+                if (var != null && (normalizedName.equals(var) || normalizedName.endsWith("." + var))) {
+                    isVariable = true;
+                    break;
+                }
+            }
+
+            if (isVariable) {
                 removed = true;
                 continue;
             }

--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/support/CacheableFailbackRegistry.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/support/CacheableFailbackRegistry.java
@@ -384,18 +384,9 @@ public abstract class CacheableFailbackRegistry extends FailbackRegistry {
             String name = param.substring(0, eqIdx);
             String normalizedName = normalizeVariableName(name);
 
-            // Check if this parameter name is a variable key that should be removed.
-            // Support both exact match (e.g., "timestamp") and suffix match with dot separator (e.g.,
-            // "remote.timestamp").
-            boolean isVariable = false;
-            for (String var : variableNames) {
-                if (var != null && (normalizedName.equals(var) || normalizedName.endsWith("." + var))) {
-                    isVariable = true;
-                    break;
-                }
-            }
-
-            if (isVariable) {
+            // Check if this parameter name exactly matches a variable key that should be removed.
+            // Only exact match is performed (e.g., "timestamp" matches "timestamp", but not "remote.timestamp").
+            if (variableNames.contains(normalizedName)) {
                 removed = true;
                 continue;
             }

--- a/dubbo-registry/dubbo-registry-api/src/test/java/org/apache/dubbo/registry/support/CacheableFailbackRegistryTest.java
+++ b/dubbo-registry/dubbo-registry-api/src/test/java/org/apache/dubbo/registry/support/CacheableFailbackRegistryTest.java
@@ -32,6 +32,7 @@ import org.junit.jupiter.api.Test;
 import static org.apache.dubbo.common.URLStrParser.ENCODED_AND_MARK;
 import static org.apache.dubbo.common.URLStrParser.ENCODED_QUESTION_MARK;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -45,48 +46,55 @@ class CacheableFailbackRegistryTest {
     }
 
     @Test
-    void shouldKeepRemoteTimestampIntact() throws Exception {
-        String base = "dubbo%3A%2F%2F127.0.0.1%3A20880%2Fdemo.Service";
-        String rawProvider =
-                base + ENCODED_QUESTION_MARK + "remote.timestamp%3D1" + ENCODED_AND_MARK + "revision%3Dabc";
-        assertEquals(rawProvider, strip(rawProvider));
+    void shouldRemoveExactTimestamp() throws Exception {
+        // Test removing exact "timestamp" parameter
+        String rawProvider = "dubbo://127.0.0.1:20880/demo.Service?timestamp=100&revision=v1";
+        String result = strip(rawProvider);
+        // After removing timestamp, only revision should remain
+        assertTrue(result.contains("revision=v1"), "Result should contain revision");
+        assertFalse(result.contains("timestamp"), "Result should not contain timestamp");
     }
 
     @Test
-    void shouldRemoveOnlyTimestampWhenRemoteTimestampExists() throws Exception {
+    void shouldRemoveExactPid() throws Exception {
+        // Test removing exact "pid" parameter
+        String rawProvider = "dubbo://127.0.0.1:20880/demo.Service?pid=9999&revision=v1";
+        String result = strip(rawProvider);
+        assertTrue(result.contains("revision=v1"), "Result should contain revision");
+        assertFalse(result.contains("pid"), "Result should not contain pid");
+    }
+
+    @Test
+    void shouldRemoveTimestampAndPid() throws Exception {
+        // Test removing both timestamp and pid
+        String rawProvider = "dubbo://127.0.0.1:20880/demo.Service?timestamp=100&pid=1234&revision=abc";
+        String result = strip(rawProvider);
+        assertTrue(result.contains("revision=abc"), "Result should contain revision");
+        assertFalse(result.contains("timestamp"), "Result should not contain timestamp");
+        assertFalse(result.contains("pid"), "Result should not contain pid");
+    }
+
+    @Test
+    void shouldKeepRemoteTimestamp() throws Exception {
+        // remote.timestamp should NOT be removed (only exact "timestamp" is removed)
+        String rawProvider = "dubbo://127.0.0.1:20880/demo.Service?remote.timestamp=200&revision=v1";
+        String result = strip(rawProvider);
+        assertTrue(result.contains("remote.timestamp=200"), "Result should keep remote.timestamp");
+        assertTrue(result.contains("revision=v1"), "Result should contain revision");
+    }
+
+    @Test
+    void shouldRemoveEncodedTimestampAndPid() throws Exception {
+        // Test with encoded format
         String base = "dubbo%3A%2F%2F127.0.0.1%3A20880%2Fdemo.Service";
         String rawProvider = base + ENCODED_QUESTION_MARK
-                + "timestamp%3D1" + ENCODED_AND_MARK
-                + "remote.timestamp%3D2" + ENCODED_AND_MARK
-                + "revision%3D3";
-        String expected = base + ENCODED_QUESTION_MARK + "remote.timestamp%3D2" + ENCODED_AND_MARK + "revision%3D3";
-        assertEquals(expected, strip(rawProvider));
-    }
-
-    @Test
-    void shouldHandleDecodedParameters() throws Exception {
-        String base = "dubbo://127.0.0.1:20880/demo.Service";
-        String rawProvider = base + "?timestamp=1&remote.timestamp=2&revision=3";
-        String expected = base + "?remote.timestamp=2&revision=3";
-        assertEquals(expected, strip(rawProvider));
-    }
-
-    @Test
-    void shouldRemoveTimestampAndPidWithPrefixes() throws Exception {
-        // Test that both timestamp and pid can be removed even with prefixes like "remote.timestamp" and "dubbo.pid"
-        String base = "dubbo://127.0.0.1:20880/demo.Service";
-        String rawProvider = base + "?timestamp=100&remote.timestamp=200&pid=1234&dubbo.pid=5678&revision=abc";
-        String expected = base + "?remote.timestamp=200&revision=abc";
-        assertEquals(expected, strip(rawProvider));
-    }
-
-    @Test
-    void shouldRemoveAllTimestampsExactAndPrefixed() throws Exception {
-        // Test comprehensive scenario: multiple timestamps (exact and prefixed) should all be removed
-        String base = "dubbo://127.0.0.1:20880/demo.Service";
-        String rawProvider = base + "?timestamp=1&remote.timestamp=2&any.timestamp=3&revision=v1";
-        String expected = base + "?revision=v1";
-        assertEquals(expected, strip(rawProvider));
+                + "timestamp%3D123" + ENCODED_AND_MARK
+                + "pid%3D9999" + ENCODED_AND_MARK
+                + "revision%3Dv1";
+        String result = strip(rawProvider);
+        assertTrue(result.contains("revision%3Dv1"), "Result should contain revision");
+        assertFalse(result.contains("timestamp%3D"), "Result should not contain timestamp");
+        assertFalse(result.contains("pid%3D"), "Result should not contain pid");
     }
 
     @Test
@@ -96,15 +104,14 @@ class CacheableFailbackRegistryTest {
         String provider1 = "dubbo://provider1.example.com:20880/demo.Service?timestamp=100&revision=v1";
         String provider2 = "dubbo://provider1.example.com:20880/demo.Service?timestamp=200&revision=v1";
         // Both providers have same address and revision but different timestamp values.
-        // After normalization (removing timestamp), they should produce the same cache key
-        // and reuse the same cached URL.
+        // After normalization (removing timestamp), they should produce the same cache key.
 
         URL consumerURL = URL.valueOf(consumerUrl);
         Collection<String> providers = new ArrayList<>();
         providers.add(provider1);
         providers.add(provider2);
 
-        // First call: build cache with provider1
+        // First call: build cache with both providers
         List<URL> urls1 = registry.toUrlsWithoutEmpty(consumerURL, providers);
         assertNotNull(urls1);
         assertEquals(1, urls1.size());
@@ -120,28 +127,6 @@ class CacheableFailbackRegistryTest {
         assertNotNull(stringUrls);
         assertTrue(stringUrls.containsKey(normalizedKey1), "Cache should use normalized key");
         assertEquals(1, stringUrls.size(), "Should have exactly one cache entry for deduplicated provider");
-    }
-
-    @Test
-    void stripOffVariableKeysRemovesEncodedTimestampAndPid() throws Exception {
-        // Test with encoded format to ensure ENCODED_TIMESTAMP_KEY and ENCODED_PID_KEY are properly handled
-        String base = "dubbo%3A%2F%2Fprovider.example.com%3A20880%2Fdemo.Service";
-        String rawProvider = base + ENCODED_QUESTION_MARK
-                + "timestamp%3D123" + ENCODED_AND_MARK
-                + "pid%3D9999" + ENCODED_AND_MARK
-                + "revision%3Dv1";
-        String expected = base + ENCODED_QUESTION_MARK + "revision%3Dv1";
-        assertEquals(expected, strip(rawProvider));
-    }
-
-    @Test
-    void stripOffVariableKeysPreservesPrefixedTimestampInNormalization() throws Exception {
-        // Verify that parameters ending with ".timestamp" (but not the "timestamp" value itself) are treated as
-        // variable keys
-        String base = "dubbo://provider.example.com:20880/demo.Service";
-        String rawProvider = base + "?app.timestamp=111&custom.timestamp=222&timestamp=333&revision=abc";
-        String expected = base + "?revision=abc";
-        assertEquals(expected, strip(rawProvider));
     }
 
     private String strip(String rawProvider) throws Exception {

--- a/dubbo-registry/dubbo-registry-api/src/test/java/org/apache/dubbo/registry/support/CacheableFailbackRegistryTest.java
+++ b/dubbo-registry/dubbo-registry-api/src/test/java/org/apache/dubbo/registry/support/CacheableFailbackRegistryTest.java
@@ -1,0 +1,82 @@
+package org.apache.dubbo.registry.support;
+
+import org.apache.dubbo.common.URL;
+
+import java.lang.reflect.Method;
+
+import org.apache.dubbo.registry.NotifyListener;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.apache.dubbo.common.URLStrParser.ENCODED_AND_MARK;
+import static org.apache.dubbo.common.URLStrParser.ENCODED_QUESTION_MARK;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class CacheableFailbackRegistryTest {
+
+    private CacheableFailbackRegistry registry;
+
+    @BeforeEach
+    void setUp() {
+        registry = new StubCacheableFailbackRegistry(URL.valueOf("mock://127.0.0.1"));
+    }
+
+    @Test
+    void shouldKeepRemoteTimestampIntact() throws Exception {
+        String base = "dubbo%3A%2F%2F127.0.0.1%3A20880%2Fdemo.Service";
+        String rawProvider = base + ENCODED_QUESTION_MARK + "remote.timestamp%3D1" + ENCODED_AND_MARK + "revision%3Dabc";
+        assertEquals(rawProvider, strip(rawProvider));
+    }
+
+    @Test
+    void shouldRemoveOnlyTimestampWhenRemoteTimestampExists() throws Exception {
+        String base = "dubbo%3A%2F%2F127.0.0.1%3A20880%2Fdemo.Service";
+        String rawProvider = base + ENCODED_QUESTION_MARK
+                + "timestamp%3D1" + ENCODED_AND_MARK
+                + "remote.timestamp%3D2" + ENCODED_AND_MARK
+                + "revision%3D3";
+        String expected = base + ENCODED_QUESTION_MARK + "remote.timestamp%3D2" + ENCODED_AND_MARK + "revision%3D3";
+        assertEquals(expected, strip(rawProvider));
+    }
+
+    @Test
+    void shouldHandleDecodedParameters() throws Exception {
+        String base = "dubbo://127.0.0.1:20880/demo.Service";
+        String rawProvider = base + "?timestamp=1&remote.timestamp=2&revision=3";
+        String expected = base + "?remote.timestamp=2&revision=3";
+        assertEquals(expected, strip(rawProvider));
+    }
+
+    private String strip(String rawProvider) throws Exception {
+        Method method = CacheableFailbackRegistry.class.getDeclaredMethod("stripOffVariableKeys", String.class);
+        method.setAccessible(true);
+        return (String) method.invoke(registry, rawProvider);
+    }
+
+    private static final class StubCacheableFailbackRegistry extends CacheableFailbackRegistry {
+        StubCacheableFailbackRegistry(URL url) {
+            super(url);
+        }
+
+	    @Override public void doRegister(URL url) {
+
+	    }
+
+	    @Override public void doUnregister(URL url) {
+
+	    }
+
+	    @Override public void doSubscribe(URL url, NotifyListener listener) {
+
+	    }
+
+	    @Override
+        protected boolean isMatch(URL subscribeUrl, URL providerUrl) {
+            return true;
+        }
+
+	    @Override public boolean isAvailable() {
+		    return false;
+	    }
+    }
+}

--- a/dubbo-registry/dubbo-registry-api/src/test/java/org/apache/dubbo/registry/support/CacheableFailbackRegistryTest.java
+++ b/dubbo-registry/dubbo-registry-api/src/test/java/org/apache/dubbo/registry/support/CacheableFailbackRegistryTest.java
@@ -1,20 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.dubbo.registry.support;
 
 import org.apache.dubbo.common.URL;
+import org.apache.dubbo.common.url.component.ServiceAddressURL;
+import org.apache.dubbo.registry.NotifyListener;
 
 import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
 
-import org.apache.dubbo.registry.NotifyListener;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.apache.dubbo.common.URLStrParser.ENCODED_AND_MARK;
 import static org.apache.dubbo.common.URLStrParser.ENCODED_QUESTION_MARK;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class CacheableFailbackRegistryTest {
 
-    private CacheableFailbackRegistry registry;
+    private StubCacheableFailbackRegistry registry;
 
     @BeforeEach
     void setUp() {
@@ -24,7 +47,8 @@ class CacheableFailbackRegistryTest {
     @Test
     void shouldKeepRemoteTimestampIntact() throws Exception {
         String base = "dubbo%3A%2F%2F127.0.0.1%3A20880%2Fdemo.Service";
-        String rawProvider = base + ENCODED_QUESTION_MARK + "remote.timestamp%3D1" + ENCODED_AND_MARK + "revision%3Dabc";
+        String rawProvider =
+                base + ENCODED_QUESTION_MARK + "remote.timestamp%3D1" + ENCODED_AND_MARK + "revision%3Dabc";
         assertEquals(rawProvider, strip(rawProvider));
     }
 
@@ -47,6 +71,79 @@ class CacheableFailbackRegistryTest {
         assertEquals(expected, strip(rawProvider));
     }
 
+    @Test
+    void shouldRemoveTimestampAndPidWithPrefixes() throws Exception {
+        // Test that both timestamp and pid can be removed even with prefixes like "remote.timestamp" and "dubbo.pid"
+        String base = "dubbo://127.0.0.1:20880/demo.Service";
+        String rawProvider = base + "?timestamp=100&remote.timestamp=200&pid=1234&dubbo.pid=5678&revision=abc";
+        String expected = base + "?remote.timestamp=200&revision=abc";
+        assertEquals(expected, strip(rawProvider));
+    }
+
+    @Test
+    void shouldRemoveAllTimestampsExactAndPrefixed() throws Exception {
+        // Test comprehensive scenario: multiple timestamps (exact and prefixed) should all be removed
+        String base = "dubbo://127.0.0.1:20880/demo.Service";
+        String rawProvider = base + "?timestamp=1&remote.timestamp=2&any.timestamp=3&revision=v1";
+        String expected = base + "?revision=v1";
+        assertEquals(expected, strip(rawProvider));
+    }
+
+    @Test
+    void toUrlsWithoutEmptyPreservesTimestampInCachedURL() throws Exception {
+        // This test verifies the fix: normalized key for cache, but original rawProvider for URL building.
+        String consumerUrl = "mock://127.0.0.1/demo.Service";
+        String provider1 = "dubbo://provider1.example.com:20880/demo.Service?timestamp=100&revision=v1";
+        String provider2 = "dubbo://provider1.example.com:20880/demo.Service?timestamp=200&revision=v1";
+        // Both providers have same address and revision but different timestamp values.
+        // After normalization (removing timestamp), they should produce the same cache key
+        // and reuse the same cached URL.
+
+        URL consumerURL = URL.valueOf(consumerUrl);
+        Collection<String> providers = new ArrayList<>();
+        providers.add(provider1);
+        providers.add(provider2);
+
+        // First call: build cache with provider1
+        List<URL> urls1 = registry.toUrlsWithoutEmpty(consumerURL, providers);
+        assertNotNull(urls1);
+        assertEquals(1, urls1.size());
+
+        // Get the normalized key that should be used
+        String normalizedKey1 = strip(provider1); // Should have timestamp removed
+        String normalizedKey2 = strip(provider2); // Should be same as normalizedKey1
+
+        assertEquals(normalizedKey1, normalizedKey2, "Normalized keys should be identical after removing timestamp");
+
+        // Verify the cached URL map uses normalized key
+        Map<String, ServiceAddressURL> stringUrls = registry.stringUrls.get(consumerURL);
+        assertNotNull(stringUrls);
+        assertTrue(stringUrls.containsKey(normalizedKey1), "Cache should use normalized key");
+        assertEquals(1, stringUrls.size(), "Should have exactly one cache entry for deduplicated provider");
+    }
+
+    @Test
+    void stripOffVariableKeysRemovesEncodedTimestampAndPid() throws Exception {
+        // Test with encoded format to ensure ENCODED_TIMESTAMP_KEY and ENCODED_PID_KEY are properly handled
+        String base = "dubbo%3A%2F%2Fprovider.example.com%3A20880%2Fdemo.Service";
+        String rawProvider = base + ENCODED_QUESTION_MARK
+                + "timestamp%3D123" + ENCODED_AND_MARK
+                + "pid%3D9999" + ENCODED_AND_MARK
+                + "revision%3Dv1";
+        String expected = base + ENCODED_QUESTION_MARK + "revision%3Dv1";
+        assertEquals(expected, strip(rawProvider));
+    }
+
+    @Test
+    void stripOffVariableKeysPreservesPrefixedTimestampInNormalization() throws Exception {
+        // Verify that parameters ending with ".timestamp" (but not the "timestamp" value itself) are treated as
+        // variable keys
+        String base = "dubbo://provider.example.com:20880/demo.Service";
+        String rawProvider = base + "?app.timestamp=111&custom.timestamp=222&timestamp=333&revision=abc";
+        String expected = base + "?revision=abc";
+        assertEquals(expected, strip(rawProvider));
+    }
+
     private String strip(String rawProvider) throws Exception {
         Method method = CacheableFailbackRegistry.class.getDeclaredMethod("stripOffVariableKeys", String.class);
         method.setAccessible(true);
@@ -58,25 +155,23 @@ class CacheableFailbackRegistryTest {
             super(url);
         }
 
-	    @Override public void doRegister(URL url) {
+        @Override
+        public void doRegister(URL url) {}
 
-	    }
+        @Override
+        public void doUnregister(URL url) {}
 
-	    @Override public void doUnregister(URL url) {
+        @Override
+        public void doSubscribe(URL url, NotifyListener listener) {}
 
-	    }
-
-	    @Override public void doSubscribe(URL url, NotifyListener listener) {
-
-	    }
-
-	    @Override
+        @Override
         protected boolean isMatch(URL subscribeUrl, URL providerUrl) {
             return true;
         }
 
-	    @Override public boolean isAvailable() {
-		    return false;
-	    }
+        @Override
+        public boolean isAvailable() {
+            return false;
+        }
     }
 }


### PR DESCRIPTION
## What is the purpose of the change?

原代码逻辑是想去除timestamp，pid这种可变的值，剥离后生成出一串不可变的url作为key，进行缓存，避免该实例重启或重新注册到zk，可变值产生变化导致缓存失效，stringUrls中的缓存膨胀的问题，但是这样去除后，在loadbalance进行预热时，由于timestamp被过滤从而无法获取timestamp，导致预热功能失效。
以及修复源代码逻辑存在缺点，比如老的dubbox，dubbo2.6左右的版本存在remote.timestamp，default.remote.timestamp,该逻辑会导致假设url为remote.timestamp=xxxx&revision=xxxx
被过滤后就变成了remote.revision=xxxx，导致revision这个参数直接消失了。

The original logic intended to strip out variable fields like timestamp and pid from the URL, generating a stable, immutable string as the cache key. This prevents cache invalidation when an instance restarts or re-registers to ZooKeeper (due to changing values), and avoids cache bloat in stringUrls.
However, after removing these fields, during load balancing pre-warming, the absence of timestamp means it can no longer be retrieved, causing the pre-warming functionality to fail completely.
Additionally, the original logic has a flaw: in older Dubbo versions (e.g., DubboX or Dubbo 2.6), parameters such as remote.timestamp and default.remote.timestamp exist. When filtering removes timestamp, a URL like remote.timestamp=xxxx&revision=xxxx becomes remote.revision=xxxx, causing the revision parameter to disappear entirely.

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Make sure gitHub actions can pass. [Why the workflow is failing and how to fix it?](../CONTRIBUTING.md)
