### PR TITLE
Fix misleading NPE when request parameter is not Serializable

### DIFF
--- a/dubbo-rpc/dubbo-rpc-dubbo/src/main/java/org/apache/dubbo/rpc/protocol/dubbo/DubboProtocol.java
+++ b/dubbo-rpc/dubbo-rpc-dubbo/src/main/java/org/apache/dubbo/rpc/protocol/dubbo/DubboProtocol.java
@@ -290,6 +290,14 @@ public class DubboProtocol extends AbstractProtocol {
         boolean isStubServiceInvoke;
         int port = channel.getLocalAddress().getPort();
         String path = (String) inv.getObjectAttachmentWithoutConvert(PATH_KEY);
+        if (path == null) {
+            throw new RemotingException(
+                    channel,
+                    "Failed to resolve service path from invocation. "
+                            + "This may be caused by non-serializable request parameters. "
+                            + "Please ensure all parameter types implement java.io.Serializable, "
+                            + "channel: " + channel.getRemoteAddress() + " --> " + channel.getLocalAddress());
+        }
 
         // if it's stub service on client side(after enable stubevent, usually is set up onconnect or ondisconnect
         // method)

--- a/dubbo-rpc/dubbo-rpc-dubbo/src/main/java/org/apache/dubbo/rpc/protocol/dubbo/DubboProtocol.java
+++ b/dubbo-rpc/dubbo-rpc-dubbo/src/main/java/org/apache/dubbo/rpc/protocol/dubbo/DubboProtocol.java
@@ -293,9 +293,10 @@ public class DubboProtocol extends AbstractProtocol {
         if (path == null) {
             throw new RemotingException(
                     channel,
-                    "Failed to resolve service path from invocation. "
-                            + "This may be caused by non-serializable request parameters. "
-                            + "Please ensure all parameter types implement java.io.Serializable, "
+                    "Service path is missing from the invocation, which indicates the invocation metadata is "
+                            + "missing or corrupted. Possible causes include a request decode failure "
+                            + "(e.g. parameter types that failed to deserialize), an incompatible protocol "
+                            + "version, or a custom codec/invocation implementation that does not set the path, "
                             + "channel: " + channel.getRemoteAddress() + " --> " + channel.getLocalAddress());
         }
 

--- a/dubbo-rpc/dubbo-rpc-dubbo/src/test/java/org/apache/dubbo/rpc/protocol/dubbo/DubboProtocolTest.java
+++ b/dubbo-rpc/dubbo-rpc-dubbo/src/test/java/org/apache/dubbo/rpc/protocol/dubbo/DubboProtocolTest.java
@@ -19,6 +19,8 @@ package org.apache.dubbo.rpc.protocol.dubbo;
 import org.apache.dubbo.common.URL;
 import org.apache.dubbo.common.extension.ExtensionLoader;
 import org.apache.dubbo.common.utils.NetUtils;
+import org.apache.dubbo.remoting.Channel;
+import org.apache.dubbo.remoting.RemotingException;
 import org.apache.dubbo.rpc.Invocation;
 import org.apache.dubbo.rpc.Invoker;
 import org.apache.dubbo.rpc.Protocol;
@@ -38,6 +40,7 @@ import org.apache.dubbo.rpc.protocol.dubbo.support.RemoteServiceImpl;
 import org.apache.dubbo.rpc.protocol.dubbo.support.Type;
 import org.apache.dubbo.rpc.service.EchoService;
 
+import java.net.InetSocketAddress;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -279,6 +282,21 @@ class DubboProtocolTest {
                             .contains(
                                     "org.apache.dubbo.rpc.protocol.dubbo.support.NonSerialized must implement java.io.Serializable"));
         }
+    }
+
+    @Test
+    void testGetInvokerThrowsOnNullPath() {
+        DubboProtocol dubboProtocol = DubboProtocol.getDubboProtocol();
+        Channel channel = Mockito.mock(Channel.class);
+        InetSocketAddress localAddress = new InetSocketAddress("127.0.0.1", 20880);
+        InetSocketAddress remoteAddress = new InetSocketAddress("127.0.0.1", 12345);
+        Mockito.when(channel.getLocalAddress()).thenReturn(localAddress);
+        Mockito.when(channel.getRemoteAddress()).thenReturn(remoteAddress);
+
+        Invocation inv = Mockito.mock(Invocation.class);
+        Mockito.when(inv.getObjectAttachmentWithoutConvert("path")).thenReturn(null);
+
+        Assertions.assertThrows(RemotingException.class, () -> dubboProtocol.getInvoker(channel, inv));
     }
 
     @Disabled


### PR DESCRIPTION
When a Dubbo service is called with non-serializable parameters, the invocation deserialization fails silently and `path` becomes null. This null path is then passed to GroupServiceKeyCache which uses a ConcurrentHashMap that does not accept null keys, resulting in a confusing NullPointerException.

Added a null check for `path` in DubboProtocol.getInvoker() to throw a clear RemotingException with a meaningful message pointing users to the actual cause (non-serializable parameters).

Fixes #16293

## What is the purpose of the change?


## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Make sure gitHub actions can pass. [Why the workflow is failing and how to fix it?](../CONTRIBUTING.md)
