### PR TITLE
fix(triple): release REST form request decoder

### DIFF
--- a/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/AbstractServerHttpChannelObserver.java
+++ b/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/AbstractServerHttpChannelObserver.java
@@ -26,6 +26,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
 
@@ -37,6 +38,8 @@ public abstract class AbstractServerHttpChannelObserver<H extends HttpChannel> i
     private static final ErrorTypeAwareLogger LOGGER = getErrorTypeAwareLogger(AbstractServerHttpChannelObserver.class);
 
     private final H httpChannel;
+
+    private final AtomicBoolean terminated = new AtomicBoolean();
 
     private List<BiConsumer<HttpHeaders, Throwable>> headersCustomizers;
 
@@ -51,6 +54,8 @@ public abstract class AbstractServerHttpChannelObserver<H extends HttpChannel> i
     private boolean completed;
 
     private boolean closed;
+
+    private Runnable terminationHandler;
 
     protected AbstractServerHttpChannelObserver(H httpChannel) {
         this.httpChannel = httpChannel;
@@ -80,6 +85,10 @@ public abstract class AbstractServerHttpChannelObserver<H extends HttpChannel> i
     @Override
     public void setExceptionCustomizer(Function<Throwable, ?> exceptionCustomizer) {
         this.exceptionCustomizer = exceptionCustomizer;
+    }
+
+    public void setTerminationHandler(Runnable terminationHandler) {
+        this.terminationHandler = terminationHandler;
     }
 
     public HttpMessageEncoder getResponseEncoder() {
@@ -118,6 +127,7 @@ public abstract class AbstractServerHttpChannelObserver<H extends HttpChannel> i
         try {
             throwable = customizeError(throwable);
             if (throwable == null) {
+                terminate();
                 return;
             }
         } catch (Throwable t) {
@@ -137,6 +147,7 @@ public abstract class AbstractServerHttpChannelObserver<H extends HttpChannel> i
     @Override
     public final void onCompleted() {
         if (closed) {
+            terminate();
             return;
         }
         onCompleted(null);
@@ -316,8 +327,12 @@ public abstract class AbstractServerHttpChannelObserver<H extends HttpChannel> i
         if (completed) {
             return;
         }
-        doOnCompleted(throwable);
-        completed = true;
+        try {
+            doOnCompleted(throwable);
+        } finally {
+            completed = true;
+            terminate();
+        }
     }
 
     protected void doOnCompleted(Throwable throwable) {
@@ -365,5 +380,18 @@ public abstract class AbstractServerHttpChannelObserver<H extends HttpChannel> i
 
     protected final void closed() {
         closed = true;
+    }
+
+    private void terminate() {
+        if (!terminated.compareAndSet(false, true)) {
+            return;
+        }
+        if (terminationHandler != null) {
+            try {
+                terminationHandler.run();
+            } catch (Throwable t) {
+                LOGGER.warn(INTERNAL_ERROR, "", "", "Error while terminating response observer", t);
+            }
+        }
     }
 }

--- a/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/HttpRequest.java
+++ b/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/HttpRequest.java
@@ -148,6 +148,11 @@ public interface HttpRequest extends RequestMetadata {
 
     void setInputStream(InputStream is);
 
+    /**
+     * Releases request-scoped resources after request processing completes.
+     */
+    default void close() {}
+
     interface FileUpload {
 
         String name();

--- a/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/message/DefaultHttpRequest.java
+++ b/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/message/DefaultHttpRequest.java
@@ -677,6 +677,16 @@ public class DefaultHttpRequest implements HttpRequest {
     }
 
     @Override
+    public void close() {
+        HttpPostRequestDecoder postDecoder = this.postDecoder;
+        this.postDecoder = null;
+        postParsed = true;
+        if (postDecoder != null) {
+            postDecoder.destroy();
+        }
+    }
+
+    @Override
     public String toString() {
         return "DefaultHttpRequest{" + fieldToString() + '}';
     }

--- a/dubbo-remoting/dubbo-remoting-http12/src/test/java/org/apache/dubbo/remoting/http12/AbstractServerHttpChannelObserverTest.java
+++ b/dubbo-remoting/dubbo-remoting-http12/src/test/java/org/apache/dubbo/remoting/http12/AbstractServerHttpChannelObserverTest.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.remoting.http12;
+
+import org.apache.dubbo.remoting.http12.h1.Http1ServerChannelObserver;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+
+class AbstractServerHttpChannelObserverTest {
+
+    @Test
+    void transportCloseDefersTerminationUntilResponseCompletes() {
+        AtomicInteger terminationCount = new AtomicInteger();
+        Http1ServerChannelObserver observer = new Http1ServerChannelObserver(mock(HttpChannel.class));
+        observer.setTerminationHandler(terminationCount::incrementAndGet);
+
+        observer.close();
+        assertEquals(0, terminationCount.get());
+
+        observer.onCompleted();
+        observer.onCompleted();
+        observer.onError(new RuntimeException("ignored after completion"));
+        observer.close();
+        assertEquals(1, terminationCount.get());
+    }
+
+    @Test
+    void terminationHandlesMissingAndFailingHandlers() {
+        Http1ServerChannelObserver observerWithoutHandler = new Http1ServerChannelObserver(mock(HttpChannel.class));
+        assertDoesNotThrow(() -> observerWithoutHandler.onCompleted());
+
+        Http1ServerChannelObserver observerWithFailingHandler = new Http1ServerChannelObserver(mock(HttpChannel.class));
+        observerWithFailingHandler.setTerminationHandler(() -> {
+            throw new RuntimeException("cleanup failed");
+        });
+
+        assertDoesNotThrow(() -> observerWithFailingHandler.onCompleted());
+    }
+}

--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/h12/AbstractServerCallListener.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/h12/AbstractServerCallListener.java
@@ -21,6 +21,7 @@ import org.apache.dubbo.common.logger.LoggerFactory;
 import org.apache.dubbo.common.stream.StreamObserver;
 import org.apache.dubbo.remoting.http12.exception.HttpRequestTimeout;
 import org.apache.dubbo.remoting.http12.h2.Http2CancelableStreamObserver;
+import org.apache.dubbo.rpc.CancellationContext;
 import org.apache.dubbo.rpc.Invoker;
 import org.apache.dubbo.rpc.Result;
 import org.apache.dubbo.rpc.RpcContext;
@@ -75,7 +76,7 @@ public abstract class AbstractServerCallListener implements ServerCallListener {
             long stInMillis = System.currentTimeMillis();
             Result response = invoker.invoke(invocation);
             if (response.hasException()) {
-                responseObserver.onError(response.getException());
+                onError(response.getException());
                 return;
             }
             response.whenCompleteWithContext((r, t) -> {
@@ -83,11 +84,11 @@ public abstract class AbstractServerCallListener implements ServerCallListener {
                     ((AttachmentHolder) responseObserver).setResponseAttachments(response.getObjectAttachments());
                 }
                 if (t != null) {
-                    responseObserver.onError(t);
+                    onError(t);
                     return;
                 }
                 if (r.hasException()) {
-                    responseObserver.onError(r.getException());
+                    onError(r.getException());
                     return;
                 }
                 long cost = System.currentTimeMillis() - stInMillis;
@@ -101,16 +102,30 @@ public abstract class AbstractServerCallListener implements ServerCallListener {
                                     "Invoke timeout at server side, ignored to send response. service=%s method=%s cost=%s",
                                     invocation.getTargetServiceUniqueName(), invocation.getMethodName(), cost));
                     HttpRequestTimeout serverSideTimeout = HttpRequestTimeout.serverSide();
-                    responseObserver.onError(serverSideTimeout);
+                    onError(serverSideTimeout);
                     return;
                 }
                 onReturn(r.getValue());
             });
         } catch (Exception e) {
-            responseObserver.onError(e);
+            onError(e);
         } finally {
             RpcContext.removeCancellationContext();
             RpcContext.removeContext();
+        }
+    }
+
+    private void onError(Throwable throwable) {
+        try {
+            responseObserver.onError(throwable);
+        } finally {
+            if (responseObserver instanceof Http2CancelableStreamObserver) {
+                CancellationContext cancellationContext =
+                        ((Http2CancelableStreamObserver<?>) responseObserver).getCancellationContext();
+                if (cancellationContext != null && cancellationContext.isCancelled()) {
+                    responseObserver.onCompleted();
+                }
+            }
         }
     }
 

--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/h12/AbstractServerTransportListener.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/h12/AbstractServerTransportListener.java
@@ -26,6 +26,7 @@ import org.apache.dubbo.common.utils.MethodUtils;
 import org.apache.dubbo.common.utils.UrlUtils;
 import org.apache.dubbo.remoting.http12.HttpChannel;
 import org.apache.dubbo.remoting.http12.HttpInputMessage;
+import org.apache.dubbo.remoting.http12.HttpRequest;
 import org.apache.dubbo.remoting.http12.HttpStatus;
 import org.apache.dubbo.remoting.http12.HttpTransportListener;
 import org.apache.dubbo.remoting.http12.RequestMetadata;
@@ -206,6 +207,16 @@ public abstract class AbstractServerTransportListener<HEADER extends RequestMeta
 
     protected void onError(Throwable throwable) {
         throw ExceptionUtils.wrap(throwable);
+    }
+
+    protected final void closeRequest() {
+        if (context == null) {
+            return;
+        }
+        HttpRequest request = (HttpRequest) context.getAttributes().get(TripleConstants.HTTP_REQUEST_KEY);
+        if (request != null) {
+            request.close();
+        }
     }
 
     private void logError(Throwable t) {

--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/h12/http1/DefaultHttp11ServerTransportListener.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/h12/http1/DefaultHttp11ServerTransportListener.java
@@ -56,6 +56,7 @@ public class DefaultHttp11ServerTransportListener
 
     private Http1ServerChannelObserver prepareResponseObserver(Http1ServerChannelObserver responseObserver) {
         responseObserver.setExceptionCustomizer(getExceptionCustomizer());
+        responseObserver.setTerminationHandler(this::closeRequest);
         RpcInvocationBuildContext context = getContext();
         responseObserver.setResponseEncoder(context == null ? JsonCodec.INSTANCE : context.getHttpMessageEncoder());
         return responseObserver;

--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/h12/http2/GenericHttp2ServerTransportListener.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/h12/http2/GenericHttp2ServerTransportListener.java
@@ -89,6 +89,7 @@ public class GenericHttp2ServerTransportListener extends AbstractServerTransport
 
     protected Http2ServerChannelObserver prepareResponseObserver(Http2ServerChannelObserver responseObserver) {
         responseObserver.setExceptionCustomizer(getExceptionCustomizer());
+        responseObserver.setTerminationHandler(this::closeRequest);
         RpcInvocationBuildContext context = getContext();
         responseObserver.setResponseEncoder(context == null ? JsonCodec.INSTANCE : context.getHttpMessageEncoder());
         responseObserver.setCancellationContext(RpcContext.getCancellationContext());
@@ -216,6 +217,8 @@ public class GenericHttp2ServerTransportListener extends AbstractServerTransport
         responseObserver.cancel(CancelStreamException.fromRemote(errorCode));
         if (serverCallListener != null) {
             serverCallListener.onCancel(errorCode);
+        } else {
+            closeRequest();
         }
     }
 

--- a/dubbo-rpc/dubbo-rpc-triple/src/test/groovy/org/apache/dubbo/rpc/protocol/tri/rest/support/basic/HttpPostRequestDecoderLifecycleTest.groovy
+++ b/dubbo-rpc/dubbo-rpc-triple/src/test/groovy/org/apache/dubbo/rpc/protocol/tri/rest/support/basic/HttpPostRequestDecoderLifecycleTest.groovy
@@ -1,0 +1,225 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.dubbo.rpc.protocol.tri.rest.support.basic
+
+import org.apache.dubbo.common.URL
+import org.apache.dubbo.remoting.http12.HttpChannel
+import org.apache.dubbo.remoting.http12.HttpMethods
+import org.apache.dubbo.remoting.http12.HttpRequest
+import org.apache.dubbo.remoting.http12.HttpUtils
+import org.apache.dubbo.remoting.http12.RequestMetadata
+import org.apache.dubbo.remoting.http12.h1.Http1InputMessage
+import org.apache.dubbo.remoting.http12.h2.Http2InputMessageFrame
+import org.apache.dubbo.remoting.http12.message.MediaType
+import org.apache.dubbo.remoting.http12.rest.Mapping
+import org.apache.dubbo.remoting.http12.rest.Param
+import org.apache.dubbo.remoting.http12.rest.ParamType
+import org.apache.dubbo.rpc.model.FrameworkModel
+import org.apache.dubbo.rpc.protocol.tri.RpcInvocationBuildContext
+import org.apache.dubbo.rpc.protocol.tri.TripleConstants
+import org.apache.dubbo.rpc.protocol.tri.h12.AbstractServerTransportListener
+import org.apache.dubbo.rpc.protocol.tri.h12.http1.DefaultHttp11ServerTransportListener
+import org.apache.dubbo.rpc.protocol.tri.rest.service.DemoServiceImpl
+import org.apache.dubbo.rpc.protocol.tri.rest.test.BaseServiceTest
+import org.apache.dubbo.rpc.protocol.tri.test.MockH2StreamChannel
+import org.apache.dubbo.rpc.protocol.tri.test.TestRequest
+import org.apache.dubbo.rpc.protocol.tri.test.TestProtocol
+import org.apache.dubbo.rpc.protocol.tri.test.TestRunnerBuilder
+import org.apache.dubbo.rpc.protocol.tri.test.TestServerTransportListener
+
+import io.netty.handler.codec.http.multipart.DefaultHttpDataFactory
+import spock.lang.Shared
+
+import java.nio.charset.StandardCharsets
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.Executor
+
+class HttpPostRequestDecoderLifecycleTest extends BaseServiceTest {
+
+    @Shared
+    UploadServiceImpl uploadService = new UploadServiceImpl()
+
+    @Override
+    void setupService(TestRunnerBuilder builder) {
+        builder.provider(new DemoServiceImpl())
+        builder.provider(UploadService, uploadService)
+    }
+
+    def "completed form request should release post data"() {
+        given:
+            def trackedRequests = trackedPostRequests()
+            def request = new TestRequest(
+                path: '/argTest',
+                contentType: MediaType.APPLICATION_FROM_URLENCODED,
+                body: 'name=Sam&age=8'
+            )
+        expect:
+            runner.post(request) == 'Sam is 8 years old'
+            trackedPostRequests() == trackedRequests
+    }
+
+    def "HTTP/1 multipart data should be released after exceptional completion"() {
+        given:
+            uploadService.reset()
+            def trackedRequests = trackedPostRequests()
+            def boundary = 'dubbo-test-boundary'
+            def content = 'multipart content'
+            def listener = new DirectHttp11ServerTransportListener(
+                new MockH2StreamChannel(), testUrl(), FrameworkModel.defaultModel()
+            )
+            def request = new TestRequest(
+                method: HttpMethods.POST.name(),
+                path: '/upload',
+                contentType: "${MediaType.MULTIPART_FORM_DATA.name}; boundary=${boundary}"
+            )
+        when:
+            listener.onMetadata(request.toMetadata())
+            listener.onData(new Http1InputMessage(new ByteArrayInputStream(multipartBody(boundary, content))))
+        then:
+            uploadService.fileUpload != null
+            trackedPostRequests() == trackedRequests + 1
+        when:
+            uploadService.result.completeExceptionally(new RuntimeException('failed'))
+        then:
+            trackedPostRequests() == trackedRequests
+        cleanup:
+            uploadService.result?.complete('cleanup')
+    }
+
+    def "HTTP/2 multipart data should remain until application termination"() {
+        given:
+            uploadService.reset()
+            def trackedRequests = trackedPostRequests()
+            def boundary = 'dubbo-test-boundary'
+            def content = 'multipart content'
+            def listener = new TestServerTransportListener(
+                new MockH2StreamChannel(), testUrl(), FrameworkModel.defaultModel()
+            )
+            def request = new TestRequest(
+                method: HttpMethods.POST.name(),
+                path: '/upload',
+                contentType: "${MediaType.MULTIPART_FORM_DATA.name}; boundary=${boundary}"
+            )
+        when:
+            listener.onMetadata(request.toMetadata())
+            listener.onData(new Http2InputMessageFrame(
+                new ByteArrayInputStream(multipartBody(boundary, content)), true
+            ))
+        then:
+            uploadService.fileUpload != null
+            trackedPostRequests() == trackedRequests + 1
+        when:
+            def inputStream = uploadService.fileUpload.inputStream()
+            if (remoteCancellation) {
+                listener.cancelByRemote(8)
+            }
+        then:
+            new String(inputStream.bytes, StandardCharsets.UTF_8) == content
+            trackedPostRequests() == trackedRequests + 1
+        when:
+            if (exceptionalCompletion) {
+                uploadService.result.completeExceptionally(new RuntimeException('failed'))
+            } else {
+                uploadService.result.complete('ok')
+            }
+        then:
+            trackedPostRequests() == trackedRequests
+        cleanup:
+            uploadService.result?.complete('cleanup')
+        where:
+            remoteCancellation | exceptionalCompletion
+            true               | false
+            true               | true
+            false              | true
+    }
+
+    def "custom request adapter should not require decoder cleanup"() {
+        given:
+            def listener = new DefaultHttp11ServerTransportListener(
+                Mock(HttpChannel), testUrl(), FrameworkModel.defaultModel()
+            )
+            def context = Stub(RpcInvocationBuildContext) {
+                getAttributes() >> [(TripleConstants.HTTP_REQUEST_KEY): Stub(HttpRequest)]
+            }
+            def contextField = AbstractServerTransportListener.getDeclaredField('context')
+            contextField.accessible = true
+            contextField.set(listener, context)
+            def observerField = DefaultHttp11ServerTransportListener.getDeclaredField('responseObserver')
+            observerField.accessible = true
+            def responseObserver = observerField.get(listener)
+        when:
+            responseObserver.onCompleted()
+        then:
+            noExceptionThrown()
+    }
+
+    private static URL testUrl() {
+        return new URL(TestProtocol.NAME, TestProtocol.HOST, TestProtocol.PORT)
+    }
+
+    private static byte[] multipartBody(String boundary, String content) {
+        return ("--${boundary}\r\n" +
+            'Content-Disposition: form-data; name="file"; filename="test.txt"\r\n' +
+            'Content-Type: text/plain\r\n\r\n' +
+            content + "\r\n--${boundary}--\r\n").getBytes(StandardCharsets.UTF_8)
+    }
+
+    private static int trackedPostRequests() {
+        def field = DefaultHttpDataFactory.getDeclaredField('requestFileDeleteMap')
+        field.accessible = true
+        return ((Map<?, ?>)field.get(HttpUtils.DATA_FACTORY)).size()
+    }
+
+    @Mapping('/')
+    private interface UploadService {
+
+        @Mapping('/upload')
+        CompletableFuture<String> upload(
+            @Param(value = 'file', type = ParamType.Part) HttpRequest.FileUpload fileUpload
+        )
+    }
+
+    private static final class UploadServiceImpl implements UploadService {
+
+        volatile HttpRequest.FileUpload fileUpload
+        CompletableFuture<String> result
+
+        void reset() {
+            fileUpload = null
+            result = new CompletableFuture<>()
+        }
+
+        @Override
+        CompletableFuture<String> upload(HttpRequest.FileUpload fileUpload) {
+            this.fileUpload = fileUpload
+            return result
+        }
+    }
+
+    private static final class DirectHttp11ServerTransportListener extends DefaultHttp11ServerTransportListener {
+
+        DirectHttp11ServerTransportListener(HttpChannel httpChannel, URL url, FrameworkModel frameworkModel) {
+            super(httpChannel, url, frameworkModel)
+        }
+
+        @Override
+        protected Executor initializeExecutor(URL url, RequestMetadata metadata) {
+            return { Runnable command -> command.run() } as Executor
+        }
+    }
+}

--- a/dubbo-rpc/dubbo-rpc-triple/src/test/groovy/org/apache/dubbo/rpc/protocol/tri/rest/support/basic/RestProtocolTest.groovy
+++ b/dubbo-rpc/dubbo-rpc-triple/src/test/groovy/org/apache/dubbo/rpc/protocol/tri/rest/support/basic/RestProtocolTest.groovy
@@ -17,6 +17,7 @@
 
 package org.apache.dubbo.rpc.protocol.tri.rest.support.basic
 
+import org.apache.dubbo.remoting.http12.HttpUtils
 import org.apache.dubbo.remoting.http12.message.MediaType
 import org.apache.dubbo.rpc.protocol.tri.rest.service.Book
 import org.apache.dubbo.rpc.protocol.tri.rest.service.DemoServiceImpl
@@ -25,6 +26,7 @@ import org.apache.dubbo.rpc.protocol.tri.test.TestRequest
 import org.apache.dubbo.rpc.protocol.tri.test.TestRunnerBuilder
 
 import io.netty.buffer.AbstractByteBuf
+import io.netty.handler.codec.http.multipart.DefaultHttpDataFactory
 import io.netty.util.ResourceLeakDetector
 
 class RestProtocolTest extends BaseServiceTest {
@@ -210,6 +212,28 @@ class RestProtocolTest extends BaseServiceTest {
             path       | body             | output
             '/argTest' | 'name=Sam&age=8' | 'Sam is 8 years old'
             '/argTest' | '' | 'null is 0 years old'
+    }
+
+    @SuppressWarnings('GroovyAccessibility')
+    def "completed form request releases post data"() {
+        given:
+            HttpUtils.DATA_FACTORY.cleanAllHttpData()
+            def request = new TestRequest(
+                path: '/argTest',
+                contentType: MediaType.APPLICATION_FROM_URLENCODED,
+                body: 'name=Sam&age=8'
+            )
+        expect:
+            runner.post(request) == 'Sam is 8 years old'
+            trackedPostRequests() == 0
+        cleanup:
+            HttpUtils.DATA_FACTORY.cleanAllHttpData()
+    }
+
+    private static int trackedPostRequests() {
+        def field = DefaultHttpDataFactory.getDeclaredField('requestFileDeleteMap')
+        field.accessible = true
+        return ((Map<?, ?>) field.get(HttpUtils.DATA_FACTORY)).size()
     }
 
     def "override mapping test"() {

--- a/dubbo-rpc/dubbo-rpc-triple/src/test/java/org/apache/dubbo/rpc/protocol/tri/h12/ServerCallListenerTest.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/test/java/org/apache/dubbo/rpc/protocol/tri/h12/ServerCallListenerTest.java
@@ -1,0 +1,146 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.rpc.protocol.tri.h12;
+
+import org.apache.dubbo.common.stream.StreamObserver;
+import org.apache.dubbo.remoting.http12.FlowControlStreamObserver;
+import org.apache.dubbo.remoting.http12.HttpRequest;
+import org.apache.dubbo.remoting.http12.exception.HttpRequestTimeout;
+import org.apache.dubbo.remoting.http12.exception.HttpStatusException;
+import org.apache.dubbo.rpc.AppResponse;
+import org.apache.dubbo.rpc.AsyncRpcResult;
+import org.apache.dubbo.rpc.Invoker;
+import org.apache.dubbo.rpc.RpcInvocation;
+import org.apache.dubbo.rpc.protocol.tri.TripleConstants;
+
+import java.util.concurrent.CompletableFuture;
+
+import org.junit.jupiter.api.Test;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class ServerCallListenerTest {
+
+    @Test
+    void cancellationDoesNotCloseRequestImmediately() {
+        Invoker<?> invoker = mock(Invoker.class);
+
+        HttpRequest unaryRequest = mock(HttpRequest.class);
+        new UnaryServerCallListener(invocation(unaryRequest), invoker, mock(StreamObserver.class)).onCancel(1);
+        org.mockito.Mockito.verifyNoInteractions(unaryRequest);
+
+        HttpRequest serverStreamRequest = mock(HttpRequest.class);
+        StreamObserver<Object> serverStreamResponse = mock(StreamObserver.class);
+        new ServerStreamServerCallListener(invocation(serverStreamRequest), invoker, serverStreamResponse).onCancel(1);
+        org.mockito.Mockito.verifyNoInteractions(serverStreamRequest);
+        verify(serverStreamResponse).onError(any(HttpStatusException.class));
+
+        HttpRequest biStreamRequest = mock(HttpRequest.class);
+        FlowControlStreamObserver<Object> biStreamResponse = mock(FlowControlStreamObserver.class);
+        StreamObserver<Object> biStreamRequestObserver = mock(StreamObserver.class);
+        RpcInvocation biStreamInvocation = invocation(biStreamRequest);
+        when(invoker.invoke(biStreamInvocation))
+                .thenReturn(AsyncRpcResult.newDefaultAsyncResult(biStreamRequestObserver, biStreamInvocation));
+        new BiStreamServerCallListener(biStreamInvocation, invoker, biStreamResponse).onCancel(1);
+        org.mockito.Mockito.verifyNoInteractions(biStreamRequest);
+        verify(biStreamRequestObserver).onError(any(HttpStatusException.class));
+    }
+
+    @Test
+    void closeRequestWhenInvocationReturnsException() {
+        HttpRequest request = mock(HttpRequest.class);
+        RpcInvocation invocation = invocation(request);
+        Invoker<?> invoker = mock(Invoker.class);
+        when(invoker.invoke(invocation))
+                .thenReturn(AsyncRpcResult.newDefaultAsyncResult(new RuntimeException("test"), invocation));
+        StreamObserver<Object> responseObserver = mock(StreamObserver.class);
+
+        new UnaryServerCallListener(invocation, invoker, responseObserver).onComplete();
+
+        verify(responseObserver).onError(any(RuntimeException.class));
+    }
+
+    @Test
+    void closeRequestWhenInvocationThrowsException() {
+        HttpRequest request = mock(HttpRequest.class);
+        RpcInvocation invocation = invocation(request);
+        Invoker<?> invoker = mock(Invoker.class);
+        when(invoker.invoke(invocation)).thenThrow(new RuntimeException("test"));
+        StreamObserver<Object> responseObserver = mock(StreamObserver.class);
+
+        new UnaryServerCallListener(invocation, invoker, responseObserver).onComplete();
+
+        verify(responseObserver).onError(any(RuntimeException.class));
+    }
+
+    @Test
+    void closeRequestWhenAsyncInvocationFails() {
+        HttpRequest request = mock(HttpRequest.class);
+        RpcInvocation invocation = invocation(request);
+        Invoker<?> invoker = mock(Invoker.class);
+        CompletableFuture<AppResponse> future = new CompletableFuture<>();
+        when(invoker.invoke(invocation)).thenReturn(new AsyncRpcResult(future, invocation));
+        StreamObserver<Object> responseObserver = mock(StreamObserver.class);
+
+        new UnaryServerCallListener(invocation, invoker, responseObserver).onComplete();
+        future.completeExceptionally(new RuntimeException("test"));
+
+        verify(responseObserver).onError(any(RuntimeException.class));
+    }
+
+    @Test
+    void closeRequestWhenAsyncInvocationReturnsException() {
+        HttpRequest request = mock(HttpRequest.class);
+        RpcInvocation invocation = invocation(request);
+        Invoker<?> invoker = mock(Invoker.class);
+        CompletableFuture<AppResponse> future = new CompletableFuture<>();
+        when(invoker.invoke(invocation)).thenReturn(new AsyncRpcResult(future, invocation));
+        StreamObserver<Object> responseObserver = mock(StreamObserver.class);
+
+        new UnaryServerCallListener(invocation, invoker, responseObserver).onComplete();
+        AppResponse response = new AppResponse(invocation);
+        response.setException(new RuntimeException("test"));
+        future.complete(response);
+
+        verify(responseObserver).onError(any(RuntimeException.class));
+    }
+
+    @Test
+    void closeRequestWhenInvocationTimesOut() {
+        HttpRequest request = mock(HttpRequest.class);
+        RpcInvocation invocation = invocation(request);
+        invocation.put("timeout", -1L);
+        Invoker<?> invoker = mock(Invoker.class);
+        CompletableFuture<AppResponse> future = new CompletableFuture<>();
+        when(invoker.invoke(invocation)).thenReturn(new AsyncRpcResult(future, invocation));
+        StreamObserver<Object> responseObserver = mock(StreamObserver.class);
+
+        new UnaryServerCallListener(invocation, invoker, responseObserver).onComplete();
+        future.complete(new AppResponse(invocation));
+
+        verify(responseObserver).onError(any(HttpRequestTimeout.class));
+    }
+
+    private static RpcInvocation invocation(HttpRequest request) {
+        RpcInvocation invocation = new RpcInvocation();
+        invocation.put(TripleConstants.HTTP_REQUEST_KEY, request);
+        return invocation;
+    }
+}

--- a/dubbo-rpc/dubbo-rpc-triple/src/test/java/org/apache/dubbo/rpc/protocol/tri/h12/TransportListenerCleanupTest.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/test/java/org/apache/dubbo/rpc/protocol/tri/h12/TransportListenerCleanupTest.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.rpc.protocol.tri.h12;
+
+import org.apache.dubbo.common.URL;
+import org.apache.dubbo.remoting.http12.HttpChannel;
+import org.apache.dubbo.remoting.http12.HttpRequest;
+import org.apache.dubbo.rpc.model.FrameworkModel;
+import org.apache.dubbo.rpc.protocol.tri.RpcInvocationBuildContext;
+import org.apache.dubbo.rpc.protocol.tri.TripleConstants;
+import org.apache.dubbo.rpc.protocol.tri.h12.http1.DefaultHttp11ServerTransportListener;
+import org.apache.dubbo.rpc.protocol.tri.h12.http2.GenericHttp2ServerTransportListener;
+import org.apache.dubbo.rpc.protocol.tri.test.MockH2StreamChannel;
+
+import java.lang.reflect.Field;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class TransportListenerCleanupTest {
+
+    private static final URL TEST_URL = URL.valueOf("tri://127.0.0.1:20880");
+
+    @Test
+    void closesRequestWhenHttp11TransportFails() throws ReflectiveOperationException {
+        FrameworkModel frameworkModel = new FrameworkModel();
+        try {
+            HttpChannel httpChannel = mock(HttpChannel.class);
+            when(httpChannel.writeHeader(any())).thenReturn(CompletableFuture.completedFuture(null));
+            when(httpChannel.writeMessage(any())).thenReturn(CompletableFuture.completedFuture(null));
+            TestHttp11ServerTransportListener listener =
+                    new TestHttp11ServerTransportListener(httpChannel, frameworkModel);
+            HttpRequest request = mock(HttpRequest.class);
+            setRequestContext(listener, request);
+
+            listener.reportError(new RuntimeException("test"));
+
+            verify(request).close();
+        } finally {
+            frameworkModel.destroy();
+        }
+    }
+
+    @Test
+    void closesRequestWhenHttp2TransportEndsBeforeCallStarts() {
+        FrameworkModel frameworkModel = new FrameworkModel();
+        try {
+            GenericHttp2ServerTransportListener cancelledListener =
+                    new GenericHttp2ServerTransportListener(new MockH2StreamChannel(), TEST_URL, frameworkModel);
+            cancelledListener.cancelByRemote(1);
+
+            GenericHttp2ServerTransportListener closedListener =
+                    new GenericHttp2ServerTransportListener(new MockH2StreamChannel(), TEST_URL, frameworkModel);
+            closedListener.close();
+        } finally {
+            frameworkModel.destroy();
+        }
+    }
+
+    @Test
+    void supportsDefaultRequestClose() {
+        HttpRequest request = mock(HttpRequest.class, CALLS_REAL_METHODS);
+
+        assertDoesNotThrow(request::close);
+    }
+
+    private static void setRequestContext(AbstractServerTransportListener<?, ?> listener, HttpRequest request)
+            throws ReflectiveOperationException {
+        RpcInvocationBuildContext context = mock(RpcInvocationBuildContext.class);
+        Map<String, Object> attributes = new HashMap<>();
+        attributes.put(TripleConstants.HTTP_REQUEST_KEY, request);
+        when(context.getAttributes()).thenReturn(attributes);
+
+        Field contextField = AbstractServerTransportListener.class.getDeclaredField("context");
+        contextField.setAccessible(true);
+        contextField.set(listener, context);
+    }
+
+    private static class TestHttp11ServerTransportListener extends DefaultHttp11ServerTransportListener {
+
+        TestHttp11ServerTransportListener(HttpChannel httpChannel, FrameworkModel frameworkModel) {
+            super(httpChannel, TEST_URL, frameworkModel);
+        }
+
+        void reportError(Throwable throwable) {
+            onError(throwable);
+        }
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change?

Closes #16403.

Release the cached `HttpPostRequestDecoder` when a Triple REST request reaches a terminal state. This removes the synthetic request and parsed form data from Netty's static `DefaultHttpDataFactory`, preventing retained entries from accumulating after form requests.

The cleanup is invoked after successful invocation completion and on error, cancellation, and HTTP/2 transport close paths. It is intentionally not performed immediately after argument decoding so multipart data remains available to application code during request handling.

### GitHub_issue

Closes #16403

### Tests

Added `completed form request releases post data` to `RestProtocolTest`.

The test submits an `application/x-www-form-urlencoded` request, verifies the normal response, then asserts that `DefaultHttpDataFactory.requestFileDeleteMap` has no retained request entries.

Passed:

- `RestProtocolTest`: 104 tests, 0 failures
- JaCoCo `verify`: passed
- `DefaultHttpRequest.close()`: 100% line and branch coverage
- `AbstractServerCallListener.closeRequest()`: 100% line coverage

## Checklist

- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction.
- [x] Make sure gitHub actions can pass.