### PR TITLE
Fix #16165: Propagate traceId and spanId to MDC in tracing handlers

### DIFF
--- a/dubbo-metrics/dubbo-tracing/src/main/java/org/apache/dubbo/tracing/handler/DubboClientTracingObservationHandler.java
+++ b/dubbo-metrics/dubbo-tracing/src/main/java/org/apache/dubbo/tracing/handler/DubboClientTracingObservationHandler.java
@@ -21,6 +21,7 @@ import org.apache.dubbo.tracing.context.DubboClientContext;
 import io.micrometer.observation.Observation;
 import io.micrometer.observation.ObservationHandler;
 import io.micrometer.tracing.Tracer;
+import org.slf4j.MDC;
 
 public class DubboClientTracingObservationHandler<T extends DubboClientContext> implements ObservationHandler<T> {
     private final Tracer tracer;
@@ -30,7 +31,27 @@ public class DubboClientTracingObservationHandler<T extends DubboClientContext> 
     }
 
     @Override
-    public void onScopeOpened(T context) {}
+    public void onScopeOpened(T context) {
+        io.micrometer.tracing.TraceContext traceContext =
+                tracer.currentTraceContext().context();
+        if (traceContext == null) {
+            return;
+        }
+        try {
+            MDC.put("traceId", traceContext.traceId());
+            MDC.put("spanId", traceContext.spanId());
+        } catch (Throwable ignored) {
+        }
+    }
+
+    @Override
+    public void onScopeClosed(T context) {
+        try {
+            MDC.remove("traceId");
+            MDC.remove("spanId");
+        } catch (Throwable ignored) {
+        }
+    }
 
     @Override
     public boolean supportsContext(Observation.Context context) {

--- a/dubbo-metrics/dubbo-tracing/src/main/java/org/apache/dubbo/tracing/handler/DubboServerTracingObservationHandler.java
+++ b/dubbo-metrics/dubbo-tracing/src/main/java/org/apache/dubbo/tracing/handler/DubboServerTracingObservationHandler.java
@@ -23,6 +23,7 @@ import io.micrometer.observation.Observation;
 import io.micrometer.observation.ObservationHandler;
 import io.micrometer.tracing.TraceContext;
 import io.micrometer.tracing.Tracer;
+import org.slf4j.MDC;
 
 public class DubboServerTracingObservationHandler<T extends DubboServerContext> implements ObservationHandler<T> {
 
@@ -41,6 +42,20 @@ public class DubboServerTracingObservationHandler<T extends DubboServerContext> 
             return;
         }
         RpcContext.getServerContext().setAttachment(DEFAULT_TRACE_ID_KEY, traceContext.traceId());
+        try {
+            MDC.put(DEFAULT_TRACE_ID_KEY, traceContext.traceId());
+            MDC.put("spanId", traceContext.spanId());
+        } catch (Throwable ignored) {
+        }
+    }
+
+    @Override
+    public void onScopeClosed(T context) {
+        try {
+            MDC.remove(DEFAULT_TRACE_ID_KEY);
+            MDC.remove("spanId");
+        } catch (Throwable ignored) {
+        }
     }
 
     @Override

--- a/dubbo-metrics/dubbo-tracing/src/test/java/org/apache/dubbo/tracing/handler/DubboClientTracingObservationHandlerTest.java
+++ b/dubbo-metrics/dubbo-tracing/src/test/java/org/apache/dubbo/tracing/handler/DubboClientTracingObservationHandlerTest.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.tracing.handler;
+
+import org.apache.dubbo.tracing.context.DubboClientContext;
+
+import io.micrometer.tracing.CurrentTraceContext;
+import io.micrometer.tracing.TraceContext;
+import io.micrometer.tracing.Tracer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.slf4j.MDC;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.when;
+
+class DubboClientTracingObservationHandlerTest {
+
+    private Tracer mockTracer;
+    private CurrentTraceContext mockCurrentTraceContext;
+    private TraceContext mockTraceContext;
+    private DubboClientContext mockContext;
+    private DubboClientTracingObservationHandler<DubboClientContext> handler;
+
+    @BeforeEach
+    void setUp() {
+        // Clear MDC before each test to ensure a clean state
+        MDC.clear();
+
+        mockTracer = Mockito.mock(Tracer.class);
+        mockCurrentTraceContext = Mockito.mock(CurrentTraceContext.class);
+        mockTraceContext = Mockito.mock(TraceContext.class);
+        mockContext = Mockito.mock(DubboClientContext.class);
+
+        when(mockTracer.currentTraceContext()).thenReturn(mockCurrentTraceContext);
+        when(mockCurrentTraceContext.context()).thenReturn(mockTraceContext);
+        when(mockTraceContext.traceId()).thenReturn("mock-trace-id-123");
+        when(mockTraceContext.spanId()).thenReturn("mock-span-id-456");
+
+        handler = new DubboClientTracingObservationHandler<>(mockTracer);
+    }
+
+    @AfterEach
+    void tearDown() {
+        MDC.clear();
+    }
+
+    @Test
+    void proveWorking_WhenScopeOpens_MdcShouldHaveIds() {
+        // 1. Verify MDC is currently empty
+        assertNull(MDC.get("traceId"));
+        assertNull(MDC.get("spanId"));
+
+        handler.onScopeOpened(mockContext);
+
+        assertEquals("mock-trace-id-123", MDC.get("traceId"), "Trace ID should be mapped to MDC!");
+        assertEquals("mock-span-id-456", MDC.get("spanId"), "Span ID should be mapped to MDC!");
+    }
+
+    @Test
+    void proveFailurePrevention_WhenScopeCloses_MdcShouldBeCleaned() {
+        handler.onScopeOpened(mockContext);
+        assertEquals("mock-trace-id-123", MDC.get("traceId"));
+
+        handler.onScopeClosed(mockContext);
+
+        // PROOF THE LEAK IS PREVENTED: MDC must be completely empty now.
+        assertNull(MDC.get("traceId"), "Trace ID leaked! It was not removed when scope closed.");
+        assertNull(MDC.get("spanId"), "Span ID leaked! It was not removed when scope closed.");
+    }
+}

