### PR TITLE
[FIX] Close channel on TLS negotiation failure to prevent zombie conn…

### DIFF
--- a/dubbo-remoting/dubbo-remoting-netty4/src/main/java/org/apache/dubbo/remoting/transport/netty4/ssl/SslServerTlsHandler.java
+++ b/dubbo-remoting/dubbo-remoting-netty4/src/main/java/org/apache/dubbo/remoting/transport/netty4/ssl/SslServerTlsHandler.java
@@ -65,8 +65,8 @@ public class SslServerTlsHandler extends ByteToMessageDecoder {
                 "",
                 "TLS negotiation failed when trying to accept new connection.",
                 cause);
-        ctx.close();
         ctx.fireExceptionCaught(cause);
+        ctx.close();
     }
 
     @Override

--- a/dubbo-remoting/dubbo-remoting-netty4/src/main/java/org/apache/dubbo/remoting/transport/netty4/ssl/SslServerTlsHandler.java
+++ b/dubbo-remoting/dubbo-remoting-netty4/src/main/java/org/apache/dubbo/remoting/transport/netty4/ssl/SslServerTlsHandler.java
@@ -65,6 +65,8 @@ public class SslServerTlsHandler extends ByteToMessageDecoder {
                 "",
                 "TLS negotiation failed when trying to accept new connection.",
                 cause);
+        ctx.close();
+        ctx.fireExceptionCaught(cause);
     }
 
     @Override

--- a/dubbo-remoting/dubbo-remoting-netty4/src/test/java/org/apache/dubbo/remoting/transport/netty4/ssl/SslServerTlsHandlerTest.java
+++ b/dubbo-remoting/dubbo-remoting-netty4/src/test/java/org/apache/dubbo/remoting/transport/netty4/ssl/SslServerTlsHandlerTest.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.remoting.transport.netty4.ssl;
+
+import io.netty.channel.embedded.EmbeddedChannel;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class SslServerTlsHandlerTest {
+
+    @Test
+    public void testExceptionCaughtShouldCloseChannel() {
+        SslServerTlsHandler handler = new SslServerTlsHandler(null);
+        EmbeddedChannel channel = new EmbeddedChannel(handler);
+
+        Throwable cause = new NoClassDefFoundError("class loading failure");
+        channel.pipeline().fireExceptionCaught(cause);
+
+        assertFalse(channel.isActive(), "channel should be closed after exceptionCaught");
+        assertFalse(channel.isOpen(), "Channel should not be open after exceptionCaught");
+    }
+}


### PR DESCRIPTION
This pull request addresses a bug in SslServerTlsHandler where exceptions during the TLS handshake were swallowed, leaving TCP channels active but dead. By adding ctx.close() to exceptionCaught, the PR ensures that failed connections are closed, enabling the consumer to detect the failure and initiate self-healing.