### PR TITLE
Fix fastjson2 concurrent ref deserialization

### DIFF
--- a/dubbo-serialization/dubbo-serialization-fastjson2/src/main/java/org/apache/dubbo/common/serialize/fastjson2/FastJson2ObjectInput.java
+++ b/dubbo-serialization/dubbo-serialization-fastjson2/src/main/java/org/apache/dubbo/common/serialize/fastjson2/FastJson2ObjectInput.java
@@ -31,16 +31,6 @@ import com.alibaba.fastjson2.JSONReader;
  */
 public class FastJson2ObjectInput implements ObjectInput {
 
-    // fastjson2 may corrupt JSONB $ref resolution when the same target class is parsed concurrently.
-    private static final Object NULL_PARSE_LOCK = new Object();
-
-    private static final ClassValue<Object> PARSE_LOCKS = new ClassValue<Object>() {
-        @Override
-        protected Object computeValue(Class<?> type) {
-            return new Object();
-        }
-    };
-
     private final Fastjson2CreatorManager fastjson2CreatorManager;
 
     private final Fastjson2SecurityManager fastjson2SecurityManager;
@@ -56,7 +46,6 @@ public class FastJson2ObjectInput implements ObjectInput {
         this.fastjson2SecurityManager = fastjson2SecurityManager;
         this.classLoader = Thread.currentThread().getContextClassLoader();
         this.is = in;
-        fastjson2CreatorManager.setCreator(classLoader);
     }
 
     @Override
@@ -157,7 +146,6 @@ public class FastJson2ObjectInput implements ObjectInput {
     private void updateClassLoaderIfNeed() {
         ClassLoader currentClassLoader = Thread.currentThread().getContextClassLoader();
         if (currentClassLoader != classLoader) {
-            fastjson2CreatorManager.setCreator(currentClassLoader);
             classLoader = currentClassLoader;
         }
     }
@@ -177,30 +165,52 @@ public class FastJson2ObjectInput implements ObjectInput {
     }
 
     private <T> T parseObject(byte[] bytes, Class<T> cls, Fastjson2SecurityManager.Handler securityFilter) {
-        synchronized (getParseLock(cls)) {
-            if (securityFilter.isCheckSerializable()) {
-                return JSONB.parseObject(
-                        bytes,
-                        cls,
-                        securityFilter,
-                        JSONReader.Feature.UseDefaultConstructorAsPossible,
-                        JSONReader.Feature.ErrorOnNoneSerializable,
-                        JSONReader.Feature.IgnoreAutoTypeNotMatch,
-                        JSONReader.Feature.UseNativeObject,
-                        JSONReader.Feature.FieldBased);
+        Fastjson2CreatorManager.ParseWarmupState warmup = fastjson2CreatorManager.getReaderWarmup(cls);
+        if (!warmup.isWarmed()) {
+            warmup.addPending();
+            if (!warmup.isWarmed()) {
+                synchronized (fastjson2CreatorManager.getReaderWarmupLock()) {
+                    if (!warmup.isWarmed()) {
+                        try {
+                            fastjson2CreatorManager.setCreator(classLoader);
+                            T result = parseObjectWithoutWarmupLock(bytes, cls, securityFilter);
+                            if (warmup.removePending() == 0) {
+                                warmup.markWarmed();
+                            }
+                            return result;
+                        } catch (RuntimeException | Error exception) {
+                            warmup.removePending();
+                            throw exception;
+                        }
+                    }
+                }
             }
+            warmup.removePending();
+        }
+        fastjson2CreatorManager.setCreator(classLoader);
+        return parseObjectWithoutWarmupLock(bytes, cls, securityFilter);
+    }
+
+    private <T> T parseObjectWithoutWarmupLock(
+            byte[] bytes, Class<T> cls, Fastjson2SecurityManager.Handler securityFilter) {
+        if (securityFilter.isCheckSerializable()) {
             return JSONB.parseObject(
                     bytes,
                     cls,
                     securityFilter,
                     JSONReader.Feature.UseDefaultConstructorAsPossible,
-                    JSONReader.Feature.UseNativeObject,
+                    JSONReader.Feature.ErrorOnNoneSerializable,
                     JSONReader.Feature.IgnoreAutoTypeNotMatch,
+                    JSONReader.Feature.UseNativeObject,
                     JSONReader.Feature.FieldBased);
         }
-    }
-
-    private Object getParseLock(Class<?> cls) {
-        return cls == null ? NULL_PARSE_LOCK : PARSE_LOCKS.get(cls);
+        return JSONB.parseObject(
+                bytes,
+                cls,
+                securityFilter,
+                JSONReader.Feature.UseDefaultConstructorAsPossible,
+                JSONReader.Feature.UseNativeObject,
+                JSONReader.Feature.IgnoreAutoTypeNotMatch,
+                JSONReader.Feature.FieldBased);
     }
 }

--- a/dubbo-serialization/dubbo-serialization-fastjson2/src/main/java/org/apache/dubbo/common/serialize/fastjson2/FastJson2ObjectInput.java
+++ b/dubbo-serialization/dubbo-serialization-fastjson2/src/main/java/org/apache/dubbo/common/serialize/fastjson2/FastJson2ObjectInput.java
@@ -31,6 +31,16 @@ import com.alibaba.fastjson2.JSONReader;
  */
 public class FastJson2ObjectInput implements ObjectInput {
 
+    // fastjson2 may corrupt JSONB $ref resolution when the same target class is parsed concurrently.
+    private static final Object NULL_PARSE_LOCK = new Object();
+
+    private static final ClassValue<Object> PARSE_LOCKS = new ClassValue<Object>() {
+        @Override
+        protected Object computeValue(Class<?> type) {
+            return new Object();
+        }
+    };
+
     private final Fastjson2CreatorManager fastjson2CreatorManager;
 
     private final Fastjson2SecurityManager fastjson2SecurityManager;
@@ -117,27 +127,7 @@ public class FastJson2ObjectInput implements ObjectInput {
                     "deserialize failed. expected read length: " + length + " but actual read: " + read);
         }
         Fastjson2SecurityManager.Handler securityFilter = fastjson2SecurityManager.getSecurityFilter();
-        T result;
-        if (securityFilter.isCheckSerializable()) {
-            result = JSONB.parseObject(
-                    bytes,
-                    cls,
-                    securityFilter,
-                    JSONReader.Feature.UseDefaultConstructorAsPossible,
-                    JSONReader.Feature.ErrorOnNoneSerializable,
-                    JSONReader.Feature.IgnoreAutoTypeNotMatch,
-                    JSONReader.Feature.UseNativeObject,
-                    JSONReader.Feature.FieldBased);
-        } else {
-            result = JSONB.parseObject(
-                    bytes,
-                    cls,
-                    securityFilter,
-                    JSONReader.Feature.UseDefaultConstructorAsPossible,
-                    JSONReader.Feature.UseNativeObject,
-                    JSONReader.Feature.IgnoreAutoTypeNotMatch,
-                    JSONReader.Feature.FieldBased);
-        }
+        T result = parseObject(bytes, cls, securityFilter);
         if (result != null && cls != null && !ClassUtils.isMatch(result.getClass(), cls)) {
             throw new IllegalArgumentException(
                     "deserialize failed. expected class: " + cls + " but actual class: " + result.getClass());
@@ -156,27 +146,7 @@ public class FastJson2ObjectInput implements ObjectInput {
                     "deserialize failed. expected read length: " + length + " but actual read: " + read);
         }
         Fastjson2SecurityManager.Handler securityFilter = fastjson2SecurityManager.getSecurityFilter();
-        T result;
-        if (securityFilter.isCheckSerializable()) {
-            result = JSONB.parseObject(
-                    bytes,
-                    cls,
-                    securityFilter,
-                    JSONReader.Feature.UseDefaultConstructorAsPossible,
-                    JSONReader.Feature.ErrorOnNoneSerializable,
-                    JSONReader.Feature.IgnoreAutoTypeNotMatch,
-                    JSONReader.Feature.UseNativeObject,
-                    JSONReader.Feature.FieldBased);
-        } else {
-            result = JSONB.parseObject(
-                    bytes,
-                    cls,
-                    securityFilter,
-                    JSONReader.Feature.UseDefaultConstructorAsPossible,
-                    JSONReader.Feature.UseNativeObject,
-                    JSONReader.Feature.IgnoreAutoTypeNotMatch,
-                    JSONReader.Feature.FieldBased);
-        }
+        T result = parseObject(bytes, cls, securityFilter);
         if (result != null && cls != null && !ClassUtils.isMatch(result.getClass(), cls)) {
             throw new IllegalArgumentException(
                     "deserialize failed. expected class: " + cls + " but actual class: " + result.getClass());
@@ -204,5 +174,33 @@ public class FastJson2ObjectInput implements ObjectInput {
             value = (value << 8) + (b & 0xFF);
         }
         return value;
+    }
+
+    private <T> T parseObject(byte[] bytes, Class<T> cls, Fastjson2SecurityManager.Handler securityFilter) {
+        synchronized (getParseLock(cls)) {
+            if (securityFilter.isCheckSerializable()) {
+                return JSONB.parseObject(
+                        bytes,
+                        cls,
+                        securityFilter,
+                        JSONReader.Feature.UseDefaultConstructorAsPossible,
+                        JSONReader.Feature.ErrorOnNoneSerializable,
+                        JSONReader.Feature.IgnoreAutoTypeNotMatch,
+                        JSONReader.Feature.UseNativeObject,
+                        JSONReader.Feature.FieldBased);
+            }
+            return JSONB.parseObject(
+                    bytes,
+                    cls,
+                    securityFilter,
+                    JSONReader.Feature.UseDefaultConstructorAsPossible,
+                    JSONReader.Feature.UseNativeObject,
+                    JSONReader.Feature.IgnoreAutoTypeNotMatch,
+                    JSONReader.Feature.FieldBased);
+        }
+    }
+
+    private Object getParseLock(Class<?> cls) {
+        return cls == null ? NULL_PARSE_LOCK : PARSE_LOCKS.get(cls);
     }
 }

--- a/dubbo-serialization/dubbo-serialization-fastjson2/src/main/java/org/apache/dubbo/common/serialize/fastjson2/Fastjson2CreatorManager.java
+++ b/dubbo-serialization/dubbo-serialization-fastjson2/src/main/java/org/apache/dubbo/common/serialize/fastjson2/Fastjson2CreatorManager.java
@@ -22,6 +22,8 @@ import org.apache.dubbo.rpc.model.FrameworkModel;
 import org.apache.dubbo.rpc.model.ScopeClassLoaderListener;
 
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import com.alibaba.fastjson2.JSONFactory;
 import com.alibaba.fastjson2.reader.ObjectReaderCreator;
@@ -38,6 +40,31 @@ public class Fastjson2CreatorManager implements ScopeClassLoaderListener<Framewo
 
     private final ConcurrentHashMap<ClassLoader, ObjectReaderCreator> readerMap = new ConcurrentHashMap<>();
     private final ConcurrentHashMap<ClassLoader, ObjectWriterCreator> writerMap = new ConcurrentHashMap<>();
+    // Drain the initial burst of cold readers before switching that target type to the lock-free path.
+    private final Object readerWarmupLock = new Object();
+    private final ParseWarmupState nullReaderWarmup = new ParseWarmupState();
+    private final ConcurrentHashMap<Class<?>, ParseWarmupState> readerWarmups = new ConcurrentHashMap<>();
+
+    static final class ParseWarmupState {
+        private final AtomicBoolean warmed = new AtomicBoolean();
+        private final AtomicInteger pending = new AtomicInteger();
+
+        boolean isWarmed() {
+            return warmed.get();
+        }
+
+        void markWarmed() {
+            warmed.set(true);
+        }
+
+        void addPending() {
+            pending.incrementAndGet();
+        }
+
+        int removePending() {
+            return pending.decrementAndGet();
+        }
+    }
 
     public Fastjson2CreatorManager(FrameworkModel frameworkModel) {
         frameworkModel.addClassLoaderListener(this);
@@ -58,6 +85,14 @@ public class Fastjson2CreatorManager implements ScopeClassLoaderListener<Framewo
         }
     }
 
+    Object getReaderWarmupLock() {
+        return readerWarmupLock;
+    }
+
+    ParseWarmupState getReaderWarmup(Class<?> type) {
+        return type == null ? nullReaderWarmup : readerWarmups.computeIfAbsent(type, ignored -> new ParseWarmupState());
+    }
+
     @Override
     public void onAddClassLoader(FrameworkModel scopeModel, ClassLoader classLoader) {
         // nop
@@ -67,5 +102,6 @@ public class Fastjson2CreatorManager implements ScopeClassLoaderListener<Framewo
     public void onRemoveClassLoader(FrameworkModel scopeModel, ClassLoader classLoader) {
         readerMap.remove(classLoader);
         writerMap.remove(classLoader);
+        readerWarmups.keySet().removeIf(type -> type.getClassLoader() == classLoader);
     }
 }

--- a/dubbo-serialization/dubbo-serialization-fastjson2/src/test/java/org/apache/dubbo/common/serialize/fastjson2/ConcurrentRefInner.java
+++ b/dubbo-serialization/dubbo-serialization-fastjson2/src/test/java/org/apache/dubbo/common/serialize/fastjson2/ConcurrentRefInner.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.common.serialize.fastjson2;
+
+import java.io.Serializable;
+import java.util.List;
+
+/**
+ * Concurrent reference deserialization fixture.
+ *
+ * @date 2026/07/29
+ */
+public class ConcurrentRefInner implements Serializable {
+    private String name;
+    private List<Long> ids;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public List<Long> getIds() {
+        return ids;
+    }
+
+    public void setIds(List<Long> ids) {
+        this.ids = ids;
+    }
+}

--- a/dubbo-serialization/dubbo-serialization-fastjson2/src/test/java/org/apache/dubbo/common/serialize/fastjson2/ConcurrentRefOuter.java
+++ b/dubbo-serialization/dubbo-serialization-fastjson2/src/test/java/org/apache/dubbo/common/serialize/fastjson2/ConcurrentRefOuter.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.common.serialize.fastjson2;
+
+import java.io.Serializable;
+import java.util.List;
+
+/**
+ * Concurrent reference deserialization fixture.
+ *
+ * @date 2026/07/29
+ */
+public class ConcurrentRefOuter implements Serializable {
+    private List<ConcurrentRefInner> items;
+
+    public List<ConcurrentRefInner> getItems() {
+        return items;
+    }
+
+    public void setItems(List<ConcurrentRefInner> items) {
+        this.items = items;
+    }
+}

--- a/dubbo-serialization/dubbo-serialization-fastjson2/src/test/java/org/apache/dubbo/common/serialize/fastjson2/FastJson2SerializationTest.java
+++ b/dubbo-serialization/dubbo-serialization-fastjson2/src/test/java/org/apache/dubbo/common/serialize/fastjson2/FastJson2SerializationTest.java
@@ -26,9 +26,11 @@ import org.apache.dubbo.rpc.model.FrameworkModel;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.File;
 import java.io.IOException;
-import java.io.Serializable;
-import java.lang.reflect.Field;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -37,49 +39,21 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
-import com.alibaba.fastjson2.JSONFactory;
-import com.alibaba.fastjson2.reader.ObjectReaderProvider;
 import com.example.test.TestPojo;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class FastJson2SerializationTest {
 
-    public static class RefOuter implements Serializable {
-        private List<RefInner> items;
-
-        public List<RefInner> getItems() {
-            return items;
-        }
-
-        public void setItems(List<RefInner> items) {
-            this.items = items;
-        }
-    }
-
-    public static class RefInner implements Serializable {
-        private String name;
-        private List<Long> ids;
-
-        public String getName() {
-            return name;
-        }
-
-        public void setName(String name) {
-            this.name = name;
-        }
-
-        public List<Long> getIds() {
-            return ids;
-        }
-
-        public void setIds(List<Long> ids) {
-            this.ids = ids;
-        }
+    public static void main(String[] args) throws Exception {
+        new FastJson2SerializationTest().runConcurrentReadObjectWithReferences();
     }
 
     @Test
@@ -417,16 +391,49 @@ public class FastJson2SerializationTest {
 
     @Test
     void testConcurrentReadObjectWithReferences() throws Exception {
+        String javaExecutable = System.getProperty("java.home") + File.separator + "bin" + File.separator + "java";
+        String classPath = System.getProperty("surefire.test.class.path", System.getProperty("java.class.path"));
+        // Use a fresh JVM for each round instead of depending on fastjson2's internal cache fields.
+        for (int round = 0; round < 10; round++) {
+            Path output = Files.createTempFile("dubbo-fastjson2-concurrent-ref-", ".log");
+            Process process = new ProcessBuilder(
+                            javaExecutable, "-cp", classPath, getClass().getName())
+                    .redirectErrorStream(true)
+                    .redirectOutput(output.toFile())
+                    .start();
+            try {
+                if (!process.waitFor(30, TimeUnit.SECONDS)) {
+                    process.destroyForcibly();
+                    throw new AssertionError("Concurrent deserialization process timed out");
+                }
+                if (process.exitValue() != 0) {
+                    String childOutput = new String(Files.readAllBytes(output), StandardCharsets.UTF_8);
+                    throw new AssertionError("Concurrent deserialization process failed:\n" + childOutput);
+                }
+            } finally {
+                if (process.isAlive()) {
+                    process.destroyForcibly();
+                    process.waitFor(5, TimeUnit.SECONDS);
+                }
+                Files.deleteIfExists(output);
+            }
+        }
+    }
+
+    private void runConcurrentReadObjectWithReferences() throws Exception {
         FrameworkModel frameworkModel = new FrameworkModel();
+        ExecutorService executor = Executors.newFixedThreadPool(200);
         try {
             Serialization serialization =
                     frameworkModel.getExtensionLoader(Serialization.class).getExtension("fastjson2");
             URL url = URL.valueOf("").setScopeModel(frameworkModel);
             byte[] bytes = serializeRefOuter(serialization, url);
 
+            Assertions.assertEquals(0, countConcurrentNullIds(serialization, url, bytes, executor));
             Assertions.assertEquals(0, countNullIds(serialization, url, bytes));
-            Assertions.assertEquals(0, countConcurrentNullIds(serialization, url, bytes));
         } finally {
+            executor.shutdownNow();
+            Assertions.assertTrue(executor.awaitTermination(5, TimeUnit.SECONDS));
             frameworkModel.destroy();
         }
     }
@@ -680,13 +687,13 @@ public class FastJson2SerializationTest {
     }
 
     private byte[] serializeRefOuter(Serialization serialization, URL url) throws IOException {
-        RefOuter outer = new RefOuter();
-        List<RefInner> items = new ArrayList<>();
+        ConcurrentRefOuter outer = new ConcurrentRefOuter();
+        List<ConcurrentRefInner> items = new ArrayList<>();
         List<Long> sharedIds = new ArrayList<>();
         sharedIds.add(1L);
         sharedIds.add(2L);
         for (int i = 0; i < 20; i++) {
-            RefInner inner = new RefInner();
+            ConcurrentRefInner inner = new ConcurrentRefInner();
             inner.setName("item-" + i);
             inner.setIds(sharedIds);
             items.add(inner);
@@ -700,73 +707,51 @@ public class FastJson2SerializationTest {
         return outputStream.toByteArray();
     }
 
-    private int countConcurrentNullIds(Serialization serialization, URL url, byte[] bytes) throws Exception {
-        int rounds = 10;
+    private int countConcurrentNullIds(Serialization serialization, URL url, byte[] bytes, ExecutorService executor)
+            throws Exception {
         int threadCount = 200;
-        AtomicInteger totalNullTasks = new AtomicInteger();
+        CyclicBarrier barrier = new CyclicBarrier(threadCount);
+        CountDownLatch endLatch = new CountDownLatch(threadCount);
+        AtomicInteger nullTasks = new AtomicInteger();
         AtomicReference<Throwable> failure = new AtomicReference<>();
 
-        for (int round = 0; round < rounds; round++) {
-            clearObjectReaderCache();
-            CyclicBarrier barrier = new CyclicBarrier(threadCount);
-            CountDownLatch endLatch = new CountDownLatch(threadCount);
-            AtomicInteger roundNullTasks = new AtomicInteger();
-            for (int i = 0; i < threadCount; i++) {
-                Thread thread = new Thread(() -> {
-                    try {
-                        barrier.await();
-                        if (countNullIds(serialization, url, bytes) > 0) {
-                            roundNullTasks.incrementAndGet();
-                        }
-                    } catch (Throwable throwable) {
-                        failure.compareAndSet(null, throwable);
-                    } finally {
-                        endLatch.countDown();
+        for (int i = 0; i < threadCount; i++) {
+            executor.execute(() -> {
+                try {
+                    barrier.await(30, TimeUnit.SECONDS);
+                    if (countNullIds(serialization, url, bytes) > 0) {
+                        nullTasks.incrementAndGet();
                     }
-                });
-                thread.start();
-            }
-            endLatch.await();
-            if (failure.get() != null) {
-                throw new AssertionError("Concurrent deserialization failed", failure.get());
-            }
-            totalNullTasks.addAndGet(roundNullTasks.get());
+                } catch (Throwable throwable) {
+                    failure.compareAndSet(null, throwable);
+                } finally {
+                    endLatch.countDown();
+                }
+            });
         }
-
-        return totalNullTasks.get();
+        if (!endLatch.await(30, TimeUnit.SECONDS)) {
+            throw new AssertionError("Concurrent deserialization timed out");
+        }
+        if (failure.get() != null) {
+            throw new AssertionError("Concurrent deserialization failed", failure.get());
+        }
+        return nullTasks.get();
     }
 
     private int countNullIds(Serialization serialization, URL url, byte[] bytes) throws Exception {
         ByteArrayInputStream inputStream = new ByteArrayInputStream(bytes);
         ObjectInput objectInput = serialization.deserialize(url, inputStream);
-        RefOuter outer = objectInput.readObject(RefOuter.class);
+        ConcurrentRefOuter outer = objectInput.readObject(ConcurrentRefOuter.class);
         if (outer == null || outer.getItems() == null) {
             return 1;
         }
 
         int nullCount = 0;
-        for (RefInner inner : outer.getItems()) {
+        for (ConcurrentRefInner inner : outer.getItems()) {
             if (inner == null || inner.getIds() == null) {
                 nullCount++;
             }
         }
         return nullCount;
-    }
-
-    @SuppressWarnings("unchecked")
-    private void clearObjectReaderCache() throws Exception {
-        ObjectReaderProvider provider = JSONFactory.getDefaultObjectReaderProvider();
-        for (String fieldName : new String[] {"cache", "cacheFieldBased"}) {
-            Field field = ObjectReaderProvider.class.getDeclaredField(fieldName);
-            field.setAccessible(true);
-            Object cache = field.get(provider);
-            if (cache instanceof Map) {
-                ((Map<?, ?>) cache).clear();
-            }
-        }
-
-        Field readerCacheField = ObjectReaderProvider.class.getDeclaredField("readerCache");
-        readerCacheField.setAccessible(true);
-        readerCacheField.set(null, null);
     }
 }

--- a/dubbo-serialization/dubbo-serialization-fastjson2/src/test/java/org/apache/dubbo/common/serialize/fastjson2/FastJson2SerializationTest.java
+++ b/dubbo-serialization/dubbo-serialization-fastjson2/src/test/java/org/apache/dubbo/common/serialize/fastjson2/FastJson2SerializationTest.java
@@ -27,18 +27,60 @@ import org.apache.dubbo.rpc.model.FrameworkModel;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.Serializable;
+import java.lang.reflect.Field;
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
+import com.alibaba.fastjson2.JSONFactory;
+import com.alibaba.fastjson2.reader.ObjectReaderProvider;
 import com.example.test.TestPojo;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class FastJson2SerializationTest {
+
+    public static class RefOuter implements Serializable {
+        private List<RefInner> items;
+
+        public List<RefInner> getItems() {
+            return items;
+        }
+
+        public void setItems(List<RefInner> items) {
+            this.items = items;
+        }
+    }
+
+    public static class RefInner implements Serializable {
+        private String name;
+        private List<Long> ids;
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public List<Long> getIds() {
+            return ids;
+        }
+
+        public void setIds(List<Long> ids) {
+            this.ids = ids;
+        }
+    }
 
     @Test
     void testReadString() throws IOException {
@@ -374,6 +416,22 @@ public class FastJson2SerializationTest {
     }
 
     @Test
+    void testConcurrentReadObjectWithReferences() throws Exception {
+        FrameworkModel frameworkModel = new FrameworkModel();
+        try {
+            Serialization serialization =
+                    frameworkModel.getExtensionLoader(Serialization.class).getExtension("fastjson2");
+            URL url = URL.valueOf("").setScopeModel(frameworkModel);
+            byte[] bytes = serializeRefOuter(serialization, url);
+
+            Assertions.assertEquals(0, countNullIds(serialization, url, bytes));
+            Assertions.assertEquals(0, countConcurrentNullIds(serialization, url, bytes));
+        } finally {
+            frameworkModel.destroy();
+        }
+    }
+
+    @Test
     void testReadObjectNotMatched() throws IOException, ClassNotFoundException {
         FrameworkModel frameworkModel = new FrameworkModel();
         Serialization serialization =
@@ -619,5 +677,96 @@ public class FastJson2SerializationTest {
             Assertions.assertThrows(IOException.class, objectInput::readObject);
             frameworkModel.destroy();
         }
+    }
+
+    private byte[] serializeRefOuter(Serialization serialization, URL url) throws IOException {
+        RefOuter outer = new RefOuter();
+        List<RefInner> items = new ArrayList<>();
+        List<Long> sharedIds = new ArrayList<>();
+        sharedIds.add(1L);
+        sharedIds.add(2L);
+        for (int i = 0; i < 20; i++) {
+            RefInner inner = new RefInner();
+            inner.setName("item-" + i);
+            inner.setIds(sharedIds);
+            items.add(inner);
+        }
+        outer.setItems(items);
+
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        ObjectOutput objectOutput = serialization.serialize(url, outputStream);
+        objectOutput.writeObject(outer);
+        objectOutput.flushBuffer();
+        return outputStream.toByteArray();
+    }
+
+    private int countConcurrentNullIds(Serialization serialization, URL url, byte[] bytes) throws Exception {
+        int rounds = 10;
+        int threadCount = 200;
+        AtomicInteger totalNullTasks = new AtomicInteger();
+        AtomicReference<Throwable> failure = new AtomicReference<>();
+
+        for (int round = 0; round < rounds; round++) {
+            clearObjectReaderCache();
+            CyclicBarrier barrier = new CyclicBarrier(threadCount);
+            CountDownLatch endLatch = new CountDownLatch(threadCount);
+            AtomicInteger roundNullTasks = new AtomicInteger();
+            for (int i = 0; i < threadCount; i++) {
+                Thread thread = new Thread(() -> {
+                    try {
+                        barrier.await();
+                        if (countNullIds(serialization, url, bytes) > 0) {
+                            roundNullTasks.incrementAndGet();
+                        }
+                    } catch (Throwable throwable) {
+                        failure.compareAndSet(null, throwable);
+                    } finally {
+                        endLatch.countDown();
+                    }
+                });
+                thread.start();
+            }
+            endLatch.await();
+            if (failure.get() != null) {
+                throw new AssertionError("Concurrent deserialization failed", failure.get());
+            }
+            totalNullTasks.addAndGet(roundNullTasks.get());
+        }
+
+        return totalNullTasks.get();
+    }
+
+    private int countNullIds(Serialization serialization, URL url, byte[] bytes) throws Exception {
+        ByteArrayInputStream inputStream = new ByteArrayInputStream(bytes);
+        ObjectInput objectInput = serialization.deserialize(url, inputStream);
+        RefOuter outer = objectInput.readObject(RefOuter.class);
+        if (outer == null || outer.getItems() == null) {
+            return 1;
+        }
+
+        int nullCount = 0;
+        for (RefInner inner : outer.getItems()) {
+            if (inner == null || inner.getIds() == null) {
+                nullCount++;
+            }
+        }
+        return nullCount;
+    }
+
+    @SuppressWarnings("unchecked")
+    private void clearObjectReaderCache() throws Exception {
+        ObjectReaderProvider provider = JSONFactory.getDefaultObjectReaderProvider();
+        for (String fieldName : new String[] {"cache", "cacheFieldBased"}) {
+            Field field = ObjectReaderProvider.class.getDeclaredField(fieldName);
+            field.setAccessible(true);
+            Object cache = field.get(provider);
+            if (cache instanceof Map) {
+                ((Map<?, ?>) cache).clear();
+            }
+        }
+
+        Field readerCacheField = ObjectReaderProvider.class.getDeclaredField("readerCache");
+        readerCacheField.setAccessible(true);
+        readerCacheField.set(null, null);
     }
 }


### PR DESCRIPTION
## What is the purpose of the change?

Fixes #16368.

Fastjson2 JSONB deserialization can lose nested fields when multiple threads deserialize the same `$ref`-heavy payload for the same target class at the same time. In the failing case, shared lists referenced by multiple child objects can become `null` after concurrent deserialization.

This change routes both `FastJson2ObjectInput#readObject` overloads through a shared helper and synchronizes the fastjson2 parse per requested target class. The lock is backed by `ClassValue`, so it does not retain application classes or classloaders, and unrelated DTO classes can still deserialize concurrently.

The regression test serializes an object graph with shared nested lists, verifies a single read succeeds, then repeatedly deserializes the same payload from 200 threads while clearing fastjson2 reader caches between rounds. Without the fix, the test reports a non-zero count of null nested fields.

Tests:

- Focused repro: `FastJson2SerializationTest#testConcurrentReadObjectWithReferences`
- Targeted slice: `FastJson2SerializationTest,TypeMatchTest`
- Surefire result: 807 tests, 0 failures, 0 errors, 0 skipped

## Checklist

- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction.
- [x] Make sure GitHub actions can pass.