### PR TITLE
Bind default flag for named protocol configs

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/config/AbstractConfig.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/config/AbstractConfig.java
@@ -817,7 +817,7 @@ public abstract class AbstractConfig implements Serializable {
 
                     Class<?> paramType = method.getParameterTypes()[0];
                     if (paramType.isArray()) {
-                        if (isIgnoredAttribute(obj.getClass(), propertyName)) {
+                        if (isIgnoredAttributeOnRefresh(obj.getClass(), propertyName)) {
                             continue;
                         }
 
@@ -859,7 +859,7 @@ public abstract class AbstractConfig implements Serializable {
                     // 'setGeneric' methods in ReferenceConfig.
                     if (StringUtils.hasText(value)
                             && ClassUtils.isTypeMatch(paramType, value)
-                            && !isIgnoredAttribute(obj.getClass(), propertyName)) {
+                            && !isIgnoredAttributeOnRefresh(obj.getClass(), propertyName)) {
                         value = environment.resolvePlaceholders(value);
                         if (StringUtils.hasText(value)) {
                             Object arg = ClassUtils.convertPrimitive(frameworkModel, paramType, value);
@@ -998,6 +998,14 @@ public abstract class AbstractConfig implements Serializable {
         Parameter parameter = getter.getAnnotation(Parameter.class);
         // not an attribute
         return parameter != null && !parameter.attribute();
+    }
+
+    private boolean isIgnoredAttributeOnRefresh(Class<?> clazz, String propertyName) {
+        // `default` participates in property binding but is intentionally excluded from URL attributes/equality.
+        if (CommonConstants.DEFAULT_KEY.equals(propertyName)) {
+            return false;
+        }
+        return isIgnoredAttribute(clazz, propertyName);
     }
 
     protected void processExtraRefresh(String preferredPrefix, InmemoryConfiguration subPropsConfiguration) {

--- a/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/AbstractConfigTest.java
+++ b/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/AbstractConfigTest.java
@@ -512,6 +512,24 @@ class AbstractConfigTest {
     }
 
     @Test
+    void testRefreshSkipsNonDefaultAttributeFalseProperties() {
+        try {
+            OverrideConfig overrideConfig = new OverrideConfig();
+            SysProps.setProperty("dubbo.override.non-attribute", "value");
+            SysProps.setProperty("dubbo.override.items[0]", "item");
+            SysProps.setProperty("dubbo.override.non-attribute-items[0]", "ignored");
+
+            overrideConfig.refresh();
+
+            Assertions.assertNull(overrideConfig.getNonAttribute());
+            Assertions.assertArrayEquals(new String[] {"item"}, overrideConfig.getItems());
+            Assertions.assertNull(overrideConfig.getNonAttributeItems());
+        } finally {
+            ApplicationModel.defaultModel().modelEnvironment().destroy();
+        }
+    }
+
+    @Test
     void testRefreshParametersWithOverrideConfigMode() {
         FrameworkModel frameworkModel = new FrameworkModel();
         try {
@@ -690,6 +708,9 @@ class AbstractConfigTest {
         public String escape;
         public String notConflictKey;
         public String notConflictKey2;
+        public String nonAttribute;
+        public String[] items;
+        public String[] nonAttributeItems;
         protected Map<String, String> parameters;
 
         public OverrideConfig() {}
@@ -764,6 +785,32 @@ class AbstractConfigTest {
 
         public void setNotConflictKey2(String notConflictKey2) {
             this.notConflictKey2 = notConflictKey2;
+        }
+
+        @Parameter(attribute = false)
+        public String getNonAttribute() {
+            return nonAttribute;
+        }
+
+        public void setNonAttribute(String nonAttribute) {
+            this.nonAttribute = nonAttribute;
+        }
+
+        public String[] getItems() {
+            return items;
+        }
+
+        public void setItems(String[] items) {
+            this.items = items;
+        }
+
+        @Parameter(attribute = false)
+        public String[] getNonAttributeItems() {
+            return nonAttributeItems;
+        }
+
+        public void setNonAttributeItems(String[] nonAttributeItems) {
+            this.nonAttributeItems = nonAttributeItems;
         }
 
         public Map<String, String> getParameters() {

--- a/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/ProtocolConfigTest.java
+++ b/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/ProtocolConfigTest.java
@@ -31,6 +31,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import static org.apache.dubbo.common.constants.CommonConstants.DEFAULT_KEY;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasEntry;
@@ -354,6 +355,37 @@ class ProtocolConfigTest {
 
             Assertions.assertEquals("rest", protocol.getName());
             Assertions.assertEquals(port1, protocol.getPort());
+        } finally {
+            DubboBootstrap.getInstance().stop();
+        }
+    }
+
+    @Test
+    void testCreateNonDefaultConfigFromPropsWithName() {
+        int port = NetUtils.getAvailablePort();
+        SysProps.setProperty("dubbo.protocols.rest.port", String.valueOf(port));
+        SysProps.setProperty("dubbo.protocols.rest.default", "false");
+
+        try {
+
+            DubboBootstrap bootstrap = DubboBootstrap.getInstance();
+            bootstrap.application("test-app").initialize();
+
+            ConfigManager configManager = bootstrap.getConfigManager();
+            Collection<ProtocolConfig> protocols = configManager.getProtocols();
+            Assertions.assertFalse(protocols.isEmpty());
+
+            ProtocolConfig protocol = configManager.getProtocol("rest").get();
+
+            Assertions.assertEquals("rest", protocol.getName());
+            Assertions.assertEquals(port, protocol.getPort());
+            Assertions.assertFalse(protocol.isDefault());
+            Assertions.assertTrue(
+                    configManager.getDefaultProtocols().stream().noneMatch(p -> "rest".equals(p.getName())));
+
+            Map<String, String> parameters = new HashMap<>();
+            ProtocolConfig.appendParameters(parameters, protocol);
+            Assertions.assertFalse(parameters.containsKey(DEFAULT_KEY));
         } finally {
             DubboBootstrap.getInstance().stop();
         }


### PR DESCRIPTION
## What is the purpose of the change?

GitHub_issue: #12961

This fixes binding for named protocol properties like
`dubbo.protocols.rest.default=false`.

The `default` getter still stays out of URL attributes, but config refresh now
allows that property to be assigned. That keeps a named protocol marked as
non-default from being returned by `getDefaultProtocols()`.

I added a regression test for a named protocol with `default=false`, including
a check that `default` is still not appended as a URL parameter.

Tested:

```text
./mvnw -pl dubbo-config/dubbo-config-api -am -Dtest=ProtocolConfigTest#testCreateNonDefaultConfigFromPropsWithName -Dsurefire.failIfNoSpecifiedTests=false test
./mvnw -pl dubbo-config/dubbo-config-api -am -Dtest=ProtocolConfigTest -Dsurefire.failIfNoSpecifiedTests=false test
```

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Make sure gitHub actions can pass. [Why the workflow is failing and how to fix it?](../CONTRIBUTING.md)