### PR TITLE
fix(metrics): export late-created thread reject and error code metrics to Prometheus

### DIFF
--- a/dubbo-metrics/dubbo-metrics-default/src/main/java/org/apache/dubbo/metrics/collector/sample/MetricThreadPoolExhaustedListener.java
+++ b/dubbo-metrics/dubbo-metrics-default/src/main/java/org/apache/dubbo/metrics/collector/sample/MetricThreadPoolExhaustedListener.java
@@ -29,6 +29,7 @@ public class MetricThreadPoolExhaustedListener implements ThreadPoolExhaustedLis
     public MetricThreadPoolExhaustedListener(String threadPoolExecutorName, DefaultMetricsCollector collector) {
         this.threadPoolExecutorName = threadPoolExecutorName;
         this.threadRejectMetricsCountSampler = new ThreadRejectMetricsCountSampler(collector);
+        this.threadRejectMetricsCountSampler.addMetricName(threadPoolExecutorName);
     }
 
     public MetricThreadPoolExhaustedListener(String threadPoolExecutorName, ThreadRejectMetricsCountSampler sampler) {

--- a/dubbo-metrics/dubbo-metrics-default/src/main/java/org/apache/dubbo/metrics/collector/sample/MetricsNameCountSampler.java
+++ b/dubbo-metrics/dubbo-metrics-default/src/main/java/org/apache/dubbo/metrics/collector/sample/MetricsNameCountSampler.java
@@ -49,9 +49,18 @@ public abstract class MetricsNameCountSampler<S, K, M extends Metric> extends Si
         this.collector.addSampler(this);
     }
 
+    @Override
+    public void inc(S source, K metricName) {
+        metricNames.add(metricName);
+        if (incrementAndGetCreated(source, metricName)) {
+            samplesChanged.set(true);
+        }
+    }
+
     public void addMetricName(K name) {
-        this.metricNames.add(name);
-        this.samplesChanged.set(true);
+        if (metricNames.add(name)) {
+            samplesChanged.set(true);
+        }
     }
 
     @Override

--- a/dubbo-metrics/dubbo-metrics-default/src/main/java/org/apache/dubbo/metrics/collector/sample/SimpleMetricsCountSampler.java
+++ b/dubbo-metrics/dubbo-metrics-default/src/main/java/org/apache/dubbo/metrics/collector/sample/SimpleMetricsCountSampler.java
@@ -37,7 +37,7 @@ public abstract class SimpleMetricsCountSampler<S, K, M extends Metric> implemen
 
     @Override
     public void inc(S source, K metricName) {
-        getAtomicCounter(source, metricName).incrementAndGet();
+        incrementAndGetCreated(source, metricName);
     }
 
     @Override
@@ -47,7 +47,7 @@ public abstract class SimpleMetricsCountSampler<S, K, M extends Metric> implemen
 
     protected abstract void countConfigure(MetricsCountSampleConfigurer<S, K, M> sampleConfigure);
 
-    private AtomicLong getAtomicCounter(S source, K metricsName) {
+    protected boolean incrementAndGetCreated(S source, K metricsName) {
         MetricsCountSampleConfigurer<S, K, M> sampleConfigure = new MetricsCountSampleConfigurer<>();
         sampleConfigure.setSource(source);
         sampleConfigure.setMetricsName(metricsName);
@@ -63,12 +63,10 @@ public abstract class SimpleMetricsCountSampler<S, K, M extends Metric> implemen
 
         Assert.notNull(sampleConfigure.getMetric(), "metrics is null");
 
-        AtomicLong atomicCounter = metricAtomic.get(sampleConfigure.getMetric());
-
-        if (atomicCounter == null) {
-            atomicCounter = ConcurrentHashMapUtils.computeIfAbsent(
-                    metricAtomic, sampleConfigure.getMetric(), k -> new AtomicLong());
-        }
-        return atomicCounter;
+        AtomicLong newCounter = new AtomicLong();
+        AtomicLong atomicCounter =
+                ConcurrentHashMapUtils.computeIfAbsent(metricAtomic, sampleConfigure.getMetric(), k -> newCounter);
+        atomicCounter.incrementAndGet();
+        return atomicCounter == newCounter;
     }
 }

