### PR TITLE
Fix startup NPE when a weakly dependent registry is unavailable (check=false)

### DIFF
--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/ListenerRegistryWrapper.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/ListenerRegistryWrapper.java
@@ -22,6 +22,7 @@ import org.apache.dubbo.common.logger.LoggerFactory;
 import org.apache.dubbo.common.utils.CollectionUtils;
 import org.apache.dubbo.common.utils.UrlUtils;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.function.Consumer;
 
@@ -41,17 +42,19 @@ public class ListenerRegistryWrapper implements Registry {
 
     @Override
     public URL getUrl() {
-        return registry.getUrl();
+        return registry == null ? null : registry.getUrl();
     }
 
     @Override
     public boolean isAvailable() {
-        return registry.isAvailable();
+        return registry != null && registry.isAvailable();
     }
 
     @Override
     public void destroy() {
-        registry.destroy();
+        if (registry != null) {
+            registry.destroy();
+        }
     }
 
     @Override
@@ -94,7 +97,9 @@ public class ListenerRegistryWrapper implements Registry {
     @Override
     public void unsubscribe(URL url, NotifyListener listener) {
         try {
-            registry.unsubscribe(url, listener);
+            if (registry != null) {
+                registry.unsubscribe(url, listener);
+            }
         } finally {
             listenerEvent(serviceListener -> serviceListener.onUnsubscribe(url, registry));
         }
@@ -102,12 +107,12 @@ public class ListenerRegistryWrapper implements Registry {
 
     @Override
     public boolean isServiceDiscovery() {
-        return registry.isServiceDiscovery();
+        return registry != null && registry.isServiceDiscovery();
     }
 
     @Override
     public List<URL> lookup(URL url) {
-        return registry.lookup(url);
+        return registry == null ? Collections.emptyList() : registry.lookup(url);
     }
 
     public Registry getRegistry() {

--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/integration/RegistryDirectory.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/integration/RegistryDirectory.java
@@ -152,10 +152,13 @@ public class RegistryDirectory<T> extends DynamicDirectory<T> {
             consumerConfigurationListener.addNotifyListener(this);
             referenceConfigurationListener = new ReferenceConfigurationListener(moduleModel, this, url);
         }
-        String registryClusterName = registry.getUrl()
-                .getParameter(
-                        RegistryConstants.REGISTRY_CLUSTER_KEY,
-                        registry.getUrl().getParameter(PROTOCOL_KEY));
+        // registry.getUrl() may be null when the registry is unavailable and check=false (e.g. a weakly
+        // dependent registry is down at startup), in which case there is no cluster name to report.
+        URL registryUrl = registry.getUrl();
+        String registryClusterName = registryUrl == null
+                ? null
+                : registryUrl.getParameter(
+                        RegistryConstants.REGISTRY_CLUSTER_KEY, registryUrl.getParameter(PROTOCOL_KEY));
         MetricsEventBus.post(RegistryEvent.toSubscribeEvent(applicationModel, registryClusterName), () -> {
             super.subscribe(url);
             return null;

--- a/dubbo-registry/dubbo-registry-api/src/test/java/org/apache/dubbo/registry/ListenerRegistryWrapperTest.java
+++ b/dubbo-registry/dubbo-registry-api/src/test/java/org/apache/dubbo/registry/ListenerRegistryWrapperTest.java
@@ -20,6 +20,7 @@ import org.apache.dubbo.common.URL;
 import org.apache.dubbo.common.url.component.ServiceConfigURL;
 import org.apache.dubbo.registry.integration.DemoService;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -72,5 +73,32 @@ class ListenerRegistryWrapperTest {
 
         registryWrapper.subscribe(subscribeUrl, notifyListener);
         verify(listener, times(1)).onSubscribe(subscribeUrl, registry);
+    }
+
+    @Test
+    void testNullRegistryIsTolerated() {
+        // When a registry is unavailable and check=false (e.g. a weakly dependent registry is down at
+        // startup), AbstractRegistryFactory returns a null registry which RegistryFactoryWrapper still
+        // wraps. The wrapper must tolerate the null delegate instead of throwing NullPointerException.
+        // See https://github.com/apache/dubbo/issues/16178.
+        ListenerRegistryWrapper wrapper = new ListenerRegistryWrapper(null, Collections.emptyList());
+
+        URL url = new ServiceConfigURL("dubbo", "127.0.0.1", 20881, DemoService.class.getName(), new HashMap<>());
+        NotifyListener notifyListener = mock(NotifyListener.class);
+
+        Assertions.assertNull(wrapper.getRegistry());
+        Assertions.assertNull(wrapper.getUrl());
+        Assertions.assertFalse(wrapper.isAvailable());
+        Assertions.assertFalse(wrapper.isServiceDiscovery());
+        Assertions.assertTrue(wrapper.lookup(url).isEmpty());
+
+        // register / subscribe / lifecycle methods must be no-ops rather than throwing
+        Assertions.assertDoesNotThrow(() -> {
+            wrapper.register(url);
+            wrapper.unregister(url);
+            wrapper.subscribe(url, notifyListener);
+            wrapper.unsubscribe(url, notifyListener);
+            wrapper.destroy();
+        });
     }
 }


### PR DESCRIPTION
## What is the purpose of the change?

Fixes #16178.

When a service subscribes to multiple registries and one of them is **weakly dependent** (`check="false"`) and **unavailable at startup**, the application fails to start with:

```
java.lang.NullPointerException: Cannot invoke "org.apache.dubbo.registry.Registry.getUrl()" because "this.registry" is null
    at org.apache.dubbo.registry.ListenerRegistryWrapper.getUrl(ListenerRegistryWrapper.java:44)
    at org.apache.dubbo.registry.integration.RegistryDirectory.subscribe(RegistryDirectory.java:...)
```

This is a regression: Dubbo `3.2.0`–`3.2.4` start successfully, `3.2.5`+ fail (also reproduced on `3.3.x`).

### Root cause

Under `check=false`, when a registry cannot be created (the registry is down), `AbstractRegistryFactory#getRegistry` swallows the exception and returns `null`. `RegistryFactoryWrapper` still wraps this `null` into a `ListenerRegistryWrapper`, so a null delegate is an **expected state** — `ListenerRegistryWrapper` already guards `register` / `unregister` / `subscribe` with `if (registry != null)`.

However:
- `getUrl` / `isAvailable` / `destroy` / `unsubscribe` / `isServiceDiscovery` / `lookup` were **not** guarded.
- `RegistryDirectory#subscribe` computes a metrics cluster name via `registry.getUrl().getParameter(...)` unconditionally. That line was introduced in #12582 (released in `3.2.5`), which is exactly why the NPE appears from `3.2.5` onward.

### What changed

1. **`ListenerRegistryWrapper`** — complete the existing null-safety: `getUrl` returns `null`, `isAvailable` / `isServiceDiscovery` return `false`, `destroy` / `unsubscribe` become no-ops, and `lookup` returns an empty list when the delegate registry is `null`.
2. **`RegistryDirectory#subscribe`** — guard the metrics cluster-name computation against a `null` registry URL (no cluster name is reported when the registry is unavailable). `RegistryEvent#toSubscribeEvent` already tolerates a `null` name.

### Verification

Added `ListenerRegistryWrapperTest#testNullRegistryIsTolerated`, which reproduces the exact NPE **without** the fix and passes **with** it. `:dubbo-registry-api` tests and `spotless:check` pass locally (JDK 21).

## Checklist
- [x] Make sure there is a [GitHub issue](https://github.com/apache/dubbo/issues/16178) field for the change.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction.
- [x] Make sure GitHub actions can pass.