### PR TITLE
[Feature] Implement Zero-Copy infrastructure in DataQueueCommand #15597

### DIFF
--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/command/DataQueueCommand.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/command/DataQueueCommand.java
@@ -19,20 +19,21 @@ package org.apache.dubbo.rpc.protocol.tri.command;
 import org.apache.dubbo.rpc.protocol.tri.stream.TripleStreamChannelFuture;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.CompositeByteBuf;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
 import io.netty.handler.codec.http2.DefaultHttp2DataFrame;
 
 public class DataQueueCommand extends StreamQueueCommand {
 
-    private final byte[] data;
+    private final ByteBuf data;
 
     private final int compressFlag;
 
     private final boolean endStream;
 
     private DataQueueCommand(
-            TripleStreamChannelFuture streamChannelFuture, byte[] data, int compressFlag, boolean endStream) {
+            TripleStreamChannelFuture streamChannelFuture, ByteBuf data, int compressFlag, boolean endStream) {
         super(streamChannelFuture);
         this.data = data;
         this.compressFlag = compressFlag;
@@ -40,7 +41,7 @@ public class DataQueueCommand extends StreamQueueCommand {
     }
 
     public static DataQueueCommand create(
-            TripleStreamChannelFuture streamChannelFuture, byte[] data, boolean endStream, int compressFlag) {
+            TripleStreamChannelFuture streamChannelFuture, ByteBuf data, boolean endStream, int compressFlag) {
         return new DataQueueCommand(streamChannelFuture, data, compressFlag, endStream);
     }
 
@@ -49,16 +50,19 @@ public class DataQueueCommand extends StreamQueueCommand {
         if (data == null) {
             ctx.write(new DefaultHttp2DataFrame(endStream), promise);
         } else {
-            ByteBuf buf = ctx.alloc().buffer();
-            buf.writeByte(compressFlag);
-            buf.writeInt(data.length);
-            buf.writeBytes(data);
-            ctx.write(new DefaultHttp2DataFrame(buf, endStream), promise);
+            ByteBuf header = ctx.alloc().buffer(5);
+            header.writeByte(compressFlag);
+            header.writeByte(data.readableBytes());
+
+            CompositeByteBuf composite = ctx.alloc().compositeBuffer();
+            composite.addComponents(true, header, this.data);
+
+            ctx.write(new DefaultHttp2DataFrame(composite, endStream), promise);
         }
     }
 
     // for test
-    public byte[] getData() {
+    public ByteBuf getData() {
         return data;
     }
 

--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/stream/AbstractTripleClientStream.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/stream/AbstractTripleClientStream.java
@@ -205,7 +205,8 @@ public abstract class AbstractTripleClientStream extends AbstractStream implemen
         final int messageSize = message.length;
         onSendingBytes(messageSize);
 
-        final DataQueueCommand cmd = DataQueueCommand.create(streamChannelFuture, message, false, compressFlag);
+        final DataQueueCommand cmd = DataQueueCommand.create(
+                streamChannelFuture, io.netty.buffer.Unpooled.wrappedBuffer(message), false, compressFlag);
         return this.writeQueue.enqueueFuture(cmd, parent.eventLoop()).addListener(future -> {
             if (!future.isSuccess()) {
                 rollbackSendingBytes(messageSize);


### PR DESCRIPTION
**Problem:** Currently, the DataQueueCommand in the Triple protocol uses byte[] for data transfer. This triggers a System.arraycopy inside the writeBytes() call when stitching the frame header with the payload. For large messages or high-throughput scenarios, this constant memory copying creates significant CPU overhead.

Solution: This PR refactors the outbound data path to support Zero-Copy transport:

DataQueueCommand: Updated to use Netty ByteBuf. It now uses CompositeByteBuf to stitch the 5-byte Triple header and the message payload without performing a memory copy.

Transport Bridge: Updated AbstractTripleClientStream to wrap outgoing payloads in Unpooled.wrappedBuffer. This ensures that even though the upper layers still use byte[], the transport layer handles them as buffers, enabling "gathering writes."

Why I limited the scope: I have intentionally avoided modifying the PackableMethod and Compressor interfaces in this PR. Updating them to ByteBuf or ByteBuffer would require breaking public APIs and introducing Netty dependencies into core modules. I believe this PR provides the necessary infrastructure for Zero-Copy first; we can discuss evolving the Serialization/Compression layers in a separate follow-up to keep this change safe and backward-compatible.

Tests: Verified that dubbo-rpc-triple compiles and core transport logic remains intact.