### PR TITLE
Fix UnsupportedOperationException in DubboDefaultPropertiesEnvironmentPostProcessor.addOrReplace on immutable property source (#16268)

### DIFF
--- a/dubbo-spring-boot-project/dubbo-spring-boot/src/main/java/org/apache/dubbo/spring/boot/env/DubboDefaultPropertiesEnvironmentPostProcessor.java
+++ b/dubbo-spring-boot-project/dubbo-spring-boot/src/main/java/org/apache/dubbo/spring/boot/env/DubboDefaultPropertiesEnvironmentPostProcessor.java
@@ -127,13 +127,17 @@ public class DubboDefaultPropertiesEnvironmentPostProcessor implements Environme
         if (propertySources.contains(PROPERTY_SOURCE_NAME)) {
             PropertySource<?> source = propertySources.get(PROPERTY_SOURCE_NAME);
             if (source instanceof MapPropertySource) {
-                target = (MapPropertySource) source;
+                // The existing backing map may be immutable, so copy into a mutable map and replace the
+                // source instead of mutating it in place. See dubbo#16268.
+                Map<String, Object> merged = new HashMap<>(((MapPropertySource) source).getSource());
                 for (Map.Entry<String, Object> entry : map.entrySet()) {
                     String key = entry.getKey();
-                    if (!target.containsProperty(key)) {
-                        target.getSource().put(key, entry.getValue());
+                    if (!merged.containsKey(key)) {
+                        merged.put(key, entry.getValue());
                     }
                 }
+                target = new MapPropertySource(PROPERTY_SOURCE_NAME, merged);
+                propertySources.replace(PROPERTY_SOURCE_NAME, target);
             }
         }
         if (target == null) {

--- a/dubbo-spring-boot-project/dubbo-spring-boot/src/test/java/org/apache/dubbo/spring/boot/env/DubboDefaultPropertiesEnvironmentPostProcessorTest.java
+++ b/dubbo-spring-boot-project/dubbo-spring-boot/src/test/java/org/apache/dubbo/spring/boot/env/DubboDefaultPropertiesEnvironmentPostProcessorTest.java
@@ -16,7 +16,9 @@
  */
 package org.apache.dubbo.spring.boot.env;
 
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.SpringApplication;
@@ -26,6 +28,7 @@ import org.springframework.core.env.MutablePropertySources;
 import org.springframework.core.env.PropertySource;
 import org.springframework.mock.env.MockEnvironment;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
@@ -105,5 +108,36 @@ class DubboDefaultPropertiesEnvironmentPostProcessorTest {
         defaultPropertySource = propertySources.get("defaultProperties");
         assertNotNull(defaultPropertySource);
         assertEquals("virtual", defaultPropertySource.getProperty("dubbo.protocol.threadpool"));
+    }
+
+    /** #16268: addOrReplace must not fail when "defaultProperties" is backed by an immutable map. */
+    @Test
+    void testPostProcessEnvironmentOnImmutableDefaultProperties() {
+        MockEnvironment environment = new MockEnvironment();
+        MutablePropertySources propertySources = environment.getPropertySources();
+        propertySources.addLast(
+                new MapPropertySource("defaultProperties", Collections.unmodifiableMap(new HashMap<String, Object>())));
+
+        instance.postProcessEnvironment(environment, springApplication);
+
+        PropertySource<?> defaultPropertySource = propertySources.get("defaultProperties");
+        assertNotNull(defaultPropertySource);
+        assertEquals("true", defaultPropertySource.getProperty("dubbo.config.multiple"));
+    }
+
+    /** #16268: on an immutable "defaultProperties", Dubbo's default must not override an existing key. */
+    @Test
+    void testImmutableDefaultPropertiesDoesNotOverrideExistingKey() {
+        MockEnvironment environment = new MockEnvironment();
+        MutablePropertySources propertySources = environment.getPropertySources();
+        Map<String, Object> existing = new HashMap<>();
+        existing.put("dubbo.config.multiple", "false");
+        propertySources.addLast(new MapPropertySource("defaultProperties", Collections.unmodifiableMap(existing)));
+
+        assertDoesNotThrow(() -> instance.postProcessEnvironment(environment, springApplication));
+
+        PropertySource<?> defaultPropertySource = propertySources.get("defaultProperties");
+        assertNotNull(defaultPropertySource);
+        assertEquals("false", defaultPropertySource.getProperty("dubbo.config.multiple"));
     }
 }


### PR DESCRIPTION
## What is the purpose of the change?

GitHub_issue: Fixes #16268

This pull request fixes the `UnsupportedOperationException` thrown by `DubboDefaultPropertiesEnvironmentPostProcessor#addOrReplace` when a `defaultProperties` source is already present and backed by an immutable map.

`addOrReplace` merged Dubbo's defaults by mutating the existing source's backing map in place via `target.getSource().put(...)`. But `MapPropertySource.getSource()` returns the map the source was constructed with, which Spring does not guarantee is mutable. Since this post-processor runs at `LOWEST_PRECEDENCE`, another `EnvironmentPostProcessor` (e.g. Nacos / Spring Cloud bootstrap) may already have registered `defaultProperties` backed by an immutable map such as Guava `ImmutableMap`, so the `put` throws:

```
java.lang.UnsupportedOperationException
    at com.google.common.collect.ImmutableMap.put(ImmutableMap.java:814)
    at org.apache.dubbo.spring.boot.env.DubboDefaultPropertiesEnvironmentPostProcessor.addOrReplace(DubboDefaultPropertiesEnvironmentPostProcessor.java:134)
```

The fix copies the existing entries into a new mutable `HashMap`, merges Dubbo's defaults only for keys not already present (unchanged precedence), and replaces the source in place via `MutablePropertySources.replace(...)` — the same approach as Spring Boot's own `DefaultPropertiesPropertySource#addOrMerge`. The mutable case behaves identically; the immutable case no longer throws. No public signature or behaviour change, and the Java 8 language level is preserved.

Two regression tests were added in `DubboDefaultPropertiesEnvironmentPostProcessorTest`: one asserts an immutable-backed `defaultProperties` no longer throws, the other asserts an already-present key is still not overridden by Dubbo's default.

## Verification

- `git diff --check`
- `./mvnw -pl dubbo-spring-boot-project/dubbo-spring-boot -am -Dtest=DubboDefaultPropertiesEnvironmentPostProcessorTest -Dsurefire.failIfNoSpecifiedTests=false test`

## Checklist

- [x] Make sure there is a GitHub_issue field for the change.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction. If the new feature or significant change is committed, please remember to add sample in dubbo samples project.
- [x] Make sure GitHub actions can pass.