### PR TITLE
fix: reject oversized telnet payload before header copy

### DIFF
--- a/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/exchange/codec/ExchangeCodec.java
+++ b/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/exchange/codec/ExchangeCodec.java
@@ -87,6 +87,13 @@ public class ExchangeCodec extends TelnetCodec {
     @Override
     public Object decode(Channel channel, ChannelBuffer buffer) throws IOException {
         int readable = buffer.readableBytes();
+        if (readable > 0
+                && isServerSide(channel)
+                && (readable < 2
+                        || buffer.getByte(buffer.readerIndex()) != MAGIC_HIGH
+                        || buffer.getByte(buffer.readerIndex() + 1) != MAGIC_LOW)) {
+            checkPayload(channel, readable);
+        }
         byte[] header = new byte[Math.min(readable, HEADER_LENGTH)];
         buffer.readBytes(header);
         return decode(channel, buffer, readable, header);

--- a/dubbo-remoting/dubbo-remoting-api/src/test/java/org/apache/dubbo/remoting/codec/ExchangeCodecTest.java
+++ b/dubbo-remoting/dubbo-remoting-api/src/test/java/org/apache/dubbo/remoting/codec/ExchangeCodecTest.java
@@ -32,6 +32,7 @@ import org.apache.dubbo.remoting.exchange.Response;
 import org.apache.dubbo.remoting.exchange.codec.ExchangeCodec;
 import org.apache.dubbo.remoting.exchange.support.DefaultFuture;
 import org.apache.dubbo.remoting.telnet.codec.TelnetCodec;
+import org.apache.dubbo.remoting.transport.ExceedPayloadLimitException;
 import org.apache.dubbo.rpc.model.FrameworkModel;
 
 import java.io.ByteArrayOutputStream;
@@ -41,6 +42,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -211,6 +213,19 @@ class ExchangeCodecTest extends TelnetCodecTest {
             Assertions.assertTrue(expected.getMessage()
                     .startsWith("Data length too large: " + Bytes.bytes2int(new byte[] {1, 1, 1, 1})));
         }
+    }
+
+    @Test
+    void testDecodeRejectsCompleteNonMagicInputBeforeCopy() {
+        Assumptions.assumeTrue(codec instanceof ExchangeCodec);
+        int payloadLimit = 16;
+        byte[] oversizedInput = new byte[payloadLimit + 1];
+        ChannelBuffer buffer = ChannelBuffers.wrappedBuffer(oversizedInput);
+        Channel channel = getServerSideChannel(url.addParameter(Constants.PAYLOAD_KEY, payloadLimit));
+
+        Assertions.assertThrows(ExceedPayloadLimitException.class, () -> codec.decode(channel, buffer));
+        Assertions.assertEquals(
+                0, buffer.readerIndex(), "payload validation should reject non-magic input before reading it");
     }
 
     @Test


### PR DESCRIPTION
When the server-side `ExchangeCodec` receives non-Dubbo input, it currently allocates and copies the entire readable buffer before the Telnet payload limit is checked. An oversized input can therefore cause an unnecessary large byte-array allocation and copy.

This change validates the readable payload size in `ExchangeCodec.decode()` before allocating the header buffer for non-magic server-side input.

### What has changed?

- Added an early `checkPayload(channel, readable)` for non-magic server-side input.
- The validation is performed before `new byte[]` and `buffer.readBytes(...)`.
- Inputs with the Dubbo magic header continue through the existing Dubbo header/body decoding path.
- Client-side decoding and Telnet command parsing behavior remain unchanged.
- No cross-packet scan state or decoder structure was introduced.

### Tests

Added a regression test to verify that:

- An oversized non-magic input throws `ExceedPayloadLimitException`.
- The input buffer is not consumed when validation fails.

Executed:

```bash
mvn -pl dubbo-remoting/dubbo-remoting-api \
  -DskipITs \
  -Dcheckstyle.skip \
  -Drat.skip=true \
  -Dtest=ExchangeCodecTest \
  test