### PR TITLE
fix(adaptive-lb): replace broken equality-based penalty with explicit freshness tracking

### DIFF
--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/AdaptiveMetrics.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/AdaptiveMetrics.java
@@ -46,6 +46,14 @@ public class AdaptiveMetrics {
     private final AtomicLong errorReq = new AtomicLong();
     private double ewma = 0;
 
+    // Coalescing freshness signal: set by setProviderMetrics(), cleared by getLoad().
+    // Indicates whether new provider metrics have arrived since the last getLoad() call.
+    // volatile for cross-thread visibility (setProviderMetrics runs in async executor,
+    // getLoad runs in caller thread). Not an event counter — intermediate updates are
+    // coalesced, which is acceptable because lastLatency and ewma are already updated
+    // to the latest values in setProviderMetrics().
+    private volatile boolean providerUpdated = false;
+
     public double getLoad(String idKey, int weight, int timeout) {
         AdaptiveMetrics metrics = getStatus(idKey);
 
@@ -57,11 +65,13 @@ public class AdaptiveMetrics {
         if (metrics.currentTime > 0) {
             long multiple = (System.currentTimeMillis() - metrics.currentTime) / timeout + 1;
             if (multiple > 0) {
-                if (metrics.currentProviderTime == metrics.currentTime) {
-                    // penalty value
-                    metrics.lastLatency = timeout * 2L;
+                if (metrics.providerUpdated) {
+                    // Fresh metrics arrived — use real lastLatency (already set by setProviderMetrics)
+                    metrics.providerUpdated = false;
                 } else {
-                    metrics.lastLatency = metrics.lastLatency >> multiple;
+                    // No fresh metrics — decay with floor to prevent collapse to zero
+                    long floor = Math.max(1L, timeout / 100L);
+                    metrics.lastLatency = Math.max(floor, metrics.lastLatency >> multiple);
                 }
                 metrics.ewma = metrics.beta * metrics.ewma + (1 - metrics.beta) * metrics.lastLatency;
                 metrics.currentTime = System.currentTimeMillis();
@@ -123,5 +133,6 @@ public class AdaptiveMetrics {
         metrics.beta = 0.5;
         // Vt =  β * Vt-1 + (1 -  β ) * θt
         metrics.ewma = metrics.beta * metrics.ewma + (1 - metrics.beta) * metrics.lastLatency;
+        metrics.providerUpdated = true;
     }
 }

--- a/dubbo-rpc/dubbo-rpc-api/src/test/java/org/apache/dubbo/rpc/AdaptiveMetricsTest.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/test/java/org/apache/dubbo/rpc/AdaptiveMetricsTest.java
@@ -84,7 +84,8 @@ class AdaptiveMetricsTest {
         // With penalty bug: ratio ≈ 1.46 (136.7 vs 200.0 EWMA). Fails.
         // With fix: ratio ≈ 20x (10 vs 200 EWMA). Passes easily.
         assertTrue(fastLoad > 0, "fastLoad should be > 0");
-        assertTrue(slowLoad / fastLoad > 2.0,
+        assertTrue(
+                slowLoad / fastLoad > 2.0,
                 "Slow/fast load ratio should be > 2x to prove real RT is used, "
                         + "got ratio=" + (slowLoad / fastLoad)
                         + " (fast=" + fastLoad + " slow=" + slowLoad + ")");
@@ -151,10 +152,8 @@ class AdaptiveMetricsTest {
         }
 
         // Strict ordering: fast < medium < slow
-        assertTrue(loadFast < loadMedium,
-                "fast(" + loadFast + ") should be < medium(" + loadMedium + ")");
-        assertTrue(loadMedium < loadSlow,
-                "medium(" + loadMedium + ") should be < slow(" + loadSlow + ")");
+        assertTrue(loadFast < loadMedium, "fast(" + loadFast + ") should be < medium(" + loadMedium + ")");
+        assertTrue(loadMedium < loadSlow, "medium(" + loadMedium + ") should be < slow(" + loadSlow + ")");
     }
 
     /**
@@ -185,9 +184,10 @@ class AdaptiveMetricsTest {
         }
         double loadAfter = am.getLoad(FAST_KEY, WEIGHT, TIMEOUT);
 
-        assertTrue(loadAfter > loadBefore,
-                "Load should increase after RT degradation (CPU held constant): "
-                        + "before=" + loadBefore + " after=" + loadAfter);
+        assertTrue(
+                loadAfter > loadBefore,
+                "Load should increase after RT degradation (CPU held constant): " + "before=" + loadBefore + " after="
+                        + loadAfter);
     }
 
     /**
@@ -212,9 +212,10 @@ class AdaptiveMetricsTest {
         double loadAfterStale = am.getLoad(FAST_KEY, WEIGHT, TIMEOUT);
 
         // The stale update should have been discarded — load should not spike
-        assertTrue(loadAfterStale <= loadAfterFresh,
-                "Stale metrics should be discarded: loadAfterFresh=" + loadAfterFresh
-                        + " loadAfterStale=" + loadAfterStale);
+        assertTrue(
+                loadAfterStale <= loadAfterFresh,
+                "Stale metrics should be discarded: loadAfterFresh=" + loadAfterFresh + " loadAfterStale="
+                        + loadAfterStale);
     }
 
     /**

--- a/dubbo-rpc/dubbo-rpc-api/src/test/java/org/apache/dubbo/rpc/AdaptiveMetricsTest.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/test/java/org/apache/dubbo/rpc/AdaptiveMetricsTest.java
@@ -1,0 +1,223 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.rpc;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit tests for {@link AdaptiveMetrics}.
+ *
+ * <p>All tests drive through the public API only (no reflection, no Thread.sleep).
+ * Verifies the fix for <a href="https://github.com/apache/dubbo/issues/15810">#15810</a>:
+ * <ul>
+ *   <li>Bug 1: penalty branch overwrites real RT on every normal response</li>
+ *   <li>Bug 2: aggressive bit-shift decay collapses latency to zero</li>
+ * </ul>
+ */
+class AdaptiveMetricsTest {
+
+    private static final String FAST_KEY = "10.0.0.1:20880/com.example.TestService";
+    private static final String SLOW_KEY = "10.0.0.2:20880/com.example.TestService";
+    private static final String MEDIUM_KEY = "10.0.0.3:20880/com.example.TestService";
+    private static final int WEIGHT = 100;
+    private static final int TIMEOUT = 100;
+
+    private Map<String, String> metricsMap(long curTime, long rt, String load) {
+        Map<String, String> map = new HashMap<>();
+        map.put("curTime", String.valueOf(curTime));
+        map.put("rt", String.valueOf(rt));
+        map.put("load", load);
+        return map;
+    }
+
+    /**
+     * Bug 1 regression: after setProviderMetrics, getLoad should use the real RT,
+     * not overwrite it with timeout * 2. A fast server (10ms) must have strictly
+     * lower load than a slow server (200ms).
+     */
+    @Test
+    void freshMetrics_usesRealLatency_notPenalty() {
+        AdaptiveMetrics am = new AdaptiveMetrics();
+        long now = System.currentTimeMillis();
+
+        // Fast server: 10ms RT
+        am.addConsumerReq(FAST_KEY);
+        am.setProviderMetrics(FAST_KEY, metricsMap(now, 10, "0.5"));
+        am.addConsumerSuccess(FAST_KEY);
+
+        double fastLoad = am.getLoad(FAST_KEY, WEIGHT, TIMEOUT);
+
+        // Slow server: 200ms RT
+        am.addConsumerReq(SLOW_KEY);
+        am.setProviderMetrics(SLOW_KEY, metricsMap(now, 200, "0.5"));
+        am.addConsumerSuccess(SLOW_KEY);
+
+        double slowLoad = am.getLoad(SLOW_KEY, WEIGHT, TIMEOUT);
+
+        // With the penalty bug, both would converge to timeout*2 → loads nearly equal
+        assertTrue(fastLoad < slowLoad,
+                "Fast server (10ms) should have lower load than slow server (200ms), "
+                        + "got fast=" + fastLoad + " slow=" + slowLoad);
+    }
+
+    /**
+     * Bug 2 regression: after multiple decay rounds without new provider metrics,
+     * load must remain above zero. Decay-to-zero would make idle servers appear
+     * "fastest" and attract all traffic.
+     */
+    @Test
+    void decayWithoutUpdate_doesNotReachZero() {
+        AdaptiveMetrics am = new AdaptiveMetrics();
+        long now = System.currentTimeMillis();
+
+        am.addConsumerReq(FAST_KEY);
+        am.setProviderMetrics(FAST_KEY, metricsMap(now, 200, "0.5"));
+        am.addConsumerSuccess(FAST_KEY);
+
+        // First getLoad consumes the providerUpdated flag
+        am.getLoad(FAST_KEY, WEIGHT, TIMEOUT);
+
+        // Multiple getLoad calls without new metrics — all enter decay branch
+        double load = 0;
+        for (int i = 0; i < 50; i++) {
+            load = am.getLoad(FAST_KEY, WEIGHT, TIMEOUT);
+        }
+
+        // With the bug: lastLatency >> large_multiple = 0, ewma → 0, load → 0
+        assertTrue(load > 0, "Load should not decay to zero after idle period, got " + load);
+    }
+
+    /**
+     * End-to-end: with 3 servers at different RTs, adaptive metrics should
+     * consistently rank them correctly after multiple rounds.
+     */
+    @Test
+    void multipleServers_fastServerPreferred() {
+        AdaptiveMetrics am = new AdaptiveMetrics();
+
+        // Simulate 20 rounds of traffic
+        for (int round = 0; round < 20; round++) {
+            long now = System.currentTimeMillis();
+
+            am.addConsumerReq(FAST_KEY);
+            am.setProviderMetrics(FAST_KEY, metricsMap(now, 10, "0.5"));
+            am.addConsumerSuccess(FAST_KEY);
+
+            am.addConsumerReq(MEDIUM_KEY);
+            am.setProviderMetrics(MEDIUM_KEY, metricsMap(now, 50, "0.5"));
+            am.addConsumerSuccess(MEDIUM_KEY);
+
+            am.addConsumerReq(SLOW_KEY);
+            am.setProviderMetrics(SLOW_KEY, metricsMap(now, 200, "0.5"));
+            am.addConsumerSuccess(SLOW_KEY);
+        }
+
+        double loadFast = am.getLoad(FAST_KEY, WEIGHT, TIMEOUT);
+        double loadMedium = am.getLoad(MEDIUM_KEY, WEIGHT, TIMEOUT);
+        double loadSlow = am.getLoad(SLOW_KEY, WEIGHT, TIMEOUT);
+
+        // Strict ordering: fast < medium < slow
+        assertTrue(loadFast < loadMedium,
+                "fast(" + loadFast + ") should be < medium(" + loadMedium + ")");
+        assertTrue(loadMedium < loadSlow,
+                "medium(" + loadMedium + ") should be < slow(" + loadSlow + ")");
+    }
+
+    /**
+     * A server that degrades (RT jumps from 10ms to 500ms) should see its
+     * load score increase, so the algorithm can shift traffic away.
+     */
+    @Test
+    void degradedServer_loadIncreases() {
+        AdaptiveMetrics am = new AdaptiveMetrics();
+
+        // Warm up with fast responses
+        for (int i = 0; i < 10; i++) {
+            long now = System.currentTimeMillis();
+            am.addConsumerReq(FAST_KEY);
+            am.setProviderMetrics(FAST_KEY, metricsMap(now, 10, "0.5"));
+            am.addConsumerSuccess(FAST_KEY);
+        }
+        double loadBefore = am.getLoad(FAST_KEY, WEIGHT, TIMEOUT);
+
+        // Server degrades: RT jumps to 500ms, CPU load spikes
+        for (int i = 0; i < 10; i++) {
+            long now = System.currentTimeMillis();
+            am.addConsumerReq(FAST_KEY);
+            am.setProviderMetrics(FAST_KEY, metricsMap(now, 500, "0.9"));
+            am.addConsumerSuccess(FAST_KEY);
+        }
+        double loadAfter = am.getLoad(FAST_KEY, WEIGHT, TIMEOUT);
+
+        assertTrue(loadAfter > loadBefore,
+                "Load should increase after degradation: before=" + loadBefore + " after=" + loadAfter);
+    }
+
+    /**
+     * Guard: out-of-order serviceTime should be discarded by setProviderMetrics.
+     * An older timestamp must not overwrite newer metrics.
+     */
+    @Test
+    void outOfOrderServiceTime_isDiscarded() {
+        AdaptiveMetrics am = new AdaptiveMetrics();
+        long now = System.currentTimeMillis();
+
+        // Set metrics with current time, RT=50ms
+        am.addConsumerReq(FAST_KEY);
+        am.setProviderMetrics(FAST_KEY, metricsMap(now, 50, "0.5"));
+        am.addConsumerSuccess(FAST_KEY);
+        double loadAfterFresh = am.getLoad(FAST_KEY, WEIGHT, TIMEOUT);
+
+        // Attempt to set metrics with an older timestamp, RT=999ms
+        am.addConsumerReq(FAST_KEY);
+        am.setProviderMetrics(FAST_KEY, metricsMap(now - 10000, 999, "1.0"));
+        am.addConsumerSuccess(FAST_KEY);
+        double loadAfterStale = am.getLoad(FAST_KEY, WEIGHT, TIMEOUT);
+
+        // The stale update should have been discarded — load should not spike
+        // (if the stale 999ms RT were accepted, loadAfterStale would be much higher)
+        assertTrue(loadAfterStale <= loadAfterFresh,
+                "Stale metrics should be discarded: loadAfterFresh=" + loadAfterFresh
+                        + " loadAfterStale=" + loadAfterStale);
+    }
+
+    /**
+     * Guard: when pickTime exceeds timeout * 2, getLoad must return 0 (forced pick)
+     * to prevent starvation. This behavior must not be broken by the fix.
+     */
+    @Test
+    void forcedPick_notBroken() {
+        AdaptiveMetrics am = new AdaptiveMetrics();
+        long now = System.currentTimeMillis();
+
+        am.addConsumerReq(FAST_KEY);
+        am.setProviderMetrics(FAST_KEY, metricsMap(now, 50, "0.5"));
+        am.addConsumerSuccess(FAST_KEY);
+
+        // Set pickTime far in the past → triggers forced pick (return 0)
+        am.setPickTime(FAST_KEY, now - TIMEOUT * 3);
+
+        double load = am.getLoad(FAST_KEY, WEIGHT, TIMEOUT);
+        assertEquals(0.0, load, "getLoad should return 0 when pickTime exceeds timeout * 2");
+    }
+}

--- a/dubbo-rpc/dubbo-rpc-api/src/test/java/org/apache/dubbo/rpc/AdaptiveMetricsTest.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/test/java/org/apache/dubbo/rpc/AdaptiveMetricsTest.java
@@ -51,33 +51,43 @@ class AdaptiveMetricsTest {
     }
 
     /**
-     * Bug 1 regression: after setProviderMetrics, getLoad should use the real RT,
-     * not overwrite it with timeout * 2. A fast server (10ms) must have strictly
-     * lower load than a slow server (200ms).
+     * Bug 1 core regression: simulate the real request cycle where each
+     * setProviderMetrics() is immediately followed by a getLoad() call.
+     * This is the exact path that triggers the penalty bug on main branch.
+     *
+     * <p>With the bug: penalty overwrites all RTs to timeout*2, so after
+     * 20 rounds fast(10ms) EWMA ≈ 137 and slow(200ms) EWMA ≈ 200, ratio < 1.5x.
+     * With the fix: fast EWMA stays near 10, slow near 200, ratio > 5x.
      */
     @Test
     void freshMetrics_usesRealLatency_notPenalty() {
         AdaptiveMetrics am = new AdaptiveMetrics();
-        long now = System.currentTimeMillis();
 
-        // Fast server: 10ms RT
-        am.addConsumerReq(FAST_KEY);
-        am.setProviderMetrics(FAST_KEY, metricsMap(now, 10, "0.5"));
-        am.addConsumerSuccess(FAST_KEY);
+        // 20 rounds: each round = setProviderMetrics + immediate getLoad (the bug path)
+        double fastLoad = 0;
+        double slowLoad = 0;
+        for (int i = 0; i < 20; i++) {
+            long now = System.currentTimeMillis();
 
-        double fastLoad = am.getLoad(FAST_KEY, WEIGHT, TIMEOUT);
+            am.addConsumerReq(FAST_KEY);
+            am.setProviderMetrics(FAST_KEY, metricsMap(now, 10, "0.5"));
+            am.addConsumerSuccess(FAST_KEY);
+            fastLoad = am.getLoad(FAST_KEY, WEIGHT, TIMEOUT);
 
-        // Slow server: 200ms RT
-        am.addConsumerReq(SLOW_KEY);
-        am.setProviderMetrics(SLOW_KEY, metricsMap(now, 200, "0.5"));
-        am.addConsumerSuccess(SLOW_KEY);
+            am.addConsumerReq(SLOW_KEY);
+            am.setProviderMetrics(SLOW_KEY, metricsMap(now, 200, "0.5"));
+            am.addConsumerSuccess(SLOW_KEY);
+            slowLoad = am.getLoad(SLOW_KEY, WEIGHT, TIMEOUT);
+        }
 
-        double slowLoad = am.getLoad(SLOW_KEY, WEIGHT, TIMEOUT);
-
-        // With the penalty bug, both would converge to timeout*2 → loads nearly equal
-        assertTrue(fastLoad < slowLoad,
-                "Fast server (10ms) should have lower load than slow server (200ms), "
-                        + "got fast=" + fastLoad + " slow=" + slowLoad);
+        // Strong assertion: the ratio must be > 2x.
+        // With penalty bug: ratio ≈ 1.46 (136.7 vs 200.0 EWMA). Fails.
+        // With fix: ratio ≈ 20x (10 vs 200 EWMA). Passes easily.
+        assertTrue(fastLoad > 0, "fastLoad should be > 0");
+        assertTrue(slowLoad / fastLoad > 2.0,
+                "Slow/fast load ratio should be > 2x to prove real RT is used, "
+                        + "got ratio=" + (slowLoad / fastLoad)
+                        + " (fast=" + fastLoad + " slow=" + slowLoad + ")");
     }
 
     /**
@@ -103,38 +113,42 @@ class AdaptiveMetricsTest {
             load = am.getLoad(FAST_KEY, WEIGHT, TIMEOUT);
         }
 
-        // With the bug: lastLatency >> large_multiple = 0, ewma → 0, load → 0
+        // With the bug: lastLatency >> large_multiple = 0, ewma -> 0, load -> 0
         assertTrue(load > 0, "Load should not decay to zero after idle period, got " + load);
     }
 
     /**
-     * End-to-end: with 3 servers at different RTs, adaptive metrics should
-     * consistently rank them correctly after multiple rounds.
+     * End-to-end: with 3 servers at different RTs, simulate the real request
+     * cycle (setProviderMetrics + getLoad each round). After 20 rounds the
+     * ordering must be strictly fast < medium < slow.
      */
     @Test
     void multipleServers_fastServerPreferred() {
         AdaptiveMetrics am = new AdaptiveMetrics();
 
-        // Simulate 20 rounds of traffic
+        double loadFast = 0;
+        double loadMedium = 0;
+        double loadSlow = 0;
+
+        // Each round: report metrics then immediately call getLoad (the real path)
         for (int round = 0; round < 20; round++) {
             long now = System.currentTimeMillis();
 
             am.addConsumerReq(FAST_KEY);
             am.setProviderMetrics(FAST_KEY, metricsMap(now, 10, "0.5"));
             am.addConsumerSuccess(FAST_KEY);
+            loadFast = am.getLoad(FAST_KEY, WEIGHT, TIMEOUT);
 
             am.addConsumerReq(MEDIUM_KEY);
             am.setProviderMetrics(MEDIUM_KEY, metricsMap(now, 50, "0.5"));
             am.addConsumerSuccess(MEDIUM_KEY);
+            loadMedium = am.getLoad(MEDIUM_KEY, WEIGHT, TIMEOUT);
 
             am.addConsumerReq(SLOW_KEY);
             am.setProviderMetrics(SLOW_KEY, metricsMap(now, 200, "0.5"));
             am.addConsumerSuccess(SLOW_KEY);
+            loadSlow = am.getLoad(SLOW_KEY, WEIGHT, TIMEOUT);
         }
-
-        double loadFast = am.getLoad(FAST_KEY, WEIGHT, TIMEOUT);
-        double loadMedium = am.getLoad(MEDIUM_KEY, WEIGHT, TIMEOUT);
-        double loadSlow = am.getLoad(SLOW_KEY, WEIGHT, TIMEOUT);
 
         // Strict ordering: fast < medium < slow
         assertTrue(loadFast < loadMedium,
@@ -145,32 +159,35 @@ class AdaptiveMetricsTest {
 
     /**
      * A server that degrades (RT jumps from 10ms to 500ms) should see its
-     * load score increase, so the algorithm can shift traffic away.
+     * load score increase. CPU load is held constant to isolate the RT signal.
      */
     @Test
     void degradedServer_loadIncreases() {
         AdaptiveMetrics am = new AdaptiveMetrics();
 
-        // Warm up with fast responses
+        // Warm up with fast responses (CPU fixed at 0.5)
         for (int i = 0; i < 10; i++) {
             long now = System.currentTimeMillis();
             am.addConsumerReq(FAST_KEY);
             am.setProviderMetrics(FAST_KEY, metricsMap(now, 10, "0.5"));
             am.addConsumerSuccess(FAST_KEY);
+            am.getLoad(FAST_KEY, WEIGHT, TIMEOUT);
         }
         double loadBefore = am.getLoad(FAST_KEY, WEIGHT, TIMEOUT);
 
-        // Server degrades: RT jumps to 500ms, CPU load spikes
+        // Server degrades: RT jumps to 500ms, CPU stays at 0.5
         for (int i = 0; i < 10; i++) {
             long now = System.currentTimeMillis();
             am.addConsumerReq(FAST_KEY);
-            am.setProviderMetrics(FAST_KEY, metricsMap(now, 500, "0.9"));
+            am.setProviderMetrics(FAST_KEY, metricsMap(now, 500, "0.5"));
             am.addConsumerSuccess(FAST_KEY);
+            am.getLoad(FAST_KEY, WEIGHT, TIMEOUT);
         }
         double loadAfter = am.getLoad(FAST_KEY, WEIGHT, TIMEOUT);
 
         assertTrue(loadAfter > loadBefore,
-                "Load should increase after degradation: before=" + loadBefore + " after=" + loadAfter);
+                "Load should increase after RT degradation (CPU held constant): "
+                        + "before=" + loadBefore + " after=" + loadAfter);
     }
 
     /**
@@ -195,7 +212,6 @@ class AdaptiveMetricsTest {
         double loadAfterStale = am.getLoad(FAST_KEY, WEIGHT, TIMEOUT);
 
         // The stale update should have been discarded — load should not spike
-        // (if the stale 999ms RT were accepted, loadAfterStale would be much higher)
         assertTrue(loadAfterStale <= loadAfterFresh,
                 "Stale metrics should be discarded: loadAfterFresh=" + loadAfterFresh
                         + " loadAfterStale=" + loadAfterStale);
@@ -214,7 +230,7 @@ class AdaptiveMetricsTest {
         am.setProviderMetrics(FAST_KEY, metricsMap(now, 50, "0.5"));
         am.addConsumerSuccess(FAST_KEY);
 
-        // Set pickTime far in the past → triggers forced pick (return 0)
+        // Set pickTime far in the past -> triggers forced pick (return 0)
         am.setPickTime(FAST_KEY, now - TIMEOUT * 3);
 
         double load = am.getLoad(FAST_KEY, WEIGHT, TIMEOUT);


### PR DESCRIPTION
## What is the purpose of the change?

Fixes two bugs in `AdaptiveMetrics.getLoad()` that cause adaptive load balancing to degrade to near-random distribution under normal traffic.

Fixes #15810

## Root Cause Analysis

### Bug 1: Penalty fires on every normal response

`setProviderMetrics()` sets both `currentProviderTime` and `currentTime` to `serviceTime` (L93-94). The penalty check `currentProviderTime == currentTime` (L58) is therefore always true after any normal response. This overwrites real RT with `timeout * 2L`, making a 10ms server indistinguishable from a 200ms server.

**Code trace:**
1. `AdaptiveLoadBalanceFilter.onResponse()` → calls `setProviderMetrics()` with real RT
2. `setProviderMetrics()` L93-94: `currentProviderTime = serviceTime; currentTime = serviceTime;` (same value)
3. Next `getLoad()` L58: `currentProviderTime == currentTime` → always true → L60: `lastLatency = timeout * 2L`
4. Real RT overwritten. EWMA fed garbage data.

### Bug 2: Decay to zero

`lastLatency >> multiple` (L62) has no floor. After 2s idle with timeout=100ms: `multiple=21`, `200 >> 21 = 0`. The slowest server appears "fastest" and gets flooded with traffic.

## What is changed?

1. **Added `volatile boolean providerUpdated` flag** — a coalescing freshness signal (not an event counter). `setProviderMetrics()` sets it to `true`; `getLoad()` checks it: if true, uses real `lastLatency` (already set by `setProviderMetrics`); if false, applies decay with floor.

2. **Removed the broken equality-based penalty trigger** — replaced `currentProviderTime == currentTime` with explicit freshness tracking via the flag. The original equality check was intended to detect stale metrics but fires on the opposite condition (fresh metrics).

3. **Decay floor: `Math.max(1L, timeout / 100L)`** — scales with service timeout. A 5000ms-timeout service gets a 50ms floor; a 100ms-timeout service gets a 1ms floor.

4. **New `AdaptiveMetricsTest`** — 6 test cases through public API (no reflection, no `Thread.sleep`):
   - `freshMetrics_usesRealLatency_notPenalty` — Bug 1 regression
   - `decayWithoutUpdate_doesNotReachZero` — Bug 2 regression
   - `multipleServers_fastServerPreferred` — end-to-end ordering
   - `degradedServer_loadIncreases` — degradation detection
   - `outOfOrderServiceTime_isDiscarded` — guard: stale timestamp rejected
   - `forcedPick_notBroken` — guard: pickTime starvation prevention intact

## Concurrency note

`providerUpdated` is `volatile` because `setProviderMetrics()` runs in an async single-thread executor (`AdaptiveLoadBalanceFilter.getExecutor()`) while `getLoad()` runs in the caller thread. The flag is a coalescing signal — if multiple `setProviderMetrics()` calls occur between two `getLoad()` calls, intermediate updates are coalesced. This is acceptable because `lastLatency` and `ewma` are already updated to the latest values in each `setProviderMetrics()` call; the flag only indicates "fresh data exists since last load calculation".

## Why this approach over PR #16048?

| Aspect | #16048 | This PR |
|--------|--------|---------|
| Penalty fix | `==` → `>` (penalty never fires) | Explicit freshness flag (correct semantics) |
| Decay floor | `Math.max(1L, ...)` (arbitrary) | `Math.max(1L, timeout/100L)` (scales with timeout) |
| Tests | Reflection + Thread.sleep | Public API only, deterministic |
| Root cause | Symptom-level condition flip | Addresses the design flaw (implicit → explicit freshness) |

## Simulation results

Python simulation comparing buggy vs fixed (faithful port of `AdaptiveMetrics.java`):

```
BUGGY:  fast(10ms) ewma=105.0  medium(50ms) ewma=125.0  slow(200ms) ewma=199.9
FIXED:  fast(10ms) ewma=10.0   medium(50ms) ewma=50.0   slow(200ms) ewma=199.9
```

After fix, EWMA accurately reflects real RT. Degradation detection and decay floor also verified. Full analysis and scripts: https://github.com/apache/dubbo/pull/16048#issuecomment-4087574069

## Verifying this change

```bash
mvn -pl dubbo-rpc/dubbo-rpc-api -am test -Dtest=AdaptiveMetricsTest
mvn -pl dubbo-cluster -am test -Dtest=AdaptiveLoadBalanceTest
```

## Checklist

- [x] Related GitHub issue referenced (Fixes #15810)
- [x] Logic change explained clearly
- [x] Unit tests added (6 cases)
- [x] Concurrency implications documented
- [x] No changes to public API surface