--- a/dubbo-metrics/dubbo-tracing/src/test/java/org/apache/dubbo/tracing/handler/DubboServerTracingObservationHandlerTest.java
+++ b/dubbo-metrics/dubbo-tracing/src/test/java/org/apache/dubbo/tracing/handler/DubboServerTracingObservationHandlerTest.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.tracing.handler;
+
+import org.apache.dubbo.rpc.RpcContext;
+import org.apache.dubbo.tracing.context.DubboServerContext;
+
+import io.micrometer.tracing.CurrentTraceContext;
+import io.micrometer.tracing.TraceContext;
+import io.micrometer.tracing.Tracer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.slf4j.MDC;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.when;
+
+class DubboServerTracingObservationHandlerTest {
+
+    private Tracer mockTracer;
+    private CurrentTraceContext mockCurrentTraceContext;
+    private TraceContext mockTraceContext;
+    private DubboServerContext mockContext;
+    private DubboServerTracingObservationHandler<DubboServerContext> handler;
+
+    @BeforeEach
+    void setUp() {
+        // Clear MDC before each test to ensure a clean state
+        MDC.clear();
+
+        mockTracer = Mockito.mock(Tracer.class);
+        mockCurrentTraceContext = Mockito.mock(CurrentTraceContext.class);
+        mockTraceContext = Mockito.mock(TraceContext.class);
+        mockContext = Mockito.mock(DubboServerContext.class);
+
+        when(mockTracer.currentTraceContext()).thenReturn(mockCurrentTraceContext);
+        when(mockCurrentTraceContext.context()).thenReturn(mockTraceContext);
+        when(mockTraceContext.traceId()).thenReturn("mock-trace-id-123");
+        when(mockTraceContext.spanId()).thenReturn("mock-span-id-456");
+
+        handler = new DubboServerTracingObservationHandler<>(mockTracer);
+    }
+
+    @AfterEach
+    void tearDown() {
+        MDC.clear();
+        RpcContext.removeServerContext();
+    }
+
+    @Test
+    void proveWorking_WhenScopeOpens_MdcShouldHaveIds() {
+        // 1. Verify MDC is currently empty
+        assertNull(MDC.get("traceId"));
+        assertNull(MDC.get("spanId"));
+
+        handler.onScopeOpened(mockContext);
+
+        assertEquals("mock-trace-id-123", MDC.get("traceId"), "Trace ID should be mapped to MDC!");
+        assertEquals("mock-span-id-456", MDC.get("spanId"), "Span ID should be mapped to MDC!");
+    }
+
+    @Test
+    void proveFailurePrevention_WhenScopeCloses_MdcShouldBeCleaned() {
+        handler.onScopeOpened(mockContext);
+        assertEquals("mock-trace-id-123", MDC.get("traceId"));
+
+        handler.onScopeClosed(mockContext);
+
+        // PROOF THE LEAK IS PREVENTED: MDC must be completely empty now.
+        assertNull(MDC.get("traceId"), "Trace ID leaked! It was not removed when scope closed.");
+        assertNull(MDC.get("spanId"), "Span ID leaked! It was not removed when scope closed.");
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change?

This PR addresses issue #16165 where `MDC.get("traceId")` returns `null` in Dubbo 3.3.2 logs, preventing trace IDs from propagating to logging patterns like `%X{traceId}`.

**Root Cause:**
While Dubbo's Micrometer Observation integration successfully captures the `TraceContext` and injects it into Dubbo's internal `RpcContext`, it did not explicitly populate the underlying SLF4J `MDC`. Unless a user was running a strictly configured Spring Boot Actuator environment (which natively registers Micrometer's `MDCScopeDecorator`), the trace context was lost for loggers on Dubbo's worker threads.

**Fix:**
- Updated `DubboServerTracingObservationHandler` and `DubboClientTracingObservationHandler` to explicitly push `traceId` and `spanId` into `org.slf4j.MDC` during `onScopeOpened()`.
- Implemented `onScopeClosed()` to clean up the MDC state via `MDC.remove()`, preventing context leaks across reused Dubbo worker threads.
- Wrapped the MDC interactions in a `try-catch(Throwable)` block as a safety mechanism to prevent `NoClassDefFoundError` crashes in edge cases where a user excludes `slf4j-api` from their classpath.

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues/16165) field for the change.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Make sure gitHub actions can pass. [Why the workflow is failing and how to fix it?](../CONTRIBUTING.md)
