### PR TITLE
Improve AddressMatch CIDR naming compatibility

### DIFF
--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/router/mesh/rule/virtualservice/match/AddressMatch.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/router/mesh/rule/virtualservice/match/AddressMatch.java
@@ -31,7 +31,13 @@ import static org.apache.dubbo.common.utils.UrlUtils.isMatchGlobPattern;
 public class AddressMatch {
     public static final ErrorTypeAwareLogger logger = LoggerFactory.getErrorTypeAwareLogger(AddressMatch.class);
     private String wildcard;
+    private String cidr;
+    /**
+     * @deprecated use {@link #getCidr()} and {@link #setCidr(String)} instead.
+     */
+    @Deprecated
     private String cird;
+
     private String exact;
 
     public String getWildcard() {
@@ -42,11 +48,29 @@ public class AddressMatch {
         this.wildcard = wildcard;
     }
 
-    public String getCird() {
-        return cird;
+    public String getCidr() {
+        return cidr != null ? cidr : cird;
     }
 
+    public void setCidr(String cidr) {
+        this.cidr = cidr;
+        this.cird = cidr;
+    }
+
+    /**
+     * @deprecated use {@link #getCidr()} instead.
+     */
+    @Deprecated
+    public String getCird() {
+        return getCidr();
+    }
+
+    /**
+     * @deprecated use {@link #setCidr(String)} instead.
+     */
+    @Deprecated
     public void setCird(String cird) {
+        this.cidr = cird;
         this.cird = cird;
     }
 
@@ -59,17 +83,17 @@ public class AddressMatch {
     }
 
     public boolean isMatch(String input) {
-        if (getCird() != null && input != null) {
+        if (getCidr() != null && input != null) {
             try {
-                return input.equals(getCird()) || matchCird(input);
+                return input.equals(getCidr()) || matchCidr(input);
             } catch (UnknownHostException e) {
                 logger.error(
                         CLUSTER_FAILED_EXEC_CONDITION_ROUTER,
                         "Executing routing rule match expression error.",
                         "",
                         String.format(
-                                "Error trying to match cird formatted address %s with input %s in AddressMatch.",
-                                getCird(), input),
+                                "Error trying to match CIDR formatted address %s with input %s in AddressMatch.",
+                                getCidr(), input),
                         e);
             }
         }
@@ -86,7 +110,7 @@ public class AddressMatch {
         return false;
     }
 
-    private boolean matchCird(String input) throws UnknownHostException {
+    private boolean matchCidr(String input) throws UnknownHostException {
         String host = input;
         int port = 0;
         int colonIndex = input.indexOf(':');
@@ -94,6 +118,6 @@ public class AddressMatch {
             host = input.substring(0, colonIndex);
             port = StringUtils.parseInteger(input.substring(colonIndex + 1));
         }
-        return matchIpExpression(getCird(), host, port);
+        return matchIpExpression(getCidr(), host, port);
     }
 }

--- a/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/router/mesh/rule/virtualservice/match/AddressMatchTest.java
+++ b/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/router/mesh/rule/virtualservice/match/AddressMatchTest.java
@@ -23,6 +23,8 @@ import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 
+import static org.apache.dubbo.common.constants.CommonConstants.ANYHOST_VALUE;
+import static org.apache.dubbo.common.constants.CommonConstants.ANY_VALUE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -71,6 +73,14 @@ class AddressMatchTest {
     }
 
     @Test
+    void cidrMatchNullAddressReturnsFalse() {
+        AddressMatch addressMatch = new AddressMatch();
+        addressMatch.setCidr("192.168.1.*");
+
+        assertFalse(addressMatch.isMatch(null));
+    }
+
+    @Test
     void wildcardMatchAddress() {
         AddressMatch addressMatch = new AddressMatch();
         addressMatch.setWildcard("192.168.1.*");
@@ -80,12 +90,39 @@ class AddressMatchTest {
     }
 
     @Test
+    void wildcardAnyAddressMatches() {
+        AddressMatch wildcardAny = new AddressMatch();
+        wildcardAny.setWildcard(ANY_VALUE);
+        assertTrue(wildcardAny.isMatch("192.168.1.63"));
+
+        AddressMatch wildcardAnyHost = new AddressMatch();
+        wildcardAnyHost.setWildcard(ANYHOST_VALUE);
+        assertTrue(wildcardAnyHost.isMatch("192.168.1.63"));
+    }
+
+    @Test
+    void wildcardMatchNullAddressReturnsFalse() {
+        AddressMatch addressMatch = new AddressMatch();
+        addressMatch.setWildcard("192.168.1.*");
+
+        assertFalse(addressMatch.isMatch(null));
+    }
+
+    @Test
     void exactMatchAddress() {
         AddressMatch addressMatch = new AddressMatch();
         addressMatch.setExact("192.168.1.63");
 
         assertTrue(addressMatch.isMatch("192.168.1.63"));
         assertFalse(addressMatch.isMatch("192.168.1.64"));
+    }
+
+    @Test
+    void exactMatchNullAddressReturnsFalse() {
+        AddressMatch addressMatch = new AddressMatch();
+        addressMatch.setExact("192.168.1.63");
+
+        assertFalse(addressMatch.isMatch(null));
     }
 
     @Test

--- a/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/router/mesh/rule/virtualservice/match/AddressMatchTest.java
+++ b/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/router/mesh/rule/virtualservice/match/AddressMatchTest.java
@@ -16,43 +16,98 @@
  */
 package org.apache.dubbo.rpc.cluster.router.mesh.rule.virtualservice.match;
 
+import org.apache.dubbo.common.utils.PojoUtils;
+
+import java.util.HashMap;
+import java.util.Map;
+
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class AddressMatchTest {
 
     @Test
-    void cirdMatchIpv4AddressWithPort() {
+    void cidrMatchIpv4AddressWithPort() {
         AddressMatch addressMatch = new AddressMatch();
-        addressMatch.setCird("192.168.1.*:90");
+        addressMatch.setCidr("192.168.1.*:90");
 
         assertTrue(addressMatch.isMatch("192.168.1.63:90"));
         assertFalse(addressMatch.isMatch("192.168.1.63:80"));
     }
 
     @Test
-    void cirdMatchIpv4AddressWithoutPort() {
+    void cidrMatchIpv4AddressWithoutPort() {
         AddressMatch addressMatch = new AddressMatch();
-        addressMatch.setCird("192.168.1.*");
+        addressMatch.setCidr("192.168.1.*");
 
         assertTrue(addressMatch.isMatch("192.168.1.63"));
     }
 
     @Test
-    void cirdMatchExactAddress() {
+    void cidrMatchExactAddress() {
         AddressMatch addressMatch = new AddressMatch();
-        addressMatch.setCird("192.168.1.63:90");
+        addressMatch.setCidr("192.168.1.63:90");
 
         assertTrue(addressMatch.isMatch("192.168.1.63:90"));
     }
 
     @Test
-    void cirdMatchIpv6Address() {
+    void cidrMatchIpv6Address() {
         AddressMatch addressMatch = new AddressMatch();
-        addressMatch.setCird("234e:0:4567:0:0:0:3d:*");
+        addressMatch.setCidr("234e:0:4567:0:0:0:3d:*");
 
         assertTrue(addressMatch.isMatch("234e:0:4567::3d:ff"));
+    }
+
+    @Test
+    void cidrMatchInvalidAddressReturnsFalse() {
+        AddressMatch addressMatch = new AddressMatch();
+        addressMatch.setCidr("192.168.1.*");
+
+        assertFalse(addressMatch.isMatch("invalid host"));
+    }
+
+    @Test
+    @SuppressWarnings("deprecation")
+    void deprecatedCirdAccessorsRemainCompatible() {
+        AddressMatch addressMatch = new AddressMatch();
+        addressMatch.setCird("192.168.1.*:90");
+
+        assertTrue(addressMatch.isMatch("192.168.1.63:90"));
+        assertEquals(addressMatch.getCidr(), addressMatch.getCird());
+    }
+
+    @Test
+    @SuppressWarnings("deprecation")
+    void cidrAndDeprecatedCirdAccessorsShareTheSameValue() {
+        AddressMatch addressMatch = new AddressMatch();
+        addressMatch.setCidr("192.168.1.*:90");
+        addressMatch.setCird("10.0.0.*:20880");
+
+        assertEquals("10.0.0.*:20880", addressMatch.getCidr());
+        assertEquals(addressMatch.getCidr(), addressMatch.getCird());
+    }
+
+    @Test
+    void cidrFieldCanBeMappedToPojo() throws ReflectiveOperationException {
+        Map<String, Object> map = new HashMap<>();
+        map.put("cidr", "192.168.1.*:90");
+
+        AddressMatch addressMatch = PojoUtils.mapToPojo(map, AddressMatch.class);
+
+        assertTrue(addressMatch.isMatch("192.168.1.63:90"));
+    }
+
+    @Test
+    void deprecatedCirdFieldCanBeMappedToPojo() throws ReflectiveOperationException {
+        Map<String, Object> map = new HashMap<>();
+        map.put("cird", "192.168.1.*:90");
+
+        AddressMatch addressMatch = PojoUtils.mapToPojo(map, AddressMatch.class);
+
+        assertTrue(addressMatch.isMatch("192.168.1.63:90"));
     }
 }

--- a/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/router/mesh/rule/virtualservice/match/AddressMatchTest.java
+++ b/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/router/mesh/rule/virtualservice/match/AddressMatchTest.java
@@ -71,6 +71,24 @@ class AddressMatchTest {
     }
 
     @Test
+    void wildcardMatchAddress() {
+        AddressMatch addressMatch = new AddressMatch();
+        addressMatch.setWildcard("192.168.1.*");
+
+        assertTrue(addressMatch.isMatch("192.168.1.63"));
+        assertFalse(addressMatch.isMatch("10.0.0.1"));
+    }
+
+    @Test
+    void exactMatchAddress() {
+        AddressMatch addressMatch = new AddressMatch();
+        addressMatch.setExact("192.168.1.63");
+
+        assertTrue(addressMatch.isMatch("192.168.1.63"));
+        assertFalse(addressMatch.isMatch("192.168.1.64"));
+    }
+
+    @Test
     @SuppressWarnings("deprecation")
     void deprecatedCirdAccessorsRemainCompatible() {
         AddressMatch addressMatch = new AddressMatch();

--- a/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/router/mesh/rule/virtualservice/match/AddressMatchTest.java
+++ b/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/router/mesh/rule/virtualservice/match/AddressMatchTest.java
@@ -92,6 +92,17 @@ class AddressMatchTest {
     }
 
     @Test
+    void cidrFallsBackToDeprecatedCirdField() throws ReflectiveOperationException {
+        AddressMatch addressMatch = new AddressMatch();
+        java.lang.reflect.Field cirdField = AddressMatch.class.getDeclaredField("cird");
+        cirdField.setAccessible(true);
+        cirdField.set(addressMatch, "192.168.1.*:90");
+
+        assertEquals("192.168.1.*:90", addressMatch.getCidr());
+        assertTrue(addressMatch.isMatch("192.168.1.63:90"));
+    }
+
+    @Test
     void cidrFieldCanBeMappedToPojo() throws ReflectiveOperationException {
         Map<String, Object> map = new HashMap<>();
         map.put("cidr", "192.168.1.*:90");

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/utils/NetUtils.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/utils/NetUtils.java
@@ -724,7 +724,7 @@ public final class NetUtils {
     /**
      * Check if address matches with specified pattern.
      *
-     * @param pattern cird pattern
+     * @param pattern CIDR pattern
      * @param address address
      * @return true if address matches with the pattern
      * @deprecated use {@link #matchIpExpression(String, String, int)} with separated host and port instead.


### PR DESCRIPTION
### What changed

This PR improves the CIDR naming in `AddressMatch` while keeping backward compatibility.

- Added `cidr` field and `getCidr` / `setCidr` accessors.
- Kept the existing `cird` field and `getCird` / `setCird` accessors as deprecated for compatibility.
- Updated internal matching logic to use `getCidr()`.
- Added tests to cover both `cidr` and deprecated `cird` field mapping through `PojoUtils`.
- Fixed the remaining `cird` typo in `NetUtils` Javadoc.

### Motivation

`cird` appears to be a typo of `cidr`, where CIDR stands for Classless Inter-Domain Routing. Since the old name may already be used by configuration binding or external code, this PR keeps backward compatibility while introducing the correct naming.

Closes #16314

### Tests

```bash
./mvnw -pl dubbo-cluster -Dtest=AddressMatchTest test
```
