### PR TITLE
chore: upgrade actions/setup-java to v6

### DIFF
--- a/.github/workflows/build-and-test-pr.yml
+++ b/.github/workflows/build-and-test-pr.yml
@@ -52,7 +52,7 @@ jobs:
       - name: "Checkout"
         uses: actions/checkout@v4
       - name: "Setup maven"
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v6
         with:
           java-version: 21
           distribution: zulu
@@ -96,7 +96,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: "Set up JDK 21"
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v6
         with:
           distribution: 'zulu'
           java-version: 21
@@ -121,7 +121,7 @@ jobs:
       - name: "Checkout code"
         uses: actions/checkout@v4
       - name: "Set up JDK"
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v6
         with:
           distribution: 'zulu'
           java-version: 21
@@ -238,7 +238,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: "Set up JDK ${{ matrix.java }}"
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v6
         with:
           distribution: 'zulu'
           java-version: ${{ matrix.java }}
@@ -348,7 +348,7 @@ jobs:
           name: samples-test-list
           path: test/jobs/
       - name: "Set up JDK ${{matrix.java}}"
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v6
         with:
           distribution: 'zulu'
           java-version: ${{matrix.java}}
@@ -463,7 +463,7 @@ jobs:
           name: test-list
           path: test/jobs/
       - name: "Set up JDK ${{matrix.java}}"
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v6
         with:
           distribution: 'zulu'
           java-version: ${{matrix.java}}
@@ -533,7 +533,7 @@ jobs:
           repository: 'apache/dubbo-samples'
           path: "./dubbo-samples"
       - name: "Set up JDK 21"
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v6
         with:
           distribution: 'zulu'
           java-version: 21
@@ -583,7 +583,7 @@ jobs:
           repository: 'apache/dubbo-integration-cases'
           path: "./dubbo-integration-cases"
       - name: "Set up JDK 21"
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v6
         with:
           distribution: 'zulu'
           java-version: 21
@@ -633,7 +633,7 @@ jobs:
           ref: main
           path: "./dubbo-test-tools"
       - name: "Set up JDK 21"
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v6
         with:
           distribution: 'zulu'
           java-version: 21

--- a/.github/workflows/build-and-test-scheduled-3.1.yml
+++ b/.github/workflows/build-and-test-scheduled-3.1.yml
@@ -40,7 +40,7 @@ jobs:
         with:
           ref: "3.1"
           path: dubbo
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v6
         with:
           distribution: 'zulu'
           java-version: 8
@@ -140,7 +140,7 @@ jobs:
         with:
           ref: "3.1"
       - name: "Set up JDK ${{ matrix.jdk }}"
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v6
         with:
           java-version: ${{ matrix.jdk }}
       - uses: actions/cache@v3
@@ -184,7 +184,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: "Set up JDK ${{ matrix.jdk }}"
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v6
         with:
           distribution: 'zulu'
           java-version: ${{ matrix.jdk }}
@@ -278,7 +278,7 @@ jobs:
           name: samples-test-list
           path: test/jobs/
       - name: "Set up JDK ${{matrix.jdk}}"
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v6
         with:
           java-version: ${{matrix.jdk}}
       - name: "Init Candidate Versions"
@@ -384,7 +384,7 @@ jobs:
           name: integration-test-list
           path: test/jobs/
       - name: "Set up JDK ${{matrix.jdk}}"
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v6
         with:
           java-version: ${{matrix.jdk}}
       - name: "Init Candidate Versions"
@@ -448,7 +448,7 @@ jobs:
           path: "./dubbo-test-tools"
 
       - name: "Set up JDK 21"
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v6
         with:
           distribution: 'zulu'
           java-version: 21

--- a/.github/workflows/build-and-test-scheduled-3.2.yml
+++ b/.github/workflows/build-and-test-scheduled-3.2.yml
@@ -40,7 +40,7 @@ jobs:
         with:
           ref: "3.2"
           path: dubbo
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v6
         with:
           distribution: 'zulu'
           java-version: 8
@@ -140,7 +140,7 @@ jobs:
         with:
           ref: "3.2"
       - name: "Set up JDK ${{ matrix.jdk }}"
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v6
         with:
           java-version: ${{ matrix.jdk }}
       - uses: actions/cache@v3
@@ -184,7 +184,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: "Set up JDK ${{ matrix.jdk }}"
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v6
         with:
           distribution: 'zulu'
           java-version: ${{ matrix.jdk }}
@@ -278,7 +278,7 @@ jobs:
           name: samples-test-list
           path: test/jobs/
       - name: "Set up JDK ${{matrix.jdk}}"
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v6
         with:
           java-version: ${{matrix.jdk}}
       - name: "Init Candidate Versions"
