### PR TITLE
test: fix assuming toString order with multiple ports in org.apache.dubbo.rpc.protocol.dubbo.status.ThreadPoolStatusCheckerTest

### DIFF
--- a/dubbo-rpc/dubbo-rpc-dubbo/src/test/java/org/apache/dubbo/rpc/protocol/dubbo/status/ThreadPoolStatusCheckerTest.java
+++ b/dubbo-rpc/dubbo-rpc-dubbo/src/test/java/org/apache/dubbo/rpc/protocol/dubbo/status/ThreadPoolStatusCheckerTest.java
@@ -44,11 +44,14 @@ class ThreadPoolStatusCheckerTest {
 
         ThreadPoolStatusChecker threadPoolStatusChecker = new ThreadPoolStatusChecker(ApplicationModel.defaultModel());
         Status status = threadPoolStatusChecker.check();
-        Assertions.assertEquals(status.getLevel(), Status.Level.WARN);
-        Assertions.assertEquals(
-                status.getMessage(),
-                "Pool status:WARN, max:1, core:1, largest:0, active:0, task:0, service port: 8888;"
-                        + "Pool status:OK, max:10, core:10, largest:0, active:0, task:0, service port: 8889");
+        Assertions.assertEquals(Status.Level.WARN, status.getLevel());
+        String msg = status.getMessage();
+        String[] parts = msg.split(";");
+        Assertions.assertEquals(2, parts.length);
+        Assertions.assertTrue(
+                msg.contains("Pool status:WARN, max:1, core:1, largest:0, active:0, task:0, service port: 8888"));
+        Assertions.assertTrue(
+                msg.contains("Pool status:OK, max:10, core:10, largest:0, active:0, task:0, service port: 8889"));
 
         // reset
         executorService1.shutdown();


### PR DESCRIPTION
## What is the purpose of the change?

The purpose of this change is to modify the test org.apache.dubbo.rpc.protocol.dubbo.status.ThreadPoolStatusCheckerTest so that it consistently succeeds. 
Fixes #16152 .

## Why does the test fail?

The test's implementation compares status message output (from a `ThreadPoolStatusChecker`) against an expected string. The expected string contains an exact order, but the `ThreadPoolStatusChecker` in reality iterates over a `Map.entrySet()` to produce its static string. Therefore, iteration order is not guaranteed. When the map returns a different order than usual, which is valid under Java specifications, the test fails.

## How to reproduce the test failure

Run the test with [NonDex](https://github.com/TestingResearchIllinois/NonDex) to shuffle collection iteration order:
```bash
  mvn edu.illinois:nondex-maven-plugin:2.2.1:nondex \
    -pl dubbo-rpc/dubbo-rpc-dubbo \
    -Dtest=org.apache.dubbo.rpc.protocol.dubbo.status.ThreadPoolStatusCheckerTest#test \
    -DnondexRuns=10
```

## Expected results

The test expects 
```
Pool status:WARN, max:1, core:1, largest:0, active:0, task:0, service port: 8888;
Pool status:OK, max:10, core:10, largest:0, active:0, task:0, service port: 8889
``` 
to be returned from `ThreadPoolStatusChecker#check#getMessage`.

## Actual results

When the collection order is shuffled, the test receives 
```
Pool status:OK, max:10, core:10, largest:0, active:0, task:0, service port: 8889;
Pool status:WARN, max:1, core:1, largest:0, active:0, task:0, service port: 8888
```

## Description of Fix

Instead of comparing the status message to an exact string:

1. Split the status message by `;`. Ensure that there are only two items in the returned array. 
2. Ensure that the status message (as a whole) contains both expected pieces, regardless of order.

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Make sure gitHub actions can pass. [Why the workflow is failing and how to fix it?](../CONTRIBUTING.md)
