### PR TITLE
Fix NetUtils.matchIpExpression to correctly parse IPv4 address with port

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/utils/NetUtils.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/utils/NetUtils.java
@@ -735,11 +735,13 @@ public final class NetUtils {
 
         String host = address;
         int port = 0;
-        // only works for ipv4 address with 'ip:port' format
-        if (address.endsWith(":")) {
-            String[] hostPort = address.split(":");
-            host = hostPort[0];
-            port = StringUtils.parseInteger(hostPort[1]);
+        // parse 'ip:port' format for IPv4 addresses
+        // use ADDRESS_PATTERN (which matches 'x.x.x.x:port') to detect IPv4 with port,
+        // and 'lastIndexOf' to avoid breaking IPv6 addresses that contain multiple colons
+        if (isValidAddress(address)) {
+            int lastColonIndex = address.lastIndexOf(':');
+            host = address.substring(0, lastColonIndex);
+            port = StringUtils.parseInteger(address.substring(lastColonIndex + 1));
         }
 
         // if the pattern is subnet format, it will not be allowed to config port param in pattern.

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/utils/NetUtilsTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/utils/NetUtilsTest.java
@@ -347,6 +347,13 @@ class NetUtilsTest {
     }
 
     @Test
+    void testMatchIpExpressionWithIpv4AddressAndPort() throws UnknownHostException {
+        assertTrue(NetUtils.matchIpExpression("*.*.*.*:90", "192.168.1.63:90"));
+        assertTrue(NetUtils.matchIpExpression("192.168.1.*:90", "192.168.1.63:90"));
+        assertFalse(NetUtils.matchIpExpression("192.168.1.*:80", "192.168.1.63:90"));
+    }
+
+    @Test
     void testMatchIpv6WithIpPort() throws UnknownHostException {
         assertTrue(NetUtils.matchIpRange("[234e:0:4567::3d:ee]", "234e:0:4567::3d:ee", 8090));
         assertTrue(NetUtils.matchIpRange("[234e:0:4567:0:0:0:3d:ee]", "234e:0:4567::3d:ee", 8090));

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/utils/NetUtilsTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/utils/NetUtilsTest.java
@@ -354,6 +354,13 @@ class NetUtilsTest {
     }
 
     @Test
+    void testMatchIpExpressionWithIpv4AddressWithoutPort() throws UnknownHostException {
+        assertTrue(NetUtils.matchIpExpression("*.*.*.*", "192.168.1.63"));
+        assertTrue(NetUtils.matchIpExpression("192.168.1.*", "192.168.1.63"));
+        assertFalse(NetUtils.matchIpExpression("192.168.1.*", "192.168.2.100"));
+    }
+
+    @Test
     void testMatchIpv6WithIpPort() throws UnknownHostException {
         assertTrue(NetUtils.matchIpRange("[234e:0:4567::3d:ee]", "234e:0:4567::3d:ee", 8090));
         assertTrue(NetUtils.matchIpRange("[234e:0:4567:0:0:0:3d:ee]", "234e:0:4567::3d:ee", 8090));


### PR DESCRIPTION
## What is the purpose of the change

Fix `NetUtils.matchIpExpression(String pattern, String address)` to correctly parse IPv4 addresses with port (e.g. `192.168.1.63:90`).

Previously the method used `address.endsWith(":")` to detect the `ip:port` format, which would never match a valid IPv4 address with port since the colon is in the middle, not at the end.

## Brief changelog

- Changed the host/port parsing logic to use the existing `isValidAddress()` method (which matches `ADDRESS_PATTERN` regex `^\d{1,3}(\.\d{1,3}){3}\:\d{1,5}$`) to detect IPv4 addresses with port
- Added test case `testMatchIpExpressionWithIpv4AddressAndPort` covering wildcard, subnet, and port-mismatch scenarios

## Verifying this change

- Added unit test that covers:
  - Wildcard pattern with port: `*.*.*.*:90` matching `192.168.1.63:90`
  - Subnet pattern with port: `192.168.1.*:90` matching `192.168.1.63:90`
  - Port mismatch: `192.168.1.*:80` not matching `192.168.1.63:90`

Fixes #16308