### PR TITLE
[INFRA] Set up default rulesets for default and release branches

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -18,8 +18,8 @@
 #
 
 notifications:
-  commits:      commits@dubbo.apache.org
-  issues:       notifications@dubbo.apache.org
+  commits: commits@dubbo.apache.org
+  issues: notifications@dubbo.apache.org
   pullrequests: notifications@dubbo.apache.org
   jira_options: link label link label
   discussions: notifications@dubbo.apache.org
@@ -37,47 +37,47 @@ github:
     # Enable GitHub Discussions for community discussions
     discussions: true
   protected_branches:
-    master: 
+    master:
       required_pull_request_reviews:
         dismiss_stale_reviews: true
         require_last_push_approval: true
         required_approving_review_count: 2
-    2.5.x: 
+    2.5.x:
       required_pull_request_reviews:
         dismiss_stale_reviews: true
         require_last_push_approval: true
         required_approving_review_count: 2
-    2.6.x: 
+    2.6.x:
       required_pull_request_reviews:
         dismiss_stale_reviews: true
         require_last_push_approval: true
         required_approving_review_count: 2
-    2.7.x: 
+    2.7.x:
       required_pull_request_reviews:
         dismiss_stale_reviews: true
         require_last_push_approval: true
         required_approving_review_count: 2
-    3.0: 
+    3.0:
       required_pull_request_reviews:
         dismiss_stale_reviews: true
         require_last_push_approval: true
         required_approving_review_count: 2
-    3.1: 
+    3.1:
       required_pull_request_reviews:
         dismiss_stale_reviews: true
         require_last_push_approval: true
         required_approving_review_count: 2
-    3.2: 
+    3.2:
       required_pull_request_reviews:
         dismiss_stale_reviews: true
         require_last_push_approval: true
         required_approving_review_count: 2
-    3.3: 
+    3.3:
       required_pull_request_reviews:
         dismiss_stale_reviews: true
         require_last_push_approval: true
         required_approving_review_count: 2
-    3.4: 
+    3.4:
       required_pull_request_reviews:
         dismiss_stale_reviews: true
         require_last_push_approval: true
@@ -94,3 +94,16 @@ github:
     - http
     - grpc
     - web
+  rulesets:
+    - name: "Default Branch Protection"
+      type: branch
+      branches:
+        includes:
+          - "~DEFAULT_BRANCH"
+          - "release/*"
+          - "rel/*"
+        excludes: []
+      bypass_teams:
+        - root
+      restrict_deletion: true
+      restrict_force_push: true


### PR DESCRIPTION
This Pull Request enables the repository to conform with the "sane default security settings" of the Apache Software Foundation by configuring a default branch ruleset that protects the default branch and any release branches.

Note that `~DEFAULT_BRANCH` is a GitHub symbolic link to the current default branch (HEAD) of the repository and does not need changing.
If the managing project does not wish to set up these defaults, please close this Pull Request. Alternatively, the project may merge this Pull Request to apply the changes immediately.

If no action is taken, this Pull Request will be automatically merged by the Apache Infrastructure team on **2026-06-14** (30 days from now).

For any further information, please reach us on Slack or at: users@infra.apache.org
