### PR TITLE
docs: correct version dependency links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,8 +76,8 @@ Explore more through our hands-on tasks:
 | **3.3.7-SNAPSHOT** | 1.8 – 25    | Coming Soon                                                                                               | ✅ JDK 25 Support
 | **3.3.6**          | 1.8 – 21    | [View Dependencies](https://github.com/apache/dubbo/blob/dubbo-3.3.6/dubbo-dependencies-bom/pom.xml#L92)  | ✅ Mutiny Reactive Support <br> ✅ Affinity Router <br> ✅ Method-level TPS Limiting <br> ✅ Spring 6 Security Plugin <br> ✅ Enhanced Environment Variable Config |
 | **3.3.5**          | 1.8 – 21    | [View Dependencies](https://github.com/apache/dubbo/blob/dubbo-3.3.5/dubbo-dependencies-bom/pom.xml#L92)  | ✅ Actively Maintained <br> ✅ Triple Protocol (gRPC/cURL) <br> ✅ REST Support <br> ✅ Spring Boot Starters      |
-| **3.2.16**         | 1.8 – 17    | [View Dependencies](https://github.com/apache/dubbo/blob/dubbo-3.2.5/dubbo-dependencies-bom/pom.xml#L94)  | ✅ Actively Maintained <br> ✅ Metrics & Tracing <br> ✅ Thread Pool Isolation <br> ✅ +30% Performance <br> ✅ Native Image Support |
-| **3.1.11**         | 1.8 – 17    | [View Dependencies](https://github.com/apache/dubbo/blob/dubbo-3.2.11/dubbo-dependencies-bom/pom.xml#L90) | ⚠️ Stable, but Not Actively Maintained                                                                         |
+| **3.2.16**         | 1.8 – 17    | [View Dependencies](https://github.com/apache/dubbo/blob/dubbo-3.2.16/dubbo-dependencies-bom/pom.xml#L94) | ✅ Actively Maintained <br> ✅ Metrics & Tracing <br> ✅ Thread Pool Isolation <br> ✅ +30% Performance <br> ✅ Native Image Support |
+| **3.1.11**         | 1.8 – 17    | [View Dependencies](https://github.com/apache/dubbo/blob/dubbo-3.1.11/dubbo-dependencies-bom/pom.xml#L90) | ⚠️ Stable, but Not Actively Maintained                                                                         |
 
 ### Dubbo2
 


### PR DESCRIPTION

**Repo:** apache/dubbo (⭐ 41000)
**Type:** docs
**Files changed:** 1
**Lines:** +2/-2

## What
This change fixes the Apache Dubbo version compatibility table in `README.md` by correcting the dependency links for versions `3.2.16` and `3.1.11`. Both rows previously linked to different release tags than the versions shown in the table, and now each row points to the matching `dubbo-dependencies-bom/pom.xml` for that release.

## Why
The README is the first place users check when choosing a Dubbo version and inspecting its dependency set. Wrong release-tag links can send readers to the wrong BOM, which is misleading when evaluating compatibility or debugging dependency differences between versions. Correcting the links improves the accuracy of the project’s primary documentation with minimal risk.

## Testing
Verified the README diff locally and confirmed the updated URLs now match the version labels shown in the compatibility table. No build or test suite was run because this is a documentation-only change.

## Risk
Low / Documentation-only change that corrects clearly mismatched version links without affecting code or build behavior.
