### PR TITLE
[ISSUE #16389] Close late input after streaming decoder shutdown

### DIFF
--- a/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/message/LengthFieldStreamingDecoder.java
+++ b/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/message/LengthFieldStreamingDecoder.java
@@ -72,7 +72,11 @@ public class LengthFieldStreamingDecoder implements StreamingDecoder {
     @Override
     public final void decode(InputStream inputStream) throws DecodeException {
         if (closing || closed) {
-            // ignored
+            try {
+                inputStream.close();
+            } catch (IOException e) {
+                throw new DecodeException(e);
+            }
             return;
         }
         accumulate.addInputStream(inputStream);

--- a/dubbo-remoting/dubbo-remoting-http12/src/test/java/org/apache/dubbo/remoting/http12/message/LengthFieldStreamingDecoderTest.java
+++ b/dubbo-remoting/dubbo-remoting-http12/src/test/java/org/apache/dubbo/remoting/http12/message/LengthFieldStreamingDecoderTest.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.remoting.http12.message;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class LengthFieldStreamingDecoderTest {
+
+    @Test
+    void closesInputReceivedAfterStreamClosed() {
+        LengthFieldStreamingDecoder decoder = new LengthFieldStreamingDecoder();
+        decoder.onStreamClosed();
+        CloseTrackingInputStream inputStream = new CloseTrackingInputStream(new byte[] {0});
+
+        decoder.decode(inputStream);
+
+        assertTrue(inputStream.closed);
+    }
+
+    @Test
+    void closesInputReceivedWhileDecoderClosing() {
+        LengthFieldStreamingDecoder decoder = new LengthFieldStreamingDecoder();
+        decoder.decode(new ByteArrayInputStream(new byte[] {0}));
+        decoder.close();
+        CloseTrackingInputStream inputStream = new CloseTrackingInputStream(new byte[] {0});
+
+        decoder.decode(inputStream);
+
+        assertTrue(inputStream.closed);
+    }
+
+    private static final class CloseTrackingInputStream extends ByteArrayInputStream {
+
+        private boolean closed;
+
+        private CloseTrackingInputStream(byte[] buf) {
+            super(buf);
+        }
+
+        @Override
+        public void close() throws IOException {
+            this.closed = true;
+            super.close();
+        }
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

Fixes #16389. Triple HTTP/2 wraps DATA frames in an auto-closing input stream. When a DATA frame arrives after the streaming decoder starts closing or has closed, the decoder previously returned without closing that stream, leaving the underlying ByteBuf unreleased.

## Brief changelog

- Close input streams rejected while the decoder is closing or closed.
- Propagate input close failures as DecodeException.
- Add regression coverage for both closing and closed decoder states.

## Verifying this change

- LengthFieldStreamingDecoderTest: 2 tests passed.
- All dubbo-remoting-http12 tests: 23 tests passed, 2 skipped.
- Spotless and reactor compilation checks passed.

The broader dependency-reactor test run reached 1,165 dubbo-common tests and was stopped by the pre-existing environment-sensitive NetUtilsTest.testMatchIpRangeMatchWhenIpWrongException failure; the target module had not started in that run.