### PR TITLE
Fix IPv4 address port parsing in NetUtils

### DIFF
--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/router/mesh/rule/virtualservice/match/AddressMatch.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/router/mesh/rule/virtualservice/match/AddressMatch.java
@@ -18,6 +18,7 @@ package org.apache.dubbo.rpc.cluster.router.mesh.rule.virtualservice.match;
 
 import org.apache.dubbo.common.logger.ErrorTypeAwareLogger;
 import org.apache.dubbo.common.logger.LoggerFactory;
+import org.apache.dubbo.common.utils.StringUtils;
 
 import java.net.UnknownHostException;
 
@@ -60,7 +61,7 @@ public class AddressMatch {
     public boolean isMatch(String input) {
         if (getCird() != null && input != null) {
             try {
-                return input.equals(getCird()) || matchIpExpression(getCird(), input);
+                return input.equals(getCird()) || matchCird(input);
             } catch (UnknownHostException e) {
                 logger.error(
                         CLUSTER_FAILED_EXEC_CONDITION_ROUTER,
@@ -83,5 +84,16 @@ public class AddressMatch {
             return input.equals(getExact());
         }
         return false;
+    }
+
+    private boolean matchCird(String input) throws UnknownHostException {
+        String host = input;
+        int port = 0;
+        int colonIndex = input.indexOf(':');
+        if (colonIndex > 0 && colonIndex == input.lastIndexOf(':')) {
+            host = input.substring(0, colonIndex);
+            port = StringUtils.parseInteger(input.substring(colonIndex + 1));
+        }
+        return matchIpExpression(getCird(), host, port);
     }
 }

--- a/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/router/mesh/rule/virtualservice/match/AddressMatchTest.java
+++ b/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/router/mesh/rule/virtualservice/match/AddressMatchTest.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.rpc.cluster.router.mesh.rule.virtualservice.match;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class AddressMatchTest {
+
+    @Test
+    void cirdMatchIpv4AddressWithPort() {
+        AddressMatch addressMatch = new AddressMatch();
+        addressMatch.setCird("192.168.1.*:90");
+
+        assertTrue(addressMatch.isMatch("192.168.1.63:90"));
+        assertFalse(addressMatch.isMatch("192.168.1.63:80"));
+    }
+
+    @Test
+    void cirdMatchIpv4AddressWithoutPort() {
+        AddressMatch addressMatch = new AddressMatch();
+        addressMatch.setCird("192.168.1.*");
+
+        assertTrue(addressMatch.isMatch("192.168.1.63"));
+    }
+
+    @Test
+    void cirdMatchExactAddress() {
+        AddressMatch addressMatch = new AddressMatch();
+        addressMatch.setCird("192.168.1.63:90");
+
+        assertTrue(addressMatch.isMatch("192.168.1.63:90"));
+    }
+
+    @Test
+    void cirdMatchIpv6Address() {
+        AddressMatch addressMatch = new AddressMatch();
+        addressMatch.setCird("234e:0:4567:0:0:0:3d:*");
+
+        assertTrue(addressMatch.isMatch("234e:0:4567::3d:ff"));
+    }
+}

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/utils/NetUtils.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/utils/NetUtils.java
@@ -722,12 +722,14 @@ public final class NetUtils {
     }
 
     /**
-     * Check if address matches with specified pattern, currently only supports ipv4, use {@link this#matchIpExpression(String, String, int)} for ipv6 addresses.
+     * Check if address matches with specified pattern.
      *
      * @param pattern cird pattern
-     * @param address 'ip:port'
+     * @param address address
      * @return true if address matches with the pattern
+     * @deprecated use {@link #matchIpExpression(String, String, int)} with separated host and port instead.
      */
+    @Deprecated
     public static boolean matchIpExpression(String pattern, String address) throws UnknownHostException {
         if (address == null) {
             return false;


### PR DESCRIPTION
Fixes #16308

## What is the purpose of the change?

This PR fixes `NetUtils.matchIpExpression(String, String)` so it can correctly parse normal IPv4 `host:port` addresses, such as `192.168.1.63:90`.

Previously, the method only split the address when it ended with `:`, so a normal IPv4 address with port was treated as the full host string and could fail with `UnknownHostException`.

The fix parses the address only when it contains exactly one colon, avoiding impact on IPv6 addresses.


## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Make sure gitHub actions can pass. [Why the workflow is failing and how to fix it?](../CONTRIBUTING.md)
