### PR TITLE
fix: keep stale addresses refreshed on metadata failure (#16375)

### DIFF
--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/event/listener/ServiceInstancesChangedListener.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/client/event/listener/ServiceInstancesChangedListener.java
@@ -185,8 +185,6 @@ public class ServiceInstancesChangedListener {
         int emptyNum = hasEmptyMetadata(revisionToInstances);
         if (emptyNum != 0) {
             hasEmptyMetadata = true;
-
-            // return if all metadata is empty, this notification will not take effect.
             if (emptyNum == revisionToInstances.size()) {
                 // 1-17 - Address refresh failed.
                 logger.error(
@@ -194,9 +192,6 @@ public class ServiceInstancesChangedListener {
                         "metadata Server failure",
                         "",
                         "Address refresh failed because of Metadata Server failure, wait for retry or new address refresh event.");
-
-                submitRetryTask(event);
-                return;
             }
         } else {
             hasEmptyMetadata = false;

--- a/dubbo-registry/dubbo-registry-api/src/test/java/org/apache/dubbo/registry/client/event/listener/ServiceInstancesChangedListenerTest.java
+++ b/dubbo-registry/dubbo-registry-api/src/test/java/org/apache/dubbo/registry/client/event/listener/ServiceInstancesChangedListenerTest.java
@@ -679,9 +679,36 @@ class ServiceInstancesChangedListenerTest {
         Assertions.assertEquals(2, serviceUrls2_after_retry.size());
     }
 
-    // Abnormal case. Instance does not have revision
+    // Revision failure scenario: after a successful notification, a later one with all metadata lookups failed
+    // should clear stale addresses.
     @Test
     @Order(12)
+    public void testRevisionFailureClearsStaleAddresses() {
+        Set<String> serviceNames = new HashSet<>();
+        serviceNames.add("app2");
+        listener = new ServiceInstancesChangedListener(serviceNames, serviceDiscovery);
+
+        ServiceInstancesChangedEvent successEvent = new ServiceInstancesChangedEvent("app2", app1FailedInstances2);
+        listener.onEvent(successEvent);
+
+        ProtocolServiceKey protocolServiceKey2 = new ProtocolServiceKey(service2, null, null, "dubbo");
+        Assertions.assertEquals(
+                2, listener.getAddresses(protocolServiceKey2, consumerURL).size());
+
+        when(serviceDiscovery.getRemoteMetadata(eq("222"), anyList())).thenReturn(MetadataInfo.EMPTY);
+        List<Object> urlsFailedRevision2 = new ArrayList<>();
+        urlsFailedRevision2.add("30.10.0.1:20880?revision=222");
+        urlsFailedRevision2.add("30.10.0.2:20880?revision=222");
+        ServiceInstancesChangedEvent failedEvent =
+                new ServiceInstancesChangedEvent("app2", buildInstances(urlsFailedRevision2));
+        listener.onEvent(failedEvent);
+
+        assertTrue(isEmpty(listener.getAddresses(protocolServiceKey2, consumerURL)));
+    }
+
+    // Abnormal case. Instance does not have revision
+    @Test
+    @Order(13)
     public void testInstanceWithoutRevision() {
         Set<String> serviceNames = new HashSet<>();
         serviceNames.add("app1");


### PR DESCRIPTION
What is the purpose of the change?
Fixes #16375

Fix stale provider addresses not being cleared when metadata lookup fails for all revisions in `ServiceInstancesChangedListener`. The listener now continues through address notification so a later refresh can evict outdated URLs instead of keeping old Pod IPs around.

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Make sure gitHub actions can pass. [Why the workflow is failing and how to fix it?](../CONTRIBUTING.md)
