### PR TITLE
fix(remoting): stop ReconnectTimerTask when client is closed

### DIFF
--- a/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/exchange/support/header/AbstractTimerTask.java
+++ b/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/exchange/support/header/AbstractTimerTask.java
@@ -85,10 +85,16 @@ public abstract class AbstractTimerTask implements TimerTask {
     @Override
     public synchronized void run(Timeout timeout) throws Exception {
         Collection<Channel> channels = channelProvider.getChannels();
+        boolean allChannelsClosed = true;
         for (Channel channel : channels) {
             if (!channel.isClosed()) {
+                allChannelsClosed = false;
                 doTask(channel);
             }
+        }
+        if (allChannelsClosed) {
+            cancel();
+            return;
         }
         reput(timeout);
     }

--- a/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/exchange/support/header/AbstractTimerTask.java
+++ b/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/exchange/support/header/AbstractTimerTask.java
@@ -85,7 +85,7 @@ public abstract class AbstractTimerTask implements TimerTask {
     @Override
     public synchronized void run(Timeout timeout) throws Exception {
         Collection<Channel> channels = channelProvider.getChannels();
-        boolean allChannelsClosed = true;
+        boolean allChannelsClosed = !channels.isEmpty();
         for (Channel channel : channels) {
             if (!channel.isClosed()) {
                 allChannelsClosed = false;

--- a/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/exchange/support/header/HeaderExchangeClient.java
+++ b/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/exchange/support/header/HeaderExchangeClient.java
@@ -150,7 +150,7 @@ public class HeaderExchangeClient implements ExchangeClient {
 
     @Override
     public boolean isClosed() {
-        return channel.isClosed();
+        return channel.isClosed() || client.isClosed();
     }
 
     @Override

--- a/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/exchange/support/header/HeaderExchangeClient.java
+++ b/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/exchange/support/header/HeaderExchangeClient.java
@@ -148,6 +148,11 @@ public class HeaderExchangeClient implements ExchangeClient {
         channel.send(message, sent);
     }
 
+    /**
+     * Check both HeaderExchangeChannel and underlying transport client,
+     * because the transport client may be closed independently (e.g., by protocol destroy)
+     * without going through HeaderExchangeClient.close().
+     */
     @Override
     public boolean isClosed() {
         return channel.isClosed() || client.isClosed();

--- a/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/exchange/support/header/ReconnectTimerTask.java
+++ b/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/exchange/support/header/ReconnectTimerTask.java
@@ -44,6 +44,12 @@ public class ReconnectTimerTask extends AbstractTimerTask {
     @Override
     protected void doTask(Channel channel) {
         try {
+            if (channel instanceof Client && ((Client) channel).isClosed()) {
+                logger.info("Client " + channel + " has been closed, cancel reconnect task.");
+                cancel();
+                return;
+            }
+
             Long lastRead = lastRead(channel);
             Long now = now();
 

--- a/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/exchange/support/header/ReconnectTimerTask.java
+++ b/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/exchange/support/header/ReconnectTimerTask.java
@@ -44,12 +44,6 @@ public class ReconnectTimerTask extends AbstractTimerTask {
     @Override
     protected void doTask(Channel channel) {
         try {
-            if (channel instanceof Client && ((Client) channel).isClosed()) {
-                logger.info("Client " + channel + " has been closed, cancel reconnect task.");
-                cancel();
-                return;
-            }
-
             Long lastRead = lastRead(channel);
             Long now = now();
 

--- a/dubbo-remoting/dubbo-remoting-api/src/test/java/org/apache/dubbo/remoting/exchange/support/header/AbstractTimerTaskTest.java
+++ b/dubbo-remoting/dubbo-remoting-api/src/test/java/org/apache/dubbo/remoting/exchange/support/header/AbstractTimerTaskTest.java
@@ -20,6 +20,7 @@ import org.apache.dubbo.common.URL;
 import org.apache.dubbo.common.timer.HashedWheelTimer;
 import org.apache.dubbo.remoting.Channel;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -106,6 +107,31 @@ class AbstractTimerTaskTest {
         Assertions.assertTrue(taskExecutionCount.get() > 1,
                 "Task should keep executing when channel is open");
         Assertions.assertFalse(task.cancel, "Task should not be cancelled when channel is open");
+
+        task.cancel();
+    }
+
+    @Test
+    void testTaskNotCancelledWhenChannelCollectionIsEmpty() throws Exception {
+        long tick = 1000 / HEARTBEAT_CHECK_TICK;
+        // Server-side scenario: ChannelProvider returns empty collection when no clients are connected
+        AbstractTimerTask task = new AbstractTimerTask(
+                ArrayList::new, timer, tick) {
+            @Override
+            protected void doTask(Channel channel) {
+                taskExecutionCount.incrementAndGet();
+            }
+        };
+        task.start();
+
+        // Let the task run several ticks with empty channel collection
+        Thread.sleep(2000L);
+
+        // Task should NOT be cancelled — empty collection is not the same as all-closed
+        Assertions.assertFalse(task.cancel,
+                "Task should not be cancelled when channel collection is empty");
+        Assertions.assertEquals(0, taskExecutionCount.get(),
+                "doTask should not be called when there are no channels");
 
         task.cancel();
     }

--- a/dubbo-remoting/dubbo-remoting-api/src/test/java/org/apache/dubbo/remoting/exchange/support/header/AbstractTimerTaskTest.java
+++ b/dubbo-remoting/dubbo-remoting-api/src/test/java/org/apache/dubbo/remoting/exchange/support/header/AbstractTimerTaskTest.java
@@ -59,8 +59,7 @@ class AbstractTimerTaskTest {
     @Test
     void testAutoCancelWhenAllChannelsClosed() throws Exception {
         long tick = 1000 / HEARTBEAT_CHECK_TICK;
-        AbstractTimerTask task = new AbstractTimerTask(
-                () -> Collections.singleton(channel), timer, tick) {
+        AbstractTimerTask task = new AbstractTimerTask(() -> Collections.singleton(channel), timer, tick) {
             @Override
             protected void doTask(Channel channel) {
                 taskExecutionCount.incrementAndGet();
@@ -83,8 +82,8 @@ class AbstractTimerTaskTest {
         int countAfterClose = taskExecutionCount.get();
 
         // Task should not have executed after channel was closed
-        Assertions.assertEquals(countBeforeClose, countAfterClose,
-                "Task should not execute after all channels are closed");
+        Assertions.assertEquals(
+                countBeforeClose, countAfterClose, "Task should not execute after all channels are closed");
 
         // Verify the task was cancelled
         Assertions.assertTrue(task.cancel, "Task should be cancelled when all channels are closed");
@@ -93,8 +92,7 @@ class AbstractTimerTaskTest {
     @Test
     void testTaskContinuesWhenChannelIsOpen() throws Exception {
         long tick = 1000 / HEARTBEAT_CHECK_TICK;
-        AbstractTimerTask task = new AbstractTimerTask(
-                () -> Collections.singleton(channel), timer, tick) {
+        AbstractTimerTask task = new AbstractTimerTask(() -> Collections.singleton(channel), timer, tick) {
             @Override
             protected void doTask(Channel channel) {
                 taskExecutionCount.incrementAndGet();
@@ -104,8 +102,7 @@ class AbstractTimerTaskTest {
 
         Thread.sleep(2000L);
 
-        Assertions.assertTrue(taskExecutionCount.get() > 1,
-                "Task should keep executing when channel is open");
+        Assertions.assertTrue(taskExecutionCount.get() > 1, "Task should keep executing when channel is open");
         Assertions.assertFalse(task.cancel, "Task should not be cancelled when channel is open");
 
         task.cancel();
@@ -115,8 +112,7 @@ class AbstractTimerTaskTest {
     void testTaskNotCancelledWhenChannelCollectionIsEmpty() throws Exception {
         long tick = 1000 / HEARTBEAT_CHECK_TICK;
         // Server-side scenario: ChannelProvider returns empty collection when no clients are connected
-        AbstractTimerTask task = new AbstractTimerTask(
-                ArrayList::new, timer, tick) {
+        AbstractTimerTask task = new AbstractTimerTask(ArrayList::new, timer, tick) {
             @Override
             protected void doTask(Channel channel) {
                 taskExecutionCount.incrementAndGet();
@@ -128,10 +124,8 @@ class AbstractTimerTaskTest {
         Thread.sleep(2000L);
 
         // Task should NOT be cancelled — empty collection is not the same as all-closed
-        Assertions.assertFalse(task.cancel,
-                "Task should not be cancelled when channel collection is empty");
-        Assertions.assertEquals(0, taskExecutionCount.get(),
-                "doTask should not be called when there are no channels");
+        Assertions.assertFalse(task.cancel, "Task should not be cancelled when channel collection is empty");
+        Assertions.assertEquals(0, taskExecutionCount.get(), "doTask should not be called when there are no channels");
 
         task.cancel();
     }

--- a/dubbo-remoting/dubbo-remoting-api/src/test/java/org/apache/dubbo/remoting/exchange/support/header/AbstractTimerTaskTest.java
+++ b/dubbo-remoting/dubbo-remoting-api/src/test/java/org/apache/dubbo/remoting/exchange/support/header/AbstractTimerTaskTest.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.remoting.exchange.support.header;
+
+import org.apache.dubbo.common.URL;
+import org.apache.dubbo.common.timer.HashedWheelTimer;
+import org.apache.dubbo.remoting.Channel;
+
+import java.util.Collections;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.apache.dubbo.remoting.Constants.HEARTBEAT_CHECK_TICK;
+
+class AbstractTimerTaskTest {
+
+    private HashedWheelTimer timer;
+    private MockChannel channel;
+    private AtomicInteger taskExecutionCount;
+
+    @BeforeEach
+    public void setup() {
+        long tickDuration = 1000;
+        timer = new HashedWheelTimer(tickDuration / HEARTBEAT_CHECK_TICK, TimeUnit.MILLISECONDS);
+        channel = new MockChannel() {
+            @Override
+            public URL getUrl() {
+                return URL.valueOf("dubbo://localhost:20880");
+            }
+        };
+        taskExecutionCount = new AtomicInteger(0);
+    }
+
+    @AfterEach
+    public void teardown() {
+        timer.stop();
+    }
+
+    @Test
+    void testAutoCancelWhenAllChannelsClosed() throws Exception {
+        long tick = 1000 / HEARTBEAT_CHECK_TICK;
+        AbstractTimerTask task = new AbstractTimerTask(
+                () -> Collections.singleton(channel), timer, tick) {
+            @Override
+            protected void doTask(Channel channel) {
+                taskExecutionCount.incrementAndGet();
+            }
+        };
+        task.start();
+
+        // Let the task run a few times while channel is open
+        Thread.sleep(1500L);
+        Assertions.assertTrue(taskExecutionCount.get() > 0, "Task should have executed at least once");
+
+        int countBeforeClose = taskExecutionCount.get();
+
+        // Close the channel
+        channel.close();
+
+        // Wait for the task to detect closure and auto-cancel
+        Thread.sleep(1500L);
+
+        int countAfterClose = taskExecutionCount.get();
+
+        // Task should not have executed after channel was closed
+        Assertions.assertEquals(countBeforeClose, countAfterClose,
+                "Task should not execute after all channels are closed");
+
+        // Verify the task was cancelled
+        Assertions.assertTrue(task.cancel, "Task should be cancelled when all channels are closed");
+    }
+
+    @Test
+    void testTaskContinuesWhenChannelIsOpen() throws Exception {
+        long tick = 1000 / HEARTBEAT_CHECK_TICK;
+        AbstractTimerTask task = new AbstractTimerTask(
+                () -> Collections.singleton(channel), timer, tick) {
+            @Override
+            protected void doTask(Channel channel) {
+                taskExecutionCount.incrementAndGet();
+            }
+        };
+        task.start();
+
+        Thread.sleep(2000L);
+
+        Assertions.assertTrue(taskExecutionCount.get() > 1,
+                "Task should keep executing when channel is open");
+        Assertions.assertFalse(task.cancel, "Task should not be cancelled when channel is open");
+
+        task.cancel();
+    }
+}

--- a/dubbo-remoting/dubbo-remoting-api/src/test/java/org/apache/dubbo/remoting/exchange/support/header/HeaderExchangeClientTest.java
+++ b/dubbo-remoting/dubbo-remoting-api/src/test/java/org/apache/dubbo/remoting/exchange/support/header/HeaderExchangeClientTest.java
@@ -47,7 +47,8 @@ public class HeaderExchangeClientTest {
 
         HeaderExchangeClient headerExchangeClient = new HeaderExchangeClient(mockClient, false);
 
-        Assertions.assertTrue(headerExchangeClient.isClosed(),
+        Assertions.assertTrue(
+                headerExchangeClient.isClosed(),
                 "HeaderExchangeClient should report closed when underlying client is closed");
     }
 
@@ -59,7 +60,8 @@ public class HeaderExchangeClientTest {
 
         HeaderExchangeClient headerExchangeClient = new HeaderExchangeClient(mockClient, false);
 
-        Assertions.assertFalse(headerExchangeClient.isClosed(),
+        Assertions.assertFalse(
+                headerExchangeClient.isClosed(),
                 "HeaderExchangeClient should report open when both channel and client are open");
     }
 }

--- a/dubbo-remoting/dubbo-remoting-api/src/test/java/org/apache/dubbo/remoting/exchange/support/header/HeaderExchangeClientTest.java
+++ b/dubbo-remoting/dubbo-remoting-api/src/test/java/org/apache/dubbo/remoting/exchange/support/header/HeaderExchangeClientTest.java
@@ -37,4 +37,29 @@ public class HeaderExchangeClientTest {
         Assertions.assertFalse(headerExchangeClient.shouldReconnect(URL.valueOf("localhost?reconnect=false")));
         Assertions.assertFalse(headerExchangeClient.shouldReconnect(URL.valueOf("localhost?reconnect=FALSE")));
     }
+
+    @Test
+    void testIsClosedWhenUnderlyingClientClosed() {
+        Client mockClient = Mockito.mock(Client.class);
+        // Underlying client is closed, but HeaderExchangeChannel is not
+        Mockito.when(mockClient.isClosed()).thenReturn(true);
+        Mockito.when(mockClient.getUrl()).thenReturn(URL.valueOf("dubbo://localhost:20880"));
+
+        HeaderExchangeClient headerExchangeClient = new HeaderExchangeClient(mockClient, false);
+
+        Assertions.assertTrue(headerExchangeClient.isClosed(),
+                "HeaderExchangeClient should report closed when underlying client is closed");
+    }
+
+    @Test
+    void testIsNotClosedWhenBothOpen() {
+        Client mockClient = Mockito.mock(Client.class);
+        Mockito.when(mockClient.isClosed()).thenReturn(false);
+        Mockito.when(mockClient.getUrl()).thenReturn(URL.valueOf("dubbo://localhost:20880"));
+
+        HeaderExchangeClient headerExchangeClient = new HeaderExchangeClient(mockClient, false);
+
+        Assertions.assertFalse(headerExchangeClient.isClosed(),
+                "HeaderExchangeClient should report open when both channel and client are open");
+    }
 }

--- a/dubbo-remoting/dubbo-remoting-api/src/test/java/org/apache/dubbo/remoting/exchange/support/header/ReconnectTimerTaskTest.java
+++ b/dubbo-remoting/dubbo-remoting-api/src/test/java/org/apache/dubbo/remoting/exchange/support/header/ReconnectTimerTaskTest.java
@@ -80,4 +80,46 @@ class ReconnectTimerTaskTest {
         Thread.sleep(2000L);
         Assertions.assertTrue(channel.getReconnectCount() > 1);
     }
+
+    @Test
+    void testStopReconnectWhenClientClosed() throws Exception {
+        url = url.addParameter(DUBBO_VERSION_KEY, "2.1.1");
+
+        // Let the task attempt reconnection while client is open and disconnected
+        Thread.sleep(1500L);
+        int reconnectCountBeforeClose = channel.getReconnectCount();
+        Assertions.assertTrue(reconnectCountBeforeClose > 0,
+                "Should have attempted reconnection while channel is not connected");
+
+        // Close the client - simulates provider going offline and client being destroyed
+        channel.close();
+
+        // Wait for the timer to fire again
+        Thread.sleep(1500L);
+
+        // After closing, reconnect count should not increase
+        Assertions.assertEquals(reconnectCountBeforeClose, channel.getReconnectCount(),
+                "Should stop reconnecting after client is closed");
+
+        // The timer task should have been cancelled
+        Assertions.assertTrue(reconnectTimerTask.cancel,
+                "Timer task should be cancelled when client is closed");
+    }
+
+    @Test
+    void testReconnectContinuesWhenNotClosed() throws Exception {
+        url = url.addParameter(DUBBO_VERSION_KEY, "2.1.1");
+
+        // Channel is disconnected but not closed - reconnection should continue
+        Thread.sleep(2000L);
+        int count1 = channel.getReconnectCount();
+        Assertions.assertTrue(count1 > 0, "Should attempt reconnection when disconnected but not closed");
+
+        Thread.sleep(1500L);
+        int count2 = channel.getReconnectCount();
+        Assertions.assertTrue(count2 > count1, "Should keep trying to reconnect");
+
+        Assertions.assertFalse(reconnectTimerTask.cancel,
+                "Timer task should not be cancelled when client is still open");
+    }
 }

--- a/dubbo-remoting/dubbo-remoting-api/src/test/java/org/apache/dubbo/remoting/exchange/support/header/ReconnectTimerTaskTest.java
+++ b/dubbo-remoting/dubbo-remoting-api/src/test/java/org/apache/dubbo/remoting/exchange/support/header/ReconnectTimerTaskTest.java
@@ -88,8 +88,8 @@ class ReconnectTimerTaskTest {
         // Let the task attempt reconnection while client is open and disconnected
         Thread.sleep(1500L);
         int reconnectCountBeforeClose = channel.getReconnectCount();
-        Assertions.assertTrue(reconnectCountBeforeClose > 0,
-                "Should have attempted reconnection while channel is not connected");
+        Assertions.assertTrue(
+                reconnectCountBeforeClose > 0, "Should have attempted reconnection while channel is not connected");
 
         // Close the client - simulates provider going offline and client being destroyed
         channel.close();
@@ -98,12 +98,13 @@ class ReconnectTimerTaskTest {
         Thread.sleep(1500L);
 
         // After closing, reconnect count should not increase
-        Assertions.assertEquals(reconnectCountBeforeClose, channel.getReconnectCount(),
+        Assertions.assertEquals(
+                reconnectCountBeforeClose,
+                channel.getReconnectCount(),
                 "Should stop reconnecting after client is closed");
 
         // The timer task should have been cancelled
-        Assertions.assertTrue(reconnectTimerTask.cancel,
-                "Timer task should be cancelled when client is closed");
+        Assertions.assertTrue(reconnectTimerTask.cancel, "Timer task should be cancelled when client is closed");
     }
 
     @Test
@@ -119,7 +120,7 @@ class ReconnectTimerTaskTest {
         int count2 = channel.getReconnectCount();
         Assertions.assertTrue(count2 > count1, "Should keep trying to reconnect");
 
-        Assertions.assertFalse(reconnectTimerTask.cancel,
-                "Timer task should not be cancelled when client is still open");
+        Assertions.assertFalse(
+                reconnectTimerTask.cancel, "Timer task should not be cancelled when client is still open");
     }
 }


### PR DESCRIPTION
## Problem

After all providers go offline, the consumer's `ReconnectTimerTask` keeps attempting to reconnect to the old provider IP indefinitely. In K8s environments where providers restart with new IPs, this generates continuous connection-refused errors and triggers false alerts.

## Root Cause

Three issues allow the reconnect timer to run indefinitely after a client should be considered closed:

1. **`AbstractTimerTask.run()`** always reschedules the timer via `reput()`, even when all channels are already closed. The task becomes an orphaned timer doing nothing but consuming resources.

2. **`HeaderExchangeClient.isClosed()`** only checks `HeaderExchangeChannel.closed` but not the underlying `Client.isClosed()`. When the underlying `AbstractClient`/`NettyClient` is closed independently (e.g., by protocol destroy), the `HeaderExchangeClient` still reports as open.

3. **`ReconnectTimerTask.doTask()`** has no defensive check for client closure before attempting reconnection. Even if the client is closed between the `run()` check and the `doTask()` execution, reconnection proceeds.

## Fix

- **`AbstractTimerTask.run()`**: When all channels report as closed, cancel the timer task instead of rescheduling. This prevents orphaned timers from running indefinitely.

- **`HeaderExchangeClient.isClosed()`**: Also check `client.isClosed()` so that if the underlying client is closed by any code path, the wrapper correctly reflects the closed state.

- **`ReconnectTimerTask.doTask()`**: Add a defensive check at the start — if the channel is a `Client` and reports as closed, cancel the timer and return immediately.

## Tests Added

| Change Point | Test |
|---|---|
| AbstractTimerTask auto-cancel on all channels closed | `AbstractTimerTaskTest.testAutoCancelWhenAllChannelsClosed()` — verifies task stops executing and cancel flag is set after channel closes |
| AbstractTimerTask continues when channel is open | `AbstractTimerTaskTest.testTaskContinuesWhenChannelIsOpen()` — regression test ensuring normal scheduling works |
| HeaderExchangeClient.isClosed() checks underlying client | `HeaderExchangeClientTest.testIsClosedWhenUnderlyingClientClosed()` — verifies isClosed() returns true when underlying client is closed |
| HeaderExchangeClient.isClosed() normal case | `HeaderExchangeClientTest.testIsNotClosedWhenBothOpen()` — regression test for normal open state |
| ReconnectTimerTask stops on client close | `ReconnectTimerTaskTest.testStopReconnectWhenClientClosed()` — verifies reconnect count stops increasing and timer is cancelled after client closes |
| ReconnectTimerTask continues when not closed | `ReconnectTimerTaskTest.testReconnectContinuesWhenNotClosed()` — regression test ensuring reconnection works for transient disconnections |

## Impact

Only affects `HeaderExchangeClient`-based connections (Dubbo protocol). The newer `AbstractNettyConnectionClient` (Triple protocol) already handles this correctly via `NettyConnectionHandler`. No behavioral change for normal reconnection scenarios — the timer still runs for transient disconnections where the client is not closed.

Fixes #15880