### PR TITLE
fix(serialize): respect WARN mode in DefaultSerializeClassChecker

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/utils/DefaultSerializeClassChecker.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/utils/DefaultSerializeClassChecker.java
@@ -111,12 +111,18 @@ public class DefaultSerializeClassChecker implements AllowClassNotifyListener {
             String msg = "[Serialization Security] Serialized class " + className
                     + " has not implement Serializable interface. "
                     + "Current mode is strict check, will disallow to deserialize it by default. ";
-            if (serializeSecurityManager.getWarnedClasses().add(className)) {
-                logger.error(PROTOCOL_UNTRUSTED_SERIALIZE_CLASS, "", "", msg);
+            if (checkSerializable && checkStatus != SerializeCheckStatus.WARN
+                    && checkStatus != SerializeCheckStatus.DISABLE) {
+                if (serializeSecurityManager.getWarnedClasses().add(className)) {
+                    logger.error(PROTOCOL_UNTRUSTED_SERIALIZE_CLASS, "", "", msg);
+                }
+                throw new IllegalArgumentException(msg);
             }
 
-            if (checkSerializable) {
-                throw new IllegalArgumentException(msg);
+            if (checkStatus == SerializeCheckStatus.WARN) {
+                if (serializeSecurityManager.getWarnedClasses().add(className)) {
+                    logger.warn(PROTOCOL_UNTRUSTED_SERIALIZE_CLASS, "", "", msg);
+                }
             }
         }
 
@@ -164,13 +170,14 @@ public class DefaultSerializeClassChecker implements AllowClassNotifyListener {
 
             if (Arrays.binarySearch(disAllowPrefixes, hash) >= 0) {
                 String msg = "[Serialization Security] Serialized class " + className + " is in disallow list. "
-                        + "Current mode is `WARN`, will disallow to deserialize it by default. "
+                        + "Current mode is `WARN`, will allow to deserialize it by default. "
+                        + "Dubbo will set to `STRICT` mode by default in the future. "
                         + "Please add it into security/serialize.allowlist or follow FAQ to configure it.";
                 if (serializeSecurityManager.getWarnedClasses().add(className)) {
                     logger.warn(PROTOCOL_UNTRUSTED_SERIALIZE_CLASS, "", "", msg);
                 }
 
-                throw new IllegalArgumentException(msg);
+                return classForName(classLoader, className);
             }
         }
 
@@ -185,13 +192,14 @@ public class DefaultSerializeClassChecker implements AllowClassNotifyListener {
 
             if (Arrays.binarySearch(disAllowPrefixes, hash) >= 0) {
                 String msg = "[Serialization Security] Serialized class " + className + " is in disallow list. "
-                        + "Current mode is `WARN`, will disallow to deserialize it by default. "
+                        + "Current mode is `WARN`, will allow to deserialize it by default. "
+                        + "Dubbo will set to `STRICT` mode by default in the future. "
                         + "Please add it into security/serialize.allowlist or follow FAQ to configure it.";
                 if (serializeSecurityManager.getWarnedClasses().add(className)) {
                     logger.warn(PROTOCOL_UNTRUSTED_SERIALIZE_CLASS, "", "", msg);
                 }
 
-                throw new IllegalArgumentException(msg);
+                return classForName(classLoader, className);
             }
         }
 

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/utils/DefaultSerializeClassChecker.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/utils/DefaultSerializeClassChecker.java
@@ -111,7 +111,8 @@ public class DefaultSerializeClassChecker implements AllowClassNotifyListener {
             String msg = "[Serialization Security] Serialized class " + className
                     + " has not implement Serializable interface. "
                     + "Current mode is strict check, will disallow to deserialize it by default. ";
-            if (checkSerializable && checkStatus != SerializeCheckStatus.WARN
+            if (checkSerializable
+                    && checkStatus != SerializeCheckStatus.WARN
                     && checkStatus != SerializeCheckStatus.DISABLE) {
                 if (serializeSecurityManager.getWarnedClasses().add(className)) {
                     logger.error(PROTOCOL_UNTRUSTED_SERIALIZE_CLASS, "", "", msg);

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/utils/DefaultSerializeClassCheckerTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/utils/DefaultSerializeClassCheckerTest.java
@@ -58,7 +58,8 @@ class DefaultSerializeClassCheckerTest {
             defaultSerializeClassChecker.loadClass(Thread.currentThread().getContextClassLoader(), int.class.getName());
         }
 
-        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+        // In WARN mode, disallowed classes should be loaded with a warning, not throw
+        Assertions.assertDoesNotThrow(() -> {
             defaultSerializeClassChecker.loadClass(
                     Thread.currentThread().getContextClassLoader(), Socket.class.getName());
         });
@@ -115,6 +116,54 @@ class DefaultSerializeClassCheckerTest {
                     .getWarnedClasses()
                     .contains(Thread.class.getName()));
         }
+
+        SystemPropertyConfigUtils.clearSystemProperty(
+                CommonConstants.DubboProperty.DUBBO_CLASS_DESERIALIZE_BLOCKED_LIST);
+    }
+
+    @Test
+    void testDisallowedClassInWarnModeDoesNotThrow() throws ClassNotFoundException {
+        SystemPropertyConfigUtils.setSystemProperty(
+                CommonConstants.DubboProperty.DUBBO_CLASS_DESERIALIZE_BLOCKED_LIST,
+                Runtime.class.getName());
+
+        SerializeSecurityManager ssm = FrameworkModel.defaultModel()
+                .getBeanFactory()
+                .getBean(SerializeSecurityManager.class);
+        ssm.setCheckStatus(SerializeCheckStatus.WARN);
+
+        DefaultSerializeClassChecker checker = DefaultSerializeClassChecker.getInstance();
+
+        // WARN mode: disallowed class should be loaded with warning, not throw
+        Assertions.assertDoesNotThrow(() -> {
+            checker.loadClass(Thread.currentThread().getContextClassLoader(), Runtime.class.getName());
+        });
+        Assertions.assertTrue(FrameworkModel.defaultModel()
+                .getBeanFactory()
+                .getBean(SerializeSecurityManager.class)
+                .getWarnedClasses()
+                .contains(Runtime.class.getName()));
+
+        SystemPropertyConfigUtils.clearSystemProperty(
+                CommonConstants.DubboProperty.DUBBO_CLASS_DESERIALIZE_BLOCKED_LIST);
+    }
+
+    @Test
+    void testDisallowedClassInStrictModeThrows() {
+        SystemPropertyConfigUtils.setSystemProperty(
+                CommonConstants.DubboProperty.DUBBO_CLASS_DESERIALIZE_BLOCKED_LIST,
+                Runtime.class.getName());
+
+        SerializeSecurityManager ssm = FrameworkModel.defaultModel()
+                .getBeanFactory()
+                .getBean(SerializeSecurityManager.class);
+        // Default is STRICT - non-allowed classes should throw
+        Assertions.assertEquals(SerializeCheckStatus.STRICT, AllowClassNotifyListener.DEFAULT_STATUS);
+
+        DefaultSerializeClassChecker checker = DefaultSerializeClassChecker.getInstance();
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+            checker.loadClass(Thread.currentThread().getContextClassLoader(), Runtime.class.getName());
+        });
 
         SystemPropertyConfigUtils.clearSystemProperty(
                 CommonConstants.DubboProperty.DUBBO_CLASS_DESERIALIZE_BLOCKED_LIST);

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/utils/DefaultSerializeClassCheckerTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/utils/DefaultSerializeClassCheckerTest.java
@@ -124,12 +124,10 @@ class DefaultSerializeClassCheckerTest {
     @Test
     void testDisallowedClassInWarnModeDoesNotThrow() throws ClassNotFoundException {
         SystemPropertyConfigUtils.setSystemProperty(
-                CommonConstants.DubboProperty.DUBBO_CLASS_DESERIALIZE_BLOCKED_LIST,
-                Runtime.class.getName());
+                CommonConstants.DubboProperty.DUBBO_CLASS_DESERIALIZE_BLOCKED_LIST, Runtime.class.getName());
 
-        SerializeSecurityManager ssm = FrameworkModel.defaultModel()
-                .getBeanFactory()
-                .getBean(SerializeSecurityManager.class);
+        SerializeSecurityManager ssm =
+                FrameworkModel.defaultModel().getBeanFactory().getBean(SerializeSecurityManager.class);
         ssm.setCheckStatus(SerializeCheckStatus.WARN);
 
         DefaultSerializeClassChecker checker = DefaultSerializeClassChecker.getInstance();
@@ -151,12 +149,10 @@ class DefaultSerializeClassCheckerTest {
     @Test
     void testDisallowedClassInStrictModeThrows() {
         SystemPropertyConfigUtils.setSystemProperty(
-                CommonConstants.DubboProperty.DUBBO_CLASS_DESERIALIZE_BLOCKED_LIST,
-                Runtime.class.getName());
+                CommonConstants.DubboProperty.DUBBO_CLASS_DESERIALIZE_BLOCKED_LIST, Runtime.class.getName());
 
-        SerializeSecurityManager ssm = FrameworkModel.defaultModel()
-                .getBeanFactory()
-                .getBean(SerializeSecurityManager.class);
+        SerializeSecurityManager ssm =
+                FrameworkModel.defaultModel().getBeanFactory().getBean(SerializeSecurityManager.class);
         // Default is STRICT - non-allowed classes should throw
         Assertions.assertEquals(SerializeCheckStatus.STRICT, AllowClassNotifyListener.DEFAULT_STATUS);
 


### PR DESCRIPTION
## Problem

`DefaultSerializeClassChecker` throws `IllegalArgumentException` even when `SerializeCheckStatus` is set to `WARN`. The WARN mode is intended to only log warnings without blocking deserialization, but three code paths still throw exceptions unconditionally.

## Root Cause

Three places in `DefaultSerializeClassChecker` ignore the `checkStatus` when deciding to throw:

1. **`loadClass0()` disallow list check (case-sensitive, line 165)**: Logs a WARN-mode message but then unconditionally throws `IllegalArgumentException`.

2. **`loadClass0()` disallow list check (case-insensitive, line 186)**: Same issue — warns then throws.

3. **`loadClass()` Serializable interface check (line 118)**: Only checks the `checkSerializable` flag but ignores `checkStatus`. In WARN mode, non-Serializable classes should be warned about, not rejected.

## Fix

- **`loadClass0()` disallow list checks**: In WARN mode, log a warning and return the loaded class via `classForName()` instead of throwing. The warning message is updated to say "will allow to deserialize" (matching the existing non-disallowed warning at line 198).

- **`loadClass()` Serializable check**: Gate the exception on `checkStatus` — only throw in STRICT mode (when `checkSerializable` is also true). In WARN mode, downgrade from `logger.error` to `logger.warn`. In DISABLE mode, skip the check entirely.

This makes `DefaultSerializeClassChecker` consistent with `Fastjson2SecurityManager`, which already handles WARN mode correctly by returning null instead of throwing.

## Tests Added

| Change Point | Test |
|---|---|
| Disallow list in WARN mode no longer throws | `testDisallowedClassInWarnModeDoesNotThrow()` — loads `Runtime.class` (disallowed) in WARN mode, verifies no exception and class is in warnedClasses |
| Disallow list in STRICT mode still throws | `testDisallowedClassInStrictModeThrows()` — confirms `Runtime.class` throws in STRICT mode (regression) |
| Non-Serializable class in WARN mode | `testCommon()` — updated: `Socket.class` (disallowed, non-Serializable) now loads without exception in WARN mode |
| Existing STRICT mode behavior preserved | `testStatus()`, `testBlockAll()`, `testAddBlock()` — all pass unchanged |

## Impact

Only affects deserialization behavior when `checkStatus` is explicitly set to `WARN`. Default mode (`STRICT`) behavior is unchanged. Users who set WARN mode will now get the expected behavior: warnings are logged but deserialization proceeds.

Fixes #15179