### PR TITLE
fix: use TreeMap to ensure consistent iteration order in ThreadPoolStatusChecker

### DIFF
--- a/dubbo-rpc/dubbo-rpc-dubbo/src/main/java/org/apache/dubbo/rpc/protocol/dubbo/status/ThreadPoolStatusChecker.java
+++ b/dubbo-rpc/dubbo-rpc-dubbo/src/main/java/org/apache/dubbo/rpc/protocol/dubbo/status/ThreadPoolStatusChecker.java
@@ -24,6 +24,7 @@ import org.apache.dubbo.common.store.DataStore;
 import org.apache.dubbo.rpc.model.ApplicationModel;
 
 import java.util.Map;
+import java.util.TreeMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ThreadPoolExecutor;
 
@@ -44,7 +45,11 @@ public class ThreadPoolStatusChecker implements StatusChecker {
 
         StringBuilder msg = new StringBuilder();
         Status.Level level = Status.Level.OK;
-        for (Map.Entry<String, Object> entry : executors.entrySet()) {
+
+        // Use TreeMap to ensure consistent iteration order by port key
+        Map<String, Object> sortedExecutors = new TreeMap<>(executors);
+
+        for (Map.Entry<String, Object> entry : sortedExecutors.entrySet()) {
             String port = entry.getKey();
             ExecutorService executor = (ExecutorService) entry.getValue();
 


### PR DESCRIPTION
## What is the purpose of the change?

Fix the flaky test `ThreadPoolStatusCheckerTest` where `Map.entrySet()` iteration order is undefined under the Java Memory Model, causing test failures when the map returns entries in a different order than expected.

## Fix

Use `TreeMap` instead of raw `Map` to sort entries by port key before building the status message. This guarantees deterministic output regardless of JVM implementation or hash map iteration order.

Fixes #16152
Fixes #16153
