### PR TITLE
Remove tomcat embed dependencies declaration as spring-boot-starter-web has already included them

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1103,9 +1103,6 @@
     </profile>
     <profile>
       <id>spring-boot-3</id>
-      <properties>
-        <tomcat.version>10.1.52</tomcat.version>
-      </properties>
       <dependencyManagement>
         <dependencies>
           <dependency>
@@ -1192,21 +1189,6 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
             <version>${spring-boot-3.version}</version>
-          </dependency>
-          <dependency>
-            <groupId>org.apache.tomcat.embed</groupId>
-            <artifactId>tomcat-embed-core</artifactId>
-            <version>${tomcat.version}</version>
-          </dependency>
-          <dependency>
-            <groupId>org.apache.tomcat.embed</groupId>
-            <artifactId>tomcat-embed-el</artifactId>
-            <version>${tomcat.version}</version>
-          </dependency>
-          <dependency>
-            <groupId>org.apache.tomcat.embed</groupId>
-            <artifactId>tomcat-embed-websocket</artifactId>
-            <version>${tomcat.version}</version>
           </dependency>
         </dependencies>
       </dependencyManagement>


### PR DESCRIPTION
## What is the purpose of the change?
Remove tomcat embed dependencies declaration from ```pom.xml``` of ```dubbo-parent``` as
1. ```spring-boot-starter-web``` has already included them.
2.  ```dubbo-spring-boot-3-autoconfigure``` imports ```spring-boot-dependencies``` pom which has defined ```tomcat.version```.

Otherwise ```dependabot[bot]]``` always try to downgrade the tomcat version of profile ```spring-boot-3``` from 10.x to 9.x, e.g.,
<img width="1106" height="492" alt="b6bfbe10-83a0-4013-86e7-dd6e3b5dfba5" src="https://github.com/user-attachments/assets/0adc0212-0a2a-4320-801c-3220e4e751b6" />


## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Make sure gitHub actions can pass. [Why the workflow is failing and how to fix it?](../CONTRIBUTING.md)
