### PR TITLE
feat: isolate dual-registration failure handling per mode

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/status/reporter/FrameworkStatusReportService.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/status/reporter/FrameworkStatusReportService.java
@@ -80,6 +80,32 @@ public class FrameworkStatusReportService implements ScopeModelAware {
         return JsonUtils.toJson(registration);
     }
 
+    /**
+     * Report a registration outcome tagged with the register mode (INTERFACE / INSTANCE), the
+     * registry address it targets, and a success flag. Used to surface partial-failure cases when
+     * Dubbo is running in dual registration mode, so observers can tell which side succeeded.
+     */
+    public void reportRegistrationOutcome(
+            String mode, String registryAddress, String serviceKey, boolean success, String errorMessage) {
+        doReport(
+                REGISTRATION_STATUS,
+                createRegistrationOutcomeReport(mode, registryAddress, serviceKey, success, errorMessage));
+    }
+
+    public String createRegistrationOutcomeReport(
+            String mode, String registryAddress, String serviceKey, boolean success, String errorMessage) {
+        HashMap<String, String> registration = new HashMap<>();
+        registration.put("application", applicationModel.getApplicationName());
+        registration.put("mode", mode);
+        registration.put("registry", registryAddress);
+        registration.put("service", serviceKey);
+        registration.put("status", success ? "SUCCESS" : "FAILED");
+        if (errorMessage != null) {
+            registration.put("error", errorMessage);
+        }
+        return JsonUtils.toJson(registration);
+    }
+
     public String createConsumptionReport(String interfaceName, String version, String group, String status) {
         HashMap<String, String> migrationStatus = new HashMap<>();
         migrationStatus.put("type", "consumption");

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/status/reporter/FrameworkStatusReportService.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/status/reporter/FrameworkStatusReportService.java
@@ -80,6 +80,10 @@ public class FrameworkStatusReportService implements ScopeModelAware {
         return JsonUtils.toJson(registration);
     }
 
+    public static final String OUTCOME_SUCCESS = "SUCCESS";
+    public static final String OUTCOME_FAILED = "FAILED";
+    public static final String OUTCOME_PENDING_RETRY = "PENDING_RETRY";
+
     /**
      * Report a registration outcome tagged with the register mode (INTERFACE / INSTANCE), the
      * registry address it targets, and a success flag. Used to surface partial-failure cases when
@@ -87,19 +91,36 @@ public class FrameworkStatusReportService implements ScopeModelAware {
      */
     public void reportRegistrationOutcome(
             String mode, String registryAddress, String serviceKey, boolean success, String errorMessage) {
+        reportRegistrationOutcome(
+                mode, registryAddress, serviceKey, success ? OUTCOME_SUCCESS : OUTCOME_FAILED, errorMessage);
+    }
+
+    /**
+     * String-status overload so callers can report outcomes that don't fit the success/failure
+     * binary — notably {@link #OUTCOME_PENDING_RETRY} for the FailbackRegistry silent-retry path
+     * where {@code register()} returned normally but the URL was queued for retry.
+     */
+    public void reportRegistrationOutcome(
+            String mode, String registryAddress, String serviceKey, String status, String errorMessage) {
         doReport(
                 REGISTRATION_STATUS,
-                createRegistrationOutcomeReport(mode, registryAddress, serviceKey, success, errorMessage));
+                createRegistrationOutcomeReport(mode, registryAddress, serviceKey, status, errorMessage));
     }
 
     public String createRegistrationOutcomeReport(
             String mode, String registryAddress, String serviceKey, boolean success, String errorMessage) {
+        return createRegistrationOutcomeReport(
+                mode, registryAddress, serviceKey, success ? OUTCOME_SUCCESS : OUTCOME_FAILED, errorMessage);
+    }
+
+    public String createRegistrationOutcomeReport(
+            String mode, String registryAddress, String serviceKey, String status, String errorMessage) {
         HashMap<String, String> registration = new HashMap<>();
         registration.put("application", applicationModel.getApplicationName());
         registration.put("mode", mode);
         registration.put("registry", registryAddress);
         registration.put("service", serviceKey);
-        registration.put("status", success ? "SUCCESS" : "FAILED");
+        registration.put("status", status);
         if (errorMessage != null) {
             registration.put("error", errorMessage);
         }

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/status/reporter/FrameworkStatusReportServiceTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/status/reporter/FrameworkStatusReportServiceTest.java
@@ -112,4 +112,54 @@ class FrameworkStatusReportServiceTest {
 
         frameworkModel.destroy();
     }
+
+    @Test
+    void testReportRegistrationOutcomeSuccess() {
+        FrameworkModel frameworkModel = new FrameworkModel();
+        ApplicationModel applicationModel = frameworkModel.newApplication();
+        ApplicationConfig app = new ApplicationConfig("APP");
+        applicationModel.getApplicationConfigManager().setApplication(app);
+        FrameworkStatusReportService reportService =
+                applicationModel.getBeanFactory().getBean(FrameworkStatusReportService.class);
+
+        reportService.reportRegistrationOutcome(
+                "INTERFACE_REGISTER", "127.0.0.1:2181", "GroupA/DemoService:1.0.0", true, null);
+
+        MockFrameworkStatusReporter statusReporter =
+                (MockFrameworkStatusReporter) applicationModel.getExtension(FrameworkStatusReporter.class, "mock");
+        Object registrationStatus = statusReporter.getReportContent().get(REGISTRATION_STATUS);
+        Assertions.assertNotNull(registrationStatus, "registration outcome should be reported");
+        Map<String, String> payload = JsonUtils.toJavaObject(String.valueOf(registrationStatus), Map.class);
+        Assertions.assertEquals("APP", payload.get("application"));
+        Assertions.assertEquals("INTERFACE_REGISTER", payload.get("mode"));
+        Assertions.assertEquals("127.0.0.1:2181", payload.get("registry"));
+        Assertions.assertEquals("GroupA/DemoService:1.0.0", payload.get("service"));
+        Assertions.assertEquals("SUCCESS", payload.get("status"));
+        Assertions.assertNull(payload.get("error"), "success outcome must not carry an error field");
+
+        frameworkModel.destroy();
+    }
+
+    @Test
+    void testReportRegistrationOutcomeFailure() {
+        FrameworkModel frameworkModel = new FrameworkModel();
+        ApplicationModel applicationModel = frameworkModel.newApplication();
+        ApplicationConfig app = new ApplicationConfig("APP");
+        applicationModel.getApplicationConfigManager().setApplication(app);
+        FrameworkStatusReportService reportService =
+                applicationModel.getBeanFactory().getBean(FrameworkStatusReportService.class);
+
+        reportService.reportRegistrationOutcome(
+                "INSTANCE_REGISTER", "127.0.0.1:2181", "GroupA/DemoService:1.0.0", false, "NoNode for /dubbo/...");
+
+        MockFrameworkStatusReporter statusReporter =
+                (MockFrameworkStatusReporter) applicationModel.getExtension(FrameworkStatusReporter.class, "mock");
+        Object registrationStatus = statusReporter.getReportContent().get(REGISTRATION_STATUS);
+        Map<String, String> payload = JsonUtils.toJavaObject(String.valueOf(registrationStatus), Map.class);
+        Assertions.assertEquals("INSTANCE_REGISTER", payload.get("mode"));
+        Assertions.assertEquals("FAILED", payload.get("status"));
+        Assertions.assertEquals("NoNode for /dubbo/...", payload.get("error"));
+
+        frameworkModel.destroy();
+    }
 }

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/status/reporter/FrameworkStatusReportServiceTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/status/reporter/FrameworkStatusReportServiceTest.java
@@ -162,4 +162,31 @@ class FrameworkStatusReportServiceTest {
 
         frameworkModel.destroy();
     }
