### PR TITLE
fix: make SpringBootConfigPropsTest immune to leaked metrics System properties

### DIFF
--- a/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/SysProps.java
+++ b/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/SysProps.java
@@ -27,6 +27,9 @@ public class SysProps {
     private static Map<String, String> map = new LinkedHashMap<String, String>();
 
     public static void reset() {
+        for (String key : map.keySet()) {
+            System.clearProperty(key);
+        }
         map.clear();
     }
 
@@ -36,9 +39,6 @@ public class SysProps {
     }
 
     public static void clear() {
-        for (String key : map.keySet()) {
-            System.clearProperty(key);
-        }
         reset();
     }
 }

--- a/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/SysProps.java
+++ b/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/SysProps.java
@@ -27,6 +27,9 @@ public class SysProps {
     private static Map<String, String> map = new LinkedHashMap<String, String>();
 
     public static void reset() {
+        for (String key : map.keySet()) {
+            System.clearProperty(key);
+        }
         map.clear();
     }
 
@@ -36,9 +39,6 @@ public class SysProps {
     }
 
     public static void clear() {
-        for (String key : map.keySet()) {
-            System.clearProperty(key);
-        }
         reset();
     }
 }

--- a/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/boot/configprops/SpringBootConfigPropsTest.java
+++ b/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/boot/configprops/SpringBootConfigPropsTest.java
@@ -79,6 +79,12 @@ class SpringBootConfigPropsTest {
 
     @BeforeAll
     public static void beforeAll() {
+        // Clear JVM System properties that other tests in the same JVM may have left set to
+        // disable metrics. Dubbo resolves dubbo.metrics.* from the System properties with the
+        // highest precedence, which would otherwise override this test's @SpringBootTest
+        // property dubbo.metrics.protocol=prometheus and fail the assertion below.
+        System.clearProperty("dubbo.metrics.protocol");
+        System.clearProperty("dubbo.metrics.enabled");
         DubboBootstrap.reset();
     }
 

--- a/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/boot/configprops/SpringBootMultipleConfigPropsTest.java
+++ b/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/boot/configprops/SpringBootMultipleConfigPropsTest.java
@@ -80,6 +80,12 @@ class SpringBootMultipleConfigPropsTest {
 
     @BeforeAll
     public static void beforeAll() {
+        // Clear JVM System properties that other tests in the same JVM may have left set to
+        // disable metrics. Dubbo resolves dubbo.metrics.* from the System properties with the
+        // highest precedence, which would otherwise override the prometheus setting expected
+        // by this test.
+        System.clearProperty("dubbo.metrics.protocol");
+        System.clearProperty("dubbo.metrics.enabled");
         DubboBootstrap.reset();
     }
 

--- a/dubbo-test/dubbo-test-common/src/main/java/org/apache/dubbo/test/common/SysProps.java
+++ b/dubbo-test/dubbo-test-common/src/main/java/org/apache/dubbo/test/common/SysProps.java
@@ -27,6 +27,9 @@ public class SysProps {
     private static Map<String, String> map = new LinkedHashMap<>();
 
     public static void reset() {
+        for (String key : map.keySet()) {
+            System.clearProperty(key);
+        }
         map.clear();
     }
 
@@ -36,9 +39,6 @@ public class SysProps {
     }
 
     public static void clear() {
-        for (String key : map.keySet()) {
-            System.clearProperty(key);
-        }
         reset();
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

`SpringBootConfigPropsTest` intermittently fails in CI with `expected: <prometheus> but was: <disabled>` at `SpringBootConfigPropsTest.java:106`.

The module's metrics-disabling tests set the JVM System property `dubbo.metrics.protocol=disabled`. Dubbo's config resolution (`Environment.getConfigurationMaps()`) gives System properties the highest precedence, so depending on test execution order within the JVM fork, that property overrides this test's `@SpringBootTest` property `dubbo.metrics.protocol=prometheus`, and the assertion fails.

## Root cause

- `dubbo-config-spring` contains 30+ tests that set `dubbo.metrics.protocol=disabled` (some via `SysProps.setProperty`, i.e. real System properties) to disable metrics in their scenarios.
- The failing test binds `MetricsConfig` through Dubbo's own configuration chain, where `SystemConfiguration` ranks first — higher than the Spring inlined test property.
- When a leaked System property survives into this test's context creation (execution-order dependent), `MetricsConfig.protocol` becomes `disabled`.

Reproduction (before fix):
`mvn -pl dubbo-config/dubbo-config-spring -am test -Dtest=SpringBootConfigPropsTest -Ddubbo.metrics.protocol=disabled` fails with the same assertion.

## Brief changelog

1. `SpringBootConfigPropsTest` / `SpringBootMultipleConfigPropsTest`: in `@BeforeAll`, clear the leaked `dubbo.metrics.protocol` / `dubbo.metrics.enabled` System properties before `DubboBootstrap.reset()`, so `prometheus` is always bound regardless of prior test state.
2. `SysProps` (dubbo-config-spring / dubbo-config-api test helpers and dubbo-test-common): make `reset()` also clear the recorded System properties (previously it only cleared the internal map), removing the footgun that could leak such properties between tests.

## Verifying the change

- After fix, the reproduction command (`-Ddubbo.metrics.protocol=disabled`) passes for both `SpringBootConfigPropsTest` and `SpringBootMultipleConfigPropsTest`.
- Regression: SysProps-related tests in dubbo-config-spring (`ConfigTest`, `DubboConfigAliasPostProcessorTest`, `DubboNamespaceHandlerTest`, `JavaConfigBeanTest`, etc.) and dubbo-config-api (`ConfigCenterConfigTest`, `ServiceConfigTest`, `ApplicationConfigTest`, `ReferenceCacheTest`, `MultiInstanceTest`) all pass.
- Spotless passes on all three modules.