### PR TITLE
Feature 2.5.x compatible fix

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/config/AbstractConfig.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/config/AbstractConfig.java
@@ -1096,6 +1096,10 @@ public abstract class AbstractConfig implements Serializable {
 
     @Override
     public boolean equals(Object obj) {
+        return equalsWithId(obj, false);
+    }
+
+    public boolean equalsWithId(Object obj, boolean ignoreId) {
         if (obj == null || obj.getClass() != this.getClass()) {
             return false;
         }
@@ -1104,11 +1108,10 @@ public abstract class AbstractConfig implements Serializable {
         }
 
         for (Method method : getAttributedMethods()) {
-            // ignore compare 'id' value
-            if ("getId".equals(method.getName())) {
-                continue;
-            }
             try {
+                if (ignoreId && "getId".equals(method.getName())) {
+                    continue;
+                }
                 Object value1 = method.invoke(this);
                 Object value2 = method.invoke(obj);
                 if (!Objects.equals(value1, value2)) {

--- a/dubbo-common/src/main/java/org/apache/dubbo/config/context/AbstractConfigManager.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/config/context/AbstractConfigManager.java
@@ -170,7 +170,7 @@ public abstract class AbstractConfigManager extends LifecycleAdapter {
         // fast check duplicated equivalent config before write lock
         if (!(config instanceof ReferenceConfigBase || config instanceof ServiceConfigBase)) {
             for (AbstractConfig value : configsMap.values()) {
-                if (value.equals(config)) {
+                if (value.equalsWithId(config, true)) {
                     return (T) value;
                 }
             }
@@ -404,7 +404,7 @@ public abstract class AbstractConfigManager extends LifecycleAdapter {
                 newOne.refresh();
             }
         }
-        return oldOne.equals(newOne);
+        return oldOne.equalsWithId(newOne, true);
     }
 
     protected <C extends AbstractConfig> String generateConfigId(C config) {

--- a/dubbo-config/dubbo-config-spring/src/main/resources/META-INF/compat/dubbo.xsd
+++ b/dubbo-config/dubbo-config-spring/src/main/resources/META-INF/compat/dubbo.xsd
@@ -1570,6 +1570,25 @@
         </xsd:annotation>
     </xsd:element>
 
+    <xsd:complexType name="annotationType">
+        <xsd:attribute name="id" type="xsd:ID">
+            <xsd:annotation>
+                <xsd:documentation><![CDATA[ The unique identifier for a bean. ]]></xsd:documentation>
+            </xsd:annotation>
+        </xsd:attribute>
+        <xsd:attribute name="package" type="xsd:string" use="optional">
+            <xsd:annotation>
+                <xsd:documentation><![CDATA[ The scan package. ]]></xsd:documentation>
+            </xsd:annotation>
+        </xsd:attribute>
+    </xsd:complexType>
+
+    <xsd:element name="annotation" type="annotationType">
+        <xsd:annotation>
+            <xsd:documentation><![CDATA[ The annotation config ]]></xsd:documentation>
+        </xsd:annotation>
+    </xsd:element>
+
     <xsd:element name="application" type="applicationType">
         <xsd:annotation>
             <xsd:documentation><![CDATA[ The application config ]]></xsd:documentation>


### PR DESCRIPTION
## What is the purpose of the change?
fix two compatible issues when migration from dubbo 2.5.x up to 3.3.x.
1. If there are two registry defined, but their properties are all same except the Id of registry. This is ok with Dubbo 2.5.x, but the project cannot start with Dubbo 3.3.x.
2. If there is dubbo:annoation in the xml config, the project cannot start with Dubbo 3.3.x

related issue #16046


## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Make sure gitHub actions can pass. [Why the workflow is failing and how to fix it?](../CONTRIBUTING.md)
