### PR TITLE
Bump protobuf-java,grpc of dubbo-security to latest version

### DIFF
--- a/dubbo-plugin/dubbo-security/pom.xml
+++ b/dubbo-plugin/dubbo-security/pom.xml
@@ -103,7 +103,7 @@
         <artifactId>protobuf-maven-plugin</artifactId>
         <version>${maven_protobuf_plugin_version}</version>
         <configuration>
-          <protocArtifact>com.google.protobuf:protoc:${protobuf-protoc_version}:exe:${os.detected.classifier}</protocArtifact>
+          <protocArtifact>com.google.protobuf:protoc:${protobuf-java_version}:exe:${os.detected.classifier}</protocArtifact>
           <pluginId>grpc-java</pluginId>
           <pluginArtifact>io.grpc:protoc-gen-grpc-java:${grpc_version}:exe:${os.detected.classifier}</pluginArtifact>
         </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -168,9 +168,10 @@
     <spring-security-6.version>6.5.7</spring-security-6.version>
     <spring-boot-3.version>3.5.9</spring-boot-3.version>
 
-    <protobuf-protoc_version>3.22.3</protobuf-protoc_version>
+    <!-- protobuf-java_version should be same as protobuf-java_version at dubbo-dependencies-bom -->
+    <protobuf-java_version>4.33.4</protobuf-java_version>
     <!-- grpc_version should be same as grpc.version at dubbo-dependencies-bom -->
-    <grpc_version>1.73.0</grpc_version>
+    <grpc_version>1.78.0</grpc_version>
     <spotless-maven-plugin.version>2.46.1</spotless-maven-plugin.version>
     <dubbo-shared-resources.version>1.0.0</dubbo-shared-resources.version>
     <palantirJavaFormat.version>2.38.0</palantirJavaFormat.version>


### PR DESCRIPTION
## What is the purpose of the change?
1. Bump protobuf-java of dubbo-security to 4.33.4
2. Bump grpc of dubbo-security to 1.78.0

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Make sure gitHub actions can pass. [Why the workflow is failing and how to fix it?](../CONTRIBUTING.md)
