### PR TITLE
[FIX] Prevent Hessian2 serializable security bypass via writeReplace (#16287)

### DIFF
--- a/dubbo-serialization/dubbo-serialization-hessian2/src/main/java/org/apache/dubbo/common/serialize/hessian2/Hessian2SerializerFactory.java
+++ b/dubbo-serialization/dubbo-serialization-hessian2/src/main/java/org/apache/dubbo/common/serialize/hessian2/Hessian2SerializerFactory.java
@@ -22,6 +22,7 @@ import java.io.InputStream;
 import java.io.Serializable;
 
 import com.alibaba.com.caucho.hessian.io.Deserializer;
+import com.alibaba.com.caucho.hessian.io.HessianProtocolException;
 import com.alibaba.com.caucho.hessian.io.InputStreamDeserializer;
 import com.alibaba.com.caucho.hessian.io.JavaDeserializer;
 import com.alibaba.com.caucho.hessian.io.JavaSerializer;
@@ -63,6 +64,18 @@ public class Hessian2SerializerFactory extends SerializerFactory {
         if (isEnableUnsafeSerializer() && JavaSerializer.getWriteReplace(cl) == null) {
             return UnsafeSerializer.create(cl);
         } else return JavaSerializer.create(cl);
+    }
+
+    @Override
+    public Serializer getSerializer(Class cl) throws HessianProtocolException {
+        try {
+            // 1. Force the security guard pre-check to run first
+            defaultSerializeClassChecker.loadClass(getClassLoader(), cl.getName());
+        } catch (ClassNotFoundException e) {
+            // ignore
+        }
+        checkSerializable(cl);
+        return super.getSerializer(cl);
     }
 
     @Override


### PR DESCRIPTION
## Description
This PR resolves a validation bypass during Hessian2 serialization where classes utilizing a custom `writeReplace()` method could inadvertently circumvent security filters.

### Core Changes
* **Enforce Validation:** Updated `Hessian2SerializerFactory` to ensure that classes implementing `writeReplace()` are rigorously checked against the `DefaultSerializeClassChecker` allowlist and standard serializable structure validations.
* **Security Alignment:** Prevents unauthorized objects from slipping past the framework's serialization guardrails via custom substitution methods.

## Related Issue
Fixes #16287

## Checklist
- [x] Code formatted locally via `mvn spotless:apply`.
- [x] Clear and concise commit messages maintained.