### PR TITLE
Configure GitHub workflows to use concurrency cancel-in-progress for pull requests

### DIFF
--- a/.github/workflows/build-and-test-pr.yml
+++ b/.github/workflows/build-and-test-pr.yml
@@ -32,6 +32,10 @@ env:
     --no-transfer-progress
     --fail-fast
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   check-format:
     name: "Check if code needs formatting"

--- a/.github/workflows/build-and-test-pr.yml
+++ b/.github/workflows/build-and-test-pr.yml
@@ -33,7 +33,9 @@ env:
     --fail-fast
 
 concurrency:
+  # One group per PR, or per ref for branch pushes.
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  # Cancel in-progress runs for PRs only, so release branch builds always complete.
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:


### PR DESCRIPTION
see recommended best practices at Apache
https://cwiki.apache.org/confluence/pages/viewpage.action?spaceKey=INFRA&title=GitHub+Actions+Recommended+Practices

**Cancel superseded PR runs**
```
When a new commit is pushed to a PR branch, the runs triggered by earlier commits keep going, even though their results are no longer relevant. A concurrency group scoped to the PR cancels those stale runs as soon as a newer commit arrives.

Scope the group by PR number so each PR only cancels its own runs, and limit cancel-in-progress to pull_request events so pushes to release branches are never interrupted.

concurrency:
  # One group per PR, or per ref for branch pushes.
  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
  # Cancel in-progress runs for PRs only, so release branch builds always complete.
  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
```

## What is the purpose of the change?


## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Make sure gitHub actions can pass. [Why the workflow is failing and how to fix it?](../CONTRIBUTING.md)
