### PR TITLE
fix: correct typo in grpc_contrib_version property name

### DIFF
--- a/dubbo-dependencies-bom/pom.xml
+++ b/dubbo-dependencies-bom/pom.xml
@@ -143,7 +143,7 @@
     <sentinel.version>1.8.10</sentinel.version>
     <seata.version>1.8.0</seata.version>
     <grpc.version>1.81.0</grpc.version>
-    <grpc_contrib_verdion>0.8.1</grpc_contrib_verdion>
+    <grpc_contrib_version>0.8.1</grpc_contrib_version>
     <jprotoc_version>1.2.2</jprotoc_version>
     <mustache_version>0.9.14</mustache_version>
     <!-- Log libs -->
@@ -911,7 +911,7 @@
       <dependency>
         <groupId>com.salesforce.servicelibs</groupId>
         <artifactId>grpc-contrib</artifactId>
-        <version>${grpc_contrib_verdion}</version>
+        <version>${grpc_contrib_version}</version>
       </dependency>
       <dependency>
         <groupId>com.salesforce.servicelibs</groupId>


### PR DESCRIPTION
## Description

Fix a typo in the BOM property name: \grpc_contrib_verdion\ should be \grpc_contrib_version\.

## Changes

- File: \dubbo-dependencies-bom/pom.xml\
  - Line 146: Changed property definition from \<grpc_contrib_verdion>\ to \<grpc_contrib_version>\
  - Line 914: Updated property reference from \\\ to \\\

## Motivation

The property name contains a typo ('verdion' instead of 'version'). While this does not affect functionality (the property is used consistently), correcting it improves code readability and maintainability.

## Testing

- Local environment limitations: Windows environment with long path issues prevents full Maven build
- This is a simple typo fix that maintains consistency between property definition and usage
- Relying on CI/CD automated testing for validation

## Apology

I apologize for any inconvenience caused by previous low-quality PRs. This fix is focused, minimal, and addresses a genuine typo in the codebase.