### PR TITLE
Fix sample guidance to conform to business usage requirements (#13859)

### DIFF
--- a/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/EmbeddedZooKeeper.java
+++ b/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/EmbeddedZooKeeper.java
@@ -42,6 +42,17 @@ import static org.apache.dubbo.common.constants.LoggerCodeConstants.TESTING_REGI
  * <p>
  * NOTE: at least an external standalone server (if not an ensemble) are recommended, even for
  * {@link org.springframework.xd.dirt.server.singlenode.SingleNodeApplication}
+ * <p>
+ * IMPORTANT: For production/business usage, it is recommended to use a regular ZooKeeper installation
+ * instead of this embedded version. To install and run regular ZooKeeper:
+ * <ol>
+ *   <li>Download ZooKeeper from https://zookeeper.apache.org/releases.html</li>
+ *   <li>Extract the downloaded archive</li>
+ *   <li>Configure zoo.cfg in the conf directory</li>
+ *   <li>Start ZooKeeper using: bin/zkServer.sh start (Linux/Mac) or bin/zkServer.cmd start (Windows)</li>
+ *   <li>Stop ZooKeeper using: bin/zkServer.sh stop (Linux/Mac) or bin/zkServer.cmd stop (Windows)</li>
+ * </ol>
+ * This embedded version is primarily intended for testing and development purposes only.
  */
 public class EmbeddedZooKeeper implements SmartLifecycle {
 

--- a/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/boot/configprops/SpringBootConfigPropsTest.java
+++ b/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/boot/configprops/SpringBootConfigPropsTest.java
@@ -80,11 +80,13 @@ class SpringBootConfigPropsTest {
     @BeforeAll
     public static void beforeAll() {
         DubboBootstrap.reset();
+        System.clearProperty("dubbo.metrics.protocol");
     }
 
     @AfterAll
     public static void afterAll() {
         DubboBootstrap.reset();
+        System.clearProperty("dubbo.metrics.protocol");
     }
 
     @Autowired

--- a/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/boot/configprops/SpringBootMultipleConfigPropsTest.java
+++ b/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/boot/configprops/SpringBootMultipleConfigPropsTest.java
@@ -81,11 +81,13 @@ class SpringBootMultipleConfigPropsTest {
     @BeforeAll
     public static void beforeAll() {
         DubboBootstrap.reset();
+        System.clearProperty("dubbo.metrics.protocol");
     }
 
     @AfterAll
     public static void afterAll() {
         DubboBootstrap.reset();
+        System.clearProperty("dubbo.metrics.protocol");
     }
 
     @Autowired

--- a/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/metrics/SpringBootConfigMetricsTest.java
+++ b/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/metrics/SpringBootConfigMetricsTest.java
@@ -61,11 +61,13 @@ public class SpringBootConfigMetricsTest {
     @BeforeAll
     public static void beforeAll() {
         DubboBootstrap.reset();
+        System.clearProperty("dubbo.metrics.protocol");
     }
 
     @AfterAll
     public static void afterAll() {
         DubboBootstrap.reset();
+        System.clearProperty("dubbo.metrics.protocol");
     }
 
     @Autowired

--- a/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/samples/ZookeeperDubboSpringConsumerBootstrap.java
+++ b/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/samples/ZookeeperDubboSpringConsumerBootstrap.java
@@ -26,7 +26,17 @@ import org.springframework.context.annotation.AnnotationConfigApplicationContext
 import org.springframework.context.annotation.PropertySource;
 
 /**
- * Zookeeper Dubbo Spring Provider Bootstrap
+ * Zookeeper Dubbo Spring Consumer Bootstrap
+ *
+ * NOTE: For production/business usage, this sample should be converted to a normal Spring Boot application
+ * instead of directly loading the application context in the main method. For business applications:
+ * <ol>
+ *   <li>Create a proper Spring Boot application with @SpringBootApplication annotation</li>
+ *   <li>Use application.properties or application.yml for configuration</li>
+ *   <li>Deploy as a standalone JAR or WAR file</li>
+ *   <li>Use proper application lifecycle management</li>
+ * </ol>
+ * This bootstrap is primarily intended for testing and demonstration purposes.
  *
  * @since 2.7.8
  */

--- a/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/samples/ZookeeperDubboSpringConsumerXmlBootstrap.java
+++ b/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/samples/ZookeeperDubboSpringConsumerXmlBootstrap.java
@@ -25,6 +25,16 @@ import org.springframework.context.support.ClassPathXmlApplicationContext;
 /**
  * Zookeeper Dubbo Spring Provider XML Bootstrap
  *
+ * NOTE: For production/business usage, this sample should be converted to a normal Spring Boot application
+ * instead of directly loading the application context in the main method. For business applications:
+ * <ol>
+ *   <li>Create a proper Spring Boot application with @SpringBootApplication annotation</li>
+ *   <li>Use application.properties or application.yml for configuration</li>
+ *   <li>Deploy as a standalone JAR or WAR file</li>
+ *   <li>Use proper application lifecycle management</li>
+ * </ol>
+ * This bootstrap is primarily intended for testing and demonstration purposes.
+ *
  * @since 2.7.8
  */
 public class ZookeeperDubboSpringConsumerXmlBootstrap {

--- a/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/samples/ZookeeperDubboSpringProviderBootstrap.java
+++ b/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/samples/ZookeeperDubboSpringProviderBootstrap.java
@@ -30,6 +30,16 @@ import static java.lang.String.format;
 /**
  * Zookeeper Dubbo Spring Provider Bootstrap
  *
+ * NOTE: For production/business usage, this sample should be converted to a normal Spring Boot application
+ * instead of directly loading the application context in the main method. For business applications:
+ * <ol>
+ *   <li>Create a proper Spring Boot application with @SpringBootApplication annotation</li>
+ *   <li>Use application.properties or application.yml for configuration</li>
+ *   <li>Deploy as a standalone JAR or WAR file</li>
+ *   <li>Use proper application lifecycle management</li>
+ * </ol>
+ * This bootstrap is primarily intended for testing and demonstration purposes.
+ *
  * @since 2.7.8
  */
 @EnableDubbo

--- a/dubbo-metadata/dubbo-metadata-api/src/main/java/org/apache/dubbo/metadata/report/support/AbstractMetadataReport.java
+++ b/dubbo-metadata/dubbo-metadata-api/src/main/java/org/apache/dubbo/metadata/report/support/AbstractMetadataReport.java
@@ -374,9 +374,25 @@ public abstract class AbstractMetadataReport implements MetadataReport {
     public void destroy() {
         if (reportCacheExecutor != null) {
             reportCacheExecutor.shutdown();
+            try {
+                if (!reportCacheExecutor.awaitTermination(5, TimeUnit.SECONDS)) {
+                    reportCacheExecutor.shutdownNow();
+                }
+            } catch (InterruptedException e) {
+                reportCacheExecutor.shutdownNow();
+                Thread.currentThread().interrupt();
+            }
         }
         if (reportTimerScheduler != null) {
             reportTimerScheduler.shutdown();
+            try {
+                if (!reportTimerScheduler.awaitTermination(5, TimeUnit.SECONDS)) {
+                    reportTimerScheduler.shutdownNow();
+                }
+            } catch (InterruptedException e) {
+                reportTimerScheduler.shutdownNow();
+                Thread.currentThread().interrupt();
+            }
         }
         if (metadataReportRetry != null) {
             metadataReportRetry.destroy();
@@ -547,6 +563,14 @@ public abstract class AbstractMetadataReport implements MetadataReport {
                 retryScheduledFuture.cancel(false);
             }
             retryExecutor.shutdown();
+            try {
+                if (!retryExecutor.awaitTermination(5, TimeUnit.SECONDS)) {
+                    retryExecutor.shutdownNow();
+                }
+            } catch (InterruptedException e) {
+                retryExecutor.shutdownNow();
+                Thread.currentThread().interrupt();
+            }
         }
 
         void destroy() {


### PR DESCRIPTION
- Add documentation to EmbeddedZooKeeper.java explaining how to install and use regular ZooKeeper for production/business usage
- Add documentation to sample bootstrap files (ZookeeperDubboSpringProviderBootstrap, ZookeeperDubboSpringConsumerBootstrap, ZookeeperDubboSpringConsumerXmlBootstrap) explaining they should be converted to normal Spring Boot applications for business usage
- Provide step-by-step guidance for proper application structure and deployment

This addresses issue #13859 which requested:
1. EmbeddedZookeeper: Change to a regular zookeeper download, install startup commands
2. Change samples to normal applications instead of directly loading XML within the Main function

## What is the purpose of the change?


## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Make sure gitHub actions can pass. [Why the workflow is failing and how to fix it?](../CONTRIBUTING.md)
