### PR TITLE
Fix #16397: return 503 (UNAVAILABLE) instead of 404 (UNIMPLEMENTED) w…

### DIFF
--- a/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/HttpStatus.java
+++ b/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/HttpStatus.java
@@ -32,7 +32,8 @@ public enum HttpStatus {
     REQUEST_TIMEOUT(408),
     CONFLICT(409),
     UNSUPPORTED_MEDIA_TYPE(415),
-    INTERNAL_SERVER_ERROR(500);
+    INTERNAL_SERVER_ERROR(500),
+    SERVICE_UNAVAILABLE(503);
 
     private final int code;
 

--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/h12/grpc/GrpcRequestHandlerMapping.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/h12/grpc/GrpcRequestHandlerMapping.java
@@ -61,6 +61,9 @@ public final class GrpcRequestHandlerMapping implements RequestHandlerMapping {
         String version = request.header(TripleHeaderEnum.SERVICE_VERSION.getKey());
         Invoker<?> invoker = pathResolver.resolve(path.getPath(), group, version);
         if (invoker == null) {
+            if(url.getOrDefaultApplicationModel().getDeployer().isStopping()){
+                throw unavailable();
+            }
             throw notFound();
         }
 
@@ -77,6 +80,11 @@ public final class GrpcRequestHandlerMapping implements RequestHandlerMapping {
 
     private static HttpStatusException notFound() {
         return new HttpStatusException(HttpStatus.NOT_FOUND.getCode(), "Invoker for gRPC not found");
+    }
+
+    private static HttpStatusException unavailable() {
+        return new HttpStatusException(
+                HttpStatus.SERVICE_UNAVAILABLE.getCode(), "Invoker for gRPC not found, service is shutting down");
     }
 
     @Override

--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/h12/grpc/GrpcRequestHandlerMapping.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/h12/grpc/GrpcRequestHandlerMapping.java
@@ -61,7 +61,7 @@ public final class GrpcRequestHandlerMapping implements RequestHandlerMapping {
         String version = request.header(TripleHeaderEnum.SERVICE_VERSION.getKey());
         Invoker<?> invoker = pathResolver.resolve(path.getPath(), group, version);
         if (invoker == null) {
-            if(url.getOrDefaultApplicationModel().getDeployer().isStopping()){
+            if (url.getOrDefaultApplicationModel().getDeployer().isStopping()) {
                 throw unavailable();
             }
             throw notFound();

--- a/dubbo-rpc/dubbo-rpc-triple/src/test/java/org/apache/dubbo/rpc/protocol/tri/h12/grpc/GrpcRequestHandlerMappingTest.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/test/java/org/apache/dubbo/rpc/protocol/tri/h12/grpc/GrpcRequestHandlerMappingTest.java
@@ -1,0 +1,44 @@
+package org.apache.dubbo.rpc.protocol.tri.h12.grpc;
+
+import org.apache.dubbo.common.URL;
+import org.apache.dubbo.common.deploy.ApplicationDeployer;
+import org.apache.dubbo.remoting.http12.HttpRequest;
+import org.apache.dubbo.remoting.http12.HttpResponse;
+import org.apache.dubbo.remoting.http12.HttpStatus;
+import org.apache.dubbo.remoting.http12.exception.HttpStatusException;
+import org.apache.dubbo.rpc.model.ApplicationModel;
+import org.apache.dubbo.rpc.model.FrameworkModel;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+// Regression test for apache/dubbo#16397: when the path can't be resolved
+// because the app is shutting down,it should return 503 (-> gRPC UNAVAILABLE,
+// retriable) instead of 404 (-> gRPC UNIMPLEMENTED, non-retriable).
+class GrpcRequestHandlerMappingTest {
+
+    @Test
+    void returnsServiceUnavailableWhenStoppingAndInvokerNotFound() {
+        FrameworkModel frameworkModel = new FrameworkModel();
+        GrpcRequestHandlerMapping mapping = new GrpcRequestHandlerMapping(frameworkModel);
+
+        ApplicationDeployer deployer = Mockito.mock(ApplicationDeployer.class);
+        Mockito.when(deployer.isStopping()).thenReturn(true);
+        ApplicationModel applicationModel = Mockito.mock(ApplicationModel.class);
+        Mockito.when(applicationModel.getDeployer()).thenReturn(deployer);
+
+        URL url = Mockito.mock(URL.class);
+        Mockito.when(url.getOrDefaultApplicationModel()).thenReturn(applicationModel);
+
+        HttpRequest request = Mockito.mock(HttpRequest.class);
+        Mockito.when(request.contentType()).thenReturn("application/grpc");
+        Mockito.when(request.uri()).thenReturn("/DemoService/sayHello");
+
+        HttpStatusException ex = Assertions.assertThrows(
+                HttpStatusException.class,
+                () -> mapping.getRequestHandler(url, request, Mockito.mock(HttpResponse.class)));
+
+        Assertions.assertEquals(HttpStatus.SERVICE_UNAVAILABLE.getCode(), ex.getStatusCode());
+    }
+}

--- a/dubbo-rpc/dubbo-rpc-triple/src/test/java/org/apache/dubbo/rpc/protocol/tri/h12/grpc/GrpcRequestHandlerMappingTest.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/test/java/org/apache/dubbo/rpc/protocol/tri/h12/grpc/GrpcRequestHandlerMappingTest.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.dubbo.rpc.protocol.tri.h12.grpc;
 
 import org.apache.dubbo.common.URL;


### PR DESCRIPTION
Fixes part of #16397.

## Problem
When `pathResolver.resolve()` fails to find an invoker because it was
unregistered during graceful shutdown, `GrpcRequestHandlerMapping` throws
a 404, which maps to gRPC `UNIMPLEMENTED`. Consumer-side cluster fault
tolerance treats `UNIMPLEMENTED` as a permanent, non-retriable error, so
it never fails over to another provider instance — turning a routine
rolling restart into a business-visible error.

## Fix
When resolution fails specifically because the application is stopping
(`ApplicationDeployer#isStopping()`), return 503 instead of 404, which
maps to gRPC `UNAVAILABLE` — a retriable status consumers already know
how to fail over on.

## Testing
Added `GrpcRequestHandlerMappingTest#returnsServiceUnavailableWhenStoppingAndInvokerNotFound`,
verifying a 503 is thrown when the app is stopping and resolution fails.