### PR TITLE
Fix CompositeInputStream.close() to close all underlying streams

### DIFF
--- a/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/CompositeInputStream.java
+++ b/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/CompositeInputStream.java
@@ -103,9 +103,21 @@ public class CompositeInputStream extends InputStream {
 
     @Override
     public void close() throws IOException {
+        IOException first = null;
         InputStream inputStream;
         while ((inputStream = inputStreams.poll()) != null) {
-            inputStream.close();
+            try {
+                inputStream.close();
+            } catch (IOException e) {
+                if (first == null) {
+                    first = e;
+                } else {
+                    first.addSuppressed(e);
+                }
+            }
+        }
+        if (first != null) {
+            throw first;
         }
     }
 


### PR DESCRIPTION
This PR fixes an exception-safety issue in `CompositeInputStream.close()`. Previously, if closing one underlying `InputStream` threw an `IOException`, `close()` returned immediately and the remaining streams were never closed, potentially leaking resources. The new logic continues closing all queued streams, then throws the first `IOException` with later close failures added as suppressed exceptions.

Fixes #16117