### PR TITLE
fix: return new BitList instance from emptyList() to prevent shared mutable state

### DIFF
--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/router/state/BitList.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/router/state/BitList.java
@@ -55,7 +55,6 @@ import java.util.concurrent.ThreadLocalRandom;
 public class BitList<E> extends AbstractList<E> implements Cloneable {
     private final BitSet rootSet;
     private volatile List<E> originList;
-    private static final BitList emptyList = new BitList(Collections.emptyList());
     private volatile List<E> tailList = null;
 
     public BitList(List<E> originList) {
@@ -174,9 +173,12 @@ public class BitList<E> extends AbstractList<E> implements Cloneable {
         return get(ThreadLocalRandom.current().nextInt(cardinality + tailSize));
     }
 
-    @SuppressWarnings("unchecked")
+    /**
+     * Returns a new empty BitList. A new instance is created on each call because BitList is mutable;
+     * a shared singleton would cause cross-caller state contamination (see issue #16131).
+     */
     public static <T> BitList<T> emptyList() {
-        return emptyList;
+        return new BitList<>(Collections.emptyList());
     }
 
     // Provided by JDK List interface

--- a/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/router/state/BitListTest.java
+++ b/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/router/state/BitListTest.java
@@ -580,6 +580,69 @@ class BitListTest {
     }
 
     @Test
+    void testEmptyListReturnsIndependentInstances() {
+        // Verify that emptyList() returns separate instances to prevent shared mutable state
+        BitList<String> empty1 = BitList.emptyList();
+        BitList<String> empty2 = BitList.emptyList();
+
+        Assertions.assertNotSame(empty1, empty2, "emptyList() must return distinct instances");
+    }
+
+    @Test
+    void testEmptyListMutationDoesNotAffectOtherEmptyList() {
+        // This test reproduces the bug from issue #16131:
+        // When emptyList() returned a shared singleton, adding elements to one
+        // empty list would contaminate all other empty lists.
+        BitList<String> empty1 = BitList.emptyList();
+        BitList<String> empty2 = BitList.emptyList();
+
+        // Simulate what AbstractDirectory does: start with emptyList, then add invokers
+        empty1.add("InvokerA");
+        empty1.add("InvokerB");
+
+        // empty2 must remain empty - this was the core bug
+        Assertions.assertTrue(empty2.isEmpty(), "Mutating one emptyList must not affect another");
+        Assertions.assertEquals(0, empty2.size());
+    }
+
+    @Test
+    void testEmptyListTailListMutationDoesNotAffectOtherEmptyList() {
+        // Test that addToTailList on one emptyList doesn't leak to another
+        BitList<String> empty1 = BitList.emptyList();
+        BitList<String> empty2 = BitList.emptyList();
+
+        empty1.addToTailList("X");
+        empty1.addToTailList("Y");
+
+        Assertions.assertEquals(2, empty1.size());
+        Assertions.assertTrue(empty2.isEmpty());
+        Assertions.assertFalse(empty2.hasMoreElementInTailList());
+    }
+
+    @Test
+    void testEmptyListAndOperationDoesNotAffectOtherEmptyList() {
+        // The and() method is used in AbstractStateRouter.route() to mutate invokers in-place.
+        // This test verifies that and() on one emptyList doesn't contaminate another.
+        BitList<String> source = new BitList<>(Arrays.asList("A", "B", "C"));
+        BitList<String> empty1 = BitList.emptyList();
+        BitList<String> empty2 = BitList.emptyList();
+
+        // and() mutates rootSet and may add tailList elements in-place
+        empty1.and(source);
+
+        Assertions.assertTrue(empty2.isEmpty(), "and() on one emptyList must not affect another");
+        Assertions.assertEquals(0, empty2.size());
+    }
+
+    @Test
+    void testEmptyListIsInitiallyEmpty() {
+        BitList<String> empty = BitList.emptyList();
+        Assertions.assertTrue(empty.isEmpty());
+        Assertions.assertEquals(0, empty.size());
+        Assertions.assertFalse(empty.iterator().hasNext());
+    }
+
+    @Test
     void testConcurrent() throws InterruptedException {
         for (int i = 0; i < 100000; i++) {
             BitList<String> bitList = new BitList<>(Collections.singletonList("test"));


### PR DESCRIPTION
## Problem

`BitList.emptyList()` returns a shared static singleton instance. Since `BitList` is mutable (supports `add()`, `addToTailList()`, `and()`, etc.), any caller that modifies the returned "empty" list inadvertently mutates the singleton, contaminating all subsequent callers.

In `AbstractDirectory`, the `invokers` field is initialized with `BitList.emptyList()`. When the first interface's invokers are added, they pollute the shared singleton. When a second interface later calls `BitList.emptyList()`, it receives a list already containing the first interface's invokers, causing traffic to be routed to the wrong instances and resulting in `NoSuchMethodError`.

## Root Cause

```java
// Shared mutable singleton - any mutation affects all callers
private static final BitList emptyList = new BitList(Collections.emptyList());

public static <T> BitList<T> emptyList() {
    return emptyList; // returns the SAME instance every time
}
```

## Fix

Return a new `BitList` instance on each call to `emptyList()`, consistent with how mutable collections should behave:

```java
public static <T> BitList<T> emptyList() {
    return new BitList<>(Collections.emptyList());
}
```

## Tests Added

- `testEmptyListReturnsIndependentInstances` — Verifies each call returns a distinct object
- `testEmptyListMutationDoesNotAffectOtherEmptyList` — Reproduces the exact bug: adding elements to one empty list must not affect another (the core scenario from #16131)
- `testEmptyListTailListMutationDoesNotAffectOtherEmptyList` — Verifies tail list mutations are also isolated
- `testEmptyListIsInitiallyEmpty` — Confirms the returned list starts truly empty

All 26 tests in `BitListTest` pass.

## Impact

- Minimal change: removes 1 static field, modifies 1 method (3 lines changed in production code)
- No behavioral change for callers — they get the same empty `BitList`, just a fresh instance
- No reference equality (`==`) checks exist against `BitList.emptyList()` in the codebase
- Fixes a critical production bug where cross-interface invoker leakage causes `NoSuchMethodError`

Fixes #16131