### PR TITLE
Simplify generic return in DescriptorUtils

### DIFF
--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/DescriptorUtils.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/DescriptorUtils.java
@@ -86,10 +86,9 @@ public final class DescriptorUtils {
 
     public static MethodDescriptor findReflectionMethodDescriptor(
             ServiceDescriptor serviceDescriptor, String methodName) {
-        MethodDescriptor methodDescriptor = null;
         if (isGeneric(methodName)) {
             // There should be one and only one
-            methodDescriptor = ServiceDescriptorInternalCache.genericService()
+            return ServiceDescriptorInternalCache.genericService()
                     .getMethods(methodName)
                     .get(0);
         } else if (isEcho(methodName)) {
@@ -98,6 +97,7 @@ public final class DescriptorUtils {
                     .getMethods(methodName)
                     .get(0);
         } else {
+            MethodDescriptor methodDescriptor = null;
             List<MethodDescriptor> methodDescriptors = serviceDescriptor.getMethods(methodName);
             if (CollectionUtils.isEmpty(methodDescriptors)) {
                 return null;
@@ -116,8 +116,8 @@ public final class DescriptorUtils {
                     methodDescriptor = methodDescriptors.get(1);
                 }
             }
+            return methodDescriptor;
         }
-        return methodDescriptor;
     }
 
     public static MethodDescriptor findTripleMethodDescriptor(

--- a/dubbo-rpc/dubbo-rpc-triple/src/test/java/org/apache/dubbo/rpc/protocol/tri/DescriptorUtilsTest.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/test/java/org/apache/dubbo/rpc/protocol/tri/DescriptorUtilsTest.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.rpc.protocol.tri;
+
+import org.apache.dubbo.common.constants.CommonConstants;
+import org.apache.dubbo.common.stream.StreamObserver;
+import org.apache.dubbo.rpc.model.MethodDescriptor;
+import org.apache.dubbo.rpc.model.ReflectionMethodDescriptor;
+import org.apache.dubbo.rpc.model.ServiceDescriptor;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+class DescriptorUtilsTest {
+
+    @Test
+    void testFindReflectionMethodDescriptorForGenericAndEcho() {
+        ServiceDescriptor serviceDescriptor = Mockito.mock(ServiceDescriptor.class);
+
+        MethodDescriptor genericDescriptor =
+                DescriptorUtils.findReflectionMethodDescriptor(serviceDescriptor, CommonConstants.$INVOKE);
+        MethodDescriptor echoDescriptor =
+                DescriptorUtils.findReflectionMethodDescriptor(serviceDescriptor, CommonConstants.$ECHO);
+
+        Assertions.assertEquals(CommonConstants.$INVOKE, genericDescriptor.getMethodName());
+        Assertions.assertTrue(genericDescriptor.isGeneric());
+        Assertions.assertEquals(CommonConstants.$ECHO, echoDescriptor.getMethodName());
+    }
+
+    @Test
+    void testFindReflectionMethodDescriptorForEmptyMethodList() {
+        ServiceDescriptor serviceDescriptor = Mockito.mock(ServiceDescriptor.class);
+        Mockito.when(serviceDescriptor.getMethods("missing")).thenReturn(Collections.emptyList());
+
+        MethodDescriptor result = DescriptorUtils.findReflectionMethodDescriptor(serviceDescriptor, "missing");
+
+        Assertions.assertNull(result);
+    }
+
+    @Test
+    void testFindReflectionMethodDescriptorForSingleMethod() throws NoSuchMethodException {
+        ServiceDescriptor serviceDescriptor = Mockito.mock(ServiceDescriptor.class);
+        MethodDescriptor unaryDescriptor =
+                new ReflectionMethodDescriptor(TestService.class.getDeclaredMethod("unary", String.class));
+        Mockito.when(serviceDescriptor.getMethods("unary")).thenReturn(Collections.singletonList(unaryDescriptor));
+
+        MethodDescriptor result = DescriptorUtils.findReflectionMethodDescriptor(serviceDescriptor, "unary");
+
+        Assertions.assertSame(unaryDescriptor, result);
+    }
+
+    @Test
+    void testFindReflectionMethodDescriptorPrefersUnaryMethodFromOverloads() throws NoSuchMethodException {
+        ServiceDescriptor serviceDescriptor = Mockito.mock(ServiceDescriptor.class);
+        MethodDescriptor unaryDescriptor =
+                new ReflectionMethodDescriptor(TestService.class.getDeclaredMethod("streaming", String.class));
+        MethodDescriptor serverStreamDescriptor = new ReflectionMethodDescriptor(
+                TestService.class.getDeclaredMethod("streaming", String.class, StreamObserver.class));
+        Mockito.when(serviceDescriptor.getMethods("streaming"))
+                .thenReturn(Arrays.asList(unaryDescriptor, serverStreamDescriptor));
+
+        MethodDescriptor result = DescriptorUtils.findReflectionMethodDescriptor(serviceDescriptor, "streaming");
+
+        Assertions.assertSame(unaryDescriptor, result);
+    }
+
+    interface TestService {
+        String unary(String value);
+
+        String streaming(String value);
+
+        void streaming(String value, StreamObserver<String> streamObserver);
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change?

This PR makes `DescriptorUtils#findReflectionMethodDescriptor` return directly from the generic branch, matching the existing echo branch.

fixs #16330

The change is a small consistency cleanup in `dubbo-rpc-triple`. It does not intend to change behavior. The generic and echo paths both resolve a single cached descriptor, so the generic branch can return immediately instead of assigning to a local variable and falling through to the final return.

## Checklist
- [x] Make sure there is a [[GitHub_issue](https://github.com/apache/dubbo/issues)](https://github.com/apache/dubbo/issues) field for the change.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction. No new unit test was added because this is a behavior-preserving refactor.
- [x] Make sure gitHub actions can pass. Local verification was attempted with `mvn -pl dubbo-rpc/dubbo-rpc-triple -am -DskipTests compile`, but the build was blocked by an existing `dubbo-maven-plugin` plugin descriptor issue (`No plugin descriptor found at META-INF/maven/plugin.xml`), which is unrelated to this change.