### PR TITLE
Return Boolean.FALSE for "off" in StringUtils.toBoolean

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/utils/StringUtils.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/utils/StringUtils.java
@@ -1428,7 +1428,7 @@ public final class StringUtils {
                     return Boolean.TRUE;
                 }
                 if ("off".equalsIgnoreCase(value)) {
-                    return Boolean.TRUE;
+                    return Boolean.FALSE;
                 }
                 break;
             case 4:

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/utils/StringUtilsTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/utils/StringUtilsTest.java
@@ -503,4 +503,20 @@ class StringUtilsTest {
         assertTrue(startsWithIgnoreCase("dubbo.Application.name", "dubbo.application."));
         assertTrue(startsWithIgnoreCase("Dubbo.application.name", "dubbo.application."));
     }
+
+    @Test
+    void testToBoolean() {
+        assertEquals(Boolean.TRUE, StringUtils.toBoolean("true"));
+        assertEquals(Boolean.FALSE, StringUtils.toBoolean("false"));
+        assertEquals(Boolean.TRUE, StringUtils.toBoolean("yes"));
+        assertEquals(Boolean.FALSE, StringUtils.toBoolean("no"));
+        assertEquals(Boolean.TRUE, StringUtils.toBoolean("on"));
+        assertEquals(Boolean.FALSE, StringUtils.toBoolean("off"));
+        assertEquals(Boolean.FALSE, StringUtils.toBoolean("OFF"));
+        assertEquals(Boolean.TRUE, StringUtils.toBoolean("1"));
+        assertEquals(Boolean.FALSE, StringUtils.toBoolean("0"));
+        assertEquals(Boolean.TRUE, StringUtils.toBoolean("y"));
+        assertEquals(Boolean.FALSE, StringUtils.toBoolean("n"));
+        assertNull(StringUtils.toBoolean("unknown"));
+    }
 }


### PR DESCRIPTION
`StringUtils.toBoolean` maps `"off"` to `Boolean.TRUE`, which inverts the value — `"off"` should be `false`. It now returns `Boolean.FALSE`, consistent with the other negative tokens (`false` / `no` / `0` / `n`).

Added a test covering the full set of boolean tokens.

## Verifying this change

The added `StringUtilsTest#testToBoolean` case fails before this change and passes after:

Before the fix:

```
$ mvn test -Dtest=StringUtilsTest -pl dubbo-common
[INFO] Running org.apache.dubbo.common.utils.StringUtilsTest
[ERROR] Tests run: 38, Failures: 1, Errors: 0, Skipped: 0 <<< FAILURE!
org.opentest4j.AssertionFailedError: expected: <false> but was: <true>
	at org.apache.dubbo.common.utils.StringUtilsTest.testToBoolean(StringUtilsTest.java:514)
[INFO] BUILD FAILURE
```

After the fix:

```
$ mvn test -Dtest=StringUtilsTest -pl dubbo-common
[INFO] Running org.apache.dubbo.common.utils.StringUtilsTest
[INFO] Tests run: 38, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```

## AI assistance disclosure

This contribution was produced with the help of an AI pipeline. The pipeline processed a large amount of source code to surface suspected bugs, reproduced a subset of them with failing unit tests and generated candidate fixes, and prepared pull requests from the ones that held up. Each PR was then reviewed and verified by a human before being opened: the fix and test were checked by hand and the test was confirmed to fail before the change and pass after.

