### PR TITLE
[ISSUE #16381] Retain registry configs with different explicit ids

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/config/context/AbstractConfigManager.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/config/context/AbstractConfigManager.java
@@ -170,7 +170,7 @@ public abstract class AbstractConfigManager extends LifecycleAdapter {
         // fast check duplicated equivalent config before write lock
         if (!(config instanceof ReferenceConfigBase || config instanceof ServiceConfigBase)) {
             for (AbstractConfig value : configsMap.values()) {
-                if (value.equals(config)) {
+                if (value.equals(config) && !hasDifferentExplicitId(value, config)) {
                     return (T) value;
                 }
             }
@@ -381,8 +381,19 @@ public abstract class AbstractConfigManager extends LifecycleAdapter {
         }
 
         // 2. find equal config
-        prevConfig = values.stream().filter(val -> isEquals(val, config)).findFirst();
+        // If the config has an explicit id, only treat it as a duplicate when the
+        // existing config has the same id. Configs with different explicit ids are
+        // considered distinct even if all other attributes are equal.
+        prevConfig = values.stream()
+                .filter(val -> isEquals(val, config) && !hasDifferentExplicitId(val, config))
+                .findFirst();
         return prevConfig;
+    }
+
+    private boolean hasDifferentExplicitId(AbstractConfig oldOne, AbstractConfig newOne) {
+        String oldId = oldOne.getId();
+        String newId = newOne.getId();
+        return oldId != null && newId != null && !oldId.equals(newId);
     }
 
     protected boolean isEquals(AbstractConfig oldOne, AbstractConfig newOne) {

--- a/dubbo-common/src/test/java/org/apache/dubbo/config/context/ConfigManagerTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/config/context/ConfigManagerTest.java
@@ -218,6 +218,45 @@ class ConfigManagerTest {
         assertEquals(configs, moduleConfigManager.getRegistries());
     }
 
+    // Test that registries with different explicit ids but same address are both retained (issue #16381)
+    @Test
+    void testRegistryConfigWithDifferentIdsSameAddress() {
+        String address = "zookeeper://127.0.0.1:2181";
+        RegistryConfig zk1 = new RegistryConfig();
+        zk1.setId("zk1");
+        zk1.setAddress(address);
+        RegistryConfig zk2 = new RegistryConfig();
+        zk2.setId("zk2");
+        zk2.setAddress(address);
+
+        configManager.addRegistry(zk1);
+        configManager.addRegistry(zk2);
+
+        // Both registries should be present since they have different explicit ids
+        assertEquals(2, configManager.getRegistries().size());
+        assertTrue(configManager.getRegistry("zk1").isPresent());
+        assertTrue(configManager.getRegistry("zk2").isPresent());
+    }
+
+    // Test that registries with same explicit id are still deduplicated
+    @Test
+    void testRegistryConfigWithSameIdSameAddress() {
+        String address = "zookeeper://127.0.0.1:2181";
+        RegistryConfig zk1 = new RegistryConfig();
+        zk1.setId("zk1");
+        zk1.setAddress(address);
+        RegistryConfig zk1Duplicate = new RegistryConfig();
+        zk1Duplicate.setId("zk1");
+        zk1Duplicate.setAddress(address);
+
+        configManager.addRegistry(zk1);
+        configManager.addRegistry(zk1Duplicate);
+
+        // Same id should be deduplicated (override)
+        assertEquals(1, configManager.getRegistries().size());
+        assertTrue(configManager.getRegistry("zk1").isPresent());
+    }
+
     // Test ConfigCenterConfig correlative methods
     @Test
     void testConfigCenterConfig() {


### PR DESCRIPTION
Fixes #16381

## What is the purpose of the change

When two `RegistryConfig` instances have different explicit ids (e.g. `zk1`, `zk2`) but the same address, the previous dedup logic incorrectly treated the second one as a duplicate of the first and dropped it. This caused `IllegalStateException: Registry not found: zk2` when later resolving the reference's registry id.

The root cause is that `AbstractConfig.equals()` intentionally ignores the `id` field, so the dedup check in `addConfig()` and `findConfigByValue()` could not distinguish configs that the user explicitly identified as different.

## Brief changelog

- In `AbstractConfigManager.addConfig()` fast-path check: skip the early return when the existing config has a different explicit id than the new config.
- In `AbstractConfigManager.findConfigByValue()`: exclude matches where both configs have non-null, different explicit ids.
- Add helper `hasDifferentExplicitId()` to encapsulate the comparison.
- Add regression tests in `ConfigManagerTest`:
  - `testRegistryConfigWithDifferentIdsSameAddress`: two registries with different ids and same address are both retained.
  - `testRegistryConfigWithSameIdSameAddress`: same-id registries are still deduplicated (override).

## Verifying this change

- `ConfigManagerTest`: 21 tests passed (including 2 new regression tests).