### PR TITLE
Fix instance push loss during initial subscribe in ServiceDiscoveryRegistry

### DIFF
--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/ServiceDiscoveryRegistry.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/ServiceDiscoveryRegistry.java
@@ -352,31 +352,44 @@ public class ServiceDiscoveryRegistry extends FailbackRegistry {
             ServiceInstancesChangedListener serviceInstancesChangedListener = serviceListeners.get(serviceNamesKey);
             if (serviceInstancesChangedListener == null) {
                 serviceInstancesChangedListener = serviceDiscovery.createListener(serviceNames);
+                serviceListeners.put(serviceNamesKey, serviceInstancesChangedListener);
+
+                // Register the push callback BEFORE the initial pull, so any push arriving
+                // during or right after the pull is delivered to our listener instead of
+                // being swallowed by the discovery SDK's local cache. See DUBBO issue on
+                // "instance push loss during initial subscribe".
+                ServiceInstancesChangedListener listenerForRegister = serviceInstancesChangedListener;
+                String serviceDiscoveryName =
+                        url.getParameter(RegistryConstants.REGISTRY_CLUSTER_KEY, url.getProtocol());
+                MetricsEventBus.post(
+                        RegistryEvent.toSsEvent(
+                                url.getApplicationModel(), serviceKey, Collections.singletonList(serviceDiscoveryName)),
+                        () -> {
+                            serviceDiscovery.addServiceInstancesChangedListener(listenerForRegister);
+                            return null;
+                        });
+
                 for (String serviceName : serviceNames) {
-                    List<ServiceInstance> serviceInstances = serviceDiscovery.getInstances(serviceName);
-                    if (CollectionUtils.isNotEmpty(serviceInstances)) {
-                        serviceInstancesChangedListener.onEvent(
-                                new ServiceInstancesChangedEvent(serviceName, serviceInstances));
+                    // Hold the same intrinsic lock as ServiceInstancesChangedListener.doOnEvent()
+                    // to serialize with any concurrent push callback. If a push has already
+                    // populated this serviceName, treat push as authoritative and skip the pull —
+                    // otherwise a stale pull result could overwrite fresher push data.
+                    synchronized (serviceInstancesChangedListener) {
+                        if (serviceInstancesChangedListener.getAllInstances().containsKey(serviceName)) {
+                            continue;
+                        }
+                        List<ServiceInstance> serviceInstances = serviceDiscovery.getInstances(serviceName);
+                        if (CollectionUtils.isNotEmpty(serviceInstances)) {
+                            serviceInstancesChangedListener.onEvent(
+                                    new ServiceInstancesChangedEvent(serviceName, serviceInstances));
+                        }
                     }
                 }
-                serviceListeners.put(serviceNamesKey, serviceInstancesChangedListener);
             }
 
             if (!serviceInstancesChangedListener.isDestroyed()) {
                 listener.addServiceListener(serviceInstancesChangedListener);
                 serviceInstancesChangedListener.addListenerAndNotify(url, listener);
-                ServiceInstancesChangedListener finalServiceInstancesChangedListener = serviceInstancesChangedListener;
-
-                String serviceDiscoveryName =
-                        url.getParameter(RegistryConstants.REGISTRY_CLUSTER_KEY, url.getProtocol());
-
-                MetricsEventBus.post(
-                        RegistryEvent.toSsEvent(
-                                url.getApplicationModel(), serviceKey, Collections.singletonList(serviceDiscoveryName)),
-                        () -> {
-                            serviceDiscovery.addServiceInstancesChangedListener(finalServiceInstancesChangedListener);
-                            return null;
-                        });
             } else {
                 logger.info(String.format("Listener of %s has been destroyed by another thread.", serviceNamesKey));
                 serviceListeners.remove(serviceNamesKey);

--- a/dubbo-registry/dubbo-registry-api/src/test/java/org/apache/dubbo/registry/client/ServiceDiscoveryRegistryTest.java
+++ b/dubbo-registry/dubbo-registry-api/src/test/java/org/apache/dubbo/registry/client/ServiceDiscoveryRegistryTest.java
@@ -41,6 +41,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
 
 import static org.apache.dubbo.common.constants.CommonConstants.CHECK_KEY;
 import static org.apache.dubbo.common.constants.CommonConstants.DUBBO;
@@ -52,8 +53,10 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
@@ -233,8 +236,8 @@ class ServiceDiscoveryRegistryTest {
                 multiAppsInstanceListener,
                 serviceDiscoveryRegistry.getServiceListeners().get(toStringKeys(multiApps)));
         verify(multiAppsInstanceListener, times(1)).addListenerAndNotify(any(), eq(testServiceListener));
-        // still called once, not executed this time
-        verify(serviceDiscovery, times(2)).addServiceInstancesChangedListener(multiAppsInstanceListener);
+        // registered only once when the listener was first created; subsequent subscribes reuse it
+        verify(serviceDiscovery, times(1)).addServiceInstancesChangedListener(multiAppsInstanceListener);
         // check different protocol
         Map<String, Set<ServiceInstancesChangedListener.NotifyListenerWithKey>> serviceListeners =
                 multiAppsInstanceListener.getServiceListeners();
@@ -255,6 +258,60 @@ class ServiceDiscoveryRegistryTest {
     @Test
     void testConcurrencySubscribe() {
         // TODO
+    }
+
+    /**
+     * The push callback must be registered on the underlying service discovery BEFORE the
+     * initial getInstances() pull. Otherwise, any push arriving while the initialization is
+     * still running (which can take seconds because of metadata fetching) is absorbed by the
+     * discovery SDK's local cache and never delivered to Dubbo, leaving allInstances stale
+     * for the entire process lifetime.
+     */
+    @Test
+    void testSubscribeURLsRegistersPushCallbackBeforePull() {
+        Set<String> singleApp = new TreeSet<>();
+        singleApp.add(APP_NAME1);
+        when(serviceDiscovery.getInstances(APP_NAME1)).thenReturn(instanceList1);
+
+        serviceDiscoveryRegistry.subscribeURLs(url, testServiceListener, singleApp);
+
+        InOrder ordered = inOrder(serviceDiscovery);
+        ordered.verify(serviceDiscovery).addServiceInstancesChangedListener(instanceListener);
+        ordered.verify(serviceDiscovery).getInstances(APP_NAME1);
+    }
+
+    /**
+     * If a push callback fires between "register" and the initial pull and has already
+     * populated allInstances for a given serviceName, the pull for that serviceName must be
+     * skipped. Otherwise a slower pull (reading a stale SDK cache) could overwrite the fresher
+     * push snapshot, leaving a ghost instance in the invoker table.
+     */
+    @Test
+    void testSubscribeURLsSkipsPullWhenPushAlreadyPopulated() {
+        Set<String> singleApp = new TreeSet<>();
+        singleApp.add(APP_NAME1);
+
+        // Simulate a push callback that fires the moment we register on the discovery SDK:
+        // it populates allInstances with the authoritative snapshot before the pull loop runs.
+        doAnswer(invocation -> {
+                    ServiceInstancesChangedListener registered = invocation.getArgument(0);
+                    registered.getAllInstances().put(APP_NAME1, instanceList2);
+                    return null;
+                })
+                .when(serviceDiscovery)
+                .addServiceInstancesChangedListener(instanceListener);
+
+        // A stale pull would return a different (larger) snapshot; it must not be applied.
+        when(serviceDiscovery.getInstances(APP_NAME1)).thenReturn(instanceList1);
+
+        serviceDiscoveryRegistry.subscribeURLs(url, testServiceListener, singleApp);
+
+        // Pull was skipped because push already populated this app.
+        verify(serviceDiscovery, never()).getInstances(APP_NAME1);
+        // No stale onEvent was pushed into the listener from the initialization path.
+        verify(instanceListener, never()).onEvent(any());
+        // The push snapshot survives.
+        assertEquals(instanceList2, instanceListener.getAllInstances().get(APP_NAME1));
     }
 
     @Test


### PR DESCRIPTION
# PR: Fix instance push loss during initial subscribe in ServiceDiscoveryRegistry

**Base branch**: `apache/dubbo:3.3` (also applies cleanly to `3.2` and `3.4`)
**Commits**: 2 (test-only `f9755db2`, then fix `ec2ba983`). Check out either to see the failing-then-passing tests.

---

## What this fixes

Fixes #16392.

`ServiceDiscoveryRegistry.subscribeURLs()` currently:

1. calls `serviceDiscovery.getInstances(serviceName)` — the initial pull,
2. runs `listener.onEvent(...)` which synchronously fetches metadata (can take seconds),
3. **only then** calls `serviceDiscovery.addServiceInstancesChangedListener(...)` to arm the push callback.

Any push arriving between step 1 and step 3 is absorbed by the discovery SDK's local cache and never reaches Dubbo. `allInstances` is then permanently stale until either (a) a later, independent push happens for the same appName, or (b) the process restarts.

We hit this in production (Nacos 2.x, Dubbo 3.2.19): a provider Nacos had removed 92 ms after our subscribe started remained a ghost invoker for the entire process lifetime, producing recurring `Fail to decode request` errors.

Timeline and full analysis are in the linked issue.

## The change

`dubbo-registry-api/…/ServiceDiscoveryRegistry.java` — `subscribeURLs()`:

1. **Register the push callback before the initial pull.** `addServiceInstancesChangedListener(...)` moves inside the `if (listener == null)` guard, ahead of the pull loop. Any push arriving during/after the pull now flows through the listener's already-armed `doOnEvent` path.

2. **Serialize the pull with the push callback.** Wrap the pull loop in `synchronized(serviceInstancesChangedListener)`. `doOnEvent` is a `synchronized` method on the same object; both now share the same intrinsic lock, so a push arriving during initialization queues cleanly instead of interleaving writes to `allInstances`.

3. **Push wins over stale pull.** Inside the synchronized region, check `listener.getAllInstances().containsKey(serviceName)` before pulling. If a push has already populated this service, treat push as authoritative and skip the pull. This prevents a slow pull (reading a stale SDK cache) from overwriting a fresher push snapshot.

Diff is under 30 lines.

## Before/after verification

Two commits are separated intentionally so the failing-then-passing tests can be observed directly:

```bash
git remote add hnpkso https://github.com/hnpkso/dubbo.git
git fetch hnpkso fix/subscribe-push-loss

git checkout  f9755db2       # test commit only

mvn -pl dubbo-registry/dubbo-registry-api test \
    -Dtest=ServiceDiscoveryRegistryTest
# Tests run: 6, Failures: 3
#   ✗ testSubscribeURLs (times(2) assertion on register)
#   ✗ testSubscribeURLsRegistersPushCallbackBeforePull  ← MAIN
#   ✗ testSubscribeURLsSkipsPullWhenPushAlreadyPopulated

git checkout ec2ba983       # fix on top

mvn -pl dubbo-registry/dubbo-registry-api test \
    -Dtest=ServiceDiscoveryRegistryTest
# Tests run: 6, Failures: 0
```

The red-to-green transition **is** the reproduction — no Nacos or external system needed.

Full module test suite: `Tests run: 111, Failures: 0`.

## Notes on behavior changes

1. **`addServiceInstancesChangedListener` cardinality**: now called once per listener lifetime, previously once per `subscribeURLs()` call. All in-tree `ServiceDiscovery` implementations already treat duplicate calls as no-ops via `instanceListeners.add()` early-return, so the change is observationally equivalent. The `testSubscribeURLs` assertion updates from `times(2)` to `times(1)` accordingly.

2. **`RegistryEvent.toSsEvent` metric cardinality** rides along with (1): it now fires once per listener creation instead of once per subscribe. If per-subscribe metric cardinality is preferred, `MetricsEventBus.post(...)` can be split back out of the register lambda without affecting correctness — happy to adjust.

3. **Push executor threads may briefly park** on the listener intrinsic lock during initial subscribe, bounded by the metadata fetch duration (~500 ms in our production). Previously such pushes were silently dropped, so this is a strict improvement.

## Scope

This PR only fixes the push-loss race in `subscribeURLs()`. `NacosServiceDiscovery` and other `ServiceDiscovery` implementations are untouched; no new SPI contract. Any unrelated concerns in the same code path are out of scope for this change.

## Related

- #14851 fixed a sibling race on the `MappingListener` side of the same subscribe path (initial-apps was `null` when the listener was constructed). The instance-list side, addressed here, has the same shape of bug (populate-before-arm) but a different failure mode (silent instance loss vs. spurious mapping event).

## Commits

- `f9755db2` — `Add failing tests for instance push loss during initial subscribe`. Tests only, fails on unmodified 3.3.
- `ec2ba983` — `Fix instance push loss during initial subscribe in ServiceDiscoveryRegistry`. Source fix, turns tests green.

Feel free to squash on merge; the two commits exist purely to make the red→green transition observable during review.
