### PR TITLE
Fix PU plaintext detection when AuthPolicy.NONE is configured

### DIFF
--- a/dubbo-remoting/dubbo-remoting-netty4/src/main/java/org/apache/dubbo/remoting/transport/netty4/NettyPortUnificationServerHandler.java
+++ b/dubbo-remoting/dubbo-remoting-netty4/src/main/java/org/apache/dubbo/remoting/transport/netty4/NettyPortUnificationServerHandler.java
@@ -127,27 +127,29 @@ public class NettyPortUnificationServerHandler extends ByteToMessageDecoder {
         if (providerConnectionConfig != null && canDetectSsl(in)) {
             if (isSsl(in)) {
                 enableSsl(ctx, providerConnectionConfig);
-            } else {
-                // check server should load TLS or not
-                if (providerConnectionConfig.getAuthPolicy() != AuthPolicy.NONE) {
-                    byte[] preface = new byte[in.readableBytes()];
-                    in.readBytes(preface);
-                    LOGGER.error(
-                            CONFIG_SSL_CONNECT_INSECURE,
-                            "client request server without TLS",
-                            "",
-                            String.format(
-                                    "Downstream=%s request without TLS preface, but server require it. " + "preface=%s",
-                                    ctx.channel().remoteAddress(), Bytes.bytes2hex(preface)));
-
-                    // Untrusted connection; discard everything and close the connection.
-                    in.clear();
-                    ctx.close();
-                }
+                return;
             }
-        } else {
-            detectProtocol(ctx, url, channel, in);
+            // check server should load TLS or not
+            if (providerConnectionConfig.getAuthPolicy() != AuthPolicy.NONE) {
+                byte[] preface = new byte[in.readableBytes()];
+                in.readBytes(preface);
+                LOGGER.error(
+                        CONFIG_SSL_CONNECT_INSECURE,
+                        "client request server without TLS",
+                        "",
+                        String.format(
+                                "Downstream=%s request without TLS preface, but server require it. " + "preface=%s",
+                                ctx.channel().remoteAddress(), Bytes.bytes2hex(preface)));
+
+                // Untrusted connection; discard everything and close the connection.
+                in.clear();
+                ctx.close();
+                return;
+            }
+            // AuthPolicy.NONE with a non-TLS client: permissive mode, fall through to
+            // plaintext protocol detection below instead of silently waiting for more data.
         }
+        detectProtocol(ctx, url, channel, in);
     }
 
     private void enableSsl(ChannelHandlerContext ctx, ProviderCert providerConnectionConfig) {

--- a/dubbo-remoting/dubbo-remoting-netty4/src/test/java/org/apache/dubbo/remoting/transport/netty4/NettyPortUnificationServerHandlerTest.java
+++ b/dubbo-remoting/dubbo-remoting-netty4/src/test/java/org/apache/dubbo/remoting/transport/netty4/NettyPortUnificationServerHandlerTest.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.remoting.transport.netty4;
+
+import org.apache.dubbo.common.URL;
+import org.apache.dubbo.remoting.ChannelHandler;
+import org.apache.dubbo.remoting.api.ProtocolDetector;
+import org.apache.dubbo.remoting.api.WireProtocol;
+import org.apache.dubbo.remoting.api.pu.ChannelOperator;
+import org.apache.dubbo.remoting.api.ssl.ContextOperator;
+import org.apache.dubbo.rpc.model.ApplicationModel;
+import org.apache.dubbo.rpc.model.FrameworkModel;
+
+import java.util.Collections;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import io.netty.buffer.Unpooled;
+import io.netty.channel.embedded.EmbeddedChannel;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
+class NettyPortUnificationServerHandlerTest {
+
+    @Test
+    void shouldDetectPlaintextProtocolWhenAuthPolicyIsNone() {
+        AtomicInteger detectCount = new AtomicInteger();
+        FrameworkModel frameworkModel = new FrameworkModel();
+        try {
+            ApplicationModel applicationModel = frameworkModel.newApplication();
+            URL url = URL.valueOf("dubbo://127.0.0.1:20880?codec=default&pu.test.cert=true")
+                    .setScopeModel(applicationModel);
+            ChannelHandler handler = mock(ChannelHandler.class);
+            WireProtocol protocol = new CountingWireProtocol(detectCount);
+            NettyPortUnificationServerHandler puHandler = new NettyPortUnificationServerHandler(
+                    url,
+                    true,
+                    Collections.singletonMap("dubbo", protocol),
+                    handler,
+                    Collections.singletonMap("dubbo", url),
+                    Collections.emptyMap());
+            EmbeddedChannel channel = new EmbeddedChannel(puHandler);
+
+            channel.writeInbound(Unpooled.wrappedBuffer(new byte[] {(byte) 0xda, (byte) 0xbb, 0, 0, 0}));
+
+            assertEquals(1, detectCount.get());
+            assertTrue(channel.isOpen());
+            channel.finishAndReleaseAll();
+        } finally {
+            frameworkModel.destroy();
+        }
+    }
+
+    private static final class CountingWireProtocol implements WireProtocol {
+        private final AtomicInteger detectCount;
+
+        private CountingWireProtocol(AtomicInteger detectCount) {
+            this.detectCount = detectCount;
+        }
+
+        @Override
+        public ProtocolDetector detector() {
+            return in -> {
+                detectCount.incrementAndGet();
+                return ProtocolDetector.Result.needMoreData();
+            };
+        }
+
+        @Override
+        public void configServerProtocolHandler(URL url, ChannelOperator operator) {}
+
+        @Override
+        public void configClientPipeline(URL url, ChannelOperator operator, ContextOperator contextOperator) {}
+
+        @Override
+        public void close() {}
+    }
+}

--- a/dubbo-remoting/dubbo-remoting-netty4/src/test/java/org/apache/dubbo/remoting/transport/netty4/PortUnificationTestCertProvider.java
+++ b/dubbo-remoting/dubbo-remoting-netty4/src/test/java/org/apache/dubbo/remoting/transport/netty4/PortUnificationTestCertProvider.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.remoting.transport.netty4;
+
+import org.apache.dubbo.common.URL;
+import org.apache.dubbo.common.extension.Activate;
+import org.apache.dubbo.common.ssl.AuthPolicy;
+import org.apache.dubbo.common.ssl.Cert;
+import org.apache.dubbo.common.ssl.CertProvider;
+import org.apache.dubbo.common.ssl.ProviderCert;
+
+@Activate(order = -10000)
+public class PortUnificationTestCertProvider implements CertProvider {
+
+    @Override
+    public boolean isSupport(URL address) {
+        return address.getParameter("pu.test.cert", false);
+    }
+
+    @Override
+    public ProviderCert getProviderConnectionConfig(URL localAddress) {
+        return new ProviderCert(new byte[0], new byte[0], null, AuthPolicy.NONE);
+    }
+
+    @Override
+    public Cert getConsumerConnectionConfig(URL remoteAddress) {
+        return null;
+    }
+}

--- a/dubbo-remoting/dubbo-remoting-netty4/src/test/resources/META-INF/dubbo/internal/org.apache.dubbo.common.ssl.CertProvider
+++ b/dubbo-remoting/dubbo-remoting-netty4/src/test/resources/META-INF/dubbo/internal/org.apache.dubbo.common.ssl.CertProvider
@@ -1,0 +1,1 @@
+pu-test-cert=org.apache.dubbo.remoting.transport.netty4.PortUnificationTestCertProvider


### PR DESCRIPTION
## What is the purpose of the change?

GitHub_issue: #16373

Fixes #16373

This pull request fixes port-unification protocol detection when provider TLS is configured with `AuthPolicy.NONE`.

`AuthPolicy.NONE` means TLS is optional. If a client sends a non-TLS first packet to the port-unification port, the server should continue with plaintext protocol detection. The current `3.3` branch enters the TLS-detection branch, sees that the packet is not TLS, and then does nothing when the auth policy is `NONE`. As a result, plaintext Dubbo detection is skipped and the connection waits until the caller times out.

The fix keeps the existing strict-TLS behavior unchanged:

- TLS first packet: enable SSL and return.
- Non-TLS first packet with required TLS: log, discard data, close the channel, and return.
- Non-TLS first packet with `AuthPolicy.NONE`: fall through to plaintext `detectProtocol(...)`.

This PR also adds a regression test that provides an optional-TLS test `CertProvider`, sends a Dubbo plaintext first packet, and verifies that the plaintext protocol detector is invoked.

Verification:

- Before the production fix, the new regression test failed because the detector count was `0` instead of `1`.
- `mvn -q -pl dubbo-remoting/dubbo-remoting-netty4 -am -Dtest=NettyPortUnificationServerHandlerTest,PortUnificationServerTest,SslServerTlsHandlerTest -Dsurefire.failIfNoSpecifiedTests=false -DskipITs -DskipIntegrationTests=true -Djacoco.skip=true test`
- `mvn -q -pl dubbo-remoting/dubbo-remoting-netty4 -am -DskipTests -DskipIntegrationTests=true -Djacoco.skip=true -Dcheckstyle.skip=false -Dcheckstyle_unix.skip=false -Drat.skip=false verify`
- `mvn -q -pl dubbo-remoting/dubbo-remoting-netty4 -am spotless:check`

## Checklist

- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before the description, using `GitHub_issue: #123456`).
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exists. If the new feature or significant change is added, please remember to add integration-test in [dubbo-samples](https://github.com/apache/dubbo-samples) project.
- [x] Make sure gitHub actions can pass, only after CI passed will we review it.
