### PR TITLE
Fix StringUtils.toBoolean to return false for "off"

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/utils/StringUtils.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/utils/StringUtils.java
@@ -1428,7 +1428,7 @@ public final class StringUtils {
                     return Boolean.TRUE;
                 }
                 if ("off".equalsIgnoreCase(value)) {
-                    return Boolean.TRUE;
+                    return Boolean.FALSE;
                 }
                 break;
             case 4:

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/utils/StringUtilsTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/utils/StringUtilsTest.java
@@ -34,6 +34,7 @@ import static org.apache.dubbo.common.utils.CollectionUtils.ofSet;
 import static org.apache.dubbo.common.utils.StringUtils.splitToList;
 import static org.apache.dubbo.common.utils.StringUtils.splitToSet;
 import static org.apache.dubbo.common.utils.StringUtils.startsWithIgnoreCase;
+import static org.apache.dubbo.common.utils.StringUtils.toBoolean;
 import static org.apache.dubbo.common.utils.StringUtils.toCommaDelimitedString;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
@@ -502,5 +503,38 @@ class StringUtilsTest {
         assertTrue(startsWithIgnoreCase("dubbo.application.name", "dubbo.application."));
         assertTrue(startsWithIgnoreCase("dubbo.Application.name", "dubbo.application."));
         assertTrue(startsWithIgnoreCase("Dubbo.application.name", "dubbo.application."));
+    }
+
+    @Test
+    void testToBoolean() {
+        // true representations
+        assertEquals(Boolean.TRUE, toBoolean("true"));
+        assertEquals(Boolean.TRUE, toBoolean("True"));
+        assertEquals(Boolean.TRUE, toBoolean("on"));
+        assertEquals(Boolean.TRUE, toBoolean("yes"));
+        assertEquals(Boolean.TRUE, toBoolean("1"));
+        assertEquals(Boolean.TRUE, toBoolean("y"));
+        assertEquals(Boolean.TRUE, toBoolean("Y"));
+
+        // false representations
+        assertEquals(Boolean.FALSE, toBoolean("false"));
+        assertEquals(Boolean.FALSE, toBoolean("False"));
+        assertEquals(Boolean.FALSE, toBoolean("off"));
+        assertEquals(Boolean.FALSE, toBoolean("Off"));
+        assertEquals(Boolean.FALSE, toBoolean("no"));
+        assertEquals(Boolean.FALSE, toBoolean("0"));
+        assertEquals(Boolean.FALSE, toBoolean("n"));
+        assertEquals(Boolean.FALSE, toBoolean("N"));
+
+        // unrecognized or empty input returns null
+        assertNull(toBoolean(null));
+        assertNull(toBoolean(""));
+        assertNull(toBoolean("dubbo"));
+
+        // the overload falls back to the default value only for unrecognized input
+        assertFalse(StringUtils.toBoolean("off", true));
+        assertTrue(StringUtils.toBoolean("on", false));
+        assertTrue(StringUtils.toBoolean("unknown", true));
+        assertFalse(StringUtils.toBoolean(null, false));
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

Fixes #16347.

`StringUtils.toBoolean("off")` returned `Boolean.TRUE`. The method's Javadoc lists `'on'/'off'`
as a boolean pair and every other falsy token is parsed correctly, so `"off"` returning true is a
copy-paste error from the adjacent `"yes"` branch:

```
on=true   off=true(!)   yes=true   no=false   true=true   false=false   1=true   0=false
```

`toBoolean` backs Triple REST argument binding (`GeneralTypeConverter`) and REST/OpenAPI config
parsing (`ConfigFactory`, `Helper`), where a value of `"off"` was interpreted as `true`.

## Brief changelog

- Return `Boolean.FALSE` for `"off"` in `StringUtils.toBoolean`.
- Add `StringUtilsTest.testToBoolean` covering the full set of supported tokens (the method had no test).

## Verifying this change

- `mvn -pl dubbo-common test -Dtest=StringUtilsTest`

## Checklist
- [x] Make sure there is a [GitHub issue](https://github.com/apache/dubbo/issues/16347) field for the change.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction.
- [x] Make sure GitHub actions can pass.
