### PR TITLE
Fix: exclude RegistryConfig when fast check duplicated equivalent config

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/config/context/AbstractConfigManager.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/config/context/AbstractConfigManager.java
@@ -168,7 +168,7 @@ public abstract class AbstractConfigManager extends LifecycleAdapter {
                 configsCache, getTagName(targetConfigType), type -> new ConcurrentHashMap<>());
 
         // fast check duplicated equivalent config before write lock
-        if (!(config instanceof ReferenceConfigBase || config instanceof ServiceConfigBase)) {
+        if (!(config instanceof ReferenceConfigBase || config instanceof ServiceConfigBase || config instanceof RegistryConfig)) {
             for (AbstractConfig value : configsMap.values()) {
                 if (value.equals(config)) {
                     return (T) value;


### PR DESCRIPTION
if the dubbo consumer xml config is as follow

    <dubbo:registry id="zk1" protocol="zookeeper"
                    address="${ZK1_ADDRESS:10.47.181.23:2181,10.47.181.24:2181,10.47.181.25:2181}"/>

    <dubbo:registry id="zk2" protocol="zookeeper"
                    address="${ZK2_ADDRESS:10.47.181.20:2181,10.47.181.21:2181,10.47.181.22:2181}"/>

    <dubbo:reference id="app1" interface="com.test.app1" registry="zk1"/>

    <dubbo:reference id="app2" interface="com.test.app2" registry="zk2"/>

in which ZK1_ADDRESS and ZK2_ADDRESS are env variables.

what is exactly needed is that ZK1_ADDRESS and ZK2_ADDRESS may be the same or different.

when ZK1_ADDRESS and ZK2_ADDRESS are the same, current implementation will only register zk1 registy config successfully, the zk2 registry config is identified as duplication，then it throws exception `java.lang.IllegalStateException: Registry not found: zk2` when loading app2 reference config

## What is the purpose of the change?


## Checklist
- [ ] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Make sure gitHub actions can pass. [Why the workflow is failing and how to fix it?](../CONTRIBUTING.md)
