### PR TITLE
fix: release late response ByteBuf when callback executor is shut down (#16415)

### DIFF
--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/stream/AbstractStream.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/stream/AbstractStream.java
@@ -18,6 +18,7 @@ package org.apache.dubbo.rpc.protocol.tri.stream;
 
 import org.apache.dubbo.common.threadpool.serial.SerializingExecutor;
 import org.apache.dubbo.common.utils.ClassUtils;
+import org.apache.dubbo.common.utils.ExecutorUtil;
 import org.apache.dubbo.rpc.model.FrameworkModel;
 
 import java.util.concurrent.Executor;
@@ -30,15 +31,36 @@ public abstract class AbstractStream implements Stream {
     protected Executor executor;
     protected final FrameworkModel frameworkModel;
 
+    /**
+     * The executor passed by the caller, kept for shutdown-state checks. It is wrapped by
+     * {@link SerializingExecutor} exposed via {@link #executor}.
+     */
+    private Executor callbackExecutor;
+
     private static final boolean HAS_PROTOBUF = ClassUtils.hasProtobuf();
 
     public AbstractStream(Executor executor, FrameworkModel frameworkModel) {
+        this.callbackExecutor = executor;
         this.executor = new SerializingExecutor(executor);
         this.frameworkModel = frameworkModel;
     }
 
     public void setExecutor(Executor executor) {
+        this.callbackExecutor = executor;
         this.executor = new SerializingExecutor(executor);
+    }
+
+    /**
+     * Whether the callback executor has been shut down (e.g. the {@code ThreadlessExecutor}
+     * of a sync call is shut down after a request timeout). {@link SerializingExecutor}
+     * silently drops tasks submitted to a shut-down executor, so callers must release any
+     * task-owned resources (e.g. a ByteBuf) when this returns {@code true}.
+     *
+     * @return true if the callback executor is an {@link java.util.concurrent.ExecutorService}
+     *         that has been shut down
+     */
+    protected boolean isCallbackExecutorShutdown() {
+        return callbackExecutor != null && ExecutorUtil.isShutdown(callbackExecutor);
     }
 
     public static boolean getGrpcStatusDetailEnabled() {

--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/stream/AbstractTripleClientStream.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/stream/AbstractTripleClientStream.java
@@ -565,6 +565,15 @@ public abstract class AbstractTripleClientStream extends AbstractStream implemen
             if (LOGGER.isDebugEnabled()) {
                 LOGGER.debug("endStream: {} DATA: {}", endStream, data.toString(StandardCharsets.UTF_8));
             }
+            if (isCallbackExecutorShutdown()) {
+                // The callback executor (e.g. ThreadlessExecutor) has been shut down, e.g.
+                // after the request timed out {@link AsyncRpcResult}. SerializingExecutor would
+                // silently drop the submitted task so doOnData would never run; release the
+                // ByteBuf now to avoid out of heap memory leakage.
+                ReferenceCountUtil.release(data);
+                LOGGER.warn(PROTOCOL_FAILED_RESPONSE, "", "", "Drop late response data, callback executor is shutdown");
+                return;
+            }
             try {
                 executor.execute(() -> doOnData(data, endStream));
             } catch (Throwable t) {
@@ -572,7 +581,7 @@ public abstract class AbstractTripleClientStream extends AbstractStream implemen
                 // ByteBuf needs to be released to avoid out of heap memory leakage.
                 // For example, ThreadLessExecutor will be shutdown when request timeout {@link AsyncRpcResult}
                 ReferenceCountUtil.release(data);
-                LOGGER.error(PROTOCOL_FAILED_RESPONSE, "", "", "submit onData task failed", t);
+                LOGGER.warn(PROTOCOL_FAILED_RESPONSE, "", "", "Drop late response data, executor rejected the task", t);
             }
         }
 

--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/stream/AbstractTripleClientStream.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/stream/AbstractTripleClientStream.java
@@ -569,7 +569,7 @@ public abstract class AbstractTripleClientStream extends AbstractStream implemen
                 // The callback executor (e.g. ThreadlessExecutor) has been shut down, e.g.
                 // after the request timed out {@link AsyncRpcResult}. SerializingExecutor would
                 // silently drop the submitted task so doOnData would never run; release the
-                // ByteBuf now to avoid out of heap memory leakage.
+                // ByteBuf now to avoid a memory leak.
                 ReferenceCountUtil.release(data);
                 LOGGER.warn(PROTOCOL_FAILED_RESPONSE, "", "", "Drop late response data, callback executor is shutdown");
                 return;
@@ -577,11 +577,11 @@ public abstract class AbstractTripleClientStream extends AbstractStream implemen
             try {
                 executor.execute(() -> doOnData(data, endStream));
             } catch (Throwable t) {
-                // Tasks will be rejected when the thread pool is closed or full,
-                // ByteBuf needs to be released to avoid out of heap memory leakage.
-                // For example, ThreadLessExecutor will be shutdown when request timeout {@link AsyncRpcResult}
+                // The task can be rejected when the thread pool is closed or full (e.g. the
+                // ThreadlessExecutor is shut down after a request timeout {@link AsyncRpcResult}).
+                // Release the ByteBuf to avoid a memory leak.
                 ReferenceCountUtil.release(data);
-                LOGGER.warn(PROTOCOL_FAILED_RESPONSE, "", "", "Drop late response data, executor rejected the task", t);
+                LOGGER.warn(PROTOCOL_FAILED_RESPONSE, "", "", "Drop response data, executor rejected the task", t);
             }
         }
 

--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/stream/AbstractTripleClientStream.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/stream/AbstractTripleClientStream.java
@@ -567,11 +567,12 @@ public abstract class AbstractTripleClientStream extends AbstractStream implemen
             }
             if (isCallbackExecutorShutdown()) {
                 // The callback executor (e.g. ThreadlessExecutor) has been shut down, e.g.
-                // after the request timed out {@link AsyncRpcResult}. SerializingExecutor would
+                // after the request timed out in {@link AsyncRpcResult}. SerializingExecutor would
                 // silently drop the submitted task so doOnData would never run; release the
-                // ByteBuf now to avoid a memory leak.
+                // ByteBuf now to avoid an off-heap memory leak.
                 ReferenceCountUtil.release(data);
-                LOGGER.warn(PROTOCOL_FAILED_RESPONSE, "", "", "Drop late response data, callback executor is shutdown");
+                LOGGER.warn(
+                        PROTOCOL_FAILED_RESPONSE, "", "", "Drop late response data: callback executor is shut down");
                 return;
             }
             try {

--- a/dubbo-rpc/dubbo-rpc-triple/src/test/java/org/apache/dubbo/rpc/protocol/tri/stream/TripleClientStreamTest.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/test/java/org/apache/dubbo/rpc/protocol/tri/stream/TripleClientStreamTest.java
@@ -17,6 +17,7 @@
 package org.apache.dubbo.rpc.protocol.tri.stream;
 
 import org.apache.dubbo.common.URL;
+import org.apache.dubbo.common.threadpool.ThreadlessExecutor;
 import org.apache.dubbo.remoting.http12.HttpHeaderNames;
 import org.apache.dubbo.remoting.http12.message.MediaType;
 import org.apache.dubbo.rpc.TriRpcStatus;
@@ -130,5 +131,44 @@ class TripleClientStreamTest {
         final ByteBuf buf = Unpooled.wrappedBuffer(data);
         transportListener.onData(buf, false);
         Assertions.assertEquals(1, listener.message.length);
+    }
+
+    @Test
+    void testOnDataReleaseByteBufAfterCallbackExecutorShutdown() {
+        final URL url = URL.valueOf("tri://127.0.0.1:8080/foo.bar.service");
+        final ModuleServiceRepository repo =
+                ApplicationModel.defaultModel().getDefaultModule().getServiceRepository();
+        repo.registerService(IGreeter.class);
+        final ServiceDescriptor serviceDescriptor = repo.getService(IGreeter.class.getName());
+        final MethodDescriptor methodDescriptor = serviceDescriptor.getMethod("echo", new Class<?>[] {String.class});
+
+        MockClientStreamListener listener = new MockClientStreamListener();
+        TripleWriteQueue writeQueue = mock(TripleWriteQueue.class);
+        final EmbeddedChannel channel = new EmbeddedChannel();
+        when(writeQueue.enqueueFuture(any(QueuedCommand.class), any(Executor.class)))
+                .thenReturn(channel.newPromise());
+        Http2StreamChannel http2StreamChannel = mock(Http2StreamChannel.class);
+        when(http2StreamChannel.isActive()).thenReturn(true);
+        when(http2StreamChannel.newSucceededFuture()).thenReturn(channel.newSucceededFuture());
+        when(http2StreamChannel.eventLoop()).thenReturn(new NioEventLoopGroup().next());
+        when(http2StreamChannel.newPromise()).thenReturn(channel.newPromise());
+        when(http2StreamChannel.parent()).thenReturn(channel);
+
+        // Mirror the sync call path (TripleInvoker#doInvoke): a per-call ThreadlessExecutor
+        // wrapped by SerializingExecutor inside AbstractStream.
+        ThreadlessExecutor callbackExecutor = new ThreadlessExecutor();
+        AbstractTripleClientStream stream = new Http2TripleClientStream(
+                url.getOrDefaultFrameworkModel(), callbackExecutor, writeQueue, listener, http2StreamChannel);
+
+        // Simulate request timeout: AsyncRpcResult#get(timeout) shuts down the executor in finally.
+        callbackExecutor.shutdown();
+
+        H2TransportListener transportListener = stream.createTransportListener();
+        final ByteBuf buf = Unpooled.buffer(16);
+        buf.writeByte(1);
+        transportListener.onData(buf, false);
+        // A late DATA frame must not leak the ByteBuf just because the callback executor
+        // was shut down by the timeout.
+        Assertions.assertEquals(0, buf.refCnt());
     }
 }

