### PR TITLE
Fix MeshRuleRouter to use OR semantics across match alternatives (fix…

### DIFF
--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/router/mesh/route/MeshRuleRouter.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/router/mesh/route/MeshRuleRouter.java
@@ -197,7 +197,7 @@ public abstract class MeshRuleRouter<T> extends AbstractStateRouter<T> implement
                 }
 
                 if (matchRequestList.stream()
-                        .allMatch(request -> request.isMatch(invocation, sourcesLabels, tracingContextProviders))) {
+                        .anyMatch(request -> request.isMatch(invocation, sourcesLabels, tracingContextProviders))) {
                     return dubboRouteDetail.getRoute();
                 }
             }

--- a/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/router/mesh/route/MeshRuleRouterTest.java
+++ b/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/router/mesh/route/MeshRuleRouterTest.java
@@ -20,9 +20,11 @@ import org.apache.dubbo.common.URL;
 import org.apache.dubbo.common.beans.factory.ScopeBeanFactory;
 import org.apache.dubbo.common.extension.ExtensionLoader;
 import org.apache.dubbo.common.utils.Holder;
+import org.apache.dubbo.common.utils.PojoUtils;
 import org.apache.dubbo.common.utils.StringUtils;
 import org.apache.dubbo.rpc.Invoker;
 import org.apache.dubbo.rpc.RpcInvocation;
+import org.apache.dubbo.rpc.cluster.router.mesh.rule.virtualservice.DubboRoute;
 import org.apache.dubbo.rpc.cluster.router.mesh.util.TracingContextProvider;
 import org.apache.dubbo.rpc.cluster.router.state.BitList;
 import org.apache.dubbo.rpc.model.ApplicationModel;
@@ -46,6 +48,7 @@ import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.constructor.SafeConstructor;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -451,5 +454,22 @@ class MeshRuleRouterTest {
         meshRuleRouter.notify(invokers);
         invokers.removeAll(Arrays.asList(isolation, testingTrunk, testing));
         assertEquals(invokers, meshRuleRouter.route(invokers.clone(), null, rpcInvocation, false, null));
+    }
+
+    @Test
+    void routeDetailShouldMatchWhenAnyRequestMatches() throws ReflectiveOperationException {
+        StandardMeshRuleRouter<Object> router = new StandardMeshRuleRouter<>(url.addParameter("trafficLabel", "gray"));
+
+        Yaml yaml = new Yaml(new SafeConstructor(new LoaderOptions()));
+        Map<String, Object> rule = yaml.load("routedetail:\n"
+                + "  - match:\n"
+                + "      - sourceLabels: {trafficLabel: blue}\n"
+                + "      - sourceLabels: {trafficLabel: gray}\n"
+                + "    route:\n"
+                + "      - destination: {host: demo, subset: gray}\n");
+
+        DubboRoute dubboRoute = PojoUtils.mapToPojo(rule, DubboRoute.class);
+
+        assertNotNull(router.getDubboRouteDestination(dubboRoute, new RpcInvocation()));
     }
 }


### PR DESCRIPTION
Fixes #16376

## What is the purpose of the change?

MeshRuleRouter.getDubboRouteDestination(DubboRoute, Invocation) used allMatch when evaluating the match list within a DubboRouteDetail, requiring every DubboMatchRequest alternative to match simultaneously. Per Dubbo's mesh routing semantics (modeled on Istio VirtualService), conditions within a single match entry should use AND, but multiple entries in the match list should use OR. This PR changes allMatch to anyMatch and adds a regression test covering the multi-alternative case, which the existing test fixtures never exercised (they only ever had a single match entry per detail, so AND and OR behaved identically).

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues/16376) field for the change.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Make sure gitHub actions can pass.