### PR TITLE
fix(metrics): support prometheus class detection for micrometer 1.13+

### DIFF
--- a/dubbo-metrics/dubbo-metrics-api/src/main/java/org/apache/dubbo/metrics/utils/MetricsSupportUtil.java
+++ b/dubbo-metrics/dubbo-metrics-api/src/main/java/org/apache/dubbo/metrics/utils/MetricsSupportUtil.java
@@ -28,7 +28,7 @@ public class MetricsSupportUtil {
         // Micrometer package changed in newer versions:
         // io.micrometer.prometheus.* -> io.micrometer.prometheusmetrics.*
         boolean micrometerPrometheusPresent = isClassPresent("io.micrometer.prometheus.PrometheusConfig")
-                || isClassPresent("io.micrometer.prometheusmetrics.PrometheusConfig");
+                | isClassPresent("io.micrometer.prometheusmetrics.PrometheusConfig");
 
         // PushGateway classes are optional for exporter-only usage and differ across versions,
         // so do not hard-fail prometheus support on them.

--- a/dubbo-metrics/dubbo-metrics-api/src/main/java/org/apache/dubbo/metrics/utils/MetricsSupportUtil.java
+++ b/dubbo-metrics/dubbo-metrics-api/src/main/java/org/apache/dubbo/metrics/utils/MetricsSupportUtil.java
@@ -25,10 +25,14 @@ public class MetricsSupportUtil {
     }
 
     public static boolean isSupportPrometheus() {
-        return isClassPresent("io.micrometer.prometheus.PrometheusConfig")
-                && isClassPresent("io.prometheus.client.exporter.BasicAuthHttpConnectionFactory")
-                && isClassPresent("io.prometheus.client.exporter.HttpConnectionFactory")
-                && isClassPresent("io.prometheus.client.exporter.PushGateway");
+        // Micrometer package changed in newer versions:
+        // io.micrometer.prometheus.* -> io.micrometer.prometheusmetrics.*
+        boolean micrometerPrometheusPresent = isClassPresent("io.micrometer.prometheus.PrometheusConfig")
+                || isClassPresent("io.micrometer.prometheusmetrics.PrometheusConfig");
+
+        // PushGateway classes are optional for exporter-only usage and differ across versions,
+        // so do not hard-fail prometheus support on them.
+        return micrometerPrometheusPresent;
     }
 
     private static boolean isClassPresent(String className) {

--- a/dubbo-metrics/dubbo-metrics-api/src/test/java/org/apache/dubbo/metrics/utils/MetricsSupportUtilTest.java
+++ b/dubbo-metrics/dubbo-metrics-api/src/test/java/org/apache/dubbo/metrics/utils/MetricsSupportUtilTest.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.metrics.utils;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class MetricsSupportUtilTest {
+
+    @Test
+    void shouldSupportMetrics() {
+        Assertions.assertTrue(MetricsSupportUtil.isSupportMetrics());
+    }
+
+    @Test
+    void shouldDetectPrometheusClasspathWithoutThrowing() {
+        Assertions.assertFalse(MetricsSupportUtil.isSupportPrometheus());
+    }
+}


### PR DESCRIPTION
## Summary

Fixes Prometheus metrics reporter support detection for newer Micrometer package naming.

## Changes

- Update MetricsSupportUtil.isSupportPrometheus() to support both:
  - io.micrometer.prometheus.PrometheusConfig (old)
  - io.micrometer.prometheusmetrics.PrometheusConfig (new)
- Remove hard requirement on legacy io.prometheus.client.exporter.* classes to avoid false negatives during reporter initialization.

## Verification

- Build and test command executed:
  - mvn -pl dubbo-config/dubbo-config-api -am -Dtest=DefaultApplicationDeployerTest -Dsurefire.failIfNoSpecifiedTests=false test`n- Result: BUILD SUCCESS

Fixes apache/dubbo#16109