--- a/dubbo-metrics/dubbo-metrics-default/src/test/java/org/apache/dubbo/metrics/metrics/model/sample/ErrorCodeSampleTest.java
+++ b/dubbo-metrics/dubbo-metrics-default/src/test/java/org/apache/dubbo/metrics/metrics/model/sample/ErrorCodeSampleTest.java
@@ -31,6 +31,7 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
 
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class ErrorCodeSampleTest {
@@ -68,6 +69,39 @@ public class ErrorCodeSampleTest {
         Assert.assertTrue(samples.size() == 4, "Wrong number of samples.");
         samples.forEach(metricSample -> Assert.assertTrue(
                 ((AtomicLong) ((CounterMetricSample<?>) metricSample).getValue()).get() == 2L, "Sample count error."));
+    }
+
+    @Test
+    void testErrorCodeMetricChangesAfterFirstLateEvent() {
+        FrameworkModel frameworkModel = FrameworkModel.defaultModel();
+        ApplicationModel applicationModel = frameworkModel.newApplication();
+
+        ApplicationConfig applicationConfig = new ApplicationConfig();
+        applicationConfig.setName("MyApplication1");
+
+        applicationModel.getApplicationConfigManager().setApplication(applicationConfig);
+
+        DefaultMetricsCollector defaultMetricsCollector = new DefaultMetricsCollector(applicationModel);
+        defaultMetricsCollector.setCollectEnabled(true);
+
+        ErrorCodeSampler sampler =
+                (ErrorCodeSampler) ReflectionUtils.getField(defaultMetricsCollector, "errorCodeSampler");
+
+        ErrorCodeMetricsListenRegister register =
+                (ErrorCodeMetricsListenRegister) ReflectionUtils.getField(sampler, "register");
+
+        Assertions.assertTrue(sampler.calSamplesChanged());
+        Assertions.assertFalse(sampler.calSamplesChanged());
+
+        register.onMessage("0-1", null);
+        Assertions.assertTrue(sampler.calSamplesChanged());
+        Assertions.assertFalse(sampler.calSamplesChanged());
+
+        register.onMessage("0-1", null);
+        Assertions.assertFalse(sampler.calSamplesChanged());
+
+        register.onMessage("0-2", null);
+        Assertions.assertTrue(sampler.calSamplesChanged());
     }
 
     @AfterEach

--- a/dubbo-metrics/dubbo-metrics-prometheus/src/test/java/org/apache/dubbo/metrics/prometheus/PrometheusMetricsThreadPoolTest.java
+++ b/dubbo-metrics/dubbo-metrics-prometheus/src/test/java/org/apache/dubbo/metrics/prometheus/PrometheusMetricsThreadPoolTest.java
@@ -20,6 +20,7 @@ import org.apache.dubbo.config.ApplicationConfig;
 import org.apache.dubbo.config.MetricsConfig;
 import org.apache.dubbo.config.nested.PrometheusConfig;
 import org.apache.dubbo.metrics.collector.DefaultMetricsCollector;
+import org.apache.dubbo.metrics.collector.sample.MetricThreadPoolExhaustedListener;
 import org.apache.dubbo.metrics.collector.sample.ThreadRejectMetricsCountSampler;
 import org.apache.dubbo.metrics.model.sample.GaugeMetricSample;
 import org.apache.dubbo.metrics.model.sample.MetricSample;
@@ -147,7 +148,6 @@ public class PrometheusMetricsThreadPoolTest {
         ThreadRejectMetricsCountSampler threadRejectMetricsCountSampler =
                 new ThreadRejectMetricsCountSampler(collector);
         threadRejectMetricsCountSampler.inc(threadPoolExecutorName, threadPoolExecutorName);
-        threadRejectMetricsCountSampler.addMetricName(threadPoolExecutorName);
         List<MetricSample> samples = collector.collect();
         for (MetricSample sample : samples) {
             Assertions.assertTrue(sample instanceof GaugeMetricSample);
@@ -158,6 +158,33 @@ public class PrometheusMetricsThreadPoolTest {
             Assertions.assertEquals(tags.get(TAG_IP), getLocalHost());
             Assertions.assertEquals(tags.get(TAG_HOSTNAME), getLocalHostName());
             Assertions.assertEquals(gaugeSample.applyAsLong(), 1);
+        }
+    }
+
+    @Test
+    void testThreadPoolRejectMetricsExportedAfterLateFirstEvent() {
+        metricsCollector.setCollectEnabled(true);
+        metricsCollector.setApplicationName(applicationModel.getApplicationName());
+        String threadPoolExecutorName = "DubboServerHandler-20816";
+
+        ThreadRejectMetricsCountSampler sampler = new ThreadRejectMetricsCountSampler(metricsCollector);
+        MetricThreadPoolExhaustedListener listener =
+                new MetricThreadPoolExhaustedListener(threadPoolExecutorName, sampler);
+
+        PrometheusMetricsReporter reporter = new PrometheusMetricsReporter(metricsConfig.toUrl(), applicationModel);
+        reporter.init();
+        try {
+            reporter.resetIfSamplesChanged();
+            Assertions.assertFalse(reporter.getResponse().contains("dubbo_thread_pool_reject_thread_count"));
+
+            listener.onEvent(null);
+            reporter.resetIfSamplesChanged();
+
+            String response = reporter.getResponse();
+            Assertions.assertTrue(response.contains("dubbo_thread_pool_reject_thread_count"));
+            Assertions.assertTrue(response.contains("thread.name=\"" + threadPoolExecutorName + "\""));
+        } finally {
+            reporter.destroy();
         }
     }
 }


### PR DESCRIPTION
## What is the purpose of the change?

Fixes #16148

Dynamically added metric series in `MetricsNameCountSampler` subclasses (e.g., `ThreadRejectMetricsCountSampler`, `ErrorCodeSampler`) are not exported to Prometheus when the first event arrives after the initial reporter sync cycle.

## Root Cause Analysis

`MetricsNameCountSampler.samplesChanged` is initialized to `true` and consumed by the reporter's first `calSamplesChanged()` poll (CAS `true → false`). At that point, `sample()` returns nothing because no actual metric series exist yet.

When the first real event arrives later (e.g., a thread pool rejection), `SimpleMetricsCountSampler.inc()` creates a new metric series entry in `metricCounter`. However, `MetricsNameCountSampler.samplesChanged` is only updated during metric name registration — it is never set back to `true` when a new metric series is first created at runtime. The reporter sees `false` on subsequent polls and never re-registers the new metric series to the Prometheus registry.

## Brief changelog

- **`SimpleMetricsCountSampler`**: Refactored `getAtomicCounter()` into `incrementAndGetCreated()` which returns `true` when a new metric series is created for the first time (detected via reference equality against the candidate `AtomicLong`).
- **`MetricsNameCountSampler`**: Override `inc()` to call `incrementAndGetCreated()` and set `samplesChanged = true` only when a new metric series is created. This avoids unnecessary re-registration for updates to already-registered series. Also made `addMetricName()` idempotent.

## How to verify

**Thread pool reject path:**

1. Start a Dubbo 3.3.x provider with `dubbo.metrics.enable-threadpool: true` and `dubbo.protocol.threads: 2`.
2. Wait 3+ minutes (so the initial `samplesChanged` flag is consumed).
3. Send enough concurrent requests to trigger thread pool exhaustion.
4. Check `/actuator/prometheus` for `dubbo_thread_pool_reject_thread_count` — it should now appear.

**Error code path** is covered by the unit test `ErrorCodeSampleTest.testErrorCodeMetricChangesAfterFirstLateEvent`, which verifies the same timing sequence with error code events.

## New tests

- `ErrorCodeSampleTest.testErrorCodeMetricChangesAfterFirstLateEvent`: Verifies the exact timing sequence — initial flag consumed, then first error event sets flag, repeat of same error does not, new error code sets flag again.
- `PrometheusMetricsThreadPoolTest.testThreadPoolRejectMetricsExportedAfterLateFirstEvent`: End-to-end test — simulates the full startup → first poll → late event timeline and asserts that Prometheus scrape output contains the late-arriving reject metric series.