### PR TITLE
fix: resolve FileInputStream resource leak in IOUtils.readLines(File)

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/utils/IOUtils.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/utils/IOUtils.java
@@ -168,7 +168,9 @@ public class IOUtils {
             return new String[0];
         }
 
-        return readLines(new FileInputStream(file));
+        try (InputStream is = new FileInputStream(file)) {
+            return readLines(is);
+        }
     }
 
     /**


### PR DESCRIPTION
## What is the purpose of the change?

Fix a FileInputStream resource leak in `IOUtils.readLines(File)`.

## What does this PR fix?

In `IOUtils.readLines(File file)`, a `FileInputStream` is created inline and passed to `readLines(InputStream)`. If an exception occurs during reading, the underlying file handle is never closed, leading to a file descriptor leak.

```java
// Before: FileInputStream is not closed on exception path
return readLines(new FileInputStream(file));
```

```java
// After: try-with-resources ensures the stream is always closed
try (InputStream is = new FileInputStream(file)) {
    return readLines(is);
}
```

## Checklist

- [x] I have read and followed the [contributing guidelines](https://github.com/apache/dubbo/blob/3.3/CONTRIBUTING.md)
- [x] This change is focused on a single issue (resource leak in `IOUtils.readLines(File)`)
- [x] I have verified this does not conflict with existing PR #15874, which fixes `read(InputStream, String)` but not `readLines(File)`

## Note

Apologies for any inconvenience. Due to local environment limitations (Windows without full JDK/Maven setup for Dubbo), I am relying on CI/CD for automated testing.