+
+    @Test
+    void testReportRegistrationOutcomePendingRetry() {
+        FrameworkModel frameworkModel = new FrameworkModel();
+        ApplicationModel applicationModel = frameworkModel.newApplication();
+        ApplicationConfig app = new ApplicationConfig("APP");
+        applicationModel.getApplicationConfigManager().setApplication(app);
+        FrameworkStatusReportService reportService =
+                applicationModel.getBeanFactory().getBean(FrameworkStatusReportService.class);
+
+        reportService.reportRegistrationOutcome(
+                "INTERFACE_REGISTER",
+                "127.0.0.1:2181",
+                "GroupA/DemoService:1.0.0",
+                FrameworkStatusReportService.OUTCOME_PENDING_RETRY,
+                "initial registration attempt failed; waiting for retry");
+
+        MockFrameworkStatusReporter statusReporter =
+                (MockFrameworkStatusReporter) applicationModel.getExtension(FrameworkStatusReporter.class, "mock");
+        Map<String, String> payload = JsonUtils.toJavaObject(
+                String.valueOf(statusReporter.getReportContent().get(REGISTRATION_STATUS)), Map.class);
+        Assertions.assertEquals("INTERFACE_REGISTER", payload.get("mode"));
+        Assertions.assertEquals("PENDING_RETRY", payload.get("status"));
+        Assertions.assertEquals("initial registration attempt failed; waiting for retry", payload.get("error"));
+
+        frameworkModel.destroy();
+    }
 }

--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/integration/RegistryProtocol.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/integration/RegistryProtocol.java
@@ -42,6 +42,7 @@ import org.apache.dubbo.registry.client.ServiceDiscoveryRegistryDirectory;
 import org.apache.dubbo.registry.client.migration.MigrationClusterInvoker;
 import org.apache.dubbo.registry.client.migration.ServiceDiscoveryMigrationInvoker;
 import org.apache.dubbo.registry.retry.ReExportTask;
+import org.apache.dubbo.registry.support.FailbackRegistry;
 import org.apache.dubbo.registry.support.SkipFailbackWrapperException;
 import org.apache.dubbo.rpc.Exporter;
 import org.apache.dubbo.rpc.Invoker;
@@ -272,21 +273,55 @@ public class RegistryProtocol implements Protocol, ScopeModelAware {
     }
 
     /**
+     * Three-state outcome for a dual-registration arm. {@link #PENDING_RETRY} distinguishes the
+     * FailbackRegistry silent-retry path ({@code check=false}, {@code doRegister} threw, URL
+     * queued for retry) from a truly successful registration — they were previously conflated
+     * because {@link Registry#register(URL)} returns normally in both cases.
+     */
+    enum RegisterOutcome {
+        SUCCESS,
+        PENDING_RETRY,
+        FAILED
+    }
+
+    /**
      * Register with independent failure handling for the dual registration mode. When the user
      * has enabled both interface-level and instance-level registration (register-mode=all), a
      * failure on one arm must not silently bring down the other; instead the failure is tagged
      * with its mode, reported to the framework status service, and only rethrown when the
      * registry URL explicitly asks for check=true.
      */
