### PR TITLE
Fix unconnected Curator client handling when registry check is false

### DIFF
--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/ListenerRegistryWrapper.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/ListenerRegistryWrapper.java
@@ -22,6 +22,7 @@ import org.apache.dubbo.common.logger.LoggerFactory;
 import org.apache.dubbo.common.utils.CollectionUtils;
 import org.apache.dubbo.common.utils.UrlUtils;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.function.Consumer;
 
@@ -32,26 +33,34 @@ public class ListenerRegistryWrapper implements Registry {
             LoggerFactory.getErrorTypeAwareLogger(ListenerRegistryWrapper.class);
 
     private final Registry registry;
+    private final URL url;
     private final List<RegistryServiceListener> listeners;
 
     public ListenerRegistryWrapper(Registry registry, List<RegistryServiceListener> listeners) {
+        this(registry, registry == null ? null : registry.getUrl(), listeners);
+    }
+
+    public ListenerRegistryWrapper(Registry registry, URL url, List<RegistryServiceListener> listeners) {
         this.registry = registry;
+        this.url = url;
         this.listeners = listeners;
     }
 
     @Override
     public URL getUrl() {
-        return registry.getUrl();
+        return registry == null ? url : registry.getUrl();
     }
 
     @Override
     public boolean isAvailable() {
-        return registry.isAvailable();
+        return registry != null && registry.isAvailable();
     }
 
     @Override
     public void destroy() {
-        registry.destroy();
+        if (registry != null) {
+            registry.destroy();
+        }
     }
 
     @Override
@@ -94,7 +103,9 @@ public class ListenerRegistryWrapper implements Registry {
     @Override
     public void unsubscribe(URL url, NotifyListener listener) {
         try {
-            registry.unsubscribe(url, listener);
+            if (registry != null) {
+                registry.unsubscribe(url, listener);
+            }
         } finally {
             listenerEvent(serviceListener -> serviceListener.onUnsubscribe(url, registry));
         }
@@ -102,12 +113,12 @@ public class ListenerRegistryWrapper implements Registry {
 
     @Override
     public boolean isServiceDiscovery() {
-        return registry.isServiceDiscovery();
+        return registry != null && registry.isServiceDiscovery();
     }
 
     @Override
     public List<URL> lookup(URL url) {
-        return registry.lookup(url);
+        return registry == null ? Collections.emptyList() : registry.lookup(url);
     }
 
     public Registry getRegistry() {

--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/RegistryFactoryWrapper.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/RegistryFactoryWrapper.java
@@ -31,6 +31,7 @@ public class RegistryFactoryWrapper implements RegistryFactory {
     public Registry getRegistry(URL url) {
         return new ListenerRegistryWrapper(
                 registryFactory.getRegistry(url),
+                url,
                 Collections.unmodifiableList(url.getOrDefaultApplicationModel()
                         .getExtensionLoader(RegistryServiceListener.class)
                         .getActivateExtension(url, "registry.listeners")));

--- a/dubbo-registry/dubbo-registry-api/src/test/java/org/apache/dubbo/registry/ListenerRegistryWrapperTest.java
+++ b/dubbo-registry/dubbo-registry-api/src/test/java/org/apache/dubbo/registry/ListenerRegistryWrapperTest.java
@@ -32,6 +32,7 @@ import static org.apache.dubbo.common.constants.CommonConstants.INTERFACE_KEY;
 import static org.apache.dubbo.registry.Constants.REGISTER_IP_KEY;
 import static org.apache.dubbo.rpc.cluster.Constants.REFER_KEY;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -98,5 +99,38 @@ class ListenerRegistryWrapperTest {
         verify(listener, times(1)).onUnregister(serviceUrl, null);
         verify(listener, times(1)).onSubscribe(serviceUrl, null);
         verify(listener, times(1)).onUnsubscribe(serviceUrl, null);
+    }
+
+    @Test
+    void testDelegatesToRegistryWhenPresent() {
+        URL registryUrl = URL.valueOf("registry://127.0.0.1:2181/org.apache.dubbo.registry.RegistryService");
+        URL serviceUrl = URL.valueOf("dubbo://127.0.0.1:20881/" + DemoService.class.getName());
+        Registry registry = mock(Registry.class);
+        NotifyListener notifyListener = mock(NotifyListener.class);
+        RegistryServiceListener listener = mock(RegistryServiceListener.class);
+
+        when(registry.getUrl()).thenReturn(registryUrl);
+        when(registry.isAvailable()).thenReturn(true);
+        when(registry.isServiceDiscovery()).thenReturn(true);
+        when(registry.lookup(serviceUrl)).thenReturn(Collections.singletonList(serviceUrl));
+
+        ListenerRegistryWrapper wrapper = new ListenerRegistryWrapper(registry, Collections.singletonList(listener));
+
+        Assertions.assertEquals(registryUrl, wrapper.getUrl());
+        Assertions.assertTrue(wrapper.isAvailable());
+        Assertions.assertTrue(wrapper.isServiceDiscovery());
+        Assertions.assertEquals(Collections.singletonList(serviceUrl), wrapper.lookup(serviceUrl));
+
+        wrapper.unsubscribe(serviceUrl, notifyListener);
+        wrapper.destroy();
+
+        verify(registry, times(2)).getUrl();
+        verify(registry).isAvailable();
+        verify(registry).isServiceDiscovery();
+        verify(registry).lookup(serviceUrl);
+        verify(registry).unsubscribe(serviceUrl, notifyListener);
+        verify(registry).destroy();
+        verify(listener, times(1)).onUnsubscribe(serviceUrl, registry);
+        verify(listener, never()).onSubscribe(serviceUrl, registry);
     }
 }

--- a/dubbo-registry/dubbo-registry-api/src/test/java/org/apache/dubbo/registry/ListenerRegistryWrapperTest.java
+++ b/dubbo-registry/dubbo-registry-api/src/test/java/org/apache/dubbo/registry/ListenerRegistryWrapperTest.java
@@ -20,6 +20,7 @@ import org.apache.dubbo.common.URL;
 import org.apache.dubbo.common.url.component.ServiceConfigURL;
 import org.apache.dubbo.registry.integration.DemoService;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -72,5 +73,30 @@ class ListenerRegistryWrapperTest {
 
         registryWrapper.subscribe(subscribeUrl, notifyListener);
         verify(listener, times(1)).onSubscribe(subscribeUrl, registry);
+    }
+
+    @Test
+    void testNullRegistryIsSafe() {
+        URL registryUrl = URL.valueOf("registry://127.0.0.1:2181/org.apache.dubbo.registry.RegistryService");
+        URL serviceUrl = URL.valueOf("dubbo://127.0.0.1:20881/" + DemoService.class.getName());
+        NotifyListener notifyListener = mock(NotifyListener.class);
+        RegistryServiceListener listener = mock(RegistryServiceListener.class);
+        ListenerRegistryWrapper wrapper =
+                new ListenerRegistryWrapper(null, registryUrl, Collections.singletonList(listener));
+
+        Assertions.assertEquals(registryUrl, wrapper.getUrl());
+        Assertions.assertFalse(wrapper.isAvailable());
+        Assertions.assertFalse(wrapper.isServiceDiscovery());
+        Assertions.assertTrue(wrapper.lookup(serviceUrl).isEmpty());
+        Assertions.assertDoesNotThrow(wrapper::destroy);
+        Assertions.assertDoesNotThrow(() -> wrapper.register(serviceUrl));
+        Assertions.assertDoesNotThrow(() -> wrapper.unregister(serviceUrl));
+        Assertions.assertDoesNotThrow(() -> wrapper.subscribe(serviceUrl, notifyListener));
+        Assertions.assertDoesNotThrow(() -> wrapper.unsubscribe(serviceUrl, notifyListener));
+
+        verify(listener, times(1)).onRegister(serviceUrl, null);
+        verify(listener, times(1)).onUnregister(serviceUrl, null);
+        verify(listener, times(1)).onSubscribe(serviceUrl, null);
+        verify(listener, times(1)).onUnsubscribe(serviceUrl, null);
     }
 }

--- a/dubbo-registry/dubbo-registry-api/src/test/java/org/apache/dubbo/registry/ListenerRegistryWrapperTest.java
+++ b/dubbo-registry/dubbo-registry-api/src/test/java/org/apache/dubbo/registry/ListenerRegistryWrapperTest.java
@@ -133,4 +133,31 @@ class ListenerRegistryWrapperTest {
         verify(listener, times(1)).onUnsubscribe(serviceUrl, registry);
         verify(listener, never()).onSubscribe(serviceUrl, registry);
     }
+
+    @Test
+    void testLegacyConstructorWithNullRegistry() {
+        URL serviceUrl = URL.valueOf("dubbo://127.0.0.1:20881/" + DemoService.class.getName());
+        ListenerRegistryWrapper wrapper = new ListenerRegistryWrapper(null, Collections.emptyList());
+
+        Assertions.assertNull(wrapper.getUrl());
+        Assertions.assertFalse(wrapper.isAvailable());
+        Assertions.assertFalse(wrapper.isServiceDiscovery());
+        Assertions.assertTrue(wrapper.lookup(serviceUrl).isEmpty());
+        Assertions.assertDoesNotThrow(wrapper::destroy);
+    }
+
+    @Test
+    void testRegistryPresentButUnavailable() {
+        URL serviceUrl = URL.valueOf("dubbo://127.0.0.1:20881/" + DemoService.class.getName());
+        Registry registry = mock(Registry.class);
+        when(registry.isAvailable()).thenReturn(false);
+        when(registry.isServiceDiscovery()).thenReturn(false);
+
+        ListenerRegistryWrapper wrapper = new ListenerRegistryWrapper(registry, Collections.emptyList());
+
+        Assertions.assertFalse(wrapper.isAvailable());
+        Assertions.assertFalse(wrapper.isServiceDiscovery());
+        verify(registry).isAvailable();
+        verify(registry).isServiceDiscovery();
+    }
 }

--- a/dubbo-registry/dubbo-registry-api/src/test/java/org/apache/dubbo/registry/RegistryFactoryWrapperTest.java
+++ b/dubbo-registry/dubbo-registry-api/src/test/java/org/apache/dubbo/registry/RegistryFactoryWrapperTest.java
@@ -19,6 +19,7 @@ package org.apache.dubbo.registry;
 import org.apache.dubbo.common.URL;
 import org.apache.dubbo.common.extension.ExtensionLoader;
 
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
@@ -52,5 +53,18 @@ class RegistryFactoryWrapperTest {
         registry.unsubscribe(url, Mockito.mock(NotifyListener.class));
         Mockito.verify(listener1, Mockito.times(1)).onUnsubscribe(url, SimpleRegistryFactory.registry);
         Mockito.verify(listener2, Mockito.times(1)).onUnsubscribe(url, SimpleRegistryFactory.registry);
+    }
+
+    @Test
+    void testNullRegistryUsesOriginalUrl() {
+        RegistryFactory nullRegistryFactory = Mockito.mock(RegistryFactory.class);
+        URL url = URL.valueOf("simple://localhost:8080/registry-service");
+        Mockito.when(nullRegistryFactory.getRegistry(url)).thenReturn(null);
+
+        Registry registry = new RegistryFactoryWrapper(nullRegistryFactory).getRegistry(url);
+
+        Assertions.assertTrue(registry instanceof ListenerRegistryWrapper);
+        Assertions.assertEquals(url, registry.getUrl());
+        Assertions.assertDoesNotThrow(() -> registry.subscribe(url, Mockito.mock(NotifyListener.class)));
     }
 }

--- a/dubbo-registry/dubbo-registry-api/src/test/java/org/apache/dubbo/registry/support/AbstractRegistryFactoryTest.java
+++ b/dubbo-registry/dubbo-registry-api/src/test/java/org/apache/dubbo/registry/support/AbstractRegistryFactoryTest.java
@@ -138,4 +138,20 @@ class AbstractRegistryFactoryTest {
         Assertions.assertFalse(registries.contains(registry1));
         Assertions.assertFalse(registries.contains(registry2));
     }
+
+    @Test
+    void testGetRegistryReturnsNullWhenCheckIsFalseAndCreateFails() {
+        AbstractRegistryFactory throwingRegistryFactory = new AbstractRegistryFactory() {
+            @Override
+            protected Registry createRegistry(URL url) {
+                throw new IllegalStateException("connect failed");
+            }
+        };
+        throwingRegistryFactory.setApplicationModel(ApplicationModel.defaultModel());
+
+        Registry registry = throwingRegistryFactory.getRegistry(
+                URL.valueOf("dubbo://" + NetUtils.getLocalHost() + ":2233?check=false"));
+
+        Assertions.assertNull(registry);
+    }
 }

--- a/dubbo-registry/dubbo-registry-multiple/src/test/java/org/apache/dubbo/registry/multiple/MultipleServiceDiscoveryTest.java
+++ b/dubbo-registry/dubbo-registry-multiple/src/test/java/org/apache/dubbo/registry/multiple/MultipleServiceDiscoveryTest.java
@@ -25,6 +25,7 @@ import org.apache.dubbo.config.ApplicationConfig;
 import org.apache.dubbo.metadata.MetadataInfo;
 import org.apache.dubbo.registry.client.DefaultServiceInstance;
 import org.apache.dubbo.registry.client.ServiceDiscovery;
+import org.apache.dubbo.registry.client.ServiceDiscoveryFactory;
 import org.apache.dubbo.registry.client.ServiceInstance;
 import org.apache.dubbo.registry.client.event.ServiceInstancesChangedEvent;
 import org.apache.dubbo.registry.client.event.listener.ServiceInstancesChangedListener;
@@ -38,6 +39,7 @@ import java.util.Map;
 
 import com.google.common.collect.Sets;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
 import static org.apache.dubbo.common.constants.CommonConstants.REVISION_KEY;
@@ -48,29 +50,30 @@ public class MultipleServiceDiscoveryTest {
     private static String mockZkAddress = "zookeeper://mock-zk:2181?check=false";
 
     @Test
-    public void testOnEvent() {
-        try {
-            String metadata_111 = "{\"app\":\"app1\",\"revision\":\"111\",\"services\":{"
-                    + "\"org.apache.dubbo.demo.DemoService:dubbo\":{\"name\":\"org.apache.dubbo.demo.DemoService\",\"protocol\":\"dubbo\",\"path\":\"org.apache.dubbo.demo.DemoService\",\"params\":{\"side\":\"provider\",\"release\":\"\",\"methods\":\"sayHello,sayHelloAsync\",\"deprecated\":\"false\",\"dubbo\":\"2.0.2\",\"pid\":\"72723\",\"interface\":\"org.apache.dubbo.demo.DemoService\",\"service-name-mapping\":\"true\",\"timeout\":\"3000\",\"generic\":\"false\",\"metadata-type\":\"remote\",\"delay\":\"5000\",\"application\":\"app1\",\"dynamic\":\"true\",\"REGISTRY_CLUSTER\":\"registry1\",\"anyhost\":\"true\",\"timestamp\":\"1625800233446\"}}"
-                    + "}}";
-            MetadataInfo metadataInfo = JsonUtils.toJavaObject(metadata_111, MetadataInfo.class);
-            ApplicationModel applicationModel = ApplicationModel.defaultModel();
-            applicationModel.getApplicationConfigManager().setApplication(new ApplicationConfig("app2"));
-            String multipleUrl = String.format(
-                    "multiple://mock-registry:2181?reference-registry=%s&child.a1=%s&check=false",
-                    mockZkAddress, mockZkAddress);
-            URL url = URL.valueOf(multipleUrl);
-            url.setScopeModel(applicationModel);
-            MultipleServiceDiscovery multipleServiceDiscovery = new MultipleServiceDiscovery(url);
-            Class<MultipleServiceDiscovery> msdClass = MultipleServiceDiscovery.class;
-            Field serviceDiscoveriesField = msdClass.getDeclaredField("serviceDiscoveries");
-            serviceDiscoveriesField.setAccessible(true);
-            ServiceDiscovery mockServiceDiscovery = Mockito.mock(ServiceDiscovery.class);
+    public void testOnEvent() throws Exception {
+        String metadata_111 = "{\"app\":\"app1\",\"revision\":\"111\",\"services\":{"
+                + "\"org.apache.dubbo.demo.DemoService:dubbo\":{\"name\":\"org.apache.dubbo.demo.DemoService\",\"protocol\":\"dubbo\",\"path\":\"org.apache.dubbo.demo.DemoService\",\"params\":{\"side\":\"provider\",\"release\":\"\",\"methods\":\"sayHello,sayHelloAsync\",\"deprecated\":\"false\",\"dubbo\":\"2.0.2\",\"pid\":\"72723\",\"interface\":\"org.apache.dubbo.demo.DemoService\",\"service-name-mapping\":\"true\",\"timeout\":\"3000\",\"generic\":\"false\",\"metadata-type\":\"remote\",\"delay\":\"5000\",\"application\":\"app1\",\"dynamic\":\"true\",\"REGISTRY_CLUSTER\":\"registry1\",\"anyhost\":\"true\",\"timestamp\":\"1625800233446\"}}"
+                + "}}";
+        MetadataInfo metadataInfo = JsonUtils.toJavaObject(metadata_111, MetadataInfo.class);
+        ApplicationModel applicationModel = ApplicationModel.defaultModel();
+        applicationModel.getApplicationConfigManager().setApplication(new ApplicationConfig("app2"));
+        String multipleUrl = String.format(
+                "multiple://mock-registry:2181?reference-registry=%s&child.a1=%s&check=false",
+                mockZkAddress, mockZkAddress);
+        URL url = URL.valueOf(multipleUrl);
+        url.setScopeModel(applicationModel);
+        ServiceDiscovery mockServiceDiscovery = Mockito.mock(ServiceDiscovery.class);
+        ServiceDiscoveryFactory mockFactory = Mockito.mock(ServiceDiscoveryFactory.class);
+        Mockito.when(mockFactory.getServiceDiscovery(Mockito.any(URL.class))).thenReturn(mockServiceDiscovery);
+
+        try (MockedStatic<ServiceDiscoveryFactory> serviceDiscoveryFactoryMockedStatic =
+                Mockito.mockStatic(ServiceDiscoveryFactory.class)) {
+            serviceDiscoveryFactoryMockedStatic
+                    .when(() -> ServiceDiscoveryFactory.getExtension(Mockito.any(URL.class)))
+                    .thenReturn(mockFactory);
             Mockito.when(mockServiceDiscovery.getRemoteMetadata(Mockito.anyString(), Mockito.anyList()))
                     .thenReturn(metadataInfo);
-            Map<String, ServiceDiscovery> mockServiceDiscoveries = new HashMap<>();
-            mockServiceDiscoveries.put("child.a1", mockServiceDiscovery);
-            serviceDiscoveriesField.set(multipleServiceDiscovery, mockServiceDiscoveries);
+            MultipleServiceDiscovery multipleServiceDiscovery = new MultipleServiceDiscovery(url);
             MultipleServiceDiscovery.MultiServiceInstancesChangedListener listener =
                     (MultipleServiceDiscovery.MultiServiceInstancesChangedListener)
                             multipleServiceDiscovery.createListener(Sets.newHashSet("app1"));
@@ -93,10 +96,6 @@ public class MultipleServiceDiscoveryTest {
                     (Map<String, List<ServiceInstancesChangedListener.ProtocolServiceKeyWithUrls>>)
                             serviceUrlsField.get(listener);
             Assert.assertTrue(!CollectionUtils.isEmptyMap(map), "url can not be empty");
-        } catch (NoSuchFieldException e) {
-            throw new RuntimeException(e);
-        } catch (IllegalAccessException e) {
-            throw new RuntimeException(e);
         }
     }
 

--- a/dubbo-registry/dubbo-registry-zookeeper/src/main/java/org/apache/dubbo/registry/zookeeper/util/CuratorFrameworkUtils.java
+++ b/dubbo-registry/dubbo-registry-zookeeper/src/main/java/org/apache/dubbo/registry/zookeeper/util/CuratorFrameworkUtils.java
@@ -18,7 +18,6 @@ package org.apache.dubbo.registry.zookeeper.util;
 
 import org.apache.dubbo.common.URL;
 import org.apache.dubbo.common.utils.StringUtils;
-import org.apache.dubbo.common.utils.UrlUtils;
 import org.apache.dubbo.registry.client.DefaultServiceInstance;
 import org.apache.dubbo.registry.client.ServiceInstance;
 import org.apache.dubbo.registry.zookeeper.ZookeeperInstance;
@@ -118,8 +117,8 @@ public abstract class CuratorFrameworkUtils {
             throw new IllegalStateException("zookeeper client initialization failed");
         }
 
-        boolean check = UrlUtils.isCheck(connectionURL);
-        if (check && !curatorFramework.getZookeeperClient().isConnected()) {
+        if (!curatorFramework.getZookeeperClient().isConnected()) {
+            curatorFramework.close();
             throw new IllegalStateException("failed to connect to zookeeper server");
         }
 

--- a/dubbo-registry/dubbo-registry-zookeeper/src/test/java/org/apache/dubbo/registry/zookeeper/ZookeeperServiceDiscoveryTest.java
+++ b/dubbo-registry/dubbo-registry-zookeeper/src/test/java/org/apache/dubbo/registry/zookeeper/ZookeeperServiceDiscoveryTest.java
@@ -220,9 +220,8 @@ class ZookeeperServiceDiscoveryTest {
         ApplicationModel applicationModel = ApplicationModel.defaultModel();
         registryUrl.setScopeModel(applicationModel);
 
-        Assertions.assertDoesNotThrow(() -> {
-            new ZookeeperServiceDiscovery(applicationModel, registryUrl);
-        });
+        Assertions.assertThrowsExactly(
+                IllegalStateException.class, () -> new ZookeeperServiceDiscovery(applicationModel, registryUrl));
     }
 
     @AfterAll

--- a/dubbo-registry/dubbo-registry-zookeeper/src/test/java/org/apache/dubbo/registry/zookeeper/util/CuratorFrameworkUtilsTest.java
+++ b/dubbo-registry/dubbo-registry-zookeeper/src/test/java/org/apache/dubbo/registry/zookeeper/util/CuratorFrameworkUtilsTest.java
@@ -48,6 +48,7 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
@@ -113,20 +114,18 @@ class CuratorFrameworkUtilsTest {
     @Test
     void testBuildCuratorFrameworkCheckConnectDefault() {
         when(mockCuratorZookeeperClient.isConnected()).thenReturn(false);
-        Assertions.assertThrowsExactly(IllegalStateException.class, () -> {
-            CuratorFramework curatorFramework = CuratorFrameworkUtils.buildCuratorFramework(registryUrl, null);
-            curatorFramework.getZookeeperClient().close();
-        });
+        Assertions.assertThrowsExactly(
+                IllegalStateException.class, () -> CuratorFrameworkUtils.buildCuratorFramework(registryUrl, null));
+        verify(mockCuratorFramework).close();
     }
 
     @Test
     void testBuildCuratorFrameworkNotCheckConnect() {
         when(mockCuratorZookeeperClient.isConnected()).thenReturn(false);
         URL url = registryUrl.addParameter(CHECK_KEY, false);
-        Assertions.assertDoesNotThrow(() -> {
-            CuratorFramework curatorFramework = CuratorFrameworkUtils.buildCuratorFramework(url, null);
-            curatorFramework.getZookeeperClient().close();
-        });
+        Assertions.assertThrowsExactly(
+                IllegalStateException.class, () -> CuratorFrameworkUtils.buildCuratorFramework(url, null));
+        verify(mockCuratorFramework).close();
     }
 
     @Test

--- a/dubbo-registry/dubbo-registry-zookeeper/src/test/java/org/apache/dubbo/registry/zookeeper/util/CuratorFrameworkUtilsTest.java
+++ b/dubbo-registry/dubbo-registry-zookeeper/src/test/java/org/apache/dubbo/registry/zookeeper/util/CuratorFrameworkUtilsTest.java
@@ -47,6 +47,7 @@ import static org.apache.dubbo.registry.zookeeper.util.CuratorFrameworkParams.RO
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -99,6 +100,7 @@ class CuratorFrameworkUtilsTest {
         CuratorFramework curatorFramework = CuratorFrameworkUtils.buildCuratorFramework(registryUrl, null);
         Assertions.assertNotNull(curatorFramework);
         Assertions.assertTrue(curatorFramework.getZookeeperClient().isConnected());
+        verify(mockCuratorFramework, never()).close();
         curatorFramework.getZookeeperClient().close();
     }
 

--- a/dubbo-remoting/dubbo-remoting-zookeeper-curator5/src/main/java/org/apache/dubbo/remoting/zookeeper/curator5/Curator5ZookeeperClient.java
+++ b/dubbo-remoting/dubbo-remoting-zookeeper-curator5/src/main/java/org/apache/dubbo/remoting/zookeeper/curator5/Curator5ZookeeperClient.java
@@ -20,7 +20,6 @@ import org.apache.dubbo.common.URL;
 import org.apache.dubbo.common.config.configcenter.ConfigItem;
 import org.apache.dubbo.common.logger.ErrorTypeAwareLogger;
 import org.apache.dubbo.common.logger.LoggerFactory;
-import org.apache.dubbo.common.utils.UrlUtils;
 
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
@@ -97,8 +96,7 @@ public class Curator5ZookeeperClient
             client.getConnectionStateListenable().addListener(new CuratorConnectionStateListener(url));
             client.start();
             boolean connected = client.blockUntilConnected(timeout, TimeUnit.MILLISECONDS);
-            boolean check = UrlUtils.isCheck(url);
-            if (check && !connected) {
+            if (!connected) {
                 // close CuratorFramework to stop re-connection.
                 client.close();
                 IllegalStateException illegalStateException =

--- a/dubbo-remoting/dubbo-remoting-zookeeper-curator5/src/test/java/org/apache/dubbo/remoting/zookeeper/curator5/Curator5ZookeeperClientManagerTest.java
+++ b/dubbo-remoting/dubbo-remoting-zookeeper-curator5/src/test/java/org/apache/dubbo/remoting/zookeeper/curator5/Curator5ZookeeperClientManagerTest.java
@@ -91,7 +91,7 @@ class Curator5ZookeeperClientManagerTest {
 
         URL url = zookeeperUrl.addParameter(CHECK_KEY, false);
         ZookeeperClientManager zookeeperClientManager = new ZookeeperClientManager();
-        Assertions.assertDoesNotThrow(() -> {
+        Assertions.assertThrowsExactly(IllegalStateException.class, () -> {
             zookeeperClientManager.connect(url);
         });
     }

--- a/dubbo-remoting/dubbo-remoting-zookeeper-curator5/src/test/java/org/apache/dubbo/remoting/zookeeper/curator5/Curator5ZookeeperClientTest.java
+++ b/dubbo-remoting/dubbo-remoting-zookeeper-curator5/src/test/java/org/apache/dubbo/remoting/zookeeper/curator5/Curator5ZookeeperClientTest.java
@@ -73,6 +73,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockConstructionWithAnswer;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class Curator5ZookeeperClientTest {
@@ -211,20 +212,18 @@ class Curator5ZookeeperClientTest {
     @Test
     void testWithInvalidServer() throws InterruptedException {
         when(mockCuratorFramework.blockUntilConnected(anyInt(), any())).thenReturn(false);
-        Assertions.assertThrows(IllegalStateException.class, () -> {
-            curatorClient = new Curator5ZookeeperClient(URL.valueOf("zookeeper://127.0.0.1:1/service?timeout=1000"));
-            curatorClient.create("/testPath", true, true);
-        });
+        Assertions.assertThrows(
+                IllegalStateException.class,
+                () -> new Curator5ZookeeperClient(URL.valueOf("zookeeper://127.0.0.1:1/service?timeout=1000")));
+        verify(mockCuratorFramework).close();
     }
 
     @Test
     void testWithInvalidServerWithoutCheck() throws InterruptedException {
         when(mockCuratorFramework.blockUntilConnected(anyInt(), any())).thenReturn(false);
         URL url = URL.valueOf("zookeeper://127.0.0.1:1/service").addParameter(CHECK_KEY, false);
-        Assertions.assertDoesNotThrow(() -> {
-            curatorClient = new Curator5ZookeeperClient(url);
-            curatorClient.create("/testPath", true, true);
-        });
+        Assertions.assertThrows(IllegalStateException.class, () -> new Curator5ZookeeperClient(url));
+        verify(mockCuratorFramework).close();
     }
 
     @Test


### PR DESCRIPTION
Fixes #16186 

## What is the purpose of the change?

This PR fixes an issue in the multi-ZooKeeper registry scenario when one registry is unavailable and configured with `check=false`.

Based on the issue report, in the `dubbo 3.3` branch, if multiple ZooKeeper registries are configured and one of them is not started with `check=false`, `Curator5ZookeeperClient` may keep an unconnected Curator client alive after `blockUntilConnected(...)` returns `false`. As a result, the following registry workflow still treats that client as usable and continues trying to create nodes on it. This can cause repeated failures in node creation, significantly slow down application startup, and eventually lead to startup failure.

From the call path, the problem has two parts:

1. `Curator5ZookeeperClient` does not fail fast enough on connection failure  
   If `blockUntilConnected(...)` returns `false`, the ZooKeeper client has not been successfully established. This should always be treated as a client creation failure, and the underlying Curator client should be closed immediately so it cannot be reused later.  
   The `check=false` semantic should only control whether the upper layer continues to throw when registry creation fails. It should not change whether the low-level ZooKeeper client itself is considered successfully created.

2. `ListenerRegistryWrapper` is not null-safe when the upper layer returns a `null` registry  
   In `AbstractRegistryFactory#getRegistry()`, when registry creation fails and `check=false`, Dubbo logs a warning and returns `null`.  
   However, `RegistryFactoryWrapper` still wraps that result, and methods such as `ListenerRegistryWrapper#getUrl()` previously dereferenced the delegate directly. This could later trigger a `NullPointerException` in paths like `RegistryDirectory#subscribe()`.

To address this, this PR includes two parts:

- Fix the connection failure handling in `Curator5ZookeeperClient`
  - When `blockUntilConnected(...) == false`, always close the client first and then throw an exception.
  - Remove the dependency on `check` in this low-level failure path.
  - Keep the client creation semantic consistent: if the connection is not established, client creation fails.

- Add null-safe handling to `ListenerRegistryWrapper`
  - Add a constructor that preserves the original `URL`.
  - Return the original URL from `getUrl()` when `registry == null`.
  - Return `false` from `isAvailable()` when `registry == null`.
  - Make `destroy()` a safe no-op when `registry == null`.
  - Add null protection to `unsubscribe()`, `isServiceDiscovery()`, and `lookup()`.
  - Keep the existing listener callback behavior unchanged.

With these changes:

- an unconnected ZooKeeper client will not be reused by the following registry workflow;
- the existing `check=false` behavior at the registry factory layer remains unchanged;
- a `null` registry can still be safely wrapped without introducing extra NPEs.

## Tests

This PR adds focused regression coverage for both the low-level client behavior and the upper-layer `check=false` flow:

- `Curator5ZookeeperClientTest`
  - verifies that when `blockUntilConnected(...)` fails, constructing `Curator5ZookeeperClient` throws `IllegalStateException` for both `check=true` and `check=false`;
  - verifies that `client.close()` is invoked on connection failure.

- `AbstractRegistryFactoryTest`
  - verifies that when `createRegistry(url)` fails and `check=false`, `getRegistry(url)` returns `null`, preserving the existing upper-layer behavior.

- `ListenerRegistryWrapperTest`
  - verifies that `getUrl()`, `isAvailable()`, `destroy()`, `lookup()`, `subscribe()`, and `unsubscribe()` are safe when `registry == null`;
  - verifies that listener callbacks are still triggered as expected in the `null registry` case.

- `RegistryFactoryWrapperTest`
  - verifies that when the underlying `RegistryFactory#getRegistry(url)` returns `null`, the wrapper still returns the original URL safely and allows subscription-related calls without throwing exceptions.

Verification command used:

```bash
mvn -pl dubbo-remoting/dubbo-remoting-zookeeper-curator5,dubbo-registry/dubbo-registry-api \
  -Dtest=Curator5ZookeeperClientTest,ListenerRegistryWrapperTest,RegistryFactoryWrapperTest,AbstractRegistryFactoryTest \
  -Dsurefire.failIfNoSpecifiedTests=false test -q
```

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Make sure gitHub actions can pass. [Why the workflow is failing and how to fix it?](../CONTRIBUTING.md)
