### PR TITLE
fix: disable lockedSynchronizers in dumpAllThreads to avoid ZGC safepoint heap scan

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -34,15 +34,9 @@ github:
     # Enable projects for project management boards
     projects: true
   protected_branches:
-    master:
-      # only disable force push
-      foo: bar
-    3.0:
-      # only disable force push
-      foo: bar
-    3.1:
-      # only disable force push
-      foo: bar
+    master: {}
+    3.0: {}
+    3.1: {}
   labels:
     - java
     - rpc

--- a/.github/workflows/build-and-test-pr.yml
+++ b/.github/workflows/build-and-test-pr.yml
@@ -610,7 +610,7 @@ jobs:
           native-image-job-reports: 'true'
       - name: "Set up Zookeeper environment"
         run: |
-          wget https://dlcdn.apache.org/zookeeper/zookeeper-3.8.4/apache-zookeeper-3.8.4-bin.tar.gz
+          wget -t 1 -T 120 https://archive.apache.org/dist/zookeeper/zookeeper-3.8.4/apache-zookeeper-3.8.4-bin.tar.gz
           tar -zxvf apache-zookeeper-3.8.4-bin.tar.gz
           mv apache-zookeeper-3.8.4-bin/conf/zoo_sample.cfg apache-zookeeper-3.8.4-bin/conf/zoo.cfg
           apache-zookeeper-3.8.4-bin/bin/zkServer.sh start

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/utils/JVMUtil.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/utils/JVMUtil.java
@@ -32,7 +32,7 @@ import static java.lang.Thread.State.WAITING;
 public class JVMUtil {
     public static void jstack(OutputStream stream) throws Exception {
         ThreadMXBean threadMxBean = ManagementFactory.getThreadMXBean();
-        for (ThreadInfo threadInfo : threadMxBean.dumpAllThreads(true, true)) {
+        for (ThreadInfo threadInfo : threadMxBean.dumpAllThreads(true, false)) {
             stream.write(getThreadDumpString(threadInfo).getBytes());
         }
     }

--- a/dubbo-dependencies-bom/pom.xml
+++ b/dubbo-dependencies-bom/pom.xml
@@ -170,7 +170,7 @@
     <spotless.action>check</spotless.action>
     <dubbo-shared-resources.version>1.0.0</dubbo-shared-resources.version>
     <palantirJavaFormat.version>2.38.0</palantirJavaFormat.version>
-    <revision>3.2.19-SNAPSHOT</revision>
+    <revision>3.2.20-SNAPSHOT</revision>
   </properties>
 
   <dependencyManagement>

--- a/dubbo-dependencies-bom/pom.xml
+++ b/dubbo-dependencies-bom/pom.xml
@@ -105,7 +105,7 @@
     <curator_test_version>2.12.0</curator_test_version>
     <jedis_version>3.10.0</jedis_version>
     <hessian_version>4.0.66</hessian_version>
-    <protobuf-java_version>3.25.4</protobuf-java_version>
+    <protobuf-java_version>4.33.4</protobuf-java_version>
     <javax_annotation-api_version>1.3.2</javax_annotation-api_version>
     <servlet_version>3.1.0</servlet_version>
     <jetty_version>9.4.56.v20240826</jetty_version>

--- a/dubbo-dependencies/dubbo-dependencies-zookeeper-curator5/pom.xml
+++ b/dubbo-dependencies/dubbo-dependencies-zookeeper-curator5/pom.xml
@@ -31,7 +31,7 @@
   <packaging>pom</packaging>
 
   <properties>
-    <revision>3.2.19-SNAPSHOT</revision>
+    <revision>3.2.20-SNAPSHOT</revision>
     <maven_flatten_version>1.6.0</maven_flatten_version>
     <curator5_version>5.1.0</curator5_version>
     <zookeeper_version>3.8.4</zookeeper_version>

--- a/dubbo-dependencies/dubbo-dependencies-zookeeper/pom.xml
+++ b/dubbo-dependencies/dubbo-dependencies-zookeeper/pom.xml
@@ -31,7 +31,7 @@
   <packaging>pom</packaging>
 
   <properties>
-    <revision>3.2.19-SNAPSHOT</revision>
+    <revision>3.2.20-SNAPSHOT</revision>
     <maven_flatten_version>1.6.0</maven_flatten_version>
     <curator_version>4.3.0</curator_version>
     <zookeeper_version>3.4.14</zookeeper_version>

--- a/dubbo-plugin/dubbo-security/pom.xml
+++ b/dubbo-plugin/dubbo-security/pom.xml
@@ -29,7 +29,6 @@
 
   <properties>
     <skip_maven_deploy>false</skip_maven_deploy>
-    <protobuf-java.version>3.22.2</protobuf-java.version>
     <grpc.version>1.55.1</grpc.version>
   </properties>
 
@@ -104,7 +103,7 @@
         <artifactId>protobuf-maven-plugin</artifactId>
         <version>0.6.1</version>
         <configuration>
-          <protocArtifact>com.google.protobuf:protoc:${protobuf-java.version}:exe:${os.detected.classifier}</protocArtifact>
+          <protocArtifact>com.google.protobuf:protoc:${protobuf-java_version}:exe:${os.detected.classifier}</protocArtifact>
           <pluginId>grpc-java</pluginId>
           <pluginArtifact>io.grpc:protoc-gen-grpc-java:${grpc.version}:exe:${os.detected.classifier}</pluginArtifact>
         </configuration>

--- a/dubbo-registry/dubbo-registry-api/src/test/java/org/apache/dubbo/registry/support/CacheableFailbackRegistryTest.java
+++ b/dubbo-registry/dubbo-registry-api/src/test/java/org/apache/dubbo/registry/support/CacheableFailbackRegistryTest.java
@@ -1,0 +1,162 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.registry.support;
+
+import org.apache.dubbo.common.URL;
+import org.apache.dubbo.common.url.component.ServiceAddressURL;
+import org.apache.dubbo.registry.NotifyListener;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.apache.dubbo.common.URLStrParser.ENCODED_AND_MARK;
+import static org.apache.dubbo.common.URLStrParser.ENCODED_QUESTION_MARK;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class CacheableFailbackRegistryTest {
+
+    private StubCacheableFailbackRegistry registry;
+
+    @BeforeEach
+    void setUp() {
+        registry = new StubCacheableFailbackRegistry(URL.valueOf("mock://127.0.0.1"));
+    }
+
+    @Test
+    void shouldRemoveExactTimestamp() throws Exception {
+        // Test removing exact "timestamp" parameter
+        String rawProvider = "dubbo://127.0.0.1:20880/demo.Service?timestamp=100&revision=v1";
+        String result = strip(rawProvider);
+        // After removing timestamp, only revision should remain
+        assertTrue(result.contains("revision=v1"), "Result should contain revision");
+        assertFalse(result.contains("timestamp"), "Result should not contain timestamp");
+    }
+
+    @Test
+    void shouldRemoveExactPid() throws Exception {
+        // Test removing exact "pid" parameter
+        String rawProvider = "dubbo://127.0.0.1:20880/demo.Service?pid=9999&revision=v1";
+        String result = strip(rawProvider);
+        assertTrue(result.contains("revision=v1"), "Result should contain revision");
+        assertFalse(result.contains("pid"), "Result should not contain pid");
+    }
+
+    @Test
+    void shouldRemoveTimestampAndPid() throws Exception {
+        // Test removing both timestamp and pid
+        String rawProvider = "dubbo://127.0.0.1:20880/demo.Service?timestamp=100&pid=1234&revision=abc";
+        String result = strip(rawProvider);
+        assertTrue(result.contains("revision=abc"), "Result should contain revision");
+        assertFalse(result.contains("timestamp"), "Result should not contain timestamp");
+        assertFalse(result.contains("pid"), "Result should not contain pid");
+    }
+
+    @Test
+    void shouldKeepRemoteTimestamp() throws Exception {
+        // remote.timestamp should NOT be removed (only exact "timestamp" is removed)
+        String rawProvider = "dubbo://127.0.0.1:20880/demo.Service?remote.timestamp=200&revision=v1";
+        String result = strip(rawProvider);
+        assertTrue(result.contains("remote.timestamp=200"), "Result should keep remote.timestamp");
+        assertTrue(result.contains("revision=v1"), "Result should contain revision");
+    }
+
+    @Test
+    void shouldRemoveEncodedTimestampAndPid() throws Exception {
+        // Test with encoded format
+        String base = "dubbo%3A%2F%2F127.0.0.1%3A20880%2Fdemo.Service";
+        String rawProvider = base + ENCODED_QUESTION_MARK
+                + "timestamp%3D123" + ENCODED_AND_MARK
+                + "pid%3D9999" + ENCODED_AND_MARK
+                + "revision%3Dv1";
+        String result = strip(rawProvider);
+        assertTrue(result.contains("revision%3Dv1"), "Result should contain revision");
+        assertFalse(result.contains("timestamp%3D"), "Result should not contain timestamp");
+        assertFalse(result.contains("pid%3D"), "Result should not contain pid");
+    }
+
+    @Test
+    void toUrlsWithoutEmptyPreservesTimestampInCachedURL() throws Exception {
+        // This test verifies the fix: normalized key for cache, but original rawProvider for URL building.
+        String consumerUrl = "mock://127.0.0.1/demo.Service";
+        String provider1 = "dubbo://provider1.example.com:20880/demo.Service?timestamp=100&revision=v1";
+        String provider2 = "dubbo://provider1.example.com:20880/demo.Service?timestamp=200&revision=v1";
+        // Both providers have same address and revision but different timestamp values.
+        // After normalization (removing timestamp), they should produce the same cache key.
+
+        URL consumerURL = URL.valueOf(consumerUrl);
+        Collection<String> providers = new ArrayList<>();
+        providers.add(provider1);
+        providers.add(provider2);
+
+        // First call: build cache with both providers
+        List<URL> urls1 = registry.toUrlsWithoutEmpty(consumerURL, providers);
+        assertNotNull(urls1);
+        assertEquals(1, urls1.size());
+
+        // Get the normalized key that should be used
+        String normalizedKey1 = strip(provider1); // Should have timestamp removed
+        String normalizedKey2 = strip(provider2); // Should be same as normalizedKey1
+
+        assertEquals(normalizedKey1, normalizedKey2, "Normalized keys should be identical after removing timestamp");
+
+        // Verify the cached URL map uses normalized key
+        Map<String, ServiceAddressURL> stringUrls = registry.stringUrls.get(consumerURL);
+        assertNotNull(stringUrls);
+        assertTrue(stringUrls.containsKey(normalizedKey1), "Cache should use normalized key");
+        assertEquals(1, stringUrls.size(), "Should have exactly one cache entry for deduplicated provider");
+    }
+
+    private String strip(String rawProvider) throws Exception {
+        Method method = CacheableFailbackRegistry.class.getDeclaredMethod("stripOffVariableKeys", String.class);
+        method.setAccessible(true);
+        return (String) method.invoke(registry, rawProvider);
+    }
+
+    private static final class StubCacheableFailbackRegistry extends CacheableFailbackRegistry {
+        StubCacheableFailbackRegistry(URL url) {
+            super(url);
+        }
+
+        @Override
+        public void doRegister(URL url) {}
+
+        @Override
+        public void doUnregister(URL url) {}
+
+        @Override
+        public void doSubscribe(URL url, NotifyListener listener) {}
+
+        @Override
+        protected boolean isMatch(URL subscribeUrl, URL providerUrl) {
+            return true;
+        }
+
+        @Override
+        public boolean isAvailable() {
+            return false;
+        }
+    }
+}

--- a/dubbo-remoting/dubbo-remoting-netty4/src/main/java/org/apache/dubbo/remoting/transport/netty4/NettyClient.java
+++ b/dubbo-remoting/dubbo-remoting-netty4/src/main/java/org/apache/dubbo/remoting/transport/netty4/NettyClient.java
@@ -122,13 +122,13 @@ public class NettyClient extends AbstractClient {
                 .channel(socketChannelClass());
 
         bootstrap.option(ChannelOption.CONNECT_TIMEOUT_MILLIS, Math.max(DEFAULT_CONNECT_TIMEOUT, getConnectTimeout()));
-        SslContext sslContext = SslContexts.buildClientSslContext(getUrl());
         bootstrap.handler(new ChannelInitializer<SocketChannel>() {
 
             @Override
             protected void initChannel(SocketChannel ch) throws Exception {
                 int heartbeatInterval = UrlUtils.getHeartbeat(getUrl());
 
+                SslContext sslContext = SslContexts.buildClientSslContext(getUrl());
                 if (sslContext != null) {
                     ch.pipeline().addLast("negotiation", new SslClientTlsHandler(sslContext));
                 }

--- a/dubbo-remoting/dubbo-remoting-netty4/src/main/java/org/apache/dubbo/remoting/transport/netty4/NettyConnectionClient.java
+++ b/dubbo-remoting/dubbo-remoting-netty4/src/main/java/org/apache/dubbo/remoting/transport/netty4/NettyConnectionClient.java
@@ -113,7 +113,6 @@ public class NettyConnectionClient extends AbstractConnectionClient {
 
         final NettyConnectionHandler connectionHandler = new NettyConnectionHandler(this);
         nettyBootstrap.option(ChannelOption.CONNECT_TIMEOUT_MILLIS, getConnectTimeout());
-        SslContext sslContext = SslContexts.buildClientSslContext(getUrl());
         nettyBootstrap.handler(new ChannelInitializer<SocketChannel>() {
             @Override
             protected void initChannel(SocketChannel ch) {
@@ -121,6 +120,7 @@ public class NettyConnectionClient extends AbstractConnectionClient {
                 final ChannelPipeline pipeline = ch.pipeline();
                 NettySslContextOperator nettySslContextOperator = new NettySslContextOperator();
 
+                SslContext sslContext = SslContexts.buildClientSslContext(getUrl());
                 if (sslContext != null) {
                     pipeline.addLast("negotiation", new SslClientTlsHandler(sslContext));
                 }

--- a/pom.xml
+++ b/pom.xml
@@ -169,7 +169,7 @@
     <spotless.action>check</spotless.action>
     <dubbo-shared-resources.version>1.0.0</dubbo-shared-resources.version>
     <palantirJavaFormat.version>2.38.0</palantirJavaFormat.version>
-    <revision>3.2.19-SNAPSHOT</revision>
+    <revision>3.2.20-SNAPSHOT</revision>
   </properties>
 
   <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -163,7 +163,7 @@
     <jacoco.skip>true</jacoco.skip>
 
     <jprotoc_version>1.2.2</jprotoc_version>
-    <protobuf-java_version>3.22.3</protobuf-java_version>
+    <protobuf-java_version>4.33.4</protobuf-java_version>
     <grpc_version>1.54.0</grpc_version>
     <spotless-maven-plugin.version>2.43.0</spotless-maven-plugin.version>
     <spotless.action>check</spotless.action>


### PR DESCRIPTION
## Summary

Fixes apache/dubbo#16194

`JVMUtil.jstack()` calls `ThreadMXBean.dumpAllThreads(true, true)`. The `lockedSynchronizers=true` parameter forces the JVM to scan the **entire Java heap** at a safepoint to find all `AbstractOwnableSynchronizer` instances. On ZGC with large heaps (65GB+), this causes catastrophic safepoint pauses (**36–39 seconds**) that freeze the entire application.

This PR changes `lockedSynchronizers` from `true` to `false`, eliminating the heap scan.

The OpenJDK community already fixed this on the tooling side ([JDK-8324066](https://bugs.openjdk.org/browse/JDK-8324066): "clhsdb jstack should not scan for j.u.c locks by default"), but the programmatic API (`ThreadMXBean.dumpAllThreads`) has no such protection.

## Changes
- `JVMUtil.java`: `dumpAllThreads(true, true)` \u2192 `dumpAllThreads(true, false)`