### PR TITLE
fix: sync local flow controller initial window with SETTINGS value

### DIFF
--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/TripleHttp2Protocol.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/TripleHttp2Protocol.java
@@ -127,9 +127,14 @@ public class TripleHttp2Protocol extends AbstractWireProtocol implements ScopeMo
 
     private Http2Connection createHttp2ClientConnection(TripleConfig tripleConfig) {
         Http2Connection connection = new DefaultHttp2Connection(false);
+        int initialWindowSize = tripleConfig.getInitialWindowSizeOrDefault();
         float windowUpdateRatio = tripleConfig.getWindowUpdateRatioOrDefault();
         connection.local().flowController(TripleHttp2LocalFlowController.newController(connection, windowUpdateRatio));
         connection.remote().flowController(TripleHttp2RemoteFlowController.newController(connection));
+        // Sync the local flow controller's initial window size with the
+        // value advertised in SETTINGS, so the local enforcement matches
+        // the window the peer is allowed to fill.
+        connection.local().flowController().initialWindowSize(initialWindowSize);
         return connection;
     }
 
@@ -265,9 +270,14 @@ public class TripleHttp2Protocol extends AbstractWireProtocol implements ScopeMo
 
     private Http2Connection createHttp2ServerConnection(TripleConfig tripleConfig) {
         Http2Connection connection = new DefaultHttp2Connection(true);
+        int initialWindowSize = tripleConfig.getInitialWindowSizeOrDefault();
         float windowUpdateRatio = tripleConfig.getWindowUpdateRatioOrDefault();
         connection.local().flowController(TripleHttp2LocalFlowController.newController(connection, windowUpdateRatio));
         connection.remote().flowController(TripleHttp2RemoteFlowController.newController(connection));
+        // Sync the local flow controller's initial window size with the
+        // value advertised in SETTINGS, so the local enforcement matches
+        // the window the peer is allowed to fill.
+        connection.local().flowController().initialWindowSize(initialWindowSize);
         return connection;
     }
 


### PR DESCRIPTION
## Problem

The Triple HTTP/2 client advertises a stream window size via SETTINGS (`SETTINGS_INITIAL_WINDOW_SIZE`) but the local `Http2LocalFlowController` retains the Netty default of 65,535 bytes. This mismatch causes two failure modes:

1. **8 MiB window**: The Java client tells the PHP server "send up to 8 MiB", the server sends 92 KiB of data, but the local flow controller rejects it with "Flow control window exceeded for stream".
2. **64 KiB window**: The PHP server exhausts the advertised window and waits for a WINDOW_UPDATE, but the client never sends one because the gRPC message cannot be assembled from partial data.

## Root Cause

In `createHttp2ClientConnection()` and `createHttp2ServerConnection()`, a custom `TripleHttp2LocalFlowController` is created and attached to the connection, but its initial window size is never updated from the default 65,535 to match the value broadcast in the SETTINGS frame. The local flow controller enforces a smaller window than what was advertised to the peer.

## Fix

After attaching the flow controllers, call `connection.local().flowController().initialWindowSize(initialWindowSize)` to synchronize the local enforcement window with the advertised SETTINGS value. This is applied in both `createHttp2ClientConnection()` and `createHttp2ServerConnection()`.

Fixes #16427