### PR TITLE
fix: JavaBeanSerializeUtil handles null key in Map serialization

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/beanutil/JavaBeanDescriptor.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/beanutil/JavaBeanDescriptor.java
@@ -116,7 +116,9 @@ public final class JavaBeanDescriptor implements Serializable, Iterable<Map.Entr
     }
 
     public Object setProperty(Object propertyName, Object propertyValue) {
-        notNull(propertyName, "Property name is null");
+        if (!isMapType()) {
+            notNull(propertyName, "Property name is null");
+        }
         return properties.put(propertyName, propertyValue);
     }
 

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/beanutil/JavaBeanSerializeUtilTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/beanutil/JavaBeanSerializeUtilTest.java
@@ -225,7 +225,26 @@ class JavaBeanSerializeUtilTest {
     }
 
     @Test
-    void testConstructorArg() {
+    public void testSerialize_MapWithNullKey() {
+        Map<String, String> map = new HashMap<>();
+        map.put("key1", "value1");
+        map.put(null, "nullKeyValue");
+
+        JavaBeanDescriptor descriptor = JavaBeanSerializeUtil.serialize(map);
+        Assertions.assertTrue(descriptor.isMapType());
+        Assertions.assertEquals(HashMap.class.getName(), descriptor.getClassName());
+        Assertions.assertEquals(2, descriptor.propertySize());
+
+        // round-trip
+        Object result = JavaBeanSerializeUtil.deserialize(descriptor);
+        Assertions.assertTrue(result instanceof Map);
+        Map<String, String> resultMap = (Map<String, String>) result;
+        Assertions.assertEquals("value1", resultMap.get("key1"));
+        Assertions.assertEquals("nullKeyValue", resultMap.get(null));
+    }
+
+    @Test
+    public void testConstructorArg() {
         Assertions.assertFalse((boolean) JavaBeanSerializeUtil.getConstructorArg(boolean.class));
         Assertions.assertFalse((boolean) JavaBeanSerializeUtil.getConstructorArg(Boolean.class));
         Assertions.assertEquals((byte) 0, JavaBeanSerializeUtil.getConstructorArg(byte.class));


### PR DESCRIPTION
## What is the purpose of the change

Fixes #16432: `JavaBeanSerializeUtil.serialize()` throws `IllegalArgumentException("Property name is null")` when serializing a `Map` that contains a `null` key.

`HashMap` permits exactly one `null` key, so this is a legal input. The Map branch in `serializeInternal` explicitly handles null keys (`key == null ? null : createDescriptorIfAbsent(...)`), but the descriptor produced is then rejected by the `notNull` check in `JavaBeanDescriptor.setProperty()`.

## Root cause

In `JavaBeanSerializeUtil.serializeInternal()` Map branch:

```java
map.forEach((key, value) -> {
    Object keyDescriptor = key == null ? null : createDescriptorIfAbsent(key, accessor, cache);
    Object valueDescriptor = value == null ? null : createDescriptorIfAbsent(value, accessor, cache);
    descriptor.setProperty(keyDescriptor, valueDescriptor);
});
```

When the map has a null key, `keyDescriptor` is `null`, and `JavaBeanDescriptor.setProperty(null, value)` throws because of the `notNull(propertyName, "Property name is null")` guard.

## Fix

Relax the `notNull` guard in `JavaBeanDescriptor.setProperty()` for map-type descriptors only — a `null` key is a legal Map key and `LinkedHashMap` (the backing storage) supports it. Bean/array/collection/class/enum descriptors keep the original null check.

## Verification

- Added `testSerialize_MapWithNullKey` (round-trip test: map with a null key serializes, deserializes, and preserves both key-value pairs)
- Existing `JavaBeanSerializeUtilTest` suite unaffected

## Checklist

- [x] I have read and agree to the Contributor Guidelines
- [x] I have added tests that prove my fix is effective
- [x] The PR targets the `3.3` branch