### PR TITLE
[Bug] Fix TOCTOU race condition in ZookeeperClientManager.getInstance()

### DIFF
--- a/dubbo-registry/dubbo-registry-api/src/test/java/org/apache/dubbo/registry/client/AbstractServiceDiscoveryFactoryTest.java
+++ b/dubbo-registry/dubbo-registry-api/src/test/java/org/apache/dubbo/registry/client/AbstractServiceDiscoveryFactoryTest.java
@@ -22,6 +22,7 @@ import org.apache.dubbo.rpc.model.ApplicationModel;
 
 import java.util.List;
 
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -50,5 +51,10 @@ class AbstractServiceDiscoveryFactoryTest {
         Assertions.assertEquals(2, allServiceDiscoveries.size());
         Assertions.assertTrue(allServiceDiscoveries.contains(serviceDiscovery1));
         Assertions.assertTrue(allServiceDiscoveries.contains(serviceDiscovery3));
+    }
+
+    @AfterAll
+    public static void clearUp() {
+        ApplicationModel.reset();
     }
 }

--- a/dubbo-remoting/dubbo-remoting-zookeeper-curator5/src/main/java/org/apache/dubbo/remoting/zookeeper/curator5/ZookeeperClientManager.java
+++ b/dubbo-remoting/dubbo-remoting-zookeeper-curator5/src/main/java/org/apache/dubbo/remoting/zookeeper/curator5/ZookeeperClientManager.java
@@ -48,10 +48,9 @@ public class ZookeeperClientManager {
     public ZookeeperClientManager() {}
 
     public static ZookeeperClientManager getInstance(ApplicationModel applicationModel) {
-        if (!managerMap.containsKey(applicationModel) || managerMap.get(applicationModel) == null) {
+        return managerMap.computeIfAbsent(applicationModel, model -> {
             ZookeeperClientManager clientManager = new ZookeeperClientManager();
-            applicationModel.addDestroyListener(m -> {
-                // destroy zookeeper clients if any
+            model.addDestroyListener(m -> {
                 try {
                     clientManager.destroy();
                 } catch (Exception e) {
@@ -63,9 +62,8 @@ public class ZookeeperClientManager {
                             e);
                 }
             });
-            managerMap.put(applicationModel, clientManager);
-        }
-        return managerMap.get(applicationModel);
+            return clientManager;
+        });
     }
 
     public ZookeeperClient connect(URL url) {

--- a/dubbo-remoting/dubbo-remoting-zookeeper-curator5/src/test/java/org/apache/dubbo/remoting/zookeeper/curator5/support/ZookeeperClientManagerTest.java
+++ b/dubbo-remoting/dubbo-remoting-zookeeper-curator5/src/test/java/org/apache/dubbo/remoting/zookeeper/curator5/support/ZookeeperClientManagerTest.java
@@ -20,8 +20,15 @@ import org.apache.dubbo.common.URL;
 import org.apache.dubbo.remoting.zookeeper.curator5.Curator5ZookeeperClient;
 import org.apache.dubbo.remoting.zookeeper.curator5.ZookeeperClient;
 import org.apache.dubbo.remoting.zookeeper.curator5.ZookeeperClientManager;
+import org.apache.dubbo.rpc.model.ApplicationModel;
 
+import java.lang.reflect.Field;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
@@ -242,6 +249,53 @@ class ZookeeperClientManagerTest {
         ZookeeperClient client1 = zookeeperClientManager.connect(url1);
         ZookeeperClient client2 = zookeeperClientManager.connect(url2);
         assertThat(client1, not(client2));
+    }
+
+    @Test
+    void testGetInstanceConcurrentRaceCondition() throws Exception {
+        // Clear static managerMap via reflection to start fresh
+        Field managerMapField = ZookeeperClientManager.class.getDeclaredField("managerMap");
+        managerMapField.setAccessible(true);
+        @SuppressWarnings("unchecked")
+        Map<?, ?> managerMap = (Map<?, ?>) managerMapField.get(null);
+        managerMap.clear();
+
+        ApplicationModel appModel = ApplicationModel.defaultModel();
+        int threadCount = 20;
+        CountDownLatch startGate = new CountDownLatch(1);
+        CountDownLatch endGate = new CountDownLatch(threadCount);
+        Set<ZookeeperClientManager> uniqueInstances = Collections.synchronizedSet(new HashSet<>());
+
+        for (int i = 0; i < threadCount; i++) {
+            new Thread(() -> {
+                        try {
+                            startGate.await();
+                            ZookeeperClientManager instance = ZookeeperClientManager.getInstance(appModel);
+                            uniqueInstances.add(instance);
+                        } catch (Exception e) {
+                            e.printStackTrace();
+                        } finally {
+                            endGate.countDown();
+                        }
+                    })
+                    .start();
+        }
+
+        startGate.countDown();
+        endGate.await();
+
+        // With the buggy code, multiple different instances may be created.
+        // With the fix (computeIfAbsent), exactly 1 instance should exist.
+        Assertions.assertEquals(
+                1,
+                uniqueInstances.size(),
+                "Expected exactly 1 ZookeeperClientManager instance, but got " + uniqueInstances.size()
+                        + ". This indicates a TOCTOU race condition in getInstance().");
+
+        // Also verify only 1 entry in the static map
+        Assertions.assertEquals(1, managerMap.size(), "Expected exactly 1 entry in managerMap");
+
+        managerMap.clear();
     }
 
     @AfterAll


### PR DESCRIPTION
## What is the purpose of the change?
Fixes a Time-Of-Check to Time-Of-Use (TOCTOU) race condition in `ZookeeperClientManager.getInstance()`.

In the current implementation, `getInstance(ApplicationModel)` uses a non-atomic check-then-act pattern (`containsKey` followed by `put`) on a `ConcurrentHashMap`. 

When multiple threads call `getInstance()` concurrently for the first time with the same `ApplicationModel`, each thread can bypass the `containsKey` check, create a separate `ZookeeperClientManager` instance, and register duplicate `addDestroyListener` callbacks. The later threads will overwrite the earlier instances in `managerMap`, causing the overwritten instances to be lost but their destroy listeners to remain registered, which leads to redundant Zookeeper client cleanup operations and resource waste.

## What is changed?
- Replaced the `containsKey` + `put` pattern with `managerMap.computeIfAbsent()` to ensure that exactly one manager instance and exactly one destroy listener are created per `ApplicationModel`, regardless of concurrency.
- Added `testGetInstanceConcurrentRaceCondition` to verify that concurrent calls safely return exactly 1 instance and create only 1 entry in the map.