### PR TITLE
Fix StringUtils.substringAfter to return empty string when the separator is absent

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/utils/StringUtils.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/utils/StringUtils.java
@@ -1308,7 +1308,7 @@ public final class StringUtils {
             return str;
         }
         int index = str.indexOf(separator);
-        return index == INDEX_NOT_FOUND ? str : str.substring(index + 1);
+        return index == INDEX_NOT_FOUND ? EMPTY_STRING : str.substring(index + 1);
     }
 
     /**

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/utils/StringUtilsTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/utils/StringUtilsTest.java
@@ -503,4 +503,18 @@ class StringUtilsTest {
         assertTrue(startsWithIgnoreCase("dubbo.Application.name", "dubbo.application."));
         assertTrue(startsWithIgnoreCase("Dubbo.application.name", "dubbo.application."));
     }
+
+    @Test
+    void testSubstringAfter() {
+        // null or empty input is returned as-is
+        assertThat(StringUtils.substringAfter(null, ':'), is(nullValue()));
+        assertEquals("", StringUtils.substringAfter("", ':'));
+        // returns the substring after the first occurrence of the separator
+        assertEquals("b", StringUtils.substringAfter("a:b", ':'));
+        assertEquals("b:c", StringUtils.substringAfter("a:b:c", ':'));
+        // separator at the end leaves nothing after it
+        assertEquals("", StringUtils.substringAfter("ab:", ':'));
+        // when the separator is absent the Javadoc promises an empty string
+        assertEquals("", StringUtils.substringAfter("abc", ':'));
+    }
 }


### PR DESCRIPTION
## What is the purpose of the change?

`StringUtils.substringAfter(String, int)` is documented to return the empty string when the
separator is not found ("If nothing is found, the empty string is returned."), but it currently
returns the **original string** instead:

```
substringAfter("a:b", ':')  -> "b"     // ok
substringAfter("abc", ':')  -> "abc"   // expected "", actually returns "abc"
```

The not-found branch was copy-pasted from the neighbouring `substringBefore` (whose contract *is*
to return the original string), which left `substringAfter` inconsistent with both its own Javadoc
and its sibling `substringAfterLast` (which correctly returns the empty string). It also diverges
from commons-lang3's `substringAfter`.

This PR makes `substringAfter` return `EMPTY_STRING` when the separator is absent, and adds a unit
test (`testSubstringAfter`) covering the documented behaviour. The new test fails before the fix
(`expected: <> but was: <abc>`) and passes after it; the full `StringUtilsTest` suite stays green.

Fixes #16349

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Make sure gitHub actions can pass. [Why the workflow is failing and how to fix it?](../CONTRIBUTING.md)
