### PR TITLE
fix: resolve method descriptor return early matching logic #16330

### DIFF
--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/DescriptorUtils.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/DescriptorUtils.java
@@ -89,7 +89,7 @@ public final class DescriptorUtils {
         MethodDescriptor methodDescriptor = null;
         if (isGeneric(methodName)) {
             // There should be one and only one
-            methodDescriptor = ServiceDescriptorInternalCache.genericService()
+            return ServiceDescriptorInternalCache.genericService()
                     .getMethods(methodName)
                     .get(0);
         } else if (isEcho(methodName)) {


### PR DESCRIPTION
## What is the purpose of the change?


## Checklist
- [x] This PR focuses on early return if the the method is  "isGeneric()" instead of waiting the final return , which is consistent with the "isEcho()"