-    private static boolean registerWithModeTag(Registry registry, URL registryUrl, URL registeredProviderUrl) {
+    private static RegisterOutcome registerWithModeTag(Registry registry, URL registryUrl, URL registeredProviderUrl) {
         String mode = resolveRegisterModeTag(registryUrl);
         String registryAddress = registryUrl.getAddress();
         try {
             register(registry, registeredProviderUrl);
-            reportRegistrationOutcome(registeredProviderUrl, mode, registryAddress, true, null);
-            return true;
+            if (registry instanceof FailbackRegistry
+                    && ((FailbackRegistry) registry).isPendingFailedRegistration(registeredProviderUrl)) {
+                // FailbackRegistry swallowed doRegister's exception under check=false and queued
+                // the URL for retry. The caller-side "registered" state must NOT claim success.
+                reportRegistrationOutcome(
+                        registeredProviderUrl,
+                        mode,
+                        registryAddress,
+                        org.apache.dubbo.common.status.reporter.FrameworkStatusReportService.OUTCOME_PENDING_RETRY,
+                        "initial registration attempt failed; waiting for retry");
+                return RegisterOutcome.PENDING_RETRY;
+            }
+            reportRegistrationOutcome(
+                    registeredProviderUrl,
+                    mode,
+                    registryAddress,
+                    org.apache.dubbo.common.status.reporter.FrameworkStatusReportService.OUTCOME_SUCCESS,
+                    null);
+            return RegisterOutcome.SUCCESS;
         } catch (RuntimeException e) {
-            reportRegistrationOutcome(registeredProviderUrl, mode, registryAddress, false, e.getMessage());
+            reportRegistrationOutcome(
+                    registeredProviderUrl,
+                    mode,
+                    registryAddress,
+                    org.apache.dubbo.common.status.reporter.FrameworkStatusReportService.OUTCOME_FAILED,
+                    e.getMessage());
             boolean check = registryUrl.getParameter(CHECK_KEY, true);
             if (check) {
                 logger.error(
@@ -305,12 +340,12 @@ public class RegistryProtocol implements Protocol, ScopeModelAware {
                     "[" + mode + "] failed to register " + registeredProviderUrl + " to registry " + registryAddress
                             + ", the other registration arm (if any) is unaffected. cause: " + e.getMessage(),
                     e);
-            return false;
+            return RegisterOutcome.FAILED;
         }
     }
 
     private static void reportRegistrationOutcome(
-            URL registeredProviderUrl, String mode, String registryAddress, boolean success, String errorMessage) {
+            URL registeredProviderUrl, String mode, String registryAddress, String status, String errorMessage) {
         try {
             org.apache.dubbo.common.status.reporter.FrameworkStatusReportService reportService =
                     ScopeModelUtil.getApplicationModel(registeredProviderUrl.getScopeModel())
@@ -318,7 +353,7 @@ public class RegistryProtocol implements Protocol, ScopeModelAware {
                             .getBean(org.apache.dubbo.common.status.reporter.FrameworkStatusReportService.class);
             if (reportService != null) {
                 reportService.reportRegistrationOutcome(
-                        mode, registryAddress, registeredProviderUrl.getServiceKey(), success, errorMessage);
+                        mode, registryAddress, registeredProviderUrl.getServiceKey(), status, errorMessage);
             }
         } catch (Throwable ignore) {
             // reporting must never affect the registration flow
@@ -357,17 +392,21 @@ public class RegistryProtocol implements Protocol, ScopeModelAware {
 
         // decide if we need to delay publish (provider itself and registry should both need to register)
         boolean register = providerUrl.getParameter(REGISTER_KEY, true) && registryUrl.getParameter(REGISTER_KEY, true);
-        if (register) {
-            registerWithModeTag(registry, registryUrl, registeredProviderUrl);
-        }
+        RegisterOutcome outcome =
+                register ? registerWithModeTag(registry, registryUrl, registeredProviderUrl) : RegisterOutcome.SUCCESS;
+        // Caller-side state must reflect the real outcome, not the intent. PENDING_RETRY means the
+        // URL is queued for a later attempt and is NOT live yet; FAILED under check=false means we
+        // swallowed the exception but the URL was never published. Either way, downstream readers
+        // of isRegistered() / RegisterStatedURL.registered should not believe the URL is live.
+        boolean actuallyRegistered = register && outcome == RegisterOutcome.SUCCESS;
 
         // register stated url on provider model
-        registerStatedUrl(registryUrl, registeredProviderUrl, register);
+        registerStatedUrl(registryUrl, registeredProviderUrl, actuallyRegistered);
 
         exporter.setRegisterUrl(registeredProviderUrl);
         exporter.setSubscribeUrl(overrideSubscribeUrl);
         exporter.setNotifyListener(overrideSubscribeListener);
-        exporter.setRegistered(register);
+        exporter.setRegistered(actuallyRegistered);
 
         ApplicationModel applicationModel = getApplicationModel(providerUrl.getScopeModel());
         if (applicationModel
@@ -1127,7 +1166,21 @@ public class RegistryProtocol implements Protocol, ScopeModelAware {
             if (registered.compareAndSet(false, true)) {
                 URL registryUrl = getRegistryUrl(originInvoker);
                 Registry registry = getRegistry(registryUrl);
-                RegistryProtocol.registerWithModeTag(registry, registryUrl, getRegisterUrl());
+                RegisterOutcome outcome;
+                try {
+                    outcome = RegistryProtocol.registerWithModeTag(registry, registryUrl, getRegisterUrl());
+                } catch (RuntimeException e) {
+                    // check=true path rethrew. The CAS already flipped to true; reset it so a later
+                    // manual retry is not a no-op.
+                    registered.set(false);
+                    throw e;
+                }
+                if (outcome != RegisterOutcome.SUCCESS) {
+                    // Silent-retry or swallowed failure: do not mark stated URLs live, and let a
+                    // subsequent register() call try again.
+                    registered.set(false);
+                    return;
+                }
 
                 ProviderModel providerModel = frameworkModel
                         .getServiceRepository()

--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/integration/RegistryProtocol.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/integration/RegistryProtocol.java
@@ -263,6 +263,68 @@ public class RegistryProtocol implements Protocol, ScopeModelAware {
         }
     }
 
+    /**
+     * Resolve the dual-registration mode tag for a registry URL so observers can distinguish
+     * which arm of the dual registration a log line or outcome report belongs to.
+     */
+    private static String resolveRegisterModeTag(URL registryUrl) {
+        return SERVICE_REGISTRY_PROTOCOL.equals(registryUrl.getProtocol()) ? "INSTANCE_REGISTER" : "INTERFACE_REGISTER";
+    }
+
+    /**
+     * Register with independent failure handling for the dual registration mode. When the user
+     * has enabled both interface-level and instance-level registration (register-mode=all), a
+     * failure on one arm must not silently bring down the other; instead the failure is tagged
+     * with its mode, reported to the framework status service, and only rethrown when the
+     * registry URL explicitly asks for check=true.
+     */
+    private static boolean registerWithModeTag(Registry registry, URL registryUrl, URL registeredProviderUrl) {
+        String mode = resolveRegisterModeTag(registryUrl);
+        String registryAddress = registryUrl.getAddress();
+        try {
+            register(registry, registeredProviderUrl);
+            reportRegistrationOutcome(registeredProviderUrl, mode, registryAddress, true, null);
+            return true;
+        } catch (RuntimeException e) {
+            reportRegistrationOutcome(registeredProviderUrl, mode, registryAddress, false, e.getMessage());
+            boolean check = registryUrl.getParameter(CHECK_KEY, true);
+            if (check) {
+                logger.error(
+                        org.apache.dubbo.common.constants.LoggerCodeConstants.CONFIG_REGISTER_INSTANCE_ERROR,
+                        "the registry is unreachable or refused the registration",
+                        "check the registry address, credentials, and permissions on the target path",
+                        "[" + mode + "] failed to register " + registeredProviderUrl + " to registry " + registryAddress
+                                + ", propagating because check=true. cause: " + e.getMessage(),
+                        e);
+                throw e;
+            }
+            logger.warn(
+                    org.apache.dubbo.common.constants.LoggerCodeConstants.CONFIG_REGISTER_INSTANCE_ERROR,
+                    "one registration arm failed while the other may still succeed",
+                    "dual registration (register-mode=all) isolates failures per arm; verify the failing registry and retry",
+                    "[" + mode + "] failed to register " + registeredProviderUrl + " to registry " + registryAddress
+                            + ", the other registration arm (if any) is unaffected. cause: " + e.getMessage(),
+                    e);
+            return false;
+        }
+    }
+
+    private static void reportRegistrationOutcome(
+            URL registeredProviderUrl, String mode, String registryAddress, boolean success, String errorMessage) {
+        try {
+            org.apache.dubbo.common.status.reporter.FrameworkStatusReportService reportService =
+                    ScopeModelUtil.getApplicationModel(registeredProviderUrl.getScopeModel())
+                            .getBeanFactory()
+                            .getBean(org.apache.dubbo.common.status.reporter.FrameworkStatusReportService.class);
+            if (reportService != null) {
+                reportService.reportRegistrationOutcome(
+                        mode, registryAddress, registeredProviderUrl.getServiceKey(), success, errorMessage);
+            }
+        } catch (Throwable ignore) {
+            // reporting must never affect the registration flow
+        }
+    }
+
     private void registerStatedUrl(URL registryUrl, URL registeredProviderUrl, boolean registered) {
         ProviderModel model = (ProviderModel) registeredProviderUrl.getServiceModel();
         model.addStatedUrl(new ProviderModel.RegisterStatedURL(registeredProviderUrl, registryUrl, registered));
@@ -296,7 +358,7 @@ public class RegistryProtocol implements Protocol, ScopeModelAware {
         // decide if we need to delay publish (provider itself and registry should both need to register)
         boolean register = providerUrl.getParameter(REGISTER_KEY, true) && registryUrl.getParameter(REGISTER_KEY, true);
         if (register) {
-            register(registry, registeredProviderUrl);
+            registerWithModeTag(registry, registryUrl, registeredProviderUrl);
         }
 
         // register stated url on provider model
@@ -1065,7 +1127,7 @@ public class RegistryProtocol implements Protocol, ScopeModelAware {
             if (registered.compareAndSet(false, true)) {
                 URL registryUrl = getRegistryUrl(originInvoker);
                 Registry registry = getRegistry(registryUrl);
-                RegistryProtocol.register(registry, getRegisterUrl());
+                RegistryProtocol.registerWithModeTag(registry, registryUrl, getRegisterUrl());
 
                 ProviderModel providerModel = frameworkModel
                         .getServiceRepository()
@@ -1078,7 +1140,7 @@ public class RegistryProtocol implements Protocol, ScopeModelAware {
                                         .getProtocol()
                                         .equals(getRegisterUrl().getProtocol()))
                         .forEach(u -> u.setRegistered(true));
-                logger.info("[INSTANCE_REGISTER] Registered dubbo service "
+                logger.info("[" + RegistryProtocol.resolveRegisterModeTag(registryUrl) + "] Registered dubbo service "
                         + getRegisterUrl().getServiceKey() + " url " + getRegisterUrl() + " to registry "
                         + registryUrl);
             }

--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/support/FailbackRegistry.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/support/FailbackRegistry.java
@@ -197,6 +197,16 @@ public abstract class FailbackRegistry extends AbstractRegistry {
         return failedRegistered;
     }
 
+    /**
+     * Whether the given URL is currently queued for retry because an immediate registration
+     * attempt failed under {@code check=false}. Used by callers outside this package to
+     * distinguish the silent-retry path ({@link #register(URL)} returning normally after
+     * {@code doRegister} threw) from a truly successful registration.
+     */
+    public boolean isPendingFailedRegistration(URL url) {
+        return failedRegistered.containsKey(url);
+    }
+
     ConcurrentMap<URL, FailedUnregisteredTask> getFailedUnregistered() {
         return failedUnregistered;
     }

--- a/dubbo-registry/dubbo-registry-api/src/test/java/org/apache/dubbo/registry/integration/CapturingFrameworkStatusReporter.java
+++ b/dubbo-registry/dubbo-registry-api/src/test/java/org/apache/dubbo/registry/integration/CapturingFrameworkStatusReporter.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.registry.integration;
+
+import org.apache.dubbo.common.status.reporter.FrameworkStatusReporter;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Test-only {@link FrameworkStatusReporter} that captures every report emitted by
+ * {@link org.apache.dubbo.common.status.reporter.FrameworkStatusReportService}, keyed by report
+ * type. Each type keeps the full history (the last value is available via {@link #last(String)}),
+ * which is needed to verify the mode-tagged outcomes reported by dual registration.
+ */
+public class CapturingFrameworkStatusReporter implements FrameworkStatusReporter {
+
+    private static final Map<String, List<Object>> REPORTS = new ConcurrentHashMap<>();
+
+    @Override
+    public void report(String type, Object obj) {
+        REPORTS.computeIfAbsent(type, k -> new ArrayList<>()).add(obj);
+    }
+
+    public static Object last(String type) {
+        List<Object> values = REPORTS.get(type);
+        return values == null || values.isEmpty() ? null : values.get(values.size() - 1);
+    }
+
+    public static void clear() {
+        REPORTS.clear();
+    }
+}

--- a/dubbo-registry/dubbo-registry-api/src/test/java/org/apache/dubbo/registry/integration/RegistryProtocolDualRegisterTest.java
+++ b/dubbo-registry/dubbo-registry-api/src/test/java/org/apache/dubbo/registry/integration/RegistryProtocolDualRegisterTest.java
@@ -23,13 +23,18 @@ import org.apache.dubbo.common.status.reporter.FrameworkStatusReporter;
 import org.apache.dubbo.common.url.component.ServiceConfigURL;
 import org.apache.dubbo.common.utils.JsonUtils;
 import org.apache.dubbo.config.ApplicationConfig;
+import org.apache.dubbo.registry.NotifyListener;
 import org.apache.dubbo.registry.Registry;
+import org.apache.dubbo.registry.support.FailbackRegistry;
+import org.apache.dubbo.rpc.Exporter;
+import org.apache.dubbo.rpc.Invoker;
 import org.apache.dubbo.rpc.model.ApplicationModel;
 import org.apache.dubbo.rpc.model.FrameworkModel;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.junit.jupiter.api.AfterEach;
@@ -41,12 +46,14 @@ import org.mockito.Mockito;
 import static org.apache.dubbo.common.status.reporter.FrameworkStatusReportService.REGISTRATION_STATUS;
 
 /**
- * Covers the dual-registration failure-isolation path introduced in
+ * Covers the dual-registration failure-isolation path and outcome propagation in
  * {@link RegistryProtocol#registerWithModeTag(Registry, URL, URL)}:
  * <ul>
- *   <li>success case reports SUCCESS tagged with INTERFACE_REGISTER / INSTANCE_REGISTER</li>
+ *   <li>SUCCESS case reports SUCCESS tagged with INTERFACE_REGISTER / INSTANCE_REGISTER</li>
  *   <li>check=true rethrows but still reports FAILED with the mode tag</li>
- *   <li>check=false swallows the failure, reports FAILED, and returns false</li>
+ *   <li>check=false swallows the failure, reports FAILED, and returns FAILED</li>
+ *   <li>FailbackRegistry silent-retry path (check=false, doRegister threw, URL queued for retry)
+ *       reports PENDING_RETRY and returns PENDING_RETRY so caller-side state stays un-registered</li>
  * </ul>
  */
 class RegistryProtocolDualRegisterTest {
@@ -101,9 +108,9 @@ class RegistryProtocolDualRegisterTest {
         Registry registry = Mockito.mock(Registry.class);
         Mockito.when(registry.getUrl()).thenReturn(registryUrl);
 
-        boolean result = invokeRegisterWithModeTag(registry, registryUrl, providerUrl);
+        String outcome = invokeRegisterWithModeTag(registry, registryUrl, providerUrl);
 
-        Assertions.assertTrue(result, "registerWithModeTag must return true on success");
+        Assertions.assertEquals("SUCCESS", outcome);
         Mockito.verify(registry).register(providerUrl);
         Map<String, String> payload = latestRegistrationPayload();
         Assertions.assertEquals("INTERFACE_REGISTER", payload.get("mode"));
@@ -118,9 +125,9 @@ class RegistryProtocolDualRegisterTest {
         Registry registry = Mockito.mock(Registry.class);
         Mockito.when(registry.getUrl()).thenReturn(registryUrl);
 
-        boolean result = invokeRegisterWithModeTag(registry, registryUrl, providerUrl);
+        String outcome = invokeRegisterWithModeTag(registry, registryUrl, providerUrl);
 
-        Assertions.assertTrue(result);
+        Assertions.assertEquals("SUCCESS", outcome);
         Assertions.assertEquals("INSTANCE_REGISTER", latestRegistrationPayload().get("mode"));
     }
 
@@ -145,7 +152,7 @@ class RegistryProtocolDualRegisterTest {
     }
 
     @Test
-    void checkFalseSwallowsFailureAndReturnsFalse() throws Exception {
+    void checkFalseSwallowsFailureAndReturnsFailed() throws Exception {
         URL registryUrl = registryUrl("service-discovery-registry", false);
         URL providerUrl = providerUrl();
         Registry registry = Mockito.mock(Registry.class);
@@ -154,13 +161,41 @@ class RegistryProtocolDualRegisterTest {
                 .when(registry)
                 .register(providerUrl);
 
-        boolean result = invokeRegisterWithModeTag(registry, registryUrl, providerUrl);
+        String outcome = invokeRegisterWithModeTag(registry, registryUrl, providerUrl);
 
-        Assertions.assertFalse(result, "registerWithModeTag must swallow and return false when check=false");
+        Assertions.assertEquals(
+                "FAILED",
+                outcome,
+                "registerWithModeTag must swallow and return FAILED when check=false on a directly-throwing Registry");
         Map<String, String> payload = latestRegistrationPayload();
         Assertions.assertEquals("INSTANCE_REGISTER", payload.get("mode"));
         Assertions.assertEquals("FAILED", payload.get("status"));
         Assertions.assertEquals("metadata center unreachable", payload.get("error"));
+    }
+
+    /**
+     * FailbackRegistry silent-retry path: {@code doRegister} throws, {@code check=false}, so the
+     * exception is swallowed and the URL is queued for retry. {@code register()} returns normally.
+     * The dual-register path must NOT classify this as SUCCESS — observers and caller-side state
+     * need to see it as PENDING_RETRY so they don't prematurely treat the URL as published.
+     */
+    @Test
+    void failbackSilentRetryReportsPendingRetry() throws Exception {
+        URL registryUrl = registryUrl("zookeeper", false);
+        URL providerUrl = providerUrl();
+        FailingFailbackRegistry registry = new FailingFailbackRegistry(registryUrl);
+
+        String outcome = invokeRegisterWithModeTag(registry, registryUrl, providerUrl);
+
+        Assertions.assertEquals("PENDING_RETRY", outcome);
+        Assertions.assertTrue(
+                registry.isPendingFailedRegistration(providerUrl),
+                "the URL should now be sitting in FailbackRegistry's retry queue");
+        Map<String, String> payload = latestRegistrationPayload();
+        Assertions.assertEquals("INTERFACE_REGISTER", payload.get("mode"));
+        Assertions.assertEquals("PENDING_RETRY", payload.get("status"));
+        Assertions.assertNotNull(
+                payload.get("error"), "pending-retry payload should describe why the initial attempt failed");
     }
 
     private URL registryUrl(String protocol, boolean check) {
@@ -183,17 +218,168 @@ class RegistryProtocolDualRegisterTest {
         return JsonUtils.toJavaObject(String.valueOf(raw), Map.class);
     }
 
-    private boolean invokeRegisterWithModeTag(Registry registry, URL registryUrl, URL providerUrl) throws Exception {
+    /**
+     * Invokes the private static {@code registerWithModeTag} and returns the enum name of the
+     * resulting {@code RegisterOutcome}, so test assertions can string-compare regardless of the
+     * enum's package-private visibility.
+     */
+    private String invokeRegisterWithModeTag(Registry registry, URL registryUrl, URL providerUrl) throws Exception {
         Method m =
                 RegistryProtocol.class.getDeclaredMethod("registerWithModeTag", Registry.class, URL.class, URL.class);
         m.setAccessible(true);
         try {
-            return (boolean) m.invoke(null, registry, registryUrl, providerUrl);
+            Object outcome = m.invoke(null, registry, registryUrl, providerUrl);
+            return ((Enum<?>) outcome).name();
         } catch (InvocationTargetException e) {
             if (e.getCause() instanceof RuntimeException) {
                 throw (RuntimeException) e.getCause();
             }
             throw e;
         }
+    }
+
+    /**
+     * Minimal FailbackRegistry whose {@link #doRegister(URL)} always throws. Drives the real
+     * {@code FailbackRegistry.register(URL)} body so {@link FailbackRegistry#isPendingFailedRegistration}
+     * actually reflects the silent-retry queue, exactly like ZookeeperRegistry / NacosRegistry do
+     * in production.
+     */
+    private static final class FailingFailbackRegistry extends FailbackRegistry {
+        private final RuntimeException failure;
+
+        FailingFailbackRegistry(URL registryUrl) {
+            super(registryUrl);
+            this.failure = new IllegalStateException("doRegister failed: ZK session expired");
+        }
+
+        @Override
+        public void doRegister(URL url) {
+            throw failure;
+        }
+
+        @Override
+        public void doUnregister(URL url) {}
+
+        @Override
+        public void doSubscribe(URL url, NotifyListener listener) {}
+
+        @Override
+        public void doUnsubscribe(URL url, NotifyListener listener) {}
+
+        @Override
+        public boolean isAvailable() {
+            return true;
+        }
+
+        // The following overrides keep the retry timer from firing during the short test window.
+        @SuppressWarnings("unused")
+        public List<URL> lookup(URL url) {
+            return java.util.Collections.emptyList();
+        }
+    }
+
+    /**
+     * ExporterChangeableWrapper.register() must leave {@code registered=false} when the underlying
+     * registration outcome is not SUCCESS. Otherwise a later manual register/re-register call is a
+     * no-op and the wrapper permanently believes it is live. This test covers the PENDING_RETRY
+     * branch (FailbackRegistry silent-retry under check=false).
+     */
+    @Test
+    void exporterWrapperRegisterResetsFlagOnPendingRetry() throws Exception {
+        URL registryUrl = registryUrl("zookeeper", false);
+        URL providerUrl = providerUrl();
+        FailingFailbackRegistry registry = new FailingFailbackRegistry(registryUrl);
+
+        Object wrapper = newWrapperWith(registry, registryUrl, providerUrl);
+        invokeWrapperRegister(wrapper);
+
+        Assertions.assertFalse(
+                readAtomicRegistered(wrapper),
+                "wrapper.registered must be reset to false when registration is PENDING_RETRY");
+    }
+
+    /**
+     * When {@code check=true} and {@code registry.register} throws, the wrapper must rethrow AND
+     * reset its CAS flag. Without the reset, a follow-up register() call short-circuits on the CAS
+     * and silently does nothing.
+     */
+    @Test
+    void exporterWrapperRegisterResetsFlagOnCheckTrueException() throws Exception {
+        URL registryUrl = registryUrl("zookeeper", true);
+        URL providerUrl = providerUrl();
+        Registry throwing = Mockito.mock(Registry.class);
+        Mockito.when(throwing.getUrl()).thenReturn(registryUrl);
+        Mockito.doThrow(new IllegalStateException("NoNode for /dubbo/..."))
+                .when(throwing)
+                .register(providerUrl);
+
+        Object wrapper = newWrapperWith(throwing, registryUrl, providerUrl);
+        Assertions.assertThrows(IllegalStateException.class, () -> invokeWrapperRegister(wrapper));
+        Assertions.assertFalse(
+                readAtomicRegistered(wrapper), "wrapper.registered must be reset to false after check=true rethrow");
+    }
+
+    /**
+     * Constructs an {@code ExporterChangeableWrapper} via reflection and installs an outer
+     * {@code RegistryProtocol} spy whose {@code getRegistry(URL)} returns the supplied fake. This
+     * lets us exercise the wrapper's {@code register()} body without standing up the full
+     * ReferenceCountExporter / RegistryFactory machinery.
+     */
+    private Object newWrapperWith(Registry registry, URL registryUrl, URL providerUrl) throws Exception {
+        RegistryProtocol outer = new RegistryProtocol() {
+            @Override
+            protected Registry getRegistry(URL url) {
+                return registry;
+            }
+
+            @Override
+            protected URL getRegistryUrl(Invoker<?> originInvoker) {
+                return registryUrl;
+            }
+        };
+        java.lang.reflect.Field fmField = RegistryProtocol.class.getDeclaredField("frameworkModel");
+        fmField.setAccessible(true);
+        fmField.set(outer, frameworkModel);
+
+        Invoker<?> originInvoker = Mockito.mock(Invoker.class);
+        Mockito.when(originInvoker.getUrl()).thenReturn(providerUrl);
+
+        Exporter<?> innerExporter = Mockito.mock(Exporter.class);
+        ReferenceCountExporter<?> refExporter =
+                new ReferenceCountExporter<>(innerExporter, providerUrl.getServiceKey(), null);
+
+        Class<?> wrapperCls =
+                Class.forName("org.apache.dubbo.registry.integration.RegistryProtocol$ExporterChangeableWrapper");
+        java.lang.reflect.Constructor<?> ctor =
+                wrapperCls.getDeclaredConstructor(RegistryProtocol.class, ReferenceCountExporter.class, Invoker.class);
+        ctor.setAccessible(true);
+        Object wrapper = ctor.newInstance(outer, refExporter, originInvoker);
+
+        // The wrapper's register() reads getRegisterUrl() — stub it by setting the field directly.
+        java.lang.reflect.Field registerUrlField = wrapperCls.getDeclaredField("registerUrl");
+        registerUrlField.setAccessible(true);
+        registerUrlField.set(wrapper, providerUrl);
+
+        return wrapper;
+    }
+
+    private void invokeWrapperRegister(Object wrapper) throws Exception {
+        java.lang.reflect.Method m = wrapper.getClass().getDeclaredMethod("register");
+        m.setAccessible(true);
+        try {
+            m.invoke(wrapper);
+        } catch (InvocationTargetException e) {
+            if (e.getCause() instanceof RuntimeException) {
+                throw (RuntimeException) e.getCause();
+            }
+            throw e;
+        }
+    }
+
+    private boolean readAtomicRegistered(Object wrapper) throws Exception {
+        java.lang.reflect.Field f = wrapper.getClass().getDeclaredField("registered");
+        f.setAccessible(true);
+        java.util.concurrent.atomic.AtomicBoolean ab = (java.util.concurrent.atomic.AtomicBoolean) f.get(wrapper);
+        return ab.get();
     }
 }

--- a/dubbo-registry/dubbo-registry-api/src/test/java/org/apache/dubbo/registry/integration/RegistryProtocolDualRegisterTest.java
+++ b/dubbo-registry/dubbo-registry-api/src/test/java/org/apache/dubbo/registry/integration/RegistryProtocolDualRegisterTest.java
@@ -1,0 +1,179 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.registry.integration;
+
+import org.apache.dubbo.common.URL;
+import org.apache.dubbo.common.deploy.ApplicationDeployer;
+import org.apache.dubbo.common.status.reporter.FrameworkStatusReportService;
+import org.apache.dubbo.common.url.component.ServiceConfigURL;
+import org.apache.dubbo.common.utils.JsonUtils;
+import org.apache.dubbo.config.ApplicationConfig;
+import org.apache.dubbo.registry.Registry;
+import org.apache.dubbo.rpc.model.ApplicationModel;
+import org.apache.dubbo.rpc.model.FrameworkModel;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import static org.apache.dubbo.common.status.reporter.FrameworkStatusReportService.REGISTRATION_STATUS;
+
+/**
+ * Covers the dual-registration failure-isolation path introduced in
+ * {@link RegistryProtocol#registerWithModeTag(Registry, URL, URL)}:
+ * <ul>
+ *   <li>success case reports SUCCESS tagged with INTERFACE_REGISTER / INSTANCE_REGISTER</li>
+ *   <li>check=true rethrows but still reports FAILED with the mode tag</li>
+ *   <li>check=false swallows the failure, reports FAILED, and returns false</li>
+ * </ul>
+ */
+class RegistryProtocolDualRegisterTest {
+
+    private FrameworkModel frameworkModel;
+    private ApplicationModel applicationModel;
+
+    @BeforeEach
+    void setUp() {
+        CapturingFrameworkStatusReporter.clear();
+        frameworkModel = new FrameworkModel();
+        applicationModel = frameworkModel.newApplication();
+        ApplicationConfig app = new ApplicationConfig("APP");
+        applicationModel.getApplicationConfigManager().setApplication(app);
+        // Ensure FrameworkStatusReportService is initialized and wires up reporters
+        applicationModel.getBeanFactory().getBean(FrameworkStatusReportService.class);
+
+        // registerWithModeTag calls register() which touches ApplicationDeployer
+        ApplicationDeployer deployer = Mockito.mock(ApplicationDeployer.class);
+        applicationModel.setDeployer(deployer);
+    }
+
+    @AfterEach
+    void tearDown() {
+        frameworkModel.destroy();
+        CapturingFrameworkStatusReporter.clear();
+    }
+
+    @Test
+    void successReportsInterfaceRegister() throws Exception {
+        URL registryUrl = registryUrl("zookeeper", false);
+        URL providerUrl = providerUrl();
+        Registry registry = Mockito.mock(Registry.class);
+        Mockito.when(registry.getUrl()).thenReturn(registryUrl);
+
+        boolean result = invokeRegisterWithModeTag(registry, registryUrl, providerUrl);
+
+        Assertions.assertTrue(result, "registerWithModeTag must return true on success");
+        Mockito.verify(registry).register(providerUrl);
+        Map<String, String> payload = latestRegistrationPayload();
+        Assertions.assertEquals("INTERFACE_REGISTER", payload.get("mode"));
+        Assertions.assertEquals("SUCCESS", payload.get("status"));
+        Assertions.assertNull(payload.get("error"));
+    }
+
+    @Test
+    void successReportsInstanceRegisterForServiceDiscoveryProtocol() throws Exception {
+        URL registryUrl = registryUrl("service-discovery-registry", false);
+        URL providerUrl = providerUrl();
+        Registry registry = Mockito.mock(Registry.class);
+        Mockito.when(registry.getUrl()).thenReturn(registryUrl);
+
+        boolean result = invokeRegisterWithModeTag(registry, registryUrl, providerUrl);
+
+        Assertions.assertTrue(result);
+        Assertions.assertEquals("INSTANCE_REGISTER", latestRegistrationPayload().get("mode"));
+    }
+
+    @Test
+    void checkTrueRethrowsButStillReportsFailure() {
+        URL registryUrl = registryUrl("zookeeper", true);
+        URL providerUrl = providerUrl();
+        Registry registry = Mockito.mock(Registry.class);
+        Mockito.when(registry.getUrl()).thenReturn(registryUrl);
+        Mockito.doThrow(new IllegalStateException("NoNode for /dubbo/..."))
+                .when(registry)
+                .register(providerUrl);
+
+        IllegalStateException thrown = Assertions.assertThrows(
+                IllegalStateException.class, () -> invokeRegisterWithModeTag(registry, registryUrl, providerUrl));
+        Assertions.assertEquals("NoNode for /dubbo/...", thrown.getMessage());
+
+        Map<String, String> payload = latestRegistrationPayload();
+        Assertions.assertEquals("INTERFACE_REGISTER", payload.get("mode"));
+        Assertions.assertEquals("FAILED", payload.get("status"));
+        Assertions.assertEquals("NoNode for /dubbo/...", payload.get("error"));
+    }
+
+    @Test
+    void checkFalseSwallowsFailureAndReturnsFalse() throws Exception {
+        URL registryUrl = registryUrl("service-discovery-registry", false);
+        URL providerUrl = providerUrl();
+        Registry registry = Mockito.mock(Registry.class);
+        Mockito.when(registry.getUrl()).thenReturn(registryUrl);
+        Mockito.doThrow(new IllegalStateException("metadata center unreachable"))
+                .when(registry)
+                .register(providerUrl);
+
+        boolean result = invokeRegisterWithModeTag(registry, registryUrl, providerUrl);
+
+        Assertions.assertFalse(result, "registerWithModeTag must swallow and return false when check=false");
+        Map<String, String> payload = latestRegistrationPayload();
+        Assertions.assertEquals("INSTANCE_REGISTER", payload.get("mode"));
+        Assertions.assertEquals("FAILED", payload.get("status"));
+        Assertions.assertEquals("metadata center unreachable", payload.get("error"));
+    }
+
+    private URL registryUrl(String protocol, boolean check) {
+        Map<String, String> params = new HashMap<>();
+        params.put("check", Boolean.toString(check));
+        URL url = new ServiceConfigURL(protocol, "127.0.0.1", 2181, params);
+        return url.setScopeModel(applicationModel);
+    }
+
+    private URL providerUrl() {
+        URL url = new ServiceConfigURL(
+                "dubbo", "127.0.0.1", 20880, "org.apache.dubbo.registry.integration.DemoService", new HashMap<>());
+        return url.setScopeModel(applicationModel);
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, String> latestRegistrationPayload() {
+        Object raw = CapturingFrameworkStatusReporter.last(REGISTRATION_STATUS);
+        Assertions.assertNotNull(raw, "registration outcome must be reported");
+        return JsonUtils.toJavaObject(String.valueOf(raw), Map.class);
+    }
+
+    private boolean invokeRegisterWithModeTag(Registry registry, URL registryUrl, URL providerUrl) throws Exception {
+        Method m =
+                RegistryProtocol.class.getDeclaredMethod("registerWithModeTag", Registry.class, URL.class, URL.class);
+        m.setAccessible(true);
+        try {
+            return (boolean) m.invoke(null, registry, registryUrl, providerUrl);
+        } catch (InvocationTargetException e) {
+            if (e.getCause() instanceof RuntimeException) {
+                throw (RuntimeException) e.getCause();
+            }
+            throw e;
+        }
+    }
+}

--- a/dubbo-registry/dubbo-registry-api/src/test/java/org/apache/dubbo/registry/integration/RegistryProtocolDualRegisterTest.java
+++ b/dubbo-registry/dubbo-registry-api/src/test/java/org/apache/dubbo/registry/integration/RegistryProtocolDualRegisterTest.java
@@ -19,6 +19,7 @@ package org.apache.dubbo.registry.integration;
 import org.apache.dubbo.common.URL;
 import org.apache.dubbo.common.deploy.ApplicationDeployer;
 import org.apache.dubbo.common.status.reporter.FrameworkStatusReportService;
+import org.apache.dubbo.common.status.reporter.FrameworkStatusReporter;
 import org.apache.dubbo.common.url.component.ServiceConfigURL;
 import org.apache.dubbo.common.utils.JsonUtils;
 import org.apache.dubbo.config.ApplicationConfig;
@@ -54,14 +55,33 @@ class RegistryProtocolDualRegisterTest {
     private ApplicationModel applicationModel;
 
     @BeforeEach
-    void setUp() {
+    void setUp() throws Exception {
         CapturingFrameworkStatusReporter.clear();
         frameworkModel = new FrameworkModel();
         applicationModel = frameworkModel.newApplication();
         ApplicationConfig app = new ApplicationConfig("APP");
         applicationModel.getApplicationConfigManager().setApplication(app);
-        // Ensure FrameworkStatusReportService is initialized and wires up reporters
-        applicationModel.getBeanFactory().getBean(FrameworkStatusReportService.class);
+
+        // Register CapturingFrameworkStatusReporter programmatically. We avoid shipping an SPI file
+        // in test resources because that would leak the reporter into every other test in this
+        // module (e.g. MigrationRuleHandlerTest, whose URL has no ApplicationConfig and whose
+        // migration path would then trigger applicationModel.getApplicationName() → ISE).
+        applicationModel
+                .getExtensionLoader(FrameworkStatusReporter.class)
+                .addExtension("capturing", CapturingFrameworkStatusReporter.class);
+
+        // FrameworkStatusReportService snapshots its `reporters` set during setApplicationModel,
+        // which may have fired already (e.g. by ApplicationModel init) before our addExtension
+        // above. Reload its reporters field from the extension loader so the capturer is present.
+        FrameworkStatusReportService svc =
+                applicationModel.getBeanFactory().getBean(FrameworkStatusReportService.class);
+        java.lang.reflect.Field reportersField = FrameworkStatusReportService.class.getDeclaredField("reporters");
+        reportersField.setAccessible(true);
+        reportersField.set(
+                svc,
+                applicationModel
+                        .getExtensionLoader(FrameworkStatusReporter.class)
+                        .getSupportedExtensionInstances());
 
         // registerWithModeTag calls register() which touches ApplicationDeployer
         ApplicationDeployer deployer = Mockito.mock(ApplicationDeployer.class);

--- a/dubbo-registry/dubbo-registry-api/src/test/resources/META-INF/dubbo/internal/org.apache.dubbo.common.status.reporter.FrameworkStatusReporter
+++ b/dubbo-registry/dubbo-registry-api/src/test/resources/META-INF/dubbo/internal/org.apache.dubbo.common.status.reporter.FrameworkStatusReporter
@@ -1,0 +1,1 @@
+capturing=org.apache.dubbo.registry.integration.CapturingFrameworkStatusReporter

--- a/dubbo-registry/dubbo-registry-api/src/test/resources/META-INF/dubbo/internal/org.apache.dubbo.common.status.reporter.FrameworkStatusReporter
+++ b/dubbo-registry/dubbo-registry-api/src/test/resources/META-INF/dubbo/internal/org.apache.dubbo.common.status.reporter.FrameworkStatusReporter
@@ -1,1 +1,0 @@
-capturing=org.apache.dubbo.registry.integration.CapturingFrameworkStatusReporter


### PR DESCRIPTION
## What is the purpose of the change?

Close https://github.com/apache/dubbo/issues/16247.

 Problem
  -----                                                                                                        
  In dual registration mode (register-mode=all) Dubbo emits a single                                                                                               provider URL through two registries:                                                                                                                           
    - interface-level  -> registry:// (ZooKeeper, Nacos, ...)                                                                                                        - instance-level   -> service-discovery-registry://                                                                                                          
                                                                                                                                                                 
  RegistryProtocol#export calls register() once; the registry wrapper                                                                                            
  fans out to both arms. Any RuntimeException from the first arm aborts
  the second, so a transient failure on the metadata center silently
  takes down the interface-level registration that was otherwise healthy
  (or vice versa). The pre-existing FrameworkStatusReportService only
  reports a coarse "instance/interface" status and cannot tell observers
  which arm failed, which swallowed the error, or why.

  Fix
  -----
  1. FrameworkStatusReportService
     - add reportRegistrationOutcome(mode, registryAddress, serviceKey,
       success, errorMessage) + createRegistrationOutcomeReport() so each
       registration attempt emits an independently tagged payload
       {application, mode, registry, service, status, error?}.

  2. RegistryProtocol
     - new registerWithModeTag(registry, registryUrl, providerUrl) wraps
       the existing register() call with per-arm failure isolation:
         * success -> report SUCCESS tagged with the resolved mode
         * RuntimeException:
             - report FAILED with the cause message
             - honor registryUrl check= parameter: rethrow iff check=true,
               otherwise log a warn under CONFIG_REGISTER_INSTANCE_ERROR
               (5-11) and return false so the sibling arm keeps going
     - resolveRegisterModeTag() centralizes the INTERFACE_REGISTER vs
       INSTANCE_REGISTER label (previously hardcoded in one log line).
     - route export() and ExporterChangeableWrapper.register() through
       the new wrapper; replace the hardcoded "[INSTANCE_REGISTER]" log
       prefix with the resolved tag.
     - reporting failures never leak into the registration flow
       (wrapped in try/catch(Throwable)).

  Tests
  -----
  - dubbo-common: FrameworkStatusReportServiceTest gains
    testReportRegistrationOutcomeSuccess / Failure covering the new
    payload shape.
  - dubbo-registry-api: new RegistryProtocolDualRegisterTest with 4
    reflection-driven cases over registerWithModeTag — success paths for
    both protocols, check=true rethrow path, check=false swallow path.
    A local CapturingFrameworkStatusReporter + SPI registration under
    src/test/resources provides the capture sink (MockFrameworkStatus-
    Reporter is scoped to dubbo-common tests and not reachable here).

Behavior change
  -----
  | Scenario | Before | After |
  |---|---|---|
  | Both arms succeed | 1 coarse `registration` report | 2 outcome reports, one per mode, `status=SUCCESS` |
  | One arm fails, `check=false` on that registry URL | exception bubbles out, sibling arm may be skipped | failure is tagged + reported `FAILED`, returns false,
   sibling arm continues |
  | One arm fails, `check=true` | exception bubbles out (no outcome report) | outcome still reported `FAILED` **then** the original exception is rethrown |      
  | Reporter itself throws | would leak into registration flow | swallowed — reporting never affects registration |


## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Make sure gitHub actions can pass. [Why the workflow is failing and how to fix it?](../CONTRIBUTING.md)
