### PR TITLE
[#16098] Fix resource leaks and improve code quality in ConfigUtils

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/utils/ConfigUtils.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/utils/ConfigUtils.java
@@ -139,7 +139,7 @@ public class ConfigUtils {
             return expression;
         }
         Matcher matcher = VARIABLE_PATTERN.matcher(expression);
-        StringBuilder sb = new StringBuilder();
+        StringBuffer sb = new StringBuffer();
         while (matcher.find()) {
             String key = matcher.group(1);
             String value = System.getProperty(key);

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/utils/ConfigUtils.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/utils/ConfigUtils.java
@@ -139,7 +139,7 @@ public class ConfigUtils {
             return expression;
         }
         Matcher matcher = VARIABLE_PATTERN.matcher(expression);
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         while (matcher.find()) {
             String key = matcher.group(1);
             String value = System.getProperty(key);
@@ -213,13 +213,8 @@ public class ConfigUtils {
         Properties properties = new Properties();
         // add scene judgement in windows environment Fix 2557
         if (checkFileNameExist(fileName)) {
-            try {
-                FileInputStream input = new FileInputStream(fileName);
-                try {
-                    properties.load(input);
-                } finally {
-                    input.close();
-                }
+            try (FileInputStream input = new FileInputStream(fileName)) {
+                properties.load(input);
             } catch (Throwable e) {
                 logger.warn(
                         COMMON_IO_EXCEPTION,
@@ -279,19 +274,11 @@ public class ConfigUtils {
         logger.info("load " + fileName + " properties file from " + set);
 
         for (java.net.URL url : set) {
-            try {
-                Properties p = new Properties();
-                InputStream input = url.openStream();
+            try (InputStream input = url.openStream()) {
                 if (input != null) {
-                    try {
-                        p.load(input);
-                        properties.putAll(p);
-                    } finally {
-                        try {
-                            input.close();
-                        } catch (Throwable t) {
-                        }
-                    }
+                    Properties p = new Properties();
+                    p.load(input);
+                    properties.putAll(p);
                 }
             } catch (Throwable e) {
                 logger.warn(
@@ -331,9 +318,10 @@ public class ConfigUtils {
             for (Set<URL> urls : ClassLoaderResourceLoader.loadResources(fileName, classLoadersToLoad)
                     .values()) {
                 for (URL url : urls) {
-                    InputStream is = url.openStream();
-                    if (is != null) {
-                        return readString(is);
+                    try (InputStream is = url.openStream()) {
+                        if (is != null) {
+                            return readString(is);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## What is the purpose of the change?

Fix resource leaks and improve code quality in `ConfigUtils` (`dubbo-common` module). Fixes #16098.

- Refactor `loadProperties()` to use try-with-resources for `FileInputStream`, eliminating manual close() calls and potential resource leaks
- Refactor multi-file loading loop to use try-with-resources for `InputStream` from URL, removing empty catch blocks
- Fix resource leak in `loadMigrationRule()` where `InputStream` from URL was never closed after reading

The most critical fix is in `loadMigrationRule()` where an `InputStream` opened via `url.openStream()` is never closed, which can lead to file handle leaks in long-running applications.

## Checklist

- [x] Make sure there is a GitHub issue filed for the change.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] This PR only changes resource management patterns without altering logic. Existing tests cover the functionality, no new unit tests needed.
- [x] GitHub Actions should pass — no logic changes, only resource management improvements.