### PR TITLE
Bump org.asynchttpclient:async-http-client from 2.12.4 to 3.0.9 and refactor DownloadZookeeperInitializer in /dubbo-test/dubbo-test-check

### DIFF
--- a/dubbo-test/dubbo-test-check/pom.xml
+++ b/dubbo-test/dubbo-test-check/pom.xml
@@ -33,7 +33,7 @@
     <curator5.version>4.2.0</curator5.version>
     <commons.compress.version>1.28.0</commons.compress.version>
     <commons.exec.version>1.6.0</commons.exec.version>
-    <async.http.client.version>2.12.4</async.http.client.version>
+    <async.http.client.version>3.0.9</async.http.client.version>
   </properties>
 
   <dependencies>

--- a/dubbo-test/dubbo-test-check/src/main/java/org/apache/dubbo/test/check/registrycenter/initializer/DownloadZookeeperInitializer.java
+++ b/dubbo-test/dubbo-test-check/src/main/java/org/apache/dubbo/test/check/registrycenter/initializer/DownloadZookeeperInitializer.java
@@ -26,6 +26,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
+import java.time.Duration;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
@@ -66,12 +67,12 @@ public class DownloadZookeeperInitializer extends ZookeeperInitializer {
     /**
      * The timeout when download zookeeper binary archive file.
      */
-    private static final int REQUEST_TIMEOUT = 180 * 1000;
+    private static final Duration REQUEST_TIMEOUT = Duration.ofSeconds(180);
 
     /**
      * The timeout when connect the download url.
      */
-    private static final int CONNECT_TIMEOUT = 60 * 1000;
+    private static final Duration CONNECT_TIMEOUT = Duration.ofSeconds(60);
 
     /**
      * Returns {@code true} if the file exists with the given file path, otherwise {@code false}.
@@ -204,7 +205,7 @@ public class DownloadZookeeperInitializer extends ZookeeperInitializer {
                     }
                 });
         // Future timeout should 2 times as equal as REQUEST_TIMEOUT, because it will retry 1 time.
-        Response response = responseFuture.get(REQUEST_TIMEOUT * 2, TimeUnit.MILLISECONDS);
+        Response response = responseFuture.get(REQUEST_TIMEOUT.getSeconds() * 2, TimeUnit.SECONDS);
         Files.copy(response.getResponseBodyAsStream(), targetPath, StandardCopyOption.REPLACE_EXISTING);
     }
 }


### PR DESCRIPTION
## What is the purpose of the change?
```DownloadZookeeperInitializer.java``` needs to be fixed if bump org.asynchttpclient:async-http-client from 2.12.4 to 3.0.9
see details at https://github.com/apache/dubbo/pull/16212

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Make sure gitHub actions can pass. [Why the workflow is failing and how to fix it?](../CONTRIBUTING.md)
