### PR TITLE
[ISSUE #16399] Close late input after DefaultStreamingDecoder shutdown

### DIFF
--- a/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/message/DefaultStreamingDecoder.java
+++ b/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/message/DefaultStreamingDecoder.java
@@ -38,7 +38,11 @@ public class DefaultStreamingDecoder implements StreamingDecoder {
     @Override
     public void decode(InputStream inputStream) throws DecodeException {
         if (closed) {
-            // ignored
+            try {
+                inputStream.close();
+            } catch (IOException e) {
+                throw new DecodeException(e);
+            }
             return;
         }
         accumulate.addInputStream(inputStream);

--- a/dubbo-remoting/dubbo-remoting-http12/src/test/java/org/apache/dubbo/remoting/http12/message/DefaultStreamingDecoderTest.java
+++ b/dubbo-remoting/dubbo-remoting-http12/src/test/java/org/apache/dubbo/remoting/http12/message/DefaultStreamingDecoderTest.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.remoting.http12.message;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class DefaultStreamingDecoderTest {
+
+    @Test
+    void closesInputReceivedAfterStreamClosed() {
+        DefaultStreamingDecoder decoder = new DefaultStreamingDecoder();
+        decoder.onStreamClosed();
+        CloseTrackingInputStream inputStream = new CloseTrackingInputStream(new byte[] {0});
+
+        decoder.decode(inputStream);
+
+        assertTrue(inputStream.closed);
+    }
+
+    @Test
+    void closesInputReceivedAfterDecoderClosed() {
+        DefaultStreamingDecoder decoder = new DefaultStreamingDecoder();
+        decoder.close();
+        CloseTrackingInputStream inputStream = new CloseTrackingInputStream(new byte[] {0});
+
+        decoder.decode(inputStream);
+
+        assertTrue(inputStream.closed);
+    }
+
+    private static final class CloseTrackingInputStream extends ByteArrayInputStream {
+
+        private boolean closed;
+
+        private CloseTrackingInputStream(byte[] buf) {
+            super(buf);
+        }
+
+        @Override
+        public void close() throws IOException {
+            this.closed = true;
+            super.close();
+        }
+    }
+}

--- a/dubbo-remoting/dubbo-remoting-http12/src/test/java/org/apache/dubbo/remoting/http12/message/DefaultStreamingDecoderTest.java
+++ b/dubbo-remoting/dubbo-remoting-http12/src/test/java/org/apache/dubbo/remoting/http12/message/DefaultStreamingDecoderTest.java
@@ -16,11 +16,15 @@
  */
 package org.apache.dubbo.remoting.http12.message;
 
+import org.apache.dubbo.remoting.http12.exception.DecodeException;
+
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class DefaultStreamingDecoderTest {
@@ -45,6 +49,25 @@ class DefaultStreamingDecoderTest {
         decoder.decode(inputStream);
 
         assertTrue(inputStream.closed);
+    }
+
+    @Test
+    void propagatesCloseFailureAsDecodeException() {
+        DefaultStreamingDecoder decoder = new DefaultStreamingDecoder();
+        decoder.onStreamClosed();
+        InputStream failingStream = new InputStream() {
+            @Override
+            public int read() throws IOException {
+                return -1;
+            }
+
+            @Override
+            public void close() throws IOException {
+                throw new IOException("close failed");
+            }
+        };
+
+        assertThrows(DecodeException.class, () -> decoder.decode(failingStream));
     }
 
     private static final class CloseTrackingInputStream extends ByteArrayInputStream {


### PR DESCRIPTION
Fixes #16399

## What is the purpose of the change

`DefaultStreamingDecoder.decode()` does not close the input stream when the decoder has already been closed (`closed == true`). In the Triple HTTP/2 path, DATA frames are wrapped in `ByteBufInputStream(content, true)` (i.e., `releaseOnClose = true`), meaning the underlying pooled `ByteBuf` is released only when `InputStream.close()` is called. If a late DATA frame arrives asynchronously after the decoder has started closing, the `ByteBuf` is never released, causing a leak.

This is the exact same bug pattern as #16389, which was fixed by #16391 for `LengthFieldStreamingDecoder`. This PR mirrors that fix for `DefaultStreamingDecoder`.

## Brief changelog

- Close input streams received in `decode()` when the decoder is closed.
- Propagate input close failures as `DecodeException`.
- Add regression coverage for both `close()` and `onStreamClosed()` decoder states.

## Verifying this change

- `DefaultStreamingDecoderTest`: 2 tests passed.
- `LengthFieldStreamingDecoderTest`: 2 tests passed.
- All `dubbo-remoting-http12` tests: 23 tests passed, 2 skipped.