### PR TITLE
Fix Hessian2 writeReplace Serializable check bypass

### DIFF
--- a/dubbo-serialization/dubbo-serialization-hessian2/src/main/java/org/apache/dubbo/common/serialize/hessian2/Hessian2SerializerFactory.java
+++ b/dubbo-serialization/dubbo-serialization-hessian2/src/main/java/org/apache/dubbo/common/serialize/hessian2/Hessian2SerializerFactory.java
@@ -51,9 +51,9 @@ public class Hessian2SerializerFactory extends SerializerFactory {
     @Override
     public Serializer getSerializer(Class cl) throws HessianProtocolException {
         // SerializerFactory handles writeReplace before getDefaultSerializer(), so enforce Dubbo's
-        // class policy here for replacement-capable classes as well.
+        // Serializable requirement here without expanding strict allow-list checks to JDK replacements.
         if (JavaSerializer.getWriteReplace(cl) != null) {
-            checkClass(cl);
+            checkSerializable(cl);
         }
         return super.getSerializer(cl);
     }

--- a/dubbo-serialization/dubbo-serialization-hessian2/src/main/java/org/apache/dubbo/common/serialize/hessian2/Hessian2SerializerFactory.java
+++ b/dubbo-serialization/dubbo-serialization-hessian2/src/main/java/org/apache/dubbo/common/serialize/hessian2/Hessian2SerializerFactory.java
@@ -22,6 +22,7 @@ import java.io.InputStream;
 import java.io.Serializable;
 
 import com.alibaba.com.caucho.hessian.io.Deserializer;
+import com.alibaba.com.caucho.hessian.io.HessianProtocolException;
 import com.alibaba.com.caucho.hessian.io.InputStreamDeserializer;
 import com.alibaba.com.caucho.hessian.io.JavaDeserializer;
 import com.alibaba.com.caucho.hessian.io.JavaSerializer;
@@ -48,17 +49,20 @@ public class Hessian2SerializerFactory extends SerializerFactory {
     }
 
     @Override
+    public Serializer getSerializer(Class cl) throws HessianProtocolException {
+        // SerializerFactory handles writeReplace before getDefaultSerializer(), so enforce Dubbo's
+        // class policy here for replacement-capable classes as well.
+        if (JavaSerializer.getWriteReplace(cl) != null) {
+            checkClass(cl);
+        }
+        return super.getSerializer(cl);
+    }
+
+    @Override
     protected Serializer getDefaultSerializer(Class cl) {
         if (_defaultSerializer != null) return _defaultSerializer;
 
-        try {
-            // pre-check if class is allow
-            defaultSerializeClassChecker.loadClass(getClassLoader(), cl.getName());
-        } catch (ClassNotFoundException e) {
-            // ignore
-        }
-
-        checkSerializable(cl);
+        checkClass(cl);
 
         if (isEnableUnsafeSerializer() && JavaSerializer.getWriteReplace(cl) == null) {
             return UnsafeSerializer.create(cl);
@@ -71,14 +75,7 @@ public class Hessian2SerializerFactory extends SerializerFactory {
             return InputStreamDeserializer.DESER;
         }
 
-        try {
-            // pre-check if class is allow
-            defaultSerializeClassChecker.loadClass(getClassLoader(), cl.getName());
-        } catch (ClassNotFoundException e) {
-            // ignore
-        }
-
-        checkSerializable(cl);
+        checkClass(cl);
 
         if (RecordUtil.isRecord(cl)) {
             return new RecordDeserializer(cl, getFieldDeserializerFactory());
@@ -87,6 +84,17 @@ public class Hessian2SerializerFactory extends SerializerFactory {
                 return new UnsafeDeserializer(cl, getFieldDeserializerFactory());
             } else return new JavaDeserializer(cl, getFieldDeserializerFactory());
         }
+    }
+
+    private void checkClass(Class<?> cl) {
+        try {
+            // pre-check if class is allow
+            defaultSerializeClassChecker.loadClass(getClassLoader(), cl.getName());
+        } catch (ClassNotFoundException e) {
+            // ignore
+        }
+
+        checkSerializable(cl);
     }
 
     private void checkSerializable(Class<?> cl) {

--- a/dubbo-serialization/dubbo-serialization-hessian2/src/test/java/org/apache/dubbo/common/serialize/hessian2/Hessian2SerializationTest.java
+++ b/dubbo-serialization/dubbo-serialization-hessian2/src/test/java/org/apache/dubbo/common/serialize/hessian2/Hessian2SerializationTest.java
@@ -28,6 +28,7 @@ import org.apache.dubbo.rpc.model.FrameworkModel;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.Serializable;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -652,6 +653,143 @@ class Hessian2SerializationTest {
             ObjectInput objectInput = serialization.deserialize(url, inputStream);
             Assertions.assertInstanceOf(Map.class, objectInput.readObject());
             frameworkModel.destroy();
+        }
+    }
+
+    @Test
+    void testWriteReplaceSelfStillRequiresSerializable() throws IOException {
+        FrameworkModel frameworkModel = new FrameworkModel();
+        try {
+            Serialization serialization =
+                    frameworkModel.getExtensionLoader(Serialization.class).getExtension("hessian2");
+            URL url = URL.valueOf("").setScopeModel(frameworkModel);
+            ObjectOutput objectOutput = serialization.serialize(url, new ByteArrayOutputStream());
+
+            Assertions.assertThrows(
+                    IOException.class, () -> objectOutput.writeObject(new NonSerializableWriteReplace("self")));
+        } finally {
+            frameworkModel.destroy();
+        }
+    }
+
+    @Test
+    void testWriteReplaceReplacementStillRequiresSerializable() throws IOException {
+        FrameworkModel frameworkModel = new FrameworkModel();
+        try {
+            Serialization serialization =
+                    frameworkModel.getExtensionLoader(Serialization.class).getExtension("hessian2");
+            URL url = URL.valueOf("").setScopeModel(frameworkModel);
+            ObjectOutput objectOutput = serialization.serialize(url, new ByteArrayOutputStream());
+
+            Assertions.assertThrows(
+                    IOException.class,
+                    () -> objectOutput.writeObject(new SerializableWriteReplaceToNonSerializableReplacement("target")));
+        } finally {
+            frameworkModel.destroy();
+        }
+    }
+
+    @Test
+    void testWriteReplaceSerializableReplacementStillWorks() throws IOException, ClassNotFoundException {
+        FrameworkModel frameworkModel = new FrameworkModel();
+        try {
+            Serialization serialization =
+                    frameworkModel.getExtensionLoader(Serialization.class).getExtension("hessian2");
+            URL url = URL.valueOf("").setScopeModel(frameworkModel);
+
+            ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+            ObjectOutput objectOutput = serialization.serialize(url, outputStream);
+            objectOutput.writeObject(new SerializableWriteReplaceToSerializableReplacement("allowed"));
+            objectOutput.flushBuffer();
+
+            ByteArrayInputStream inputStream = new ByteArrayInputStream(outputStream.toByteArray());
+            ObjectInput objectInput = serialization.deserialize(url, inputStream);
+            Assertions.assertEquals(new SerializableReplacement("allowed"), objectInput.readObject());
+        } finally {
+            frameworkModel.destroy();
+        }
+    }
+
+    public static class NonSerializableWriteReplace {
+        private String value;
+
+        public NonSerializableWriteReplace() {}
+
+        public NonSerializableWriteReplace(String value) {
+            this.value = value;
+        }
+
+        private Object writeReplace() {
+            return this;
+        }
+    }
+
+    public static class SerializableWriteReplaceToNonSerializableReplacement implements Serializable {
+        private String value;
+
+        public SerializableWriteReplaceToNonSerializableReplacement() {}
+
+        public SerializableWriteReplaceToNonSerializableReplacement(String value) {
+            this.value = value;
+        }
+
+        private Object writeReplace() {
+            return new NonSerializableReplacement(value);
+        }
+    }
+
+    public static class NonSerializableReplacement {
+        private String value;
+
+        public NonSerializableReplacement() {}
+
+        public NonSerializableReplacement(String value) {
+            this.value = value;
+        }
+
+        private Object writeReplace() {
+            return this;
+        }
+    }
+
+    public static class SerializableWriteReplaceToSerializableReplacement implements Serializable {
+        private String value;
+
+        public SerializableWriteReplaceToSerializableReplacement() {}
+
+        public SerializableWriteReplaceToSerializableReplacement(String value) {
+            this.value = value;
+        }
+
+        private Object writeReplace() {
+            return new SerializableReplacement(value);
+        }
+    }
+
+    public static class SerializableReplacement implements Serializable {
+        private String value;
+
+        public SerializableReplacement() {}
+
+        public SerializableReplacement(String value) {
+            this.value = value;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof SerializableReplacement)) {
+                return false;
+            }
+            SerializableReplacement that = (SerializableReplacement) o;
+            return value.equals(that.value);
+        }
+
+        @Override
+        public int hashCode() {
+            return value.hashCode();
         }
     }
 }