--- a/dubbo-rpc/dubbo-rpc-triple/src/test/java/org/apache/dubbo/rpc/protocol/tri/stream/TripleClientStreamTest.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/test/java/org/apache/dubbo/rpc/protocol/tri/stream/TripleClientStreamTest.java
@@ -46,7 +46,6 @@ import java.util.concurrent.Executor;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.embedded.EmbeddedChannel;
-import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.HttpScheme;
 import io.netty.handler.codec.http2.DefaultHttp2Headers;
@@ -80,7 +79,7 @@ class TripleClientStreamTest {
         Http2StreamChannel http2StreamChannel = mock(Http2StreamChannel.class);
         when(http2StreamChannel.isActive()).thenReturn(true);
         when(http2StreamChannel.newSucceededFuture()).thenReturn(channel.newSucceededFuture());
-        when(http2StreamChannel.eventLoop()).thenReturn(new NioEventLoopGroup().next());
+        when(http2StreamChannel.eventLoop()).thenReturn(channel.eventLoop());
         when(http2StreamChannel.newPromise()).thenReturn(channel.newPromise());
         when(http2StreamChannel.parent()).thenReturn(channel);
         AbstractTripleClientStream stream = new Http2TripleClientStream(
@@ -150,7 +149,7 @@ class TripleClientStreamTest {
         Http2StreamChannel http2StreamChannel = mock(Http2StreamChannel.class);
         when(http2StreamChannel.isActive()).thenReturn(true);
         when(http2StreamChannel.newSucceededFuture()).thenReturn(channel.newSucceededFuture());
-        when(http2StreamChannel.eventLoop()).thenReturn(new NioEventLoopGroup().next());
+        when(http2StreamChannel.eventLoop()).thenReturn(channel.eventLoop());
         when(http2StreamChannel.newPromise()).thenReturn(channel.newPromise());
         when(http2StreamChannel.parent()).thenReturn(channel);
 


### PR DESCRIPTION
## What is the purpose of the change

Fixes #16415.

When a sync Triple call times out, `AsyncRpcResult#get(timeout)` shuts down the per-call `ThreadlessExecutor` in a `finally` block. Any DATA frame that arrives afterwards is handed to `AbstractTripleClientStream.ClientTransportListener.onData()`, which submits the decode task via `SerializingExecutor`. Because the underlying executor is already shut down, `SerializingExecutor` silently drops the submitted task, so `doOnData()` never runs and the DATA frame's `ByteBuf` (wrapped in `ByteBufInputStream(data, true)` only inside `doOnData`) is never released — a Netty ByteBuf leak that grows on every timed-out call with in-flight response data.

## Root cause

For a sync Triple call the callback executor is a per-call `ThreadlessExecutor`. On timeout, `AsyncRpcResult#get(timeout)` shuts it down in a `finally` block. Late DATA frames are then submitted to a `SerializingExecutor` wrapping that shut-down executor; `SerializingExecutor` silently drops them (a behavior from #15122), so `doOnData()` never executes and the ByteBuf is never released.

## Brief changelog

1. `AbstractStream` (`dubbo-rpc-triple`): retain the raw callback executor and expose `isCallbackExecutorShutdown()`.
2. `AbstractTripleClientStream` (`dubbo-rpc-triple`): in `onData`, when the callback executor has been shut down, release the DATA frame's `ByteBuf` immediately instead of submitting a task that would be silently dropped; log at WARN since dropping late data after a timeout is expected.

## Verifying the change

- `TripleClientStreamTest#testOnDataReleaseByteBufAfterCallbackExecutorShutdown` (new): a DATA-frame ByteBuf received after the callback executor is shut down is released (`refCnt == 0`). This test fails before the fix (`refCnt == 1`).

Fixes #16415