### PR TITLE
Improve generic type safety of CollectionUtils.sort

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/utils/CollectionUtils.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/utils/CollectionUtils.java
@@ -68,10 +68,9 @@ public class CollectionUtils {
 
     private CollectionUtils() {}
 
-    @SuppressWarnings({"unchecked", "rawtypes"})
-    public static <T> List<T> sort(List<T> list) {
+    public static <T extends Comparable<? super T>> List<T> sort(List<T> list) {
         if (isNotEmpty(list)) {
-            Collections.sort((List) list);
+            Collections.sort(list);
         }
         return list;
     }

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/utils/CollectionUtilsTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/utils/CollectionUtilsTest.java
@@ -244,4 +244,39 @@ class CollectionUtilsTest {
         expectedSet.add("C");
         assertEquals(expectedSet, set);
     }
+
+    @Test
+    void sortShouldSupportComparableSuperType() {
+        List<Student> students = new ArrayList<>(Arrays.asList(new Student("b"), new Student("a")));
+
+        List<Student> sorted = CollectionUtils.sort(students);
+
+        assertEquals("a", sorted.get(0).getName());
+        assertEquals("b", sorted.get(1).getName());
+    }
+
+    private static class Person implements Comparable<Person> {
+
+        private final String name;
+
+        private Person(String name) {
+            this.name = name;
+        }
+
+        public String getName() {
+            return this.name;
+        }
+
+        @Override
+        public int compareTo(Person other) {
+            return this.name.compareTo(other.name);
+        }
+    }
+
+    private static class Student extends Person {
+
+        private Student(String name) {
+            super(name);
+        }
+    }
 }


### PR DESCRIPTION
### What is changed


This PR updates `CollectionUtils.sort` to use a bounded generic type:

```java
<T extends Comparable<? super T>>
```
To 

```java
public static <T extends Comparable<? super T>> List<T> sort(List<T> list)
```

The raw cast is also removed:

```java
Collections.sort((List) list);
```

to 

```java
Collections.sort(list);
```


## Why

CollectionUtils.sort currently accepts any List<T> and relies on a raw cast with suppressed warnings.

This means callers can pass a list whose elements do not implement Comparable, and the code still compiles. However, sorting such a list can fail at runtime.

By using:


```java
<T extends Comparable<? super T>>
```


the method now follows the same generic constraint style as java.util.Collections.sort.

This ensures that only naturally comparable elements can be passed to the method.

## Benefit

- Improves compile-time type safety
- Removes raw type usage
- Removes unchecked/raw warning suppression
- Preserves the original return type as List<T>
- Aligns the method with Java collection sorting conventions
- Supports inherited comparison cases, for example when a subtype inherits Comparable<SuperType>

## Compatibility

The erased method signature remains sort(List), so this change should be binary-compatible.

However, this may be source-incompatible for callers that currently pass non-comparable element types to CollectionUtils.sort. Those usages would already be unsafe because they may fail at runtime.

## Tests

Added/updated tests to verify:

Sorting a normal comparable list
Sorting a subtype whose parent implements Comparable<Parent>

Fixes #16235
