### PR TITLE
Fix: Remove unnecessary pattern check for password in ConfigValidationUtils

### DIFF
--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/utils/ConfigValidationUtils.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/utils/ConfigValidationUtils.java
@@ -747,6 +747,7 @@ public class ConfigValidationUtils {
         }
         List<String> ignoreCheckKeys = new ArrayList<>();
         ignoreCheckKeys.add(BACKUP_KEY);
+        ignoreCheckKeys.add(PASSWORD_KEY);
         String ignoreCheckKeysStr = parameters.get(IGNORE_CHECK_KEYS);
         if (!StringUtils.isBlank(ignoreCheckKeysStr)) {
             ignoreCheckKeys.addAll(Arrays.asList(ignoreCheckKeysStr.split(",")));


### PR DESCRIPTION
## Description
This PR removes the unnecessary pattern check for `password` in `ConfigValidationUtils.checkParameterName`.

**Problem:**
Previously, `checkParameterName` validated all parameters (except `backup`) using `PATTERN_NAME_HAS_SYMBOL`, which disallowed many special characters commonly used in passwords (e.g., `@`, `!`, `#`). This caused issues when using Nacos with complex passwords configured via parameters.

**Fix:**
Added `PASSWORD_KEY` to the `ignoreCheckKeys` list in `checkParameterName`, ensuring passwords are exempted from pattern validation (length check in `validateRegistryConfig` remains).

**Fixes:** #16073

## 描述 (Chinese)
修复 `ConfigValidationUtils` 中对 `password` 参数进行不必要的正则校验问题。

**问题：**
此前 `checkParameterName` 会对所有参数（除 `backup` 外）使用 `PATTERN_NAME_HAS_SYMBOL` 进行校验，该正则不支持密码中常见的特殊字符（如 `@`、`!`、`#`），导致 Nacos 等注册中心使用复杂密码时校验失败。

**修复：**
将 `PASSWORD_KEY` 加入 `checkParameterName` 的忽略列表，跳过正则检查（长度检查仍保留）。

**修复：** #16073