### PR TITLE
Fix Triple client to stop deframing when response headers are invalid

### DIFF
--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/stream/AbstractTripleClientStream.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/stream/AbstractTripleClientStream.java
@@ -369,6 +369,7 @@ public abstract class AbstractTripleClientStream extends AbstractStream implemen
         }
 
         void onHeaderReceived(Http2Headers headers) {
+
             if (transportError != null) {
                 transportError.appendDescription("headers:" + headers);
                 return;
@@ -387,6 +388,13 @@ public abstract class AbstractTripleClientStream extends AbstractStream implemen
             }
             headerReceived = true;
             transportError = validateHeaderStatus(headers);
+
+            if (transportError != null) {
+                // stop stream immediately if response is not valid gRPC
+                writeQueue.enqueue(CancelQueueCommand.createCommand(streamChannelFuture, Http2Error.NO_ERROR));
+                rst = true;
+                return;
+            }
 
             // todo support full payload compressor
             CharSequence messageEncoding = headers.get(TripleHeaderEnum.GRPC_ENCODING.getKey());
@@ -571,6 +579,7 @@ public abstract class AbstractTripleClientStream extends AbstractStream implemen
         }
 
         private void doOnData(ByteBuf data, boolean endStream) {
+
             if (transportError != null) {
                 transportError.appendDescription("Data:" + data.toString(StandardCharsets.UTF_8));
                 ReferenceCountUtil.release(data);


### PR DESCRIPTION
## What is the purpose of the change?

When using Triple through gateways like APISIX, the client may receive a non-gRPC HTTP response (for example `text/plain` like `"Hello"`).  
Previously, the Triple client still initialized the deframer and attempted to decode the payload, which led to parsing errors and `CANCELLED` exceptions.

This change makes the Triple client **fail fast** when response headers are invalid:
- immediately cancels the stream
- prevents deframer creation
- ensures non-gRPC HTTP bodies never enter the gRPC decoder

This avoids incorrect decoding and provides a clearer failure path.

Related issue: #15968

---

## What was changed?

- Added early cancellation when header validation fails in `onHeaderReceived`
- Ensured invalid responses never reach the deframer
- Kept existing DATA-frame guard as a second safety layer

---

## How was this tested?

- `mvn -pl dubbo-rpc/dubbo-rpc-triple -am test`
- Full build on branch `3.3`

---

## Checklist

- [x] Make sure there is a GitHub issue for the change  
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why  
- [ ] Write necessary unit-test to verify your logic correction (not added; transport layer behavior validated by build and manual verification)  
- [x] Make sure GitHub actions can pass  
