### PR TITLE
Fix HTTP/3 server startup when REST runs in servlet mode

### DIFF
--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/Http3Exchanger.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/Http3Exchanger.java
@@ -80,6 +80,11 @@ public final class Http3Exchanger {
     }
 
     public static RemotingServer bind(URL url) {
+
+        if (isRestServletMode(url)) {
+            return null;
+        }
+
         if (isEnabled(url)) {
             return ConcurrentHashMapUtils.computeIfAbsent(SERVERS, url.getAddress(), addr -> {
                 try {
@@ -135,6 +140,10 @@ public final class Http3Exchanger {
             pipeline.addLast(new IdleStateHandler(heartbeat, 0, 0, TimeUnit.MILLISECONDS));
             pipeline.addLast(new TriplePingPongHandler(closeTimeout));
         };
+    }
+
+    private static boolean isRestServletMode(URL url) {
+        return "rest".equalsIgnoreCase(url.getProtocol()) && "servlet".equalsIgnoreCase(url.getParameter("server"));
     }
 
     public static void close() {

--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/stream/AbstractTripleClientStream.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/stream/AbstractTripleClientStream.java
@@ -369,6 +369,7 @@ public abstract class AbstractTripleClientStream extends AbstractStream implemen
         }
 
         void onHeaderReceived(Http2Headers headers) {
+
             if (transportError != null) {
                 transportError.appendDescription("headers:" + headers);
                 return;
@@ -387,6 +388,13 @@ public abstract class AbstractTripleClientStream extends AbstractStream implemen
             }
             headerReceived = true;
             transportError = validateHeaderStatus(headers);
+
+            if (transportError != null) {
+                // stop stream immediately if response is not valid gRPC
+                writeQueue.enqueue(CancelQueueCommand.createCommand(streamChannelFuture, Http2Error.NO_ERROR));
+                rst = true;
+                return;
+            }
 
             // todo support full payload compressor
             CharSequence messageEncoding = headers.get(TripleHeaderEnum.GRPC_ENCODING.getKey());
@@ -571,6 +579,7 @@ public abstract class AbstractTripleClientStream extends AbstractStream implemen
         }
 
         private void doOnData(ByteBuf data, boolean endStream) {
+
             if (transportError != null) {
                 transportError.appendDescription("Data:" + data.toString(StandardCharsets.UTF_8));
                 ReferenceCountUtil.release(data);


### PR DESCRIPTION
## What is the purpose of the change?

When Dubbo REST is configured to run in `server=servlet` mode, the servlet
container (such as Tomcat or Jetty) is responsible for managing the server
lifecycle and port binding.

However, `Http3Exchanger.bind(URL)` still attempted to start an internal
Netty HTTP/3 server in this mode. This can lead to port conflicts and
unexpected behavior because two servers attempt to bind to the same port.

This PR fixes the incorrect server startup behavior in REST servlet mode.

Fixes #15273

---

## What is changed?

### 1. Prevent HTTP/3 server startup in REST servlet mode

A small guard is added in `Http3Exchanger.bind(URL)` to detect REST servlet
deployments:

- If the protocol is `rest`
- And the URL parameter `server=servlet` is present
- Skip HTTP/3 server initialization

This ensures that the servlet container remains the sole owner of the
server lifecycle and port binding.

### 2. Introduce a helper method for clarity

A dedicated helper method is added to encapsulate the REST servlet mode
check, improving readability and future maintainability.

---

## Why is this needed?

Dubbo REST deployments running in servlet mode rely on the container to
manage networking resources. Starting an additional Netty HTTP/3 server
in this scenario can cause:

- Port binding conflicts
- Unclear server ownership
- Unexpected startup failures

Without this fix, REST servlet users enabling HTTP/3 may encounter runtime
errors that are difficult to diagnose.

This change aligns HTTP/3 behavior with Dubbo’s existing REST servlet
architecture.

---

## Verifying this change

- Code formatting verified with `mvn spotless:apply`
- Module build passed locally:

```bash
mvn -pl dubbo-rpc/dubbo-rpc-triple -am -DskipTests clean install
```
---

## Checklist
- [x] Make sure there is a GitHub issue field for the change.
- [x] Write a pull request description that is detailed enough.
- [ ] Write necessary unit-test.
- [x] Make sure github actions can pass.
