### PR TITLE
Require comparable elements for CollectionUtils.sort

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/utils/CollectionUtils.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/utils/CollectionUtils.java
@@ -68,10 +68,9 @@ public class CollectionUtils {
 
     private CollectionUtils() {}
 
-    @SuppressWarnings({"unchecked", "rawtypes"})
-    public static <T> List<T> sort(List<T> list) {
+    public static <T extends Comparable<? super T>> List<T> sort(List<T> list) {
         if (isNotEmpty(list)) {
-            Collections.sort((List) list);
+            Collections.sort(list);
         }
         return list;
     }


### PR DESCRIPTION
## What is the purpose of the change?

GitHub_issue: #16235

`CollectionUtils.sort` delegates to `Collections.sort`, but its generic
signature did not require comparable elements. This adds the same
`Comparable` bound and removes the raw cast, so invalid callers fail at
compile time instead of at runtime.

The existing sort tests still pass, and the affected cluster module compiles
with the stricter signature.

Tests:

```text
./mvnw -pl dubbo-common -Dtest=CollectionUtilsTest#testSort+testSortNull test
./mvnw -pl dubbo-cluster -am -DskipTests compile
```

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Make sure gitHub actions can pass. [Why the workflow is failing and how to fix it?](../CONTRIBUTING.md)