@@ -384,7 +384,7 @@ jobs:
           name: integration-test-list
           path: test/jobs/
       - name: "Set up JDK ${{matrix.jdk}}"
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v6
         with:
           java-version: ${{matrix.jdk}}
       - name: "Init Candidate Versions"
@@ -448,7 +448,7 @@ jobs:
           path: "./dubbo-test-tools"
 
       - name: "Set up JDK 21"
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v6
         with:
           distribution: 'zulu'
           java-version: 21

--- a/.github/workflows/build-and-test-scheduled-3.3.yml
+++ b/.github/workflows/build-and-test-scheduled-3.3.yml
@@ -40,7 +40,7 @@ jobs:
         with:
           ref: "3.3"
           path: dubbo
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v6
         with:
           distribution: 'zulu'
           java-version: 21
@@ -146,7 +146,7 @@ jobs:
         with:
           ref: "3.3"
       - name: "Set up JDK ${{ matrix.jdk }}"
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v6
         with:
           java-version: ${{ matrix.jdk }}
       - uses: actions/cache@v3
@@ -196,7 +196,7 @@ jobs:
         run: echo "MAVEN_OPTS=--sun-misc-unsafe-memory-access=allow" >> $env:GITHUB_ENV
       - uses: actions/checkout@v4
       - name: "Set up JDK ${{ matrix.jdk }}"
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v6
         with:
           distribution: 'zulu'
           java-version: ${{ matrix.jdk }}
@@ -293,7 +293,7 @@ jobs:
           name: samples-test-list
           path: test/jobs/
       - name: "Set up JDK ${{matrix.jdk}}"
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v6
         with:
           java-version: ${{matrix.jdk}}
       - name: "Init Candidate Versions"
@@ -402,7 +402,7 @@ jobs:
           name: integration-test-list
           path: test/jobs/
       - name: "Set up JDK ${{matrix.jdk}}"
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v6
         with:
           java-version: ${{matrix.jdk}}
       - name: "Init Candidate Versions"
@@ -466,7 +466,7 @@ jobs:
           path: "./dubbo-test-tools"
 
       - name: "Set up JDK 21"
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v6
         with:
           distribution: 'zulu'
           java-version: 21

--- a/.github/workflows/release-test.yml
+++ b/.github/workflows/release-test.yml
@@ -38,7 +38,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           path: dubbo
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v6
         with:
           distribution: 'zulu'
           java-version: 21
@@ -140,7 +140,7 @@ jobs:
         if: ${{ matrix.jdk >= 24 && startsWith(matrix.os, 'windows') }}
         run: echo "MAVEN_OPTS=--sun-misc-unsafe-memory-access=allow" >> $env:GITHUB_ENV
       - name: "Set up JDK ${{ matrix.jdk }}"
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v6
         with:
           java-version: ${{ matrix.jdk }}
           distribution: 'zulu'
@@ -191,7 +191,7 @@ jobs:
         if: ${{ matrix.jdk >= 24 && startsWith(matrix.os, 'windows') }}
         run: echo "MAVEN_OPTS=--sun-misc-unsafe-memory-access=allow" >> $env:GITHUB_ENV
       - name: "Set up JDK ${{ matrix.jdk }}"
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v6
         with:
           distribution: 'zulu'
           java-version: ${{ matrix.jdk }}
@@ -288,7 +288,7 @@ jobs:
           name: samples-test-list
           path: test/jobs/
       - name: "Set up JDK ${{matrix.jdk}}"
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v6
         with:
           java-version: ${{matrix.jdk}}
       - name: "Init Candidate Versions"
@@ -391,7 +391,7 @@ jobs:
           name: integration-test-list
           path: test/jobs/
       - name: "Set up JDK ${{matrix.jdk}}"
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v6
         with:
           java-version: ${{matrix.jdk}}
       - name: "Init Candidate Versions"
@@ -448,7 +448,7 @@ jobs:
           path: "./dubbo-test-tools"
 
       - name: "Set up JDK 21"
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v6
         with:
           java-version: 21
           distribution: 'zulu'


### PR DESCRIPTION
## What is the purpose of the change?

Upgrade every active GitHub workflow reference from setup-java v1/v4 to v6.

GitHub_issue: N/A (routine CI dependency maintenance).

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction. Not applicable; this only updates the CI action version. `git diff --check` passes and no setup-java references older than v6 remain.
- [ ] Make sure gitHub actions can pass. [Why the workflow is failing and how to fix it?](../CONTRIBUTING.md)
