### PR TITLE
Detect ip:port with contains in NetUtils.matchIpExpression

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/utils/NetUtils.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/utils/NetUtils.java
@@ -738,7 +738,7 @@ public final class NetUtils {
         String host = address;
         int port = 0;
         // only works for ipv4 address with 'ip:port' format
-        if (address.endsWith(":")) {
+        if (address.contains(":")) {
             String[] hostPort = address.split(":");
             host = hostPort[0];
             port = StringUtils.parseInteger(hostPort[1]);

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/utils/NetUtilsTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/utils/NetUtilsTest.java
@@ -347,6 +347,22 @@ class NetUtilsTest {
     }
 
     @Test
+    void testMatchIpExpressionDeprecatedTwoArgsWithIpPort() throws UnknownHostException {
+        // The deprecated 2-arg matchIpExpression should correctly parse host and port from
+        // an "ip:port" address string. Normal addresses like "192.168.1.63:90" should
+        // split into host="192.168.1.63" and port=90.
+        // With contains(":") this works; with endsWith(":") it does not.
+
+        // Pattern with port: host must match AND port must match
+        assertTrue(NetUtils.matchIpExpression("192.168.1.63:90", "192.168.1.63:90"));
+        assertFalse(NetUtils.matchIpExpression("192.168.1.63:90", "192.168.1.63:80"));
+
+        // Pattern without port: only host must match
+        assertTrue(NetUtils.matchIpExpression("192.168.1.*", "192.168.1.63:90"));
+        assertTrue(NetUtils.matchIpExpression("192.168.1.192/26", "192.168.1.199:8080"));
+    }
+
+    @Test
     void testMatchIpv6WithIpPort() throws UnknownHostException {
         assertTrue(NetUtils.matchIpRange("[234e:0:4567::3d:ee]", "234e:0:4567::3d:ee", 8090));
         assertTrue(NetUtils.matchIpRange("[234e:0:4567:0:0:0:3d:ee]", "234e:0:4567::3d:ee", 8090));


### PR DESCRIPTION
The deprecated two-arg `matchIpExpression(pattern, address)` uses `address.endsWith(":")` to detect the `ip:port` format. A real address such as `192.168.1.63:90` ends with the port, not a colon, so the host/port split is skipped — the full `host:port` string is then used as the host and matching fails. Use `contains(":")` to detect the separator.

Added a test covering `ip:port` addresses against patterns with and without a port.

## Verifying this change

The added `NetUtilsTest#testMatchIpExpressionDeprecatedTwoArgsWithIpPort` fails before this change and passes after:

Before the fix:

```
$ mvn test -Dtest=NetUtilsTest -pl dubbo-common
[INFO] Running org.apache.dubbo.common.utils.NetUtilsTest
[ERROR] Tests run: 49, Failures: 0, Errors: 1, Skipped: 2 <<< ERROR!
java.net.UnknownHostException: 192.168.1.63:90: invalid IPv6 address literal
	at org.apache.dubbo.common.utils.NetUtils.matchIpRange(NetUtils.java:784)
	at org.apache.dubbo.common.utils.NetUtils.matchIpExpression(NetUtils.java:753)
	at org.apache.dubbo.common.utils.NetUtilsTest.testMatchIpExpressionDeprecatedTwoArgsWithIpPort(NetUtilsTest.java:357)
[INFO] BUILD FAILURE
```

After the fix:

```
$ mvn test -Dtest=NetUtilsTest -pl dubbo-common
[INFO] Running org.apache.dubbo.common.utils.NetUtilsTest
[INFO] Tests run: 49, Failures: 0, Errors: 0, Skipped: 2
[INFO] BUILD SUCCESS
```

## AI assistance disclosure

This contribution was produced with the help of an AI pipeline. The pipeline processed a large amount of source code to surface suspected bugs, reproduced a subset of them with failing unit tests and generated candidate fixes, and prepared pull requests from the ones that held up. Each PR was then reviewed and verified by a human before being opened: the fix and test were checked by hand and the test was confirmed to fail before the change and pass after.