--- a/dubbo-serialization/dubbo-serialization-hessian2/src/test/java/org/apache/dubbo/common/serialize/hessian2/Hessian2SerializationTest.java
+++ b/dubbo-serialization/dubbo-serialization-hessian2/src/test/java/org/apache/dubbo/common/serialize/hessian2/Hessian2SerializationTest.java
@@ -29,6 +29,7 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.Serializable;
+import java.lang.reflect.Method;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -38,6 +39,7 @@ import java.util.concurrent.ThreadLocalRandom;
 
 import com.example.test.TestPojo;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
 
 import static org.apache.dubbo.common.constants.CommonConstants.DubboProperty.DUBBO_HESSIAN_ALLOW_NON_SERIALIZABLE;
@@ -707,6 +709,42 @@ class Hessian2SerializationTest {
             Assertions.assertEquals(new SerializableReplacement("allowed"), objectInput.readObject());
         } finally {
             frameworkModel.destroy();
+        }
+    }
+
+    @Test
+    void testJdkImmutableListWithWriteReplaceCanSerializeInStrictMode() throws Exception {
+        List<String> immutableList = newJdkImmutableList("one", "two");
+        Assumptions.assumeTrue(immutableList != null, "JDK immutable collections are available since Java 9");
+
+        FrameworkModel frameworkModel = new FrameworkModel();
+        try {
+            Serialization serialization =
+                    frameworkModel.getExtensionLoader(Serialization.class).getExtension("hessian2");
+            frameworkModel
+                    .getBeanFactory()
+                    .getBean(SerializeSecurityManager.class)
+                    .setCheckStatus(SerializeCheckStatus.STRICT);
+            URL url = URL.valueOf("").setScopeModel(frameworkModel);
+
+            ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+            ObjectOutput objectOutput = serialization.serialize(url, outputStream);
+            Assertions.assertDoesNotThrow(() -> {
+                objectOutput.writeObject(immutableList);
+                objectOutput.flushBuffer();
+            });
+        } finally {
+            frameworkModel.destroy();
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static List<String> newJdkImmutableList(String first, String second) throws Exception {
+        try {
+            Method of = List.class.getMethod("of", Object.class, Object.class);
+            return (List<String>) of.invoke(null, first, second);
+        } catch (NoSuchMethodException e) {
+            return null;
         }
     }
 


### PR DESCRIPTION
## What is the purpose of the change?

Fixes #16287.

`Hessian2SerializerFactory` currently enforces Dubbo's serialization class policy from `getDefaultSerializer()`. However, hessian-lite resolves classes with `writeReplace()` before it reaches `getDefaultSerializer()`, so non-Serializable classes with `writeReplace()` can bypass the sender-side Serializable check.

This change enforces the same class policy in `getSerializer(Class)` for replacement-capable classes before delegating to hessian-lite, while keeping the existing default serializer/deserializer checks shared through one helper.

## Brief changelog

- Enforce Dubbo's serialization class policy for Hessian2 classes that define `writeReplace()`.
- Keep existing `getDefaultSerializer()` and `getDefaultDeserializer()` checks by sharing the same `checkClass()` helper.
- Add regression coverage for:
  - non-Serializable class whose `writeReplace()` returns itself;
  - Serializable class whose `writeReplace()` returns a non-Serializable replacement with its own `writeReplace()`;
  - valid Serializable replacement path.

## Verifying this change

- `git diff --check`
- `mvn -am -pl dubbo-serialization/dubbo-serialization-hessian2 -Dtest=Hessian2SerializationTest -Dsurefire.failIfNoSpecifiedTests=false -Dcheckstyle.skip=true -Drat.skip=true test`

## Checklist

- [x] Make sure there is a GitHub issue field for the change. (#16287)
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction.
- [x] Make sure GitHub Actions can pass.