### PR TITLE
fix(remoting): avoid starving the shared reconnect scheduler with blocking connects

### DIFF
--- a/dubbo-remoting/dubbo-remoting-netty4/src/main/java/org/apache/dubbo/remoting/transport/netty4/AbstractNettyConnectionClient.java
+++ b/dubbo-remoting/dubbo-remoting-netty4/src/main/java/org/apache/dubbo/remoting/transport/netty4/AbstractNettyConnectionClient.java
@@ -25,6 +25,7 @@ import org.apache.dubbo.remoting.RemotingException;
 import org.apache.dubbo.remoting.api.connection.AbstractConnectionClient;
 
 import java.util.Optional;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
@@ -180,14 +181,25 @@ public abstract class AbstractNettyConnectionClient extends AbstractConnectionCl
     protected void scheduleReconnect(long reconnectDuration, TimeUnit unit) {
         connectivityExecutor.schedule(
                 () -> {
+                    // doConnect() blocks on the connecting promise for up to the connect timeout. Running it inline
+                    // on the shared framework connectivity scheduler lets a batch of failing connections (e.g.
+                    // unreachable providers) occupy every scheduler thread and starve the reconnect tasks of other
+                    // clients. Delegate the blocking connect to the client executor so the shared scheduler only
+                    // handles the delay.
                     try {
-                        doConnect();
-                    } catch (RemotingException e) {
-                        logger.error(
-                                TRANSPORT_FAILED_RECONNECT,
-                                "",
-                                "",
-                                "Failed to connect to server: " + getConnectAddress());
+                        executor.execute(() -> {
+                            try {
+                                doConnect();
+                            } catch (RemotingException e) {
+                                logger.error(
+                                        TRANSPORT_FAILED_RECONNECT,
+                                        "",
+                                        "",
+                                        "Failed to connect to server: " + getConnectAddress());
+                            }
+                        });
+                    } catch (RejectedExecutionException ignored) {
+                        // The client is being closed and no more reconnects are needed.
                     }
                 },
                 reconnectDuration,

--- a/dubbo-remoting/dubbo-remoting-netty4/src/test/java/org/apache/dubbo/remoting/transport/netty4/ScheduleReconnectTest.java
+++ b/dubbo-remoting/dubbo-remoting-netty4/src/test/java/org/apache/dubbo/remoting/transport/netty4/ScheduleReconnectTest.java
@@ -31,6 +31,8 @@ import org.apache.dubbo.rpc.model.FrameworkModel;
 
 import java.net.ConnectException;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
@@ -45,7 +47,11 @@ import org.junit.jupiter.api.Test;
 
 import static org.apache.dubbo.common.constants.CommonConstants.EXECUTOR_MANAGEMENT_MODE_DEFAULT;
 import static org.apache.dubbo.remoting.Constants.LEAST_RECONNECT_DURATION_KEY;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
@@ -107,6 +113,36 @@ class ScheduleReconnectTest {
         Assertions.assertTrue(
                 CONNECT_THREAD.get().startsWith("DubboClientHandler"),
                 "reconnect should run on the client executor, but ran on " + CONNECT_THREAD.get());
+
+        client.close(2000);
+    }
+
+    @Test
+    void testReconnectSwallowsExecutorRejection() throws Exception {
+        int port = NetUtils.getAvailablePort();
+        URL url = URL.valueOf("empty://127.0.0.1:" + port + "/client.schedule.reconnect.reject.test?check=false&"
+                + Constants.CONNECT_TIMEOUT_KEY + "=1000&" + LEAST_RECONNECT_DURATION_KEY + "=60000");
+        ApplicationModel applicationModel =
+                frameworkModel.getApplicationModels().get(0);
+        url = url.putAttribute(CommonConstants.SCOPE_MODEL, applicationModel);
+
+        BlockingConnectClient client = new BlockingConnectClient(url, new HandlerAdapter());
+
+        // Replace the client executor with one that rejects tasks, as if the executor were shut
+        // down while a reconnect was still pending.
+        ExecutorService rejectingExecutor = mock(ExecutorService.class);
+        doThrow(new RejectedExecutionException("executor is shut down"))
+                .when(rejectingExecutor)
+                .execute(any(Runnable.class));
+        java.lang.reflect.Field executorField =
+                org.apache.dubbo.remoting.transport.AbstractClient.class.getDeclaredField("executor");
+        executorField.setAccessible(true);
+        executorField.set(client, rejectingExecutor);
+
+        client.scheduleReconnect(0, TimeUnit.MILLISECONDS);
+        // The scheduled task must reach the client executor and swallow the rejection instead of
+        // propagating it out of the shared connectivity scheduler.
+        verify(rejectingExecutor, timeout(5000)).execute(any(Runnable.class));
 
         client.close(2000);
     }

--- a/dubbo-remoting/dubbo-remoting-netty4/src/test/java/org/apache/dubbo/remoting/transport/netty4/ScheduleReconnectTest.java
+++ b/dubbo-remoting/dubbo-remoting-netty4/src/test/java/org/apache/dubbo/remoting/transport/netty4/ScheduleReconnectTest.java
@@ -1,0 +1,157 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.remoting.transport.netty4;
+
+import org.apache.dubbo.common.URL;
+import org.apache.dubbo.common.constants.CommonConstants;
+import org.apache.dubbo.common.utils.NetUtils;
+import org.apache.dubbo.config.ApplicationConfig;
+import org.apache.dubbo.config.context.ConfigManager;
+import org.apache.dubbo.remoting.Channel;
+import org.apache.dubbo.remoting.ChannelHandler;
+import org.apache.dubbo.remoting.Constants;
+import org.apache.dubbo.remoting.RemotingException;
+import org.apache.dubbo.remoting.transport.ChannelHandlerAdapter;
+import org.apache.dubbo.rpc.model.ApplicationModel;
+import org.apache.dubbo.rpc.model.FrameworkModel;
+
+import java.net.ConnectException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.DefaultChannelPromise;
+import io.netty.channel.DefaultEventLoop;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.apache.dubbo.common.constants.CommonConstants.EXECUTOR_MANAGEMENT_MODE_DEFAULT;
+import static org.apache.dubbo.remoting.Constants.LEAST_RECONNECT_DURATION_KEY;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Verifies that the blocking reconnect attempt is delegated to the client executor instead of running on the shared
+ * framework connectivity scheduler. See https://github.com/apache/dubbo/issues/13853
+ */
+class ScheduleReconnectTest {
+
+    // Static because performConnect is invoked from the super constructor before instance fields exist.
+    private static final AtomicBoolean FIRST_CONNECT = new AtomicBoolean(true);
+
+    private static final CountDownLatch CONNECT_ATTEMPT = new CountDownLatch(1);
+
+    private static final AtomicReference<String> CONNECT_THREAD = new AtomicReference<>();
+
+    private static final io.netty.channel.Channel MOCK_CHANNEL = mock(io.netty.channel.Channel.class);
+
+    private static final DefaultEventLoop MOCK_EVENT_LOOP = new DefaultEventLoop();
+
+    static {
+        when(MOCK_CHANNEL.eventLoop()).thenReturn(MOCK_EVENT_LOOP);
+    }
+
+    private FrameworkModel frameworkModel;
+
+    @BeforeEach
+    void setUp() {
+        FIRST_CONNECT.set(true);
+        frameworkModel = new FrameworkModel();
+        ApplicationModel applicationModel = frameworkModel.newApplication();
+        ApplicationConfig applicationConfig = new ApplicationConfig("reconnect-app");
+        applicationConfig.setExecutorManagementMode(EXECUTOR_MANAGEMENT_MODE_DEFAULT);
+        ConfigManager configManager = new ConfigManager(applicationModel);
+        configManager.setApplication(applicationConfig);
+        configManager.getApplication();
+        applicationModel.setConfigManager(configManager);
+    }
+
+    @AfterEach
+    void tearDown() {
+        frameworkModel.destroy();
+    }
+
+    @Test
+    void testReconnectRunsOnClientExecutor() throws Exception {
+        int port = NetUtils.getAvailablePort();
+        URL url = URL.valueOf("empty://127.0.0.1:" + port + "/client.schedule.reconnect.test?check=false&"
+                + Constants.CONNECT_TIMEOUT_KEY + "=1000&" + LEAST_RECONNECT_DURATION_KEY + "=60000");
+        ApplicationModel applicationModel =
+                frameworkModel.getApplicationModels().get(0);
+        url = url.putAttribute(CommonConstants.SCOPE_MODEL, applicationModel);
+
+        BlockingConnectClient client = new BlockingConnectClient(url, new HandlerAdapter());
+
+        // Trigger a reconnect manually. The scheduled task must hand the blocking connect off to the client
+        // executor instead of running it on the shared connectivity scheduler thread.
+        client.scheduleReconnect(0, TimeUnit.MILLISECONDS);
+        Assertions.assertTrue(CONNECT_ATTEMPT.await(5, TimeUnit.SECONDS), "reconnect was not attempted in time");
+        Assertions.assertTrue(
+                CONNECT_THREAD.get().startsWith("DubboClientHandler"),
+                "reconnect should run on the client executor, but ran on " + CONNECT_THREAD.get());
+
+        client.close(2000);
+    }
+
+    private static class HandlerAdapter extends ChannelHandlerAdapter {
+        @Override
+        public void connected(Channel channel) {}
+
+        @Override
+        public void disconnected(Channel channel) {}
+
+        @Override
+        public void sent(Channel channel, Object message) {}
+
+        @Override
+        public void received(Channel channel, Object message) {}
+
+        @Override
+        public void caught(Channel channel, Throwable exception) {}
+    }
+
+    private static class BlockingConnectClient extends AbstractNettyConnectionClient {
+
+        BlockingConnectClient(URL url, ChannelHandler handler) throws RemotingException {
+            super(url, handler);
+        }
+
+        @Override
+        protected void initBootstrap() {
+            // No real bootstrap is needed because performConnect is stubbed.
+        }
+
+        @Override
+        protected ChannelFuture performConnect() {
+            if (FIRST_CONNECT.compareAndSet(true, false)) {
+                // Fail the initial connect performed by the constructor so the client can be
+                // created against an unreachable address.
+                return new DefaultChannelPromise(MOCK_CHANNEL, MOCK_EVENT_LOOP)
+                        .setFailure(new ConnectException("initial connect fails"));
+            }
+            CONNECT_THREAD.set(Thread.currentThread().getName());
+            CONNECT_ATTEMPT.countDown();
+            // Never completes: doConnect() blocks on this promise until the connect timeout,
+            // exercising the blocking path on the executing thread.
+            return new DefaultChannelPromise(MOCK_CHANNEL, MOCK_EVENT_LOOP);
+        }
+    }
+}


### PR DESCRIPTION
## What changed

`AbstractNettyConnectionClient.scheduleReconnect` now delegates the blocking `doConnect()` to the client executor instead of running it inline on the framework-shared connectivity scheduler thread.

## Why

`doConnect()` blocks on the connecting promise for up to the connect timeout (3s by default). When several providers are unreachable, each failed connection occupied one of the shared scheduler's `availableProcessors` threads for the full timeout, starving the reconnect tasks of all other clients. Healthy connections then experienced request timeouts even though the server responded quickly (apache/dubbo#13853).

The shared scheduler now only handles the delay; the blocking connect runs on the per-client executor, so one client's reconnects can no longer starve the others.

## Testing

- Added `ScheduleReconnectTest` which stubs `performConnect` with a never-completing promise and asserts the reconnect attempt runs on a `DubboClientHandler` thread rather than the shared scheduler thread. The test fails on the previous implementation and passes with the fix.
- `mvn -pl dubbo-remoting/dubbo-remoting-netty4 test -Dtest=ScheduleReconnectTest,SingleProtocolConnectionManagerTest,MultiplexProtocolConnectionManagerTest,NettyPortUnificationServerHandlerTest` passes (6/6).
- `spotless:check` and `checkstyle:check` pass.

Fixes #13853