### PR TITLE
fix: disable lockedSynchronizers in dumpAllThreads to avoid ZGC safepoint heap scan

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/constants/CommonConstants.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/constants/CommonConstants.java
@@ -607,6 +607,8 @@ public interface CommonConstants {
      */
     String DUBBO_JSTACK_MAXLINE = "dubbo.jstack-dump.max-line";
 
+    String DUBBO_JSTACK_LOCKED_SYNCHRONIZERS = "dubbo.jstack-dump.locked-synchronizers";
+
     String ENCODE_IN_IO_THREAD_KEY = "encode.in.io";
 
     boolean DEFAULT_ENCODE_IN_IO_THREAD = false;
@@ -723,6 +725,8 @@ public interface CommonConstants {
          * used in JVMUtil.java ,Control stack print lines, default is 32 lines
          */
         String DUBBO_JSTACK_MAXLINE = "dubbo.jstack-dump.max-line";
+
+        String DUBBO_JSTACK_LOCKED_SYNCHRONIZERS = "dubbo.jstack-dump.locked-synchronizers";
 
         /**
          * The property name for {@link NetworkInterface#getDisplayName() the name of network interface} that the Dubbo

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/utils/JVMUtil.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/utils/JVMUtil.java
@@ -33,7 +33,12 @@ import static java.lang.Thread.State.WAITING;
 public class JVMUtil {
     public static void jstack(OutputStream stream) throws Exception {
         ThreadMXBean threadMxBean = ManagementFactory.getThreadMXBean();
-        for (ThreadInfo threadInfo : threadMxBean.dumpAllThreads(true, true)) {
+        // Pass lockedSynchronizers=false to avoid a full heap scan at safepoint.
+        // With lockedSynchronizers=true, the JVM iterates the entire heap to find all
+        // AbstractOwnableSynchronizer instances. On ZGC with large heaps, this causes
+        // tens-of-seconds safepoint pauses due to load barrier overhead on every reference.
+        // See: https://github.com/apache/dubbo/issues/16194
+        for (ThreadInfo threadInfo : threadMxBean.dumpAllThreads(true, false)) {
             stream.write(getThreadDumpString(threadInfo).getBytes(StandardCharsets.UTF_8));
         }
     }

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/utils/JVMUtil.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/utils/JVMUtil.java
@@ -33,7 +33,13 @@ import static java.lang.Thread.State.WAITING;
 public class JVMUtil {
     public static void jstack(OutputStream stream) throws Exception {
         ThreadMXBean threadMxBean = ManagementFactory.getThreadMXBean();
-        for (ThreadInfo threadInfo : threadMxBean.dumpAllThreads(true, false)) {
+        boolean lockedSynchronizers = false;
+        String lockedSynchronizersStr = SystemPropertyConfigUtils.getSystemProperty(
+                CommonConstants.DubboProperty.DUBBO_JSTACK_LOCKED_SYNCHRONIZERS);
+        if (StringUtils.isNotEmpty(lockedSynchronizersStr)) {
+            lockedSynchronizers = Boolean.parseBoolean(lockedSynchronizersStr);
+        }
+        for (ThreadInfo threadInfo : threadMxBean.dumpAllThreads(true, lockedSynchronizers)) {
             stream.write(getThreadDumpString(threadInfo).getBytes(StandardCharsets.UTF_8));
         }
     }

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/utils/JVMUtil.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/utils/JVMUtil.java
@@ -33,11 +33,6 @@ import static java.lang.Thread.State.WAITING;
 public class JVMUtil {
     public static void jstack(OutputStream stream) throws Exception {
         ThreadMXBean threadMxBean = ManagementFactory.getThreadMXBean();
-        // Pass lockedSynchronizers=false to avoid a full heap scan at safepoint.
-        // With lockedSynchronizers=true, the JVM iterates the entire heap to find all
-        // AbstractOwnableSynchronizer instances. On ZGC with large heaps, this causes
-        // tens-of-seconds safepoint pauses due to load barrier overhead on every reference.
-        // See: https://github.com/apache/dubbo/issues/16194
         for (ThreadInfo threadInfo : threadMxBean.dumpAllThreads(true, false)) {
             stream.write(getThreadDumpString(threadInfo).getBytes(StandardCharsets.UTF_8));
         }


### PR DESCRIPTION
## What is the purpose of the change

Fixes #16194

`JVMUtil.jstack()` calls `ThreadMXBean.dumpAllThreads(true, true)`. The `lockedSynchronizers=true` parameter forces the JVM to scan the **entire Java heap** at a safepoint to find all `AbstractOwnableSynchronizer` instances. On ZGC with large heaps, this causes catastrophic safepoint pauses (**36–39 seconds** measured on a 65GB heap with ~1950 threads) that freeze the entire application.

This PR changes `lockedSynchronizers` from `true` to `false`, eliminating the heap scan.

### Root Cause

On ZGC, `HeapInspection::find_instances_at_safepoint()` iterates the entire heap, and every object reference must pass through ZGC's load barrier (color bit check → relocate → forwarding table → remap). On our 65GB heap, this resulted in a **~37-second safepoint pause**. For comparison, normal ZGC safepoint operations (Mark Start, Mark End, Relocate Start) complete in 0.1–0.8ms.

The OpenJDK community already fixed this on the tooling side ([JDK-8324066](https://bugs.openjdk.org/browse/JDK-8324066): "clhsdb jstack should not scan for j.u.c locks by default"), but the programmatic API (`ThreadMXBean.dumpAllThreads`) has no such protection.

### Production Impact

When `AbortPolicyWithReport` fires on ZGC + large heap:
1. `dumpAllThreads(true, true)` → 37s full application freeze
2. Queued requests immediately exhaust pool on release → cascading freezes
3. Observed: **4 consecutive dumps → ~150s near-total service unavailability**

## Brief changelog

- `JVMUtil.jstack()`: Change `dumpAllThreads(true, true)` to `dumpAllThreads(true, false)`

## What is lost

Only the "Locked synchronizers" section at the bottom of each thread's dump — i.e., `java.util.concurrent.locks.ReentrantLock` / `ReadWriteLock` ownership. All other diagnostic info is retained:

| Information | Retained? |
|---|---|
| Thread name, ID, state | Yes |
| Full stack traces | Yes |
| `synchronized` block contention (BLOCKED on ...) | Yes |
| `synchronized` monitor ownership (- locked ...) | Yes |
| Waiting/parking state | Yes |
| Lock owner for BLOCKED threads | Yes |
| **j.u.c.locks ownership (ReentrantLock, etc.)** | **No** |

## Verifying this change

Existing tests pass — all tests in `AbortPolicyWithReportTest` mock the `jstack()` method and are not affected by the parameter change.

The fix can be verified by:
1. Deploy a Dubbo app with ZGC + large heap (≥32GB)
2. Exhaust the thread pool to trigger `AbortPolicyWithReport`
3. Observe safepoint duration in GC logs — should drop from ~37s to <100ms