### PR TITLE
fix(common): close input stream in ConfigUtils#loadProperties fallback

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/utils/ConfigUtils.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/utils/ConfigUtils.java
@@ -257,8 +257,10 @@ public class ConfigUtils {
             }
 
             // fall back to use method getResourceAsStream
-            try {
-                properties.load(ClassUtils.getClassLoader().getResourceAsStream(fileName));
+            try (InputStream input = ClassUtils.getClassLoader().getResourceAsStream(fileName)) {
+                if (input != null) {
+                    properties.load(input);
+                }
             } catch (Throwable e) {
                 logger.warn(
                         COMMON_IO_EXCEPTION,


### PR DESCRIPTION
## What
Fixes an input stream resource leak in `ConfigUtils.loadProperties(...)` when `allowMultiFile == false` and fallback loading path is used.

Previously the code called:
- `properties.load(ClassUtils.getClassLoader().getResourceAsStream(fileName));`

This could leave the stream unclosed. The fallback now uses try-with-resources and null-checks the stream before loading.

## Why
This addresses issue #16098 and keeps resource handling consistent with other load paths in `ConfigUtils`.

## Verification
- `./mvnw -pl dubbo-common -Dtest=ConfigUtilsTest test -DskipITs`
- Result: BUILD SUCCESS (`Tests run: 25, Failures: 0, Errors: 0, Skipped: 1`)

Fixes #16098
