### PR TITLE
Fix adaptive metrics decay when provider metrics are not updated

### DIFF
--- a/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/loadbalance/AdaptiveLoadBalanceTest.java
+++ b/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/loadbalance/AdaptiveLoadBalanceTest.java
@@ -214,4 +214,45 @@ class AdaptiveLoadBalanceTest extends LoadBalanceBaseTest {
         field.setAccessible(true);
         field.set(obj, value);
     }
+
+    @Test
+    @Order(3)
+    void testAdaptiveMetricsDecayHighQps() throws Exception {
+        AdaptiveMetrics metrics = new AdaptiveMetrics();
+
+        String id = "highQpsTest";
+        int timeout = 100;
+
+        Map<String, String> map = new HashMap<>();
+        map.put("curTime", String.valueOf(System.currentTimeMillis()));
+        map.put("rt", "300");
+        map.put("load", "1");
+
+        metrics.setProviderMetrics(id, map);
+
+        AdaptiveMetrics status = metrics.getStatus(id);
+
+        long past = System.currentTimeMillis() - 1000;
+        setLongField(status, "currentTime", past);
+        setLongField(status, "currentProviderTime", past);
+
+        long before = getLongField(status, "lastLatency");
+
+        // simulate high QPS: many rapid getLoad calls without provider updates
+        for (int i = 0; i < 1000; i++) {
+            metrics.getLoad(id, 100, timeout);
+        }
+
+        Thread.sleep(120);
+
+        for (int i = 0; i < 1000; i++) {
+            metrics.getLoad(id, 100, timeout);
+        }
+
+        long after = getLongField(status, "lastLatency");
+
+        Assertions.assertTrue(after > 0);
+        Assertions.assertNotEquals(before, after);
+        Assertions.assertNotEquals(timeout * 2L, after);
+    }
 }

--- a/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/loadbalance/AdaptiveLoadBalanceTest.java
+++ b/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/loadbalance/AdaptiveLoadBalanceTest.java
@@ -21,6 +21,7 @@ import org.apache.dubbo.rpc.AdaptiveMetrics;
 import org.apache.dubbo.rpc.Invoker;
 import org.apache.dubbo.rpc.model.ApplicationModel;
 
+import java.lang.reflect.Field;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -164,5 +165,53 @@ class AdaptiveLoadBalanceTest extends LoadBalanceBaseTest {
         Assertions.assertTrue(
                 Math.abs(sumInvoker5 / (weightMap.get(weightInvoker5) * ewma5) - expectWeightValue) < maxDeviation,
                 "select failed!");
+    }
+
+    @Test
+    @Order(2)
+    void testAdaptiveMetricsDecayWithoutProviderUpdate() throws Exception {
+        AdaptiveMetrics metrics = new AdaptiveMetrics();
+
+        String id = "test";
+        int timeout = 100;
+
+        Map<String, String> map = new HashMap<>();
+        map.put("curTime", String.valueOf(System.currentTimeMillis()));
+        map.put("rt", "200");
+        map.put("load", "0.5");
+
+        metrics.setProviderMetrics(id, map);
+
+        AdaptiveMetrics status = metrics.getStatus(id);
+
+        long past = System.currentTimeMillis() - 500;
+        setLongField(status, "currentTime", past);
+        setLongField(status, "currentProviderTime", past);
+
+        long before = getLongField(status, "lastLatency");
+
+        metrics.getLoad(id, 100, timeout);
+
+        Thread.sleep(150);
+
+        metrics.getLoad(id, 100, timeout);
+
+        long after = getLongField(status, "lastLatency");
+
+        Assertions.assertTrue(after > 0);
+        Assertions.assertNotEquals(timeout * 2L, after);
+        Assertions.assertNotEquals(before, after);
+    }
+
+    private long getLongField(Object obj, String name) throws Exception {
+        Field field = obj.getClass().getDeclaredField(name);
+        field.setAccessible(true);
+        return (long) field.get(obj);
+    }
+
+    private void setLongField(Object obj, String name, long value) throws Exception {
+        Field field = obj.getClass().getDeclaredField(name);
+        field.setAccessible(true);
+        field.set(obj, value);
     }
 }

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/AdaptiveMetrics.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/AdaptiveMetrics.java
@@ -57,11 +57,11 @@ public class AdaptiveMetrics {
         if (metrics.currentTime > 0) {
             long multiple = (System.currentTimeMillis() - metrics.currentTime) / timeout + 1;
             if (multiple > 0) {
-                if (metrics.currentProviderTime == metrics.currentTime) {
+                if (metrics.currentProviderTime > metrics.currentTime) {
                     // penalty value
                     metrics.lastLatency = timeout * 2L;
                 } else {
-                    metrics.lastLatency = metrics.lastLatency >> multiple;
+                    metrics.lastLatency = Math.max(1L, metrics.lastLatency >> multiple);
                 }
                 metrics.ewma = metrics.beta * metrics.ewma + (1 - metrics.beta) * metrics.lastLatency;
                 metrics.currentTime = System.currentTimeMillis();


### PR DESCRIPTION
## What is the purpose of the change?

This PR fixes an issue in AdaptiveLoadBalance / AdaptiveMetrics where latency decay behaves incorrectly when provider metrics are not updated for a period of time.

Currently, when no new provider metrics arrive, getLoad() may repeatedly apply the penalty branch or aggressively right-shift lastLatency, which can result in stale or extreme values dominating EWMA. This makes adaptive load balancing unstable, especially in low-QPS or intermittent-update scenarios.

This PR ensures that latency decays safely and progressively instead of collapsing or being stuck at penalty values.

Fixes #15810


## What is changed?

### 1. Improved decay logic in AdaptiveMetrics#getLoad()

- Prevents lastLatency from collapsing to zero.  
- Ensures decay happens smoothly when provider metrics are not refreshed.  
- Avoids repeatedly applying the penalty path when timestamps are equal.

### 2. Added unit test

Added `testAdaptiveMetricsDecayWithoutProviderUpdate`

Verifies that when provider metrics are not updated:

- latency decays over time  
- penalty value is not stuck  
- EWMA continues to evolve  


## Why is this needed?

Adaptive load balancing relies on EWMA latency to reflect recent performance trends.

Without this fix:

- old latency values can dominate indefinitely  
- penalty values may be repeatedly re-applied  
- low-traffic services become unfairly weighted  

This change makes adaptive load balancing more stable, realistic, and robust under real-world traffic patterns.


## Verifying this change

- Added new unit test covering the decay scenario  
- All tests pass locally:
      
```bash
mvn -pl dubbo-cluster -am test
```

## Checklist

- [x] Related GitHub issue referenced (Fixes #15810)  
- [x] Logic change explained clearly  
- [x] Unit test added  
- [x] All tests passing locally  
