### PR TITLE
fix(triple): clean up REST form request decoder

### DIFF
--- a/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/AbstractServerHttpChannelObserver.java
+++ b/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/AbstractServerHttpChannelObserver.java
@@ -26,6 +26,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
 
@@ -37,6 +38,8 @@ public abstract class AbstractServerHttpChannelObserver<H extends HttpChannel> i
     private static final ErrorTypeAwareLogger LOGGER = getErrorTypeAwareLogger(AbstractServerHttpChannelObserver.class);
 
     private final H httpChannel;
+
+    private final AtomicBoolean terminated = new AtomicBoolean();
 
     private List<BiConsumer<HttpHeaders, Throwable>> headersCustomizers;
 
@@ -51,6 +54,8 @@ public abstract class AbstractServerHttpChannelObserver<H extends HttpChannel> i
     private boolean completed;
 
     private boolean closed;
+
+    private Runnable terminationHandler;
 
     protected AbstractServerHttpChannelObserver(H httpChannel) {
         this.httpChannel = httpChannel;
@@ -80,6 +85,10 @@ public abstract class AbstractServerHttpChannelObserver<H extends HttpChannel> i
     @Override
     public void setExceptionCustomizer(Function<Throwable, ?> exceptionCustomizer) {
         this.exceptionCustomizer = exceptionCustomizer;
+    }
+
+    public void setTerminationHandler(Runnable terminationHandler) {
+        this.terminationHandler = terminationHandler;
     }
 
     public HttpMessageEncoder getResponseEncoder() {
@@ -118,6 +127,7 @@ public abstract class AbstractServerHttpChannelObserver<H extends HttpChannel> i
         try {
             throwable = customizeError(throwable);
             if (throwable == null) {
+                terminate();
                 return;
             }
         } catch (Throwable t) {
@@ -316,8 +326,12 @@ public abstract class AbstractServerHttpChannelObserver<H extends HttpChannel> i
         if (completed) {
             return;
         }
-        doOnCompleted(throwable);
-        completed = true;
+        try {
+            doOnCompleted(throwable);
+        } finally {
+            completed = true;
+            terminate();
+        }
     }
 
     protected void doOnCompleted(Throwable throwable) {
@@ -365,5 +379,19 @@ public abstract class AbstractServerHttpChannelObserver<H extends HttpChannel> i
 
     protected final void closed() {
         closed = true;
+        terminate();
+    }
+
+    private void terminate() {
+        if (!terminated.compareAndSet(false, true)) {
+            return;
+        }
+        if (terminationHandler != null) {
+            try {
+                terminationHandler.run();
+            } catch (Throwable t) {
+                LOGGER.warn(INTERNAL_ERROR, "", "", "Error while terminating response observer", t);
+            }
+        }
     }
 }

--- a/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/AbstractServerHttpChannelObserver.java
+++ b/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/AbstractServerHttpChannelObserver.java
@@ -147,6 +147,7 @@ public abstract class AbstractServerHttpChannelObserver<H extends HttpChannel> i
     @Override
     public final void onCompleted() {
         if (closed) {
+            terminate();
             return;
         }
         onCompleted(null);
@@ -379,7 +380,6 @@ public abstract class AbstractServerHttpChannelObserver<H extends HttpChannel> i
 
     protected final void closed() {
         closed = true;
-        terminate();
     }
 
     private void terminate() {

--- a/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/message/DefaultHttpRequest.java
+++ b/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/message/DefaultHttpRequest.java
@@ -622,6 +622,14 @@ public class DefaultHttpRequest implements HttpRequest {
         return postDecoder;
     }
 
+    public void destroyPostRequestDecoder() {
+        HttpPostRequestDecoder postDecoder = this.postDecoder;
+        if (postDecoder != null) {
+            this.postDecoder = null;
+            postDecoder.destroy();
+        }
+    }
+
     @Override
     @SuppressWarnings("unchecked")
     public <T> T attribute(String name) {

--- a/dubbo-remoting/dubbo-remoting-http12/src/test/java/org/apache/dubbo/remoting/http12/AbstractServerHttpChannelObserverTest.java
+++ b/dubbo-remoting/dubbo-remoting-http12/src/test/java/org/apache/dubbo/remoting/http12/AbstractServerHttpChannelObserverTest.java
@@ -38,6 +38,7 @@ class AbstractServerHttpChannelObserverTest {
         assertEquals(0, terminationCount.get());
 
         observer.onCompleted();
+        observer.onCompleted();
         observer.onError(new RuntimeException("ignored after completion"));
         observer.close();
         assertEquals(1, terminationCount.get());

--- a/dubbo-remoting/dubbo-remoting-http12/src/test/java/org/apache/dubbo/remoting/http12/AbstractServerHttpChannelObserverTest.java
+++ b/dubbo-remoting/dubbo-remoting-http12/src/test/java/org/apache/dubbo/remoting/http12/AbstractServerHttpChannelObserverTest.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.remoting.http12;
+
+import org.apache.dubbo.remoting.http12.h1.Http1ServerChannelObserver;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+
+class AbstractServerHttpChannelObserverTest {
+
+    @Test
+    void transportCloseDefersTerminationUntilResponseCompletes() {
+        AtomicInteger terminationCount = new AtomicInteger();
+        Http1ServerChannelObserver observer = new Http1ServerChannelObserver(mock(HttpChannel.class));
+        observer.setTerminationHandler(terminationCount::incrementAndGet);
+
+        observer.close();
+        assertEquals(0, terminationCount.get());
+
+        observer.onCompleted();
+        observer.onError(new RuntimeException("ignored after completion"));
+        observer.close();
+        assertEquals(1, terminationCount.get());
+    }
+
+    @Test
+    void terminationHandlesMissingAndFailingHandlers() {
+        Http1ServerChannelObserver observerWithoutHandler = new Http1ServerChannelObserver(mock(HttpChannel.class));
+        assertDoesNotThrow(() -> observerWithoutHandler.onCompleted());
+
+        Http1ServerChannelObserver observerWithFailingHandler = new Http1ServerChannelObserver(mock(HttpChannel.class));
+        observerWithFailingHandler.setTerminationHandler(() -> {
+            throw new RuntimeException("cleanup failed");
+        });
+
+        assertDoesNotThrow(() -> observerWithFailingHandler.onCompleted());
+    }
+}

--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/h12/AbstractServerCallListener.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/h12/AbstractServerCallListener.java
@@ -88,6 +88,12 @@ public abstract class AbstractServerCallListener implements ServerCallListener {
                 }
                 if (r.hasException()) {
                     responseObserver.onError(r.getException());
+                    if (responseObserver instanceof Http2CancelableStreamObserver
+                            && ((Http2CancelableStreamObserver<?>) responseObserver)
+                                    .getCancellationContext()
+                                    .isCancelled()) {
+                        responseObserver.onCompleted();
+                    }
                     return;
                 }
                 long cost = System.currentTimeMillis() - stInMillis;

--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/h12/AbstractServerTransportListener.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/h12/AbstractServerTransportListener.java
@@ -30,6 +30,7 @@ import org.apache.dubbo.remoting.http12.HttpStatus;
 import org.apache.dubbo.remoting.http12.HttpTransportListener;
 import org.apache.dubbo.remoting.http12.RequestMetadata;
 import org.apache.dubbo.remoting.http12.exception.HttpStatusException;
+import org.apache.dubbo.remoting.http12.message.DefaultHttpRequest;
 import org.apache.dubbo.remoting.http12.message.MethodMetadata;
 import org.apache.dubbo.rpc.HeaderFilter;
 import org.apache.dubbo.rpc.Invoker;
@@ -335,6 +336,16 @@ public abstract class AbstractServerTransportListener<HEADER extends RequestMeta
 
     protected final void setHttpMessageListener(HttpMessageListener httpMessageListener) {
         this.httpMessageListener = httpMessageListener;
+    }
+
+    protected final void destroyPostRequestDecoder() {
+        if (context == null) {
+            return;
+        }
+        Object request = context.getAttributes().get(TripleConstants.HTTP_REQUEST_KEY);
+        if (request instanceof DefaultHttpRequest) {
+            ((DefaultHttpRequest) request).destroyPostRequestDecoder();
+        }
     }
 
     protected Function<Throwable, Object> getExceptionCustomizer() {

--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/h12/http1/DefaultHttp11ServerTransportListener.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/h12/http1/DefaultHttp11ServerTransportListener.java
@@ -56,6 +56,7 @@ public class DefaultHttp11ServerTransportListener
 
     private Http1ServerChannelObserver prepareResponseObserver(Http1ServerChannelObserver responseObserver) {
         responseObserver.setExceptionCustomizer(getExceptionCustomizer());
+        responseObserver.setTerminationHandler(this::destroyPostRequestDecoder);
         RpcInvocationBuildContext context = getContext();
         responseObserver.setResponseEncoder(context == null ? JsonCodec.INSTANCE : context.getHttpMessageEncoder());
         return responseObserver;

--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/h12/http2/GenericHttp2ServerTransportListener.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/h12/http2/GenericHttp2ServerTransportListener.java
@@ -89,6 +89,7 @@ public class GenericHttp2ServerTransportListener extends AbstractServerTransport
 
     protected Http2ServerChannelObserver prepareResponseObserver(Http2ServerChannelObserver responseObserver) {
         responseObserver.setExceptionCustomizer(getExceptionCustomizer());
+        responseObserver.setTerminationHandler(this::destroyPostRequestDecoder);
         RpcInvocationBuildContext context = getContext();
         responseObserver.setResponseEncoder(context == null ? JsonCodec.INSTANCE : context.getHttpMessageEncoder());
         responseObserver.setCancellationContext(RpcContext.getCancellationContext());

--- a/dubbo-rpc/dubbo-rpc-triple/src/test/groovy/org/apache/dubbo/rpc/protocol/tri/rest/support/basic/HttpPostRequestDecoderLifecycleTest.groovy
+++ b/dubbo-rpc/dubbo-rpc-triple/src/test/groovy/org/apache/dubbo/rpc/protocol/tri/rest/support/basic/HttpPostRequestDecoderLifecycleTest.groovy
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.dubbo.rpc.protocol.tri.rest.support.basic
+
+import org.apache.dubbo.remoting.http12.HttpUtils
+import org.apache.dubbo.remoting.http12.message.MediaType
+import org.apache.dubbo.rpc.protocol.tri.rest.service.DemoServiceImpl
+import org.apache.dubbo.rpc.protocol.tri.rest.test.BaseServiceTest
+import org.apache.dubbo.rpc.protocol.tri.test.TestRequest
+import org.apache.dubbo.rpc.protocol.tri.test.TestRunnerBuilder
+
+import io.netty.handler.codec.http.multipart.DefaultHttpDataFactory
+
+class HttpPostRequestDecoderLifecycleTest extends BaseServiceTest {
+
+    @Override
+    void setupService(TestRunnerBuilder builder) {
+        builder.provider(new DemoServiceImpl())
+    }
+
+    def "completed form request should release post data"() {
+        given:
+            def trackedRequests = trackedPostRequests()
+            def request = new TestRequest(
+                path: '/argTest',
+                contentType: MediaType.APPLICATION_FROM_URLENCODED,
+                body: 'name=Sam&age=8'
+            )
+        expect:
+            runner.post(request) == 'Sam is 8 years old'
+            trackedPostRequests() == trackedRequests
+    }
+
+    private static int trackedPostRequests() {
+        def field = DefaultHttpDataFactory.getDeclaredField('requestFileDeleteMap')
+        field.accessible = true
+        return ((Map<?, ?>)field.get(HttpUtils.DATA_FACTORY)).size()
+    }
+}

--- a/dubbo-rpc/dubbo-rpc-triple/src/test/groovy/org/apache/dubbo/rpc/protocol/tri/rest/support/basic/HttpPostRequestDecoderLifecycleTest.groovy
+++ b/dubbo-rpc/dubbo-rpc-triple/src/test/groovy/org/apache/dubbo/rpc/protocol/tri/rest/support/basic/HttpPostRequestDecoderLifecycleTest.groovy
@@ -73,34 +73,40 @@ class HttpPostRequestDecoderLifecycleTest extends BaseServiceTest {
             trackedPostRequests() == trackedRequests
     }
 
-    def "HTTP/1 form request should release post data after completion"() {
-        given:
-            def trackedRequests = trackedPostRequests()
-            def listener = new DirectHttp11ServerTransportListener(
-                new MockH2StreamChannel(), testUrl(), FrameworkModel.defaultModel()
-            )
-            def request = new TestRequest(
-                method: HttpMethods.POST.name(),
-                path: '/argTest',
-                contentType: MediaType.APPLICATION_FROM_URLENCODED
-            )
-        when:
-            listener.onMetadata(request.toMetadata())
-            listener.onData(new Http1InputMessage(new ByteArrayInputStream('name=Sam&age=8'.bytes)))
-        then:
-            trackedPostRequests() == trackedRequests
-    }
-
-    def "HTTP/2 cancellation should keep multipart data until application completion"() {
+    def "HTTP/1 multipart data should be released after exceptional completion"() {
         given:
             uploadService.reset()
             def trackedRequests = trackedPostRequests()
             def boundary = 'dubbo-test-boundary'
             def content = 'multipart content'
-            def body = "--${boundary}\r\n" +
-                'Content-Disposition: form-data; name="file"; filename="test.txt"\r\n' +
-                'Content-Type: text/plain\r\n\r\n' +
-                content + "\r\n--${boundary}--\r\n"
+            def listener = new DirectHttp11ServerTransportListener(
+                new MockH2StreamChannel(), testUrl(), FrameworkModel.defaultModel()
+            )
+            def request = new TestRequest(
+                method: HttpMethods.POST.name(),
+                path: '/upload',
+                contentType: "${MediaType.MULTIPART_FORM_DATA.name}; boundary=${boundary}"
+            )
+        when:
+            listener.onMetadata(request.toMetadata())
+            listener.onData(new Http1InputMessage(new ByteArrayInputStream(multipartBody(boundary, content))))
+        then:
+            uploadService.fileUpload != null
+            trackedPostRequests() == trackedRequests + 1
+        when:
+            uploadService.result.completeExceptionally(new RuntimeException('failed'))
+        then:
+            trackedPostRequests() == trackedRequests
+        cleanup:
+            uploadService.result?.complete('cleanup')
+    }
+
+    def "HTTP/2 multipart data should remain until application termination"() {
+        given:
+            uploadService.reset()
+            def trackedRequests = trackedPostRequests()
+            def boundary = 'dubbo-test-boundary'
+            def content = 'multipart content'
             def listener = new TestServerTransportListener(
                 new MockH2StreamChannel(), testUrl(), FrameworkModel.defaultModel()
             )
@@ -112,23 +118,34 @@ class HttpPostRequestDecoderLifecycleTest extends BaseServiceTest {
         when:
             listener.onMetadata(request.toMetadata())
             listener.onData(new Http2InputMessageFrame(
-                new ByteArrayInputStream(body.getBytes(StandardCharsets.UTF_8)), true
+                new ByteArrayInputStream(multipartBody(boundary, content)), true
             ))
         then:
             uploadService.fileUpload != null
             trackedPostRequests() == trackedRequests + 1
         when:
             def inputStream = uploadService.fileUpload.inputStream()
-            listener.cancelByRemote(8)
+            if (remoteCancellation) {
+                listener.cancelByRemote(8)
+            }
         then:
             new String(inputStream.bytes, StandardCharsets.UTF_8) == content
             trackedPostRequests() == trackedRequests + 1
         when:
-            uploadService.result.complete('ok')
+            if (exceptionalCompletion) {
+                uploadService.result.completeExceptionally(new RuntimeException('failed'))
+            } else {
+                uploadService.result.complete('ok')
+            }
         then:
             trackedPostRequests() == trackedRequests
         cleanup:
             uploadService.result?.complete('cleanup')
+        where:
+            remoteCancellation | exceptionalCompletion
+            true               | false
+            true               | true
+            false              | true
     }
 
     def "custom request adapter should not require decoder cleanup"() {
@@ -153,6 +170,13 @@ class HttpPostRequestDecoderLifecycleTest extends BaseServiceTest {
 
     private static URL testUrl() {
         return new URL(TestProtocol.NAME, TestProtocol.HOST, TestProtocol.PORT)
+    }
+
+    private static byte[] multipartBody(String boundary, String content) {
+        return ("--${boundary}\r\n" +
+            'Content-Disposition: form-data; name="file"; filename="test.txt"\r\n' +
+            'Content-Type: text/plain\r\n\r\n' +
+            content + "\r\n--${boundary}--\r\n").getBytes(StandardCharsets.UTF_8)
     }
 
     private static int trackedPostRequests() {

--- a/dubbo-rpc/dubbo-rpc-triple/src/test/groovy/org/apache/dubbo/rpc/protocol/tri/rest/support/basic/HttpPostRequestDecoderLifecycleTest.groovy
+++ b/dubbo-rpc/dubbo-rpc-triple/src/test/groovy/org/apache/dubbo/rpc/protocol/tri/rest/support/basic/HttpPostRequestDecoderLifecycleTest.groovy
@@ -17,20 +17,47 @@
 
 package org.apache.dubbo.rpc.protocol.tri.rest.support.basic
 
+import org.apache.dubbo.common.URL
+import org.apache.dubbo.remoting.http12.HttpChannel
+import org.apache.dubbo.remoting.http12.HttpMethods
+import org.apache.dubbo.remoting.http12.HttpRequest
 import org.apache.dubbo.remoting.http12.HttpUtils
+import org.apache.dubbo.remoting.http12.RequestMetadata
+import org.apache.dubbo.remoting.http12.h1.Http1InputMessage
+import org.apache.dubbo.remoting.http12.h2.Http2InputMessageFrame
 import org.apache.dubbo.remoting.http12.message.MediaType
+import org.apache.dubbo.remoting.http12.rest.Mapping
+import org.apache.dubbo.remoting.http12.rest.Param
+import org.apache.dubbo.remoting.http12.rest.ParamType
+import org.apache.dubbo.rpc.model.FrameworkModel
+import org.apache.dubbo.rpc.protocol.tri.RpcInvocationBuildContext
+import org.apache.dubbo.rpc.protocol.tri.TripleConstants
+import org.apache.dubbo.rpc.protocol.tri.h12.AbstractServerTransportListener
+import org.apache.dubbo.rpc.protocol.tri.h12.http1.DefaultHttp11ServerTransportListener
 import org.apache.dubbo.rpc.protocol.tri.rest.service.DemoServiceImpl
 import org.apache.dubbo.rpc.protocol.tri.rest.test.BaseServiceTest
+import org.apache.dubbo.rpc.protocol.tri.test.MockH2StreamChannel
 import org.apache.dubbo.rpc.protocol.tri.test.TestRequest
+import org.apache.dubbo.rpc.protocol.tri.test.TestProtocol
 import org.apache.dubbo.rpc.protocol.tri.test.TestRunnerBuilder
+import org.apache.dubbo.rpc.protocol.tri.test.TestServerTransportListener
 
 import io.netty.handler.codec.http.multipart.DefaultHttpDataFactory
+import spock.lang.Shared
+
+import java.nio.charset.StandardCharsets
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.Executor
 
 class HttpPostRequestDecoderLifecycleTest extends BaseServiceTest {
+
+    @Shared
+    UploadServiceImpl uploadService = new UploadServiceImpl()
 
     @Override
     void setupService(TestRunnerBuilder builder) {
         builder.provider(new DemoServiceImpl())
+        builder.provider(UploadService, uploadService)
     }
 
     def "completed form request should release post data"() {
@@ -46,9 +73,129 @@ class HttpPostRequestDecoderLifecycleTest extends BaseServiceTest {
             trackedPostRequests() == trackedRequests
     }
 
+    def "HTTP/1 form request should release post data after completion"() {
+        given:
+            def trackedRequests = trackedPostRequests()
+            def listener = new DirectHttp11ServerTransportListener(
+                new MockH2StreamChannel(), testUrl(), FrameworkModel.defaultModel()
+            )
+            def request = new TestRequest(
+                method: HttpMethods.POST.name(),
+                path: '/argTest',
+                contentType: MediaType.APPLICATION_FROM_URLENCODED
+            )
+        when:
+            listener.onMetadata(request.toMetadata())
+            listener.onData(new Http1InputMessage(new ByteArrayInputStream('name=Sam&age=8'.bytes)))
+        then:
+            trackedPostRequests() == trackedRequests
+    }
+
+    def "HTTP/2 cancellation should keep multipart data until application completion"() {
+        given:
+            uploadService.reset()
+            def trackedRequests = trackedPostRequests()
+            def boundary = 'dubbo-test-boundary'
+            def content = 'multipart content'
+            def body = "--${boundary}\r\n" +
+                'Content-Disposition: form-data; name="file"; filename="test.txt"\r\n' +
+                'Content-Type: text/plain\r\n\r\n' +
+                content + "\r\n--${boundary}--\r\n"
+            def listener = new TestServerTransportListener(
+                new MockH2StreamChannel(), testUrl(), FrameworkModel.defaultModel()
+            )
+            def request = new TestRequest(
+                method: HttpMethods.POST.name(),
+                path: '/upload',
+                contentType: "${MediaType.MULTIPART_FORM_DATA.name}; boundary=${boundary}"
+            )
+        when:
+            listener.onMetadata(request.toMetadata())
+            listener.onData(new Http2InputMessageFrame(
+                new ByteArrayInputStream(body.getBytes(StandardCharsets.UTF_8)), true
+            ))
+        then:
+            uploadService.fileUpload != null
+            trackedPostRequests() == trackedRequests + 1
+        when:
+            def inputStream = uploadService.fileUpload.inputStream()
+            listener.cancelByRemote(8)
+        then:
+            new String(inputStream.bytes, StandardCharsets.UTF_8) == content
+            trackedPostRequests() == trackedRequests + 1
+        when:
+            uploadService.result.complete('ok')
+        then:
+            trackedPostRequests() == trackedRequests
+        cleanup:
+            uploadService.result?.complete('cleanup')
+    }
+
+    def "custom request adapter should not require decoder cleanup"() {
+        given:
+            def listener = new DefaultHttp11ServerTransportListener(
+                Mock(HttpChannel), testUrl(), FrameworkModel.defaultModel()
+            )
+            def context = Stub(RpcInvocationBuildContext) {
+                getAttributes() >> [(TripleConstants.HTTP_REQUEST_KEY): Stub(HttpRequest)]
+            }
+            def contextField = AbstractServerTransportListener.getDeclaredField('context')
+            contextField.accessible = true
+            contextField.set(listener, context)
+            def observerField = DefaultHttp11ServerTransportListener.getDeclaredField('responseObserver')
+            observerField.accessible = true
+            def responseObserver = observerField.get(listener)
+        when:
+            responseObserver.onCompleted()
+        then:
+            noExceptionThrown()
+    }
+
+    private static URL testUrl() {
+        return new URL(TestProtocol.NAME, TestProtocol.HOST, TestProtocol.PORT)
+    }
+
     private static int trackedPostRequests() {
         def field = DefaultHttpDataFactory.getDeclaredField('requestFileDeleteMap')
         field.accessible = true
         return ((Map<?, ?>)field.get(HttpUtils.DATA_FACTORY)).size()
+    }
+
+    @Mapping('/')
+    private interface UploadService {
+
+        @Mapping('/upload')
+        CompletableFuture<String> upload(
+            @Param(value = 'file', type = ParamType.Part) HttpRequest.FileUpload fileUpload
+        )
+    }
+
+    private static final class UploadServiceImpl implements UploadService {
+
+        volatile HttpRequest.FileUpload fileUpload
+        CompletableFuture<String> result
+
+        void reset() {
+            fileUpload = null
+            result = new CompletableFuture<>()
+        }
+
+        @Override
+        CompletableFuture<String> upload(HttpRequest.FileUpload fileUpload) {
+            this.fileUpload = fileUpload
+            return result
+        }
+    }
+
+    private static final class DirectHttp11ServerTransportListener extends DefaultHttp11ServerTransportListener {
+
+        DirectHttp11ServerTransportListener(HttpChannel httpChannel, URL url, FrameworkModel frameworkModel) {
+            super(httpChannel, url, frameworkModel)
+        }
+
+        @Override
+        protected Executor initializeExecutor(URL url, RequestMetadata metadata) {
+            return { Runnable command -> command.run() } as Executor
+        }
     }
 }


### PR DESCRIPTION
## What is the purpose of the change?

Closes #16403.

When Triple REST parses an `application/x-www-form-urlencoded` or `multipart/form-data` request, `DefaultHttpRequest` lazily creates and caches an `HttpPostRequestDecoder`. The decoder was not destroyed after the request completed, so `DefaultHttpDataFactory` continued to retain the request and its form data.

This change attaches decoder cleanup to the HTTP response lifecycle:

- Add a dedicated method to destroy the decoder cached by `DefaultHttpRequest`.
- Register decoder cleanup with both HTTP/1.1 and HTTP/2 server response observers.
- Clean up after normal or error response termination, while ensuring cleanup runs only once when multiple terminal signals are received.
- If the transport closes before an asynchronous unary invocation completes normally, defer cleanup until the invocation completes so multipart data remains available to the service method during request processing.

## How was it tested?

Extended `HttpPostRequestDecoderLifecycleTest` to cover the real Triple REST request path:

- Verify that a form request no longer remains tracked by `DefaultHttpDataFactory` after normal completion.
- Verify decoder cleanup through the HTTP/1.1 response observer.
- Verify that HTTP/2 remote cancellation does not release multipart data while an asynchronous service invocation is still using it, and that the data is released after the invocation completes.
- Verify that custom request adapters that do not use `DefaultHttpRequest` do not require decoder cleanup.

Added `AbstractServerHttpChannelObserverTest` to verify that transport closure defers cleanup until normal application completion and that cleanup runs only once when multiple terminal signals are received. The targeted tests passed.

Commands:

```shell
./mvnw -pl dubbo-remoting/dubbo-remoting-http12 -Dtest=AbstractServerHttpChannelObserverTest test
./mvnw -pl dubbo-rpc/dubbo-rpc-triple -am -Dtest=HttpPostRequestDecoderLifecycleTest -Dsurefire.failIfNoSpecifiedTests=false test
```

The changed files were also formatted with `codestyle/dubbo_codestyle_for_idea.xml`. Maven Checkstyle and Spotless checks passed.

## Checklist

- [x] Make sure there is a [GitHub issue](https://github.com/apache/dubbo/issues) for the change.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how it does it, and why it does it.
- [x] Write the necessary unit tests to verify the code.
- [x] Make sure GitHub Actions can pass.