### PR TITLE
fix: allow metadata service export when application deployer is PENDING

### DIFF
--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/deploy/DefaultApplicationDeployer.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/deploy/DefaultApplicationDeployer.java
@@ -1296,7 +1296,11 @@ public class DefaultApplicationDeployer extends AbstractDeployer<ApplicationMode
     }
 
     private void doExportMetadataService() {
-        if (!isStarting() && !isStarted() && !isCompletion()) {
+        // Skip only when the application is shutting down or has failed.
+        // PENDING is allowed so that programmatic ServiceConfig.export() invoked
+        // before the application has been started can still trigger the
+        // metadata service export (see issue #14859).
+        if (isStopping() || isStopped() || isFailed()) {
             return;
         }
         for (DeployListener<ApplicationModel> listener : listeners) {

--- a/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/deploy/DefaultApplicationDeployerTest.java
+++ b/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/deploy/DefaultApplicationDeployerTest.java
@@ -16,10 +16,16 @@
  */
 package org.apache.dubbo.config.deploy;
 
+import org.apache.dubbo.common.deploy.ApplicationDeployListener;
 import org.apache.dubbo.common.utils.Assert;
 import org.apache.dubbo.config.MetricsConfig;
 import org.apache.dubbo.metrics.utils.MetricsSupportUtil;
+import org.apache.dubbo.rpc.model.ApplicationModel;
+import org.apache.dubbo.rpc.model.FrameworkModel;
 
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import static org.apache.dubbo.common.constants.MetricsConstants.PROTOCOL_PROMETHEUS;
@@ -39,5 +45,66 @@ class DefaultApplicationDeployerTest {
         boolean importPrometheus =
                 PROTOCOL_PROMETHEUS.equals(metricsConfig.getProtocol()) && !MetricsSupportUtil.isSupportPrometheus();
         Assert.assertTrue(!importPrometheus, " should return false");
+    }
+
+    /**
+     * See <a href="https://github.com/apache/dubbo/issues/14859">#14859</a>.
+     * <p>
+     * Programmatic {@code ServiceConfig.export()} may invoke
+     * {@code ApplicationDeployer.exportMetadataService()} while the application
+     * deployer is still in the {@code PENDING} state (e.g. when the user wires
+     * Dubbo via XML without any {@code <dubbo:service/>} entry and then exports
+     * services manually). The metadata service must still be exported in that
+     * case, otherwise instance-level registration is silently skipped.
+     */
+    @Test
+    void exportMetadataServiceShouldFireListenersWhenDeployerIsPending() {
+        FrameworkModel frameworkModel = new FrameworkModel();
+        try {
+            ApplicationModel applicationModel = frameworkModel.newApplication();
+            DefaultApplicationDeployer deployer =
+                    (DefaultApplicationDeployer) DefaultApplicationDeployer.get(applicationModel);
+
+            AtomicInteger moduleStartedInvocations = new AtomicInteger();
+            deployer.addDeployListener(new ApplicationDeployListener() {
+                @Override
+                public void onInitialize(ApplicationModel scopeModel) {}
+
+                @Override
+                public void onStarting(ApplicationModel scopeModel) {}
+
+                @Override
+                public void onStarted(ApplicationModel scopeModel) {}
+
+                @Override
+                public void onCompletion(ApplicationModel scopeModel) {}
+
+                @Override
+                public void onStopping(ApplicationModel scopeModel) {}
+
+                @Override
+                public void onStopped(ApplicationModel scopeModel) {}
+
+                @Override
+                public void onFailure(ApplicationModel scopeModel, Throwable cause) {}
+
+                @Override
+                public void onModuleStarted(ApplicationModel scopeModel) {
+                    moduleStartedInvocations.incrementAndGet();
+                }
+            });
+
+            // Sanity: the deployer is in PENDING state until start() is called.
+            Assertions.assertTrue(deployer.isPending());
+
+            deployer.exportMetadataService();
+
+            Assertions.assertEquals(
+                    1,
+                    moduleStartedInvocations.get(),
+                    "ApplicationDeployListener.onModuleStarted should be invoked even when the deployer is in PENDING state");
+        } finally {
+            frameworkModel.destroy();
+        }
     }
 }


### PR DESCRIPTION
Fix https://github.com/apache/dubbo/issues/14859

## Problem

When a service is exported programmatically via `ServiceConfig.export()` before the application context has been started (typical of XML-driven Dubbo wiring without `<dubbo:service/>` entries), the deployer is still in the `PENDING` state. In that state `DefaultApplicationDeployer#doExportMetadataService` returns immediately, so the metadata service is never exported and the `ApplicationDeployListener#onModuleStarted` listeners that drive instance-level registration are never fired.

## Root Cause

```java
private void doExportMetadataService() {
    if (!isStarting() && !isStarted() && !isCompletion()) {
        return;
    }
    ...
}
```

The guard is an inclusive whitelist of three lifecycle states. Any other state — including the `PENDING` state of a freshly-created deployer — is treated as "skip". For programmatic export this happens before `start()` is invoked, so the metadata service is silently skipped.

## Fix

Replace the whitelist with an exclusion of the only states in which we genuinely cannot run a metadata export: shutting-down (`STOPPING` / `STOPPED`) and failed (`FAILED`). `PENDING`, `INIT`, `STARTING`, `STARTED`, `COMPLETION` all proceed.

```java
if (isStopping() || isStopped() || isFailed()) {
    return;
}
```

## Tests Added

| Change point | Test |
|--------------|------|
| Metadata export is now allowed in `PENDING` state | `exportMetadataServiceShouldFireListenersWhenDeployerIsPending()` — registers an `ApplicationDeployListener`, asserts the deployer is in `PENDING`, calls `exportMetadataService()`, asserts `onModuleStarted` fired exactly once |

`mvn -am -pl dubbo-config/dubbo-config-api test -Dtest=DefaultApplicationDeployerTest -Dsurefire.failIfNoSpecifiedTests=false` — 3/3 tests pass.

## Impact

- Programmatic `ServiceConfig.export()` made against a `PENDING` deployer now correctly exports the metadata service (this was already the behaviour in 3.2.x and is the regression that #14859 reports).
- Existing flows where `exportMetadataService()` is invoked from `STARTING`/`STARTED`/`COMPLETION` still work (those states were already accepted by the old guard).
- The new exclusion of `STOPPING`/`STOPPED`/`FAILED` mirrors the original intent of the guard while no longer dropping the `PENDING` case.

Fixes #14859