### PR TITLE
fix: use thread-safe collections in SchemaDescriptorRegistry

### DIFF
--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/service/SchemaDescriptorRegistry.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/service/SchemaDescriptorRegistry.java
@@ -18,8 +18,6 @@ package org.apache.dubbo.rpc.protocol.tri.service;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -35,7 +33,7 @@ public class SchemaDescriptorRegistry {
 
     private static final Map<String, Map<Integer, FileDescriptor>> EXTENSIONS = new ConcurrentHashMap<>();
 
-    private static final Set<String> SERVICES = new HashSet<>();
+    private static final Set<String> SERVICES = ConcurrentHashMap.newKeySet();
 
     public static void addSchemaDescriptor(String serviceName, FileDescriptor fd) {
         SERVICES.add(serviceName);
@@ -58,11 +56,7 @@ public class SchemaDescriptorRegistry {
     private static void addExtension(FieldDescriptor extension, FileDescriptor fd) {
         String name = extension.getContainingType().getFullName();
         int number = extension.getNumber();
-        if (!EXTENSIONS.containsKey(name)) {
-            EXTENSIONS.put(name, new HashMap<>());
-        }
-        Map<Integer, FileDescriptor> fdMap = EXTENSIONS.get(name);
-        fdMap.put(number, fd);
+        EXTENSIONS.computeIfAbsent(name, k -> new ConcurrentHashMap<>()).put(number, fd);
     }
 
     public static FileDescriptor getFileDescriptorByExtensionAndNumber(String extension, int number) {


### PR DESCRIPTION
## Problem

`SchemaDescriptorRegistry` has three thread-safety issues. This class is called during gRPC service registration, which can happen from multiple threads concurrently.

### Issue 1: `SERVICES` uses plain `HashSet`

```java
private static final Set<String> SERVICES = new HashSet<>(); // NOT thread-safe

public static void addSchemaDescriptor(String serviceName, FileDescriptor fd) {
    SERVICES.add(serviceName);  // concurrent write — can corrupt internal state
```

### Issue 2: Check-then-act race in `addExtension()`

```java
if (!EXTENSIONS.containsKey(name)) {       // Thread A: false
    EXTENSIONS.put(name, new HashMap<>());  // Thread A: puts HashMap-1
}                                           // Thread B: also false (race!)
                                            // Thread B: puts HashMap-2, overwriting HashMap-1!
Map<Integer, FileDescriptor> fdMap = EXTENSIONS.get(name);
fdMap.put(number, fd);  // Thread A writes to HashMap-2 (Thread B's), HashMap-1 entries lost
```

### Issue 3: Inner `HashMap` accessed concurrently

The inner `Map<Integer, FileDescriptor>` created in `addExtension()` is a plain `HashMap`, but `fdMap.put()` can be called concurrently from different threads registering different extensions for the same containing type.

## Fix

Three minimal changes (net -6 lines):

1. `SERVICES`: `new HashSet<>()` → `ConcurrentHashMap.newKeySet()`
2. `addExtension`: check-then-act → `EXTENSIONS.computeIfAbsent(name, k -> new ConcurrentHashMap<>()).put(number, fd)`
3. Inner map: `new HashMap<>()` → `new ConcurrentHashMap<>()` (via the `computeIfAbsent` lambda)

All changes are API-compatible drop-in replacements with zero behavioral change.

## Tests

No new tests added — this is a pure collection type replacement. The class has no existing tests and creating `FileDescriptor` instances requires protobuf compilation infrastructure. The fix is self-evidently correct: replacing non-thread-safe collections with their concurrent equivalents.

## Impact

- 1 file changed, 2 insertions, 8 deletions
- Eliminates risk of data corruption in gRPC reflection service registration
- Zero behavioral change for callers