### PR TITLE
Close channel on TLS exception to prevent half-open connections

### DIFF
--- a/dubbo-remoting/dubbo-remoting-netty4/src/main/java/org/apache/dubbo/remoting/transport/netty4/ssl/SslClientTlsHandler.java
+++ b/dubbo-remoting/dubbo-remoting-netty4/src/main/java/org/apache/dubbo/remoting/transport/netty4/ssl/SslClientTlsHandler.java
@@ -70,7 +70,7 @@ public class SslClientTlsHandler extends ChannelInboundHandlerAdapter {
                         "",
                         "TLS negotiation failed when trying to accept new connection.",
                         handshakeEvent.cause());
-                ctx.fireExceptionCaught(handshakeEvent.cause());
+                ctx.close();
             }
         }
     }

--- a/dubbo-remoting/dubbo-remoting-netty4/src/main/java/org/apache/dubbo/remoting/transport/netty4/ssl/SslClientTlsHandler.java
+++ b/dubbo-remoting/dubbo-remoting-netty4/src/main/java/org/apache/dubbo/remoting/transport/netty4/ssl/SslClientTlsHandler.java
@@ -68,8 +68,9 @@ public class SslClientTlsHandler extends ChannelInboundHandlerAdapter {
                         INTERNAL_ERROR,
                         "unknown error in remoting module",
                         "",
-                        "TLS negotiation failed when trying to accept new connection.",
+                        "TLS negotiation failed when connecting to remote server.",
                         handshakeEvent.cause());
+                ctx.fireExceptionCaught(handshakeEvent.cause());
                 ctx.close();
             }
         }

--- a/dubbo-remoting/dubbo-remoting-netty4/src/main/java/org/apache/dubbo/remoting/transport/netty4/ssl/SslServerTlsHandler.java
+++ b/dubbo-remoting/dubbo-remoting-netty4/src/main/java/org/apache/dubbo/remoting/transport/netty4/ssl/SslServerTlsHandler.java
@@ -65,6 +65,7 @@ public class SslServerTlsHandler extends ByteToMessageDecoder {
                 "",
                 "TLS negotiation failed when trying to accept new connection.",
                 cause);
+        ctx.close();
     }
 
     @Override

--- a/dubbo-remoting/dubbo-remoting-netty4/src/test/java/org/apache/dubbo/remoting/transport/netty4/ssl/SslHandlerExceptionTest.java
+++ b/dubbo-remoting/dubbo-remoting-netty4/src/test/java/org/apache/dubbo/remoting/transport/netty4/ssl/SslHandlerExceptionTest.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.remoting.transport.netty4.ssl;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelPipeline;
+import io.netty.handler.ssl.SslContext;
+import io.netty.handler.ssl.SslHandshakeCompletionEvent;
+import org.junit.jupiter.api.Test;
+
+import javax.net.ssl.SSLHandshakeException;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Verify that TLS handlers properly close channels on exceptions,
+ * preventing half-open connections that are TCP-alive but application-dead.
+ */
+class SslHandlerExceptionTest {
+
+    @Test
+    void serverTlsHandler_exceptionCaught_shouldCloseChannel() throws Exception {
+        ChannelHandlerContext ctx = mock(ChannelHandlerContext.class);
+        ChannelPipeline pipeline = mock(ChannelPipeline.class);
+        when(ctx.pipeline()).thenReturn(pipeline);
+
+        SslServerTlsHandler handler = new SslServerTlsHandler(null, true);
+        NoClassDefFoundError error = new NoClassDefFoundError(
+                "Could not initialize class io.netty.buffer.PooledUnsafeDirectByteBuf");
+
+        handler.exceptionCaught(ctx, error);
+
+        verify(ctx).close();
+    }
+
+    @Test
+    void clientTlsHandler_handshakeFailure_shouldCloseChannel() throws Exception {
+        ChannelHandlerContext ctx = mock(ChannelHandlerContext.class);
+
+        SslClientTlsHandler handler = new SslClientTlsHandler(mock(SslContext.class));
+        SslHandshakeCompletionEvent failureEvent = new SslHandshakeCompletionEvent(
+                new SSLHandshakeException("TLS handshake timeout"));
+
+        handler.userEventTriggered(ctx, failureEvent);
+
+        verify(ctx).close();
+    }
+}

--- a/dubbo-remoting/dubbo-remoting-netty4/src/test/java/org/apache/dubbo/remoting/transport/netty4/ssl/SslHandlerExceptionTest.java
+++ b/dubbo-remoting/dubbo-remoting-netty4/src/test/java/org/apache/dubbo/remoting/transport/netty4/ssl/SslHandlerExceptionTest.java
@@ -16,13 +16,13 @@
  */
 package org.apache.dubbo.remoting.transport.netty4.ssl;
 
+import javax.net.ssl.SSLHandshakeException;
+
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPipeline;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslHandshakeCompletionEvent;
 import org.junit.jupiter.api.Test;
-
-import javax.net.ssl.SSLHandshakeException;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -41,8 +41,8 @@ class SslHandlerExceptionTest {
         when(ctx.pipeline()).thenReturn(pipeline);
 
         SslServerTlsHandler handler = new SslServerTlsHandler(null, true);
-        NoClassDefFoundError error = new NoClassDefFoundError(
-                "Could not initialize class io.netty.buffer.PooledUnsafeDirectByteBuf");
+        NoClassDefFoundError error =
+                new NoClassDefFoundError("Could not initialize class io.netty.buffer.PooledUnsafeDirectByteBuf");
 
         handler.exceptionCaught(ctx, error);
 
@@ -54,8 +54,8 @@ class SslHandlerExceptionTest {
         ChannelHandlerContext ctx = mock(ChannelHandlerContext.class);
 
         SslClientTlsHandler handler = new SslClientTlsHandler(mock(SslContext.class));
-        SslHandshakeCompletionEvent failureEvent = new SslHandshakeCompletionEvent(
-                new SSLHandshakeException("TLS handshake timeout"));
+        SslHandshakeCompletionEvent failureEvent =
+                new SslHandshakeCompletionEvent(new SSLHandshakeException("TLS handshake timeout"));
 
         handler.userEventTriggered(ctx, failureEvent);
 

--- a/dubbo-remoting/dubbo-remoting-netty4/src/test/java/org/apache/dubbo/remoting/transport/netty4/ssl/SslHandlerExceptionTest.java
+++ b/dubbo-remoting/dubbo-remoting-netty4/src/test/java/org/apache/dubbo/remoting/transport/netty4/ssl/SslHandlerExceptionTest.java
@@ -19,14 +19,12 @@ package org.apache.dubbo.remoting.transport.netty4.ssl;
 import javax.net.ssl.SSLHandshakeException;
 
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.channel.ChannelPipeline;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslHandshakeCompletionEvent;
 import org.junit.jupiter.api.Test;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 /**
  * Verify that TLS handlers properly close channels on exceptions,
@@ -37,8 +35,6 @@ class SslHandlerExceptionTest {
     @Test
     void serverTlsHandler_exceptionCaught_shouldCloseChannel() throws Exception {
         ChannelHandlerContext ctx = mock(ChannelHandlerContext.class);
-        ChannelPipeline pipeline = mock(ChannelPipeline.class);
-        when(ctx.pipeline()).thenReturn(pipeline);
 
         SslServerTlsHandler handler = new SslServerTlsHandler(null, true);
         NoClassDefFoundError error =


### PR DESCRIPTION
## What is the purpose of the change?

Fixes #16201

`SslServerTlsHandler.exceptionCaught()` only logged errors without closing the channel or propagating the exception. This caused channels to remain TCP-active but application-dead (half-open) when non-IOException/non-OutOfMemoryError exceptions (e.g., `NoClassDefFoundError`) occurred during Netty's read loop.

**Impact**: Consumer-side `DubboInvoker.isAvailable()` always returned `true` for these broken connections (it only checks TCP-level `channel.isActive()`), so the `addInvalidateInvoker` mechanism never triggered. The broken Provider was never removed from `validInvokers`, causing continuous RPC timeouts.

**Changes**:
- **`SslServerTlsHandler.exceptionCaught()`**: Added `ctx.close()` after logging, consistent with the `userEventTriggered()` method in the same class which already closes the channel on TLS handshake failure.
- **`SslClientTlsHandler.userEventTriggered()`**: Changed from `ctx.fireExceptionCaught()` to `ctx.close()` on handshake failure, consistent with server-side behavior and ensuring the channel is properly closed so the Consumer can detect the failure.

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change. (#16201)
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Make sure gitHub actions can pass. [Why the workflow is failing and how to fix it?](../CONTRIBUTING.md)

Made with [Cursor](https://cursor.com)