### PR TITLE
Fix RpcInvocation attribute cloning

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/utils/LRU2Cache.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/utils/LRU2Cache.java
@@ -42,7 +42,7 @@ public class LRU2Cache<K, V> extends LinkedHashMap<K, V> {
     private volatile int maxCapacity;
 
     // as history list
-    private final PreCache<K, Boolean> preCache;
+    private final PreCache<K, V> preCache;
 
     public LRU2Cache() {
         this(DEFAULT_MAX_CAPACITY);
@@ -89,7 +89,7 @@ public class LRU2Cache<K, V> extends LinkedHashMap<K, V> {
                 return super.put(key, value);
             } else {
                 // add it to history list
-                preCache.put(key, true);
+                preCache.put(key, value);
                 return value;
             }
         } finally {
@@ -99,12 +99,41 @@ public class LRU2Cache<K, V> extends LinkedHashMap<K, V> {
 
     @Override
     public V computeIfAbsent(K key, Function<? super K, ? extends V> fn) {
-        V value = get(key);
-        if (value == null) {
-            value = fn.apply(key);
-            put(key, value);
+        V cachedValue;
+        lock.lock();
+        try {
+            if (super.containsKey(key)) {
+                return super.get(key);
+            }
+            if (preCache.containsKey(key)) {
+                cachedValue = preCache.remove(key);
+                super.put(key, cachedValue);
+                return cachedValue;
+            }
+        } finally {
+            lock.unlock();
         }
-        return value;
+
+        V computedValue = fn.apply(key);
+        if (computedValue == null) {
+            return null;
+        }
+
+        lock.lock();
+        try {
+            if (super.containsKey(key)) {
+                return super.get(key);
+            }
+            if (preCache.containsKey(key)) {
+                cachedValue = preCache.remove(key);
+                super.put(key, cachedValue);
+                return cachedValue;
+            }
+            preCache.put(key, computedValue);
+            return computedValue;
+        } finally {
+            lock.unlock();
+        }
     }
 
     @Override

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/utils/LRU2CacheTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/utils/LRU2CacheTest.java
@@ -18,6 +18,8 @@ package org.apache.dubbo.common.utils;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.concurrent.atomic.AtomicInteger;
+
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -121,5 +123,20 @@ class LRU2CacheTest {
         cache.get("5");
 
         assertTrue(cache.size() <= 2);
+    }
+
+    @Test
+    void testComputeIfAbsentPromotesFromPreCache() {
+        LRU2Cache<String, Integer> cache = new LRU2Cache<>(3);
+        AtomicInteger counter = new AtomicInteger();
+
+        Integer first = cache.computeIfAbsent("one", key -> counter.incrementAndGet());
+        assertThat(first, equalTo(1));
+        assertFalse(cache.containsKey("one"));
+
+        Integer second = cache.computeIfAbsent("one", key -> counter.incrementAndGet());
+        assertThat(second, equalTo(1));
+        assertTrue(cache.containsKey("one"));
+        assertThat(counter.get(), equalTo(1));
     }
 }

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/utils/LRU2CacheTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/utils/LRU2CacheTest.java
@@ -16,9 +16,9 @@
  */
 package org.apache.dubbo.common.utils;
 
-import org.junit.jupiter.api.Test;
-
 import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;

--- a/dubbo-metrics/dubbo-metrics-otlp/pom.xml
+++ b/dubbo-metrics/dubbo-metrics-otlp/pom.xml
@@ -60,11 +60,6 @@
       <artifactId>micrometer-registry-otlp</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.dubbo</groupId>
-      <artifactId>dubbo-metrics-default</artifactId>
-      <version>${project.parent.version}</version>
-    </dependency>
-    <dependency>
       <groupId>com.squareup.okhttp3</groupId>
       <artifactId>mockwebserver</artifactId>
       <scope>test</scope>


### PR DESCRIPTION
## What is the purpose of the change?

Fix the issue where RpcInvocation's copy constructor shares the same attributes map with the source invocation.  
This causes cloned invocations to be affected by later mutations to the original attributes, which is unexpected for a deep clone.  
The change clones the attributes map and adds a unit test to verify the behavior.

Fixes #16069

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues/16069) field for the change.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Make sure gitHub actions can pass. [Why the workflow is failing and how to fix it?](../CONTRIBUTING.md)
