### PR TITLE
test: add unit test for multiple clients watching same service in Tri Health

### DIFF
--- a/dubbo-rpc/dubbo-rpc-triple/src/test/java/org/apache/dubbo/rpc/protocol/tri/service/TriHealthImplTest.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/test/java/org/apache/dubbo/rpc/protocol/tri/service/TriHealthImplTest.java
@@ -96,24 +96,41 @@ class TriHealthImplTest {
     @Test
     void testMultipleClientsWatchingSameService() throws Exception {
         TriHealthImpl triHealth = new TriHealthImpl();
-        HealthCheckRequest request =
-                HealthCheckRequest.newBuilder().setService("multi-client").build();
+        HealthCheckRequest request = HealthCheckRequest.newBuilder()
+                .setService("multi-client-service")
+                .build();
         triHealth.setStatus(request.getService(), ServingStatus.SERVING);
 
+        RpcContext.removeCancellationContext();
+
+        // Create multiple mock clients
         StreamObserver<HealthCheckResponse> client1 = new MockStreamObserver();
         StreamObserver<HealthCheckResponse> client2 = new MockStreamObserver();
+        StreamObserver<HealthCheckResponse> client3 = new MockStreamObserver();
 
+        // Register all clients
         triHealth.watch(request, client1);
         triHealth.watch(request, client2);
+        triHealth.watch(request, client3);
 
-        // Verify both clients get notified
+        // Verify all are registered
+        HashMap<String, IdentityHashMap<StreamObserver<HealthCheckResponse>, Boolean>> watches = getWatches(triHealth);
+        Assertions.assertEquals(watches.get(request.getService()).size(), 3);
+
+        // When status changes, all clients should be notified
         triHealth.setStatus(request.getService(), ServingStatus.NOT_SERVING);
 
         MockStreamObserver mock1 = (MockStreamObserver) client1;
         MockStreamObserver mock2 = (MockStreamObserver) client2;
+        MockStreamObserver mock3 = (MockStreamObserver) client3;
 
+        // Initial + status change
         Assertions.assertEquals(mock1.getCount(), 2);
         Assertions.assertEquals(mock2.getCount(), 2);
+        Assertions.assertEquals(mock3.getCount(), 2);
+
+        RpcContext.getCancellationContext().close();
+        Assertions.assertTrue(watches.isEmpty());
     }
 
     private void turnOffTerminal(TriHealthImpl triHealth) throws NoSuchFieldException, IllegalAccessException {

--- a/dubbo-rpc/dubbo-rpc-triple/src/test/java/org/apache/dubbo/rpc/protocol/tri/service/TriHealthImplTest.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/test/java/org/apache/dubbo/rpc/protocol/tri/service/TriHealthImplTest.java
@@ -93,6 +93,29 @@ class TriHealthImplTest {
         Assertions.assertTrue(watches.isEmpty());
     }
 
+    @Test
+    void testMultipleClientsWatchingSameService() throws Exception {
+        TriHealthImpl triHealth = new TriHealthImpl();
+        HealthCheckRequest request =
+                HealthCheckRequest.newBuilder().setService("multi-client").build();
+        triHealth.setStatus(request.getService(), ServingStatus.SERVING);
+
+        StreamObserver<HealthCheckResponse> client1 = new MockStreamObserver();
+        StreamObserver<HealthCheckResponse> client2 = new MockStreamObserver();
+
+        triHealth.watch(request, client1);
+        triHealth.watch(request, client2);
+
+        // Verify both clients get notified
+        triHealth.setStatus(request.getService(), ServingStatus.NOT_SERVING);
+
+        MockStreamObserver mock1 = (MockStreamObserver) client1;
+        MockStreamObserver mock2 = (MockStreamObserver) client2;
+
+        Assertions.assertEquals(mock1.getCount(), 2);
+        Assertions.assertEquals(mock2.getCount(), 2);
+    }
+
     private void turnOffTerminal(TriHealthImpl triHealth) throws NoSuchFieldException, IllegalAccessException {
         Field terminalField = triHealth.getClass().getDeclaredField("terminal");
         terminalField.setAccessible(true);


### PR DESCRIPTION
## What is the purpose of the change?
This pull request introduces a new unit test `testMultipleClientsWatchingSameService` to `TriHealthImplTest`. The purpose is to verify that the Triple health check implementation correctly notifies multiple stream observers (`StreamObserver`) when they are simultaneously watching the same service and a status change occurs.

## Brief Changelog
* **TriHealthImplTest.java**: Added `testMultipleClientsWatchingSameService()` unit test verifying multi-client subscription updates.

## Verifying this change
This change is a pure test enhancement. You can verify it runs and passes successfully by running:
```cmd
mvn test -pl dubbo-rpc/dubbo-rpc-triple -Dtest=TriHealthImplTest