### PR TITLE
Add regression test for NettyChannel cleanup on repeated disconnects

### DIFF
--- a/dubbo-remoting/dubbo-remoting-netty4/src/test/java/org/apache/dubbo/remoting/transport/netty4/NettyChannelTest.java
+++ b/dubbo-remoting/dubbo-remoting-netty4/src/test/java/org/apache/dubbo/remoting/transport/netty4/NettyChannelTest.java
@@ -138,4 +138,24 @@ class NettyChannelTest {
         Assertions.assertEquals(nettyChannel, nettyChannel);
         Assertions.assertNotEquals(nettyChannel, nettyChannel2);
     }
+
+    @Test
+    void testChannelMapCleanupOnRepeatedAddRemove() {
+        Channel channel = Mockito.mock(Channel.class);
+        Mockito.when(channel.isActive()).thenReturn(true);
+
+        URL url = URL.valueOf("test://127.0.0.1/test");
+        ChannelHandler handler = Mockito.mock(ChannelHandler.class);
+
+        for (int i = 0; i < 100; i++) {
+            NettyChannel nettyChannel = NettyChannel.getOrAddChannel(channel, url, handler);
+            Assertions.assertNotNull(nettyChannel);
+            NettyChannel.removeChannel(channel);
+        }
+
+        NettyChannel nettyChannel = NettyChannel.getOrAddChannel(channel, url, handler);
+        Assertions.assertTrue(nettyChannel.isActive());
+
+        NettyChannel.removeChannel(channel);
+    }
 }


### PR DESCRIPTION
## What is the purpose of the change?

This PR adds a regression test to validate the NettyChannel lifecycle cleanup behavior.
The test ensures that channels can be safely removed and re-created across repeated
add/remove cycles, preventing channel map leaks observed in issue #16054.

## What is changed?

- Added a unit test in `NettyChannelTest` to cover repeated channel add/remove scenarios.

## Checklist

- [x] The issue has been investigated and is already fixed in the codebase
- [x] Added a regression test to prevent future regressions
- [x] All tests pass locally
