### PR TITLE
 [ISSUE #16399] Close late input after streaming decoder shutdown

### DIFF
--- a/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/message/DefaultStreamingDecoder.java
+++ b/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/message/DefaultStreamingDecoder.java
@@ -38,7 +38,13 @@ public class DefaultStreamingDecoder implements StreamingDecoder {
     @Override
     public void decode(InputStream inputStream) throws DecodeException {
         if (closed) {
-            // ignored
+            // Close late input rejected after the decoder has been closed, so the
+            // underlying ByteBuf (wrapped with releaseOnClose) is released.
+            try {
+                inputStream.close();
+            } catch (IOException e) {
+                throw new DecodeException(e);
+            }
             return;
         }
         accumulate.addInputStream(inputStream);

--- a/dubbo-remoting/dubbo-remoting-http12/src/test/java/org/apache/dubbo/remoting/http12/message/DefaultStreamingDecoderTest.java
+++ b/dubbo-remoting/dubbo-remoting-http12/src/test/java/org/apache/dubbo/remoting/http12/message/DefaultStreamingDecoderTest.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.remoting.http12.message;
+
+import org.apache.dubbo.remoting.http12.exception.DecodeException;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class DefaultStreamingDecoderTest {
+
+    @Test
+    void closesInputReceivedAfterStreamClosed() {
+        DefaultStreamingDecoder decoder = new DefaultStreamingDecoder();
+        decoder.onStreamClosed();
+        CloseTrackingInputStream inputStream = new CloseTrackingInputStream(new byte[] {0});
+
+        decoder.decode(inputStream);
+
+        assertTrue(inputStream.closed);
+    }
+
+    @Test
+    void propagatesCloseFailureAsDecodeException() {
+        DefaultStreamingDecoder decoder = new DefaultStreamingDecoder();
+        decoder.onStreamClosed();
+        IOExceptionCloseInputStream inputStream = new IOExceptionCloseInputStream(new byte[] {0});
+
+        DecodeException ex = assertThrows(DecodeException.class, () -> decoder.decode(inputStream));
+        assertEquals(IOException.class, ex.getCause().getClass());
+    }
+
+    private static final class CloseTrackingInputStream extends ByteArrayInputStream {
+
+        private boolean closed;
+
+        private CloseTrackingInputStream(byte[] buf) {
+            super(buf);
+        }
+
+        @Override
+        public void close() throws IOException {
+            this.closed = true;
+            super.close();
+        }
+    }
+
+    private static final class IOExceptionCloseInputStream extends ByteArrayInputStream {
+
+        private IOExceptionCloseInputStream(byte[] buf) {
+            super(buf);
+        }
+
+        @Override
+        public void close() throws IOException {
+            throw new IOException("simulated close failure");
+        }
+    }
+}

--- a/dubbo-remoting/dubbo-remoting-websocket/src/main/java/org/apache/dubbo/remoting/websocket/FinalFragmentStreamingDecoder.java
+++ b/dubbo-remoting/dubbo-remoting-websocket/src/main/java/org/apache/dubbo/remoting/websocket/FinalFragmentStreamingDecoder.java
@@ -44,7 +44,13 @@ public class FinalFragmentStreamingDecoder implements StreamingDecoder {
     @Override
     public void decode(InputStream inputStream) throws DecodeException {
         if (closing || closed) {
-            // ignored
+            // Close late input rejected after the decoder has been closed, so the
+            // underlying ByteBuf (wrapped with releaseOnClose) is released.
+            try {
+                inputStream.close();
+            } catch (IOException e) {
+                throw new DecodeException(e);
+            }
             return;
         }
         accumulate.addInputStream(inputStream);

--- a/dubbo-remoting/dubbo-remoting-websocket/src/test/java/org/apache/dubbo/remoting/websocket/FinalFragmentStreamingDecoderTest.java
+++ b/dubbo-remoting/dubbo-remoting-websocket/src/test/java/org/apache/dubbo/remoting/websocket/FinalFragmentStreamingDecoderTest.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.remoting.websocket;
+
+import org.apache.dubbo.remoting.http12.exception.DecodeException;
+import org.apache.dubbo.remoting.http12.message.StreamingDecoder;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class FinalFragmentStreamingDecoderTest {
+
+    @Test
+    void closesInputReceivedAfterStreamClosed() {
+        FinalFragmentStreamingDecoder decoder = new FinalFragmentStreamingDecoder();
+        decoder.onStreamClosed();
+        CloseTrackingInputStream inputStream = new CloseTrackingInputStream(new byte[] {0});
+
+        decoder.decode(inputStream);
+
+        assertTrue(inputStream.closed);
+    }
+
+    @Test
+    void closesInputReceivedAfterClose() {
+        FinalFragmentStreamingDecoder decoder = new FinalFragmentStreamingDecoder();
+        decoder.setFragmentListener(new StreamingDecoder.FragmentListener() {
+            @Override
+            public void bytesRead(int numBytes) {}
+
+            @Override
+            public void onFragmentMessage(InputStream rawMessage, int messageLength) {}
+        });
+        decoder.close();
+        CloseTrackingInputStream inputStream = new CloseTrackingInputStream(new byte[] {0});
+
+        decoder.decode(inputStream);
+
+        assertTrue(inputStream.closed);
+    }
+
+    @Test
+    void propagatesCloseFailureAsDecodeException() {
+        FinalFragmentStreamingDecoder decoder = new FinalFragmentStreamingDecoder();
+        decoder.onStreamClosed();
+        IOExceptionCloseInputStream inputStream = new IOExceptionCloseInputStream(new byte[] {0});
+
+        DecodeException ex = assertThrows(DecodeException.class, () -> decoder.decode(inputStream));
+        assertEquals(IOException.class, ex.getCause().getClass());
+    }
+
+    private static final class CloseTrackingInputStream extends ByteArrayInputStream {
+
+        private boolean closed;
+
+        private CloseTrackingInputStream(byte[] buf) {
+            super(buf);
+        }
+
+        @Override
+        public void close() throws IOException {
+            this.closed = true;
+            super.close();
+        }
+    }
+
+    private static final class IOExceptionCloseInputStream extends ByteArrayInputStream {
+
+        private IOExceptionCloseInputStream(byte[] buf) {
+            super(buf);
+        }
+
+        @Override
+        public void close() throws IOException {
+            throw new IOException("simulated close failure");
+        }
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

Fixes #16399. Mirror the #16391 fix for **both** streaming decoder implementations: when `decode()` is called after the decoder has been shut down, the input stream is now closed to release the underlying pooled `ByteBuf` wrapped with `releaseOnClose = true`.

#16391 introduced an early-return guard in both decoders but did not close the input on that guard, so the `ByteBuf` leaked. This PR closes that gap in both implementations.

## Brief changelog

### 1. `DefaultStreamingDecoder` (dubbo-remoting-http12)
- Close input streams rejected after the decoder has been closed (`closed == true` early-return branch).
- Propagate input close failures as `DecodeException` (consistent with #16391).

### 2. `FinalFragmentStreamingDecoder` (dubbo-remoting-websocket)
- Close input streams rejected after the decoder has been closed or is closing (`closing || closed` early-return branch) — the symmetric counterpart of the `DefaultStreamingDecoder` fix, in the websocket module.

## Verifying this change

- `DefaultStreamingDecoderTest` (http12): closed-path + exception propagation.
- `FinalFragmentStreamingDecoderTest` (websocket, new test dir): closed-path + closing-path + exception propagation.
- Spotless and module compilation checks passed.
