### PR TITLE
fix: make LRU2Cache.computeIfAbsent thread-safe

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/utils/LRU2Cache.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/utils/LRU2Cache.java
@@ -99,12 +99,23 @@ public class LRU2Cache<K, V> extends LinkedHashMap<K, V> {
 
     @Override
     public V computeIfAbsent(K key, Function<? super K, ? extends V> fn) {
-        V value = get(key);
-        if (value == null) {
-            value = fn.apply(key);
-            put(key, value);
+        lock.lock();
+        try {
+            V value = super.get(key);
+            if (value == null) {
+                value = fn.apply(key);
+                // Inline the LRU-2 promotion logic from put() to avoid releasing the lock
+                if (preCache.containsKey(key)) {
+                    preCache.remove(key);
+                    super.put(key, value);
+                } else {
+                    preCache.put(key, true);
+                }
+            }
+            return value;
+        } finally {
+            lock.unlock();
         }
-        return value;
     }
 
     @Override

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/utils/LRU2CacheTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/utils/LRU2CacheTest.java
@@ -16,10 +16,14 @@
  */
 package org.apache.dubbo.common.utils;
 
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicInteger;
+
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -99,6 +103,69 @@ class LRU2CacheTest {
         // Old entries should be gone
         assertFalse(cache.containsKey("1"));
         assertFalse(cache.containsKey("2"));
+    }
+
+    @Test
+    void testComputeIfAbsentBasic() {
+        LRU2Cache<String, String> cache = new LRU2Cache<>(10);
+        // First call: goes to preCache, function is called
+        String result1 = cache.computeIfAbsent("key", k -> k.toUpperCase());
+        assertEquals("KEY", result1);
+
+        // Second call: promotes from preCache to main cache, function is called again (LRU-2 semantics)
+        String result2 = cache.computeIfAbsent("key", k -> k.toUpperCase());
+        assertEquals("KEY", result2);
+
+        // Third call: found in main cache, function should NOT be called
+        AtomicInteger callCount = new AtomicInteger(0);
+        String result3 = cache.computeIfAbsent("key", k -> {
+            callCount.incrementAndGet();
+            return k.toUpperCase();
+        });
+        assertEquals("KEY", result3);
+        assertEquals(0, callCount.get(), "Function should not be called when value is in main cache");
+    }
+
+    @Test
+    void testComputeIfAbsentConcurrency() throws InterruptedException {
+        LRU2Cache<String, String> cache = new LRU2Cache<>(1000);
+        int threadCount = 10;
+        int iterations = 1000;
+
+        // Pre-warm: put keys twice to promote them into main cache
+        for (int i = 0; i < 100; i++) {
+            String key = "key-" + i;
+            cache.put(key, key.toUpperCase());
+            cache.put(key, key.toUpperCase());
+        }
+
+        CountDownLatch startLatch = new CountDownLatch(1);
+        CountDownLatch doneLatch = new CountDownLatch(threadCount);
+        AtomicInteger errors = new AtomicInteger(0);
+
+        for (int t = 0; t < threadCount; t++) {
+            new Thread(() -> {
+                        try {
+                            startLatch.await();
+                            for (int i = 0; i < iterations; i++) {
+                                String key = "key-" + (i % 100);
+                                String value = cache.computeIfAbsent(key, k -> k.toUpperCase());
+                                if (value == null || !value.equals(key.toUpperCase())) {
+                                    errors.incrementAndGet();
+                                }
+                            }
+                        } catch (Exception e) {
+                            errors.incrementAndGet();
+                        } finally {
+                            doneLatch.countDown();
+                        }
+                    })
+                    .start();
+        }
+
+        startLatch.countDown();
+        doneLatch.await();
+        assertEquals(0, errors.get(), "Concurrent computeIfAbsent should not produce errors");
     }
 
     @Test


### PR DESCRIPTION
## Problem

`LRU2Cache.computeIfAbsent()` releases the lock between `get()` and `put()`, breaking the atomicity that **all other methods** in this class maintain. Every other method (`get`, `put`, `remove`, `size`, `clear`, `containsKey`, `setMaxCapacity`) correctly holds the lock for the entire operation, but `computeIfAbsent` does not:

```java
// Current broken code - lock released between get() and put()
public V computeIfAbsent(K key, Function<? super K, ? extends V> fn) {
    V value = get(key);       // acquires lock, releases lock
    if (value == null) {
        value = fn.apply(key); // no lock held
        put(key, value);       // acquires lock, releases lock
    }
    return value;
}
```

This is called from the **Triple protocol hot path** in `StreamUtils.lruHeaderMap.computeIfAbsent(key, k -> k.toLowerCase())` for every RPC request.

### Impact

Under concurrency, multiple threads can:
1. Both see `get(key) == null`
2. Both compute `fn.apply(key)` (duplicate work)
3. Both call `put(key, value)` — the double-put defeats the LRU-2 promotion logic (first put goes to pre-cache, second put unintentionally promotes to main cache)

## Root Cause

The method was composed from the public `get()` and `put()` methods (which each independently acquire/release the lock) instead of operating on the underlying `LinkedHashMap` directly under a single lock span.

## Fix

Hold the lock across the entire `computeIfAbsent` operation, using `super.get()` / `super.put()` directly and inlining the LRU-2 promotion logic to avoid nested lock acquisition:

```java
public V computeIfAbsent(K key, Function<? super K, ? extends V> fn) {
    lock.lock();
    try {
        V value = super.get(key);
        if (value == null) {
            value = fn.apply(key);
            if (preCache.containsKey(key)) {
                preCache.remove(key);
                super.put(key, value);
            } else {
                preCache.put(key, true);
            }
        }
        return value;
    } finally {
        lock.unlock();
    }
}
```

## Tests Added

- `testComputeIfAbsentBasic` — Verifies correct LRU-2 semantics: first call goes to pre-cache, second promotes, third returns from main cache without calling the function
- `testComputeIfAbsentConcurrency` — 10 threads × 1000 iterations calling `computeIfAbsent` concurrently, verifying no errors or corruption

All 6 tests in `LRU2CacheTest` pass.

## Impact

- Minimal change: 1 method rewritten in 1 file
- Preserves existing LRU-2 semantics
- Fixes thread safety in Triple protocol header processing hot path