### PR TITLE
fix: use ConcurrentHashMap for Version.VERSION2INT to prevent concurrent corruption

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/Version.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/Version.java
@@ -28,10 +28,10 @@ import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.security.CodeSource;
 import java.util.Enumeration;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -58,7 +58,7 @@ public final class Version {
     public static final int LOWEST_VERSION_FOR_RESPONSE_ATTACHMENT = 2000200; // 2.0.2
 
     public static final int HIGHEST_PROTOCOL_VERSION = 2009900; // 2.0.99
-    private static final Map<String, Integer> VERSION2INT = new HashMap<>();
+    private static final Map<String, Integer> VERSION2INT = new ConcurrentHashMap<>();
 
     static {
         // get dubbo version and last commit id

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/version/VersionTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/version/VersionTest.java
@@ -24,6 +24,8 @@ import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.net.URL;
 import java.util.Enumeration;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -96,6 +98,42 @@ class VersionTest {
         Assertions.assertFalse(Version.isRelease263OrHigher("2.6.1.1"));
         Assertions.assertTrue(Version.isRelease263OrHigher("2.6.3"));
         Assertions.assertTrue(Version.isRelease263OrHigher("2.6.3.0"));
+    }
+
+    @Test
+    void testGetIntVersionConcurrency() throws InterruptedException {
+        int threadCount = 10;
+        int iterations = 1000;
+        CountDownLatch startLatch = new CountDownLatch(1);
+        CountDownLatch doneLatch = new CountDownLatch(threadCount);
+        AtomicInteger errors = new AtomicInteger(0);
+
+        String[] versions = {"2.6.1", "2.7.0", "3.0.0", "2.0.2", "2.0.99", "3.1.0", "2.6.3.1", "2.7.0.RC1"};
+        int[] expected = {2060100, 2070000, 3000000, 2000200, 2009900, 3010000, 2060301, 2070000};
+
+        for (int t = 0; t < threadCount; t++) {
+            new Thread(() -> {
+                        try {
+                            startLatch.await();
+                            for (int i = 0; i < iterations; i++) {
+                                int idx = i % versions.length;
+                                int result = Version.getIntVersion(versions[idx]);
+                                if (result != expected[idx]) {
+                                    errors.incrementAndGet();
+                                }
+                            }
+                        } catch (Exception e) {
+                            errors.incrementAndGet();
+                        } finally {
+                            doneLatch.countDown();
+                        }
+                    })
+                    .start();
+        }
+
+        startLatch.countDown();
+        doneLatch.await();
+        Assertions.assertEquals(0, errors.get(), "Concurrent getIntVersion should return consistent results");
     }
 
     @Test


### PR DESCRIPTION
## Problem

`Version.VERSION2INT` uses a plain `HashMap` that is accessed concurrently from the RPC hot path:

```java
private static final Map<String, Integer> VERSION2INT = new HashMap<>(); // NOT thread-safe

public static int getIntVersion(String version) {
    Integer v = VERSION2INT.get(version);  // concurrent read
    if (v == null) {
        v = parseInt(version);
        VERSION2INT.put(version, v);       // concurrent write
    }
    return v;
}
```

This is called via `isSupportResponseAttachment()` on **every RPC call** to check protocol compatibility.

### Impact

Concurrent `put()` during `HashMap` internal resize can corrupt the hash table's bucket chain, causing threads to **hang permanently in an infinite loop** during `get()` — a well-documented JDK issue with unsynchronized `HashMap` access. This is a classic production incident pattern that is difficult to diagnose.

## Root Cause

`HashMap` was used where `ConcurrentHashMap` is required. The code comment on the field even notes it is used for performance ("int compare expect to has higher performance than string"), but the collection itself is not thread-safe.

## Fix

Replace `new HashMap<>()` with `new ConcurrentHashMap<>()`. The check-then-act pattern in `getIntVersion()` is acceptable because:
1. The computation is **idempotent** (same version string always produces the same int)
2. Worst case under concurrent miss: two threads compute and put the same value — no data loss or corruption with `ConcurrentHashMap`

## Tests Added

- `testGetIntVersionConcurrency` — 10 threads × 1000 iterations calling `getIntVersion` with various version strings concurrently, verifying consistent results

All 9 tests in `VersionTest` pass.

## Impact

- 1-line production change: `HashMap` → `ConcurrentHashMap`
- Zero behavioral change
- Eliminates risk of thread hangs in the RPC protocol path