### PR TITLE
Improve type safety of CollectionUtils.toTreeSet

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/utils/CollectionUtils.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/utils/CollectionUtils.java
@@ -419,7 +419,7 @@ public class CollectionUtils {
         return values.get(0);
     }
 
-    public static <T> Set<T> toTreeSet(Set<T> set) {
+    public static <T extends Comparable<? super T>> Set<T> toTreeSet(Set<T> set) {
         if (isEmpty(set)) {
             return set;
         }
@@ -427,6 +427,15 @@ public class CollectionUtils {
             set = new TreeSet<>(set);
         }
         return set;
+    }
+
+    public static <T> Set<T> toTreeSet(Set<T> set, Comparator<? super T> comparator) {
+        if (set == null) {
+            return set;
+        }
+        Set<T> treeSet = new TreeSet<>(comparator);
+        treeSet.addAll(set);
+        return treeSet;
     }
 
     public static <T> Set<T> newHashSet(int expectedSize) {

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/utils/CollectionUtilsTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/utils/CollectionUtilsTest.java
@@ -278,6 +278,13 @@ class CollectionUtilsTest {
         Assertions.assertSame(comparator, ((TreeSet<PriorityItem>) sorted).comparator());
     }
 
+    @Test
+    void toTreeSetShouldReturnNullForNullInputWithComparator() {
+        Comparator<PriorityItem> comparator = Comparator.comparingInt(PriorityItem::getPriority);
+
+        assertNull(CollectionUtils.toTreeSet(null, comparator));
+    }
+
     private static class Person implements Comparable<Person> {
 
         private final String name;

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/utils/CollectionUtilsTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/utils/CollectionUtilsTest.java
@@ -21,12 +21,14 @@ import org.apache.dubbo.config.ProtocolConfig;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeSet;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -255,6 +257,27 @@ class CollectionUtilsTest {
         assertEquals("b", sorted.get(1).getName());
     }
 
+    @Test
+    void toTreeSetShouldSupportExplicitComparator() {
+        Set<PriorityItem> items = new LinkedHashSet<>(Arrays.asList(new PriorityItem(3), new PriorityItem(1)));
+
+        Set<PriorityItem> sorted = CollectionUtils.toTreeSet(items, Comparator.comparingInt(PriorityItem::getPriority));
+
+        List<PriorityItem> sortedList = new ArrayList<>(sorted);
+        assertEquals(1, sortedList.get(0).getPriority());
+        assertEquals(3, sortedList.get(1).getPriority());
+    }
+
+    @Test
+    void toTreeSetShouldPreserveComparatorForEmptyInput() {
+        Comparator<PriorityItem> comparator = Comparator.comparingInt(PriorityItem::getPriority);
+
+        Set<PriorityItem> sorted = CollectionUtils.toTreeSet(new LinkedHashSet<>(), comparator);
+
+        assertTrue(sorted instanceof TreeSet);
+        Assertions.assertSame(comparator, ((TreeSet<PriorityItem>) sorted).comparator());
+    }
+
     private static class Person implements Comparable<Person> {
 
         private final String name;
@@ -277,6 +300,19 @@ class CollectionUtilsTest {
 
         private Student(String name) {
             super(name);
+        }
+    }
+
+    private static class PriorityItem {
+
+        private final int priority;
+
+        private PriorityItem(int priority) {
+            this.priority = priority;
+        }
+
+        private int getPriority() {
+            return priority;
         }
     }
 }


### PR DESCRIPTION
## What is the purpose of the change?

GitHub_issue: Fixes #16297

This pull request improves the type safety of `CollectionUtils.toTreeSet`.

The existing single-argument overload accepted any `Set<T>`, but its implementation delegates to `TreeSet`, which requires naturally comparable elements unless a comparator is provided. The updated signature makes that requirement explicit at compile time:

```java
public static <T extends Comparable<? super T>> Set<T> toTreeSet(Set<T> set)
```

This pull request also adds a comparator-based overload for custom ordering and non-`Comparable` element types:

```java
public static <T> Set<T> toTreeSet(Set<T> set, Comparator<? super T> comparator)
```

For non-null empty inputs, the comparator overload returns an empty `TreeSet` that preserves the provided comparator.

Verification:

- `mvn -pl dubbo-common -Dtest=CollectionUtilsTest test`
- `git diff --check`

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Make sure gitHub actions can pass. [Why the workflow is failing and how to fix it?](../CONTRIBUTING.md)
