### PR TITLE
Fix #16295: JSON SPI loading without optional dependencies

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/utils/JsonUtils.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/utils/JsonUtils.java
@@ -24,6 +24,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.ServiceConfigurationError;
 import java.util.ServiceLoader;
 import java.util.TreeMap;
 
@@ -79,10 +80,9 @@ public class JsonUtils {
     private static JsonUtil loadExtensions(String name, ClassLoader classLoader, Map<String, JsonUtil> extensions) {
         ServiceLoader<JsonUtil> loader = ServiceLoader.load(JsonUtil.class, classLoader);
         Iterator<JsonUtil> it = loader.iterator();
-        // In JDK 21+, ServiceLoader.hasNext() may throw NoClassDefFoundError
-        // when checking class dependencies, so we need to catch it here
         while (true) {
             try {
+                // ServiceLoader may resolve provider constructors in hasNext(), before next() can be called.
                 if (!it.hasNext()) {
                     break;
                 }
@@ -93,9 +93,7 @@ public class JsonUtils {
                     }
                     extensions.put(extension.getName(), extension);
                 }
-            } catch (Throwable ignored) {
-                // Ignore loading failures (e.g., NoClassDefFoundError in JDK 25)
-                // and continue with the next extension
+            } catch (ServiceConfigurationError | LinkageError | RuntimeException ignored) {
             }
         }
         return null;

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/utils/JsonUtilsTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/utils/JsonUtilsTest.java
@@ -27,6 +27,9 @@ import org.apache.dubbo.common.utils.json.TestObjectA;
 import org.apache.dubbo.common.utils.json.TestObjectB;
 
 import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.net.URL;
+import java.net.URLClassLoader;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -394,6 +397,42 @@ class JsonUtilsTest {
         allowJackson.set(true);
 
         setJson(null);
+    }
+
+    @Test
+    void testLoadExtensionsWithoutOptionalGsonDependency() throws Exception {
+        URL classes = GsonImpl.class.getProtectionDomain().getCodeSource().getLocation();
+        Map<String, JsonUtil> extensions = new HashMap<>();
+
+        try (URLClassLoader classLoader = new URLClassLoader(new URL[] {classes}, JsonUtils.class.getClassLoader()) {
+            @Override
+            protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+                if (name.startsWith("com.google.gson.")) {
+                    throw new ClassNotFoundException(name);
+                }
+                if (name.equals("org.apache.dubbo.common.json.impl.GsonImpl")) {
+                    synchronized (getClassLoadingLock(name)) {
+                        Class<?> loaded = findLoadedClass(name);
+                        if (loaded == null) {
+                            loaded = findClass(name);
+                        }
+                        if (resolve) {
+                            resolveClass(loaded);
+                        }
+                        return loaded;
+                    }
+                }
+                return super.loadClass(name, resolve);
+            }
+        }) {
+            Method loadExtensions =
+                    JsonUtils.class.getDeclaredMethod("loadExtensions", String.class, ClassLoader.class, Map.class);
+            loadExtensions.setAccessible(true);
+            loadExtensions.invoke(null, null, classLoader, extensions);
+        }
+
+        Assertions.assertInstanceOf(FastJson2Impl.class, extensions.get("fastjson2"));
+        Assertions.assertFalse(extensions.containsKey("gson"));
     }
 
     private static Field jsonFieldCache;


### PR DESCRIPTION
## What is the purpose of the change?

Fixes #16295.

On JDK 25, `ServiceLoader.Iterator#hasNext()` may resolve a JSON provider's constructor and its referenced types. If an optional JSON implementation such as Gson is not present, this can throw `NoClassDefFoundError` before Dubbo can continue to the default fastjson2 implementation.

## Brief changelog

- Keep `ServiceLoader#hasNext()`, provider construction, and support checks inside the guarded iteration.
- Skip provider loading failures caused by `ServiceConfigurationError`, `LinkageError`, or provider runtime exceptions.
- Avoid catching fatal JVM errors through a blanket `Throwable` catch.
- Add a regression test that hides all Gson classes while retaining the Gson service provider entry, and verifies that fastjson2 is still discovered.

## Verifying this change

- Reproduced the original `NoClassDefFoundError: com/google/gson/JsonSyntaxException` locally on Temurin JDK 25.0.3 with the Dubbo 3.3.6 loading logic and Gson removed from the runtime classpath.
- Verified the fixed runtime selects `FastJson2Impl` without Gson on JDK 25.0.3 and JDK 26.0.1.
- `JsonUtilsTest`: 6 tests passed on JDK 25.0.3.
- The new missing-Gson regression test passed on JDK 25.0.3 and JDK 26.0.1.
- Spotless formatting check passed.
