### PR TITLE
Reset ApplicationModel after running AbstractServiceDiscoveryFactoryTest

### DIFF
--- a/dubbo-registry/dubbo-registry-api/src/test/java/org/apache/dubbo/registry/client/AbstractServiceDiscoveryFactoryTest.java
+++ b/dubbo-registry/dubbo-registry-api/src/test/java/org/apache/dubbo/registry/client/AbstractServiceDiscoveryFactoryTest.java
@@ -22,6 +22,7 @@ import org.apache.dubbo.rpc.model.ApplicationModel;
 
 import java.util.List;
 
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -50,5 +51,10 @@ class AbstractServiceDiscoveryFactoryTest {
         Assertions.assertEquals(2, allServiceDiscoveries.size());
         Assertions.assertTrue(allServiceDiscoveries.contains(serviceDiscovery1));
         Assertions.assertTrue(allServiceDiscoveries.contains(serviceDiscovery3));
+    }
+
+    @AfterAll
+    public static void clearUp() {
+        ApplicationModel.reset();
     }
 }


### PR DESCRIPTION
## What is the purpose of the change?
IllegalState Duplicate Configs found as ApplicationModel wasn't reset after running AbstractServiceDiscoveryFactoryTest.
```
2026-04-23T01:44:49.6169654Z [ERROR] Errors: 
2026-04-23T01:44:49.6172976Z [ERROR]   StandardMetadataServiceURLBuilderTest.setUp:44 » IllegalState Duplicate Configs found for ApplicationConfig, only one unique ApplicationConfig is allowed for one application. previous: <dubbo:application name="AbstractServiceDiscoveryFactoryTest" />, later: <dubbo:application name="demo" metadataServicePort="7001" />. According to config mode [STRICT], please remove redundant configs and keep only one.
2026-04-23T01:44:49.6175341Z [INFO] 
```

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Make sure gitHub actions can pass. [Why the workflow is failing and how to fix it?](../CONTRIBUTING.md)
