### PR TITLE
fix: throw clear exception when request parameter is not Serializable

### DIFF
--- a/dubbo-rpc/dubbo-rpc-dubbo/src/main/java/org/apache/dubbo/rpc/protocol/dubbo/DubboCodec.java
+++ b/dubbo-rpc/dubbo-rpc-dubbo/src/main/java/org/apache/dubbo/rpc/protocol/dubbo/DubboCodec.java
@@ -294,7 +294,19 @@ public class DubboCodec extends ExchangeCodec {
         Object[] args = inv.getArguments();
         if (args != null) {
             for (int i = 0; i < args.length; i++) {
-                out.writeObject(callbackServiceCodec.encodeInvocationArgument(channel, inv, i));
+                Object arg = callbackServiceCodec.encodeInvocationArgument(channel, inv, i);
+                try {
+                    out.writeObject(arg);
+                } catch (IOException e) {
+                    Throwable cause = e.getCause() != null ? e.getCause().getCause() : null;
+                    if (cause instanceof IllegalArgumentException
+                            && cause.getMessage() != null
+                            && cause.getMessage().contains("has not implement Serializable")) {
+                        throw new IOException(arg.getClass().getName()
+                                + " must implement java.io.Serializable", e);
+                    }
+                    throw e;
+                }
             }
         }
         out.writeAttachments(inv.getObjectAttachments());
@@ -313,7 +325,18 @@ public class DubboCodec extends ExchangeCodec {
                 out.writeByte(attach ? RESPONSE_NULL_VALUE_WITH_ATTACHMENTS : RESPONSE_NULL_VALUE);
             } else {
                 out.writeByte(attach ? RESPONSE_VALUE_WITH_ATTACHMENTS : RESPONSE_VALUE);
-                out.writeObject(ret);
+                try {
+                    out.writeObject(ret);
+                } catch (IOException e) {
+                    Throwable cause = e.getCause() != null ? e.getCause().getCause() : null;
+                    if (cause instanceof IllegalArgumentException
+                            && cause.getMessage() != null
+                            && cause.getMessage().contains("has not implement Serializable")) {
+                        throw new IOException(ret.getClass().getName()
+                                + " must implement java.io.Serializable", e);
+                    }
+                    throw e;
+                }
             }
         } else {
             out.writeByte(attach ? RESPONSE_WITH_EXCEPTION_WITH_ATTACHMENTS : RESPONSE_WITH_EXCEPTION);

--- a/dubbo-rpc/dubbo-rpc-dubbo/src/main/java/org/apache/dubbo/rpc/protocol/dubbo/DubboCodec.java
+++ b/dubbo-rpc/dubbo-rpc-dubbo/src/main/java/org/apache/dubbo/rpc/protocol/dubbo/DubboCodec.java
@@ -302,8 +302,7 @@ public class DubboCodec extends ExchangeCodec {
                     if (cause instanceof IllegalArgumentException
                             && cause.getMessage() != null
                             && cause.getMessage().contains("has not implement Serializable")) {
-                        throw new IOException(arg.getClass().getName()
-                                + " must implement java.io.Serializable", e);
+                        throw new IOException(arg.getClass().getName() + " must implement java.io.Serializable", e);
                     }
                     throw e;
                 }
@@ -332,8 +331,7 @@ public class DubboCodec extends ExchangeCodec {
                     if (cause instanceof IllegalArgumentException
                             && cause.getMessage() != null
                             && cause.getMessage().contains("has not implement Serializable")) {
-                        throw new IOException(ret.getClass().getName()
-                                + " must implement java.io.Serializable", e);
+                        throw new IOException(ret.getClass().getName() + " must implement java.io.Serializable", e);
                     }
                     throw e;
                 }

--- a/dubbo-rpc/dubbo-rpc-dubbo/src/test/java/org/apache/dubbo/rpc/protocol/dubbo/DubboProtocolTest.java
+++ b/dubbo-rpc/dubbo-rpc-dubbo/src/test/java/org/apache/dubbo/rpc/protocol/dubbo/DubboProtocolTest.java
@@ -234,7 +234,6 @@ class DubboProtocolTest {
     }
 
     @Test
-    @Disabled
     public void testNonSerializedParameter() {
         DemoService service = new DemoServiceImpl();
         int port = NetUtils.getAvailablePort();
@@ -258,7 +257,6 @@ class DubboProtocolTest {
     }
 
     @Test
-    @Disabled
     public void testReturnNonSerialized() {
         DemoService service = new DemoServiceImpl();
         int port = NetUtils.getAvailablePort();


### PR DESCRIPTION
Previously, passing a non-Serializable parameter to a Dubbo service resulted in a confusing error message. Now a clear IOException with the class name and 'must implement java.io.Serializable' is thrown at encode time in both request and response paths.

Fixes #16293

## What is the purpose of the change?
This PR fixes a misleading error message when calling a Dubbo service 
with a parameter or return value that does not implement 
`java.io.Serializable`.

Previously, the error was buried inside internal serialization layers 
and did not clearly indicate the root cause, making it hard to diagnose.
Now a clear `IOException` containing the class name and 
`must implement java.io.Serializable` is thrown at encode time in both 
request and response paths.

### What is changed?

- `DubboCodec.encodeRequestData()`: wraps `writeObject()` in a 
try/catch that intercepts the internal `IllegalArgumentException` and 
rethrows a clear `IOException` with the offending class name.
- `DubboCodec.encodeResponseData()`: same treatment for the response path.
- `DubboProtocolTest`: re-enabled `testNonSerializedParameter` and 
`testReturnNonSerialized` which were previously `@Disabled` because 
the expected behavior was not implemented.

### Verifying this change

All tests in `dubbo-rpc-dubbo` module pass locally, including the 
two previously disabled tests that now validate the correct behavior.

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Make sure gitHub actions can pass. [Why the workflow is failing and how to fix it?](../CONTRIBUTING.md)
