### PR TITLE
fix(serialization): enforce writeReplace security check for hessian2

### DIFF
--- a/dubbo-serialization/dubbo-serialization-hessian2/src/main/java/org/apache/dubbo/common/serialize/hessian2/Hessian2SerializerFactory.java
+++ b/dubbo-serialization/dubbo-serialization-hessian2/src/main/java/org/apache/dubbo/common/serialize/hessian2/Hessian2SerializerFactory.java
@@ -20,7 +20,9 @@ import org.apache.dubbo.common.utils.DefaultSerializeClassChecker;
 
 import java.io.Serializable;
 
+import com.alibaba.com.caucho.hessian.io.AbstractSerializerFactory;
 import com.alibaba.com.caucho.hessian.io.Deserializer;
+import com.alibaba.com.caucho.hessian.io.HessianProtocolException;
 import com.alibaba.com.caucho.hessian.io.JavaDeserializer;
 import com.alibaba.com.caucho.hessian.io.JavaSerializer;
 import com.alibaba.com.caucho.hessian.io.Serializer;
@@ -34,6 +36,12 @@ public class Hessian2SerializerFactory extends SerializerFactory {
             ClassLoader classLoader, DefaultSerializeClassChecker defaultSerializeClassChecker) {
         super(classLoader);
         this.defaultSerializeClassChecker = defaultSerializeClassChecker;
+        // hessian-lite 3.2.x resolves classes with a writeReplace() method to
+        // JavaSerializer directly and never reaches getDefaultSerializer(), so
+        // such classes would otherwise skip checkSerializable(). Prepend a
+        // check factory that applies the same check and then falls through to
+        // the normal resolution chain. See https://github.com/apache/dubbo/issues/16287.
+        addFactory(new WriteReplaceCheckFactory());
     }
 
     @Override
@@ -82,5 +90,40 @@ public class Hessian2SerializerFactory extends SerializerFactory {
             throw new IllegalStateException(
                     "Serialized class " + cl.getName() + " must implement java.io.Serializable");
         }
+    }
+
+    /**
+     * Applies {@link #checkSerializable(Class)} to classes carrying a
+     * writeReplace() method before hessian-lite resolves them, and returns
+     * null so the normal SerializerFactory resolution chain keeps control.
+     */
+    private final class WriteReplaceCheckFactory extends AbstractSerializerFactory {
+        @Override
+        public Serializer getSerializer(Class cl) throws HessianProtocolException {
+            if (hasWriteReplace(cl)) {
+                checkSerializable(cl);
+            }
+            return null;
+        }
+
+        @Override
+        public Deserializer getDeserializer(Class cl) throws HessianProtocolException {
+            return null;
+        }
+    }
+
+    /**
+     * Mirrors hessian-lite 3.2.x JavaSerializer.getWriteReplace: walks the
+     * superclass chain for a no-arg writeReplace() method of any visibility.
+     */
+    private static boolean hasWriteReplace(Class<?> cl) {
+        for (; cl != null; cl = cl.getSuperclass()) {
+            for (java.lang.reflect.Method method : cl.getDeclaredMethods()) {
+                if ("writeReplace".equals(method.getName()) && method.getParameterTypes().length == 0) {
+                    return true;
+                }
+            }
+        }
+        return false;
     }
 }

--- a/dubbo-serialization/dubbo-serialization-hessian2/src/test/java/org/apache/dubbo/common/serialize/hessian2/Hessian2WriteReplaceSecurityTest.java
+++ b/dubbo-serialization/dubbo-serialization-hessian2/src/test/java/org/apache/dubbo/common/serialize/hessian2/Hessian2WriteReplaceSecurityTest.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.common.serialize.hessian2;
+
+import org.apache.dubbo.common.URL;
+import org.apache.dubbo.common.serialize.ObjectOutput;
+import org.apache.dubbo.common.serialize.Serialization;
+import org.apache.dubbo.rpc.model.FrameworkModel;
+
+import java.io.ByteArrayOutputStream;
+import java.io.Serializable;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Regression tests for https://github.com/apache/dubbo/issues/16287: classes
+ * with a writeReplace() method must not bypass the serialization security
+ * check enforced by {@link Hessian2SerializerFactory#checkSerializable}.
+ */
+class Hessian2WriteReplaceSecurityTest {
+
+    /** Non-Serializable class whose writeReplace() returns a legal value. */
+    static class NotSerializableWithReplace {
+        Object writeReplace() {
+            return "replaced";
+        }
+    }
+
+    /** Serializable class whose writeReplace() returns a non-Serializable holder. */
+    static class SerializableWithHolderReplace implements Serializable {
+        private static final long serialVersionUID = 1L;
+
+        Object writeReplace() {
+            return new SecretHolder("s3cret");
+        }
+    }
+
+    static final class SecretHolder {
+        @SuppressWarnings("unused")
+        private final String secret;
+
+        SecretHolder(String secret) {
+            this.secret = secret;
+        }
+    }
+
+    /** Legal case: a Serializable class whose writeReplace() returns a String. */
+    static class SerializableWithStringReplace implements Serializable {
+        private static final long serialVersionUID = 1L;
+
+        Object writeReplace() {
+            return "replaced";
+        }
+    }
+
+    private ObjectOutput newOutput() throws java.io.IOException {
+        FrameworkModel frameworkModel = new FrameworkModel();
+        Serialization serialization =
+                frameworkModel.getExtensionLoader(Serialization.class).getExtension("hessian2");
+        URL url = URL.valueOf("").setScopeModel(frameworkModel);
+        return serialization.serialize(url, new ByteArrayOutputStream());
+    }
+
+    @Test
+    void nonSerializableWithReplaceIsRejected() throws Exception {
+        ObjectOutput out = newOutput();
+        assertThrows(java.io.IOException.class, () -> {
+            out.writeObject(new NotSerializableWithReplace());
+            out.flushBuffer();
+        });
+    }
+
+    @Test
+    void nonSerializableReplacementIsRejected() throws Exception {
+        ObjectOutput out = newOutput();
+        assertThrows(java.io.IOException.class, () -> {
+            out.writeObject(new SerializableWithHolderReplace());
+            out.flushBuffer();
+        });
+    }
+
+    @Test
+    void serializableWithLegalReplaceStillWorks() throws Exception {
+        ObjectOutput out = newOutput();
+        out.writeObject(new SerializableWithStringReplace());
+        out.flushBuffer();
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

hessian-lite 3.2.x resolves classes that declare a `writeReplace()` method directly to `JavaSerializer`, before `getDefaultSerializer()` is ever consulted. Such classes therefore skipped the `checkSerializable()` security check entirely: a class that does **not** implement `Serializable` could be serialized as long as it declared `writeReplace()` (verified against 3.2 with a reproduction test). This is the serialization security bypass reported in #16287.

The 3.3 line is unaffected (hessian-lite 4.0.5 checks the original class in the `writeReplace` branch).

## Brief changelog

- `Hessian2SerializerFactory` registers a pre-flight `AbstractSerializerFactory` via `addFactory` that applies the existing `checkSerializable()` to classes carrying a `writeReplace()` method, then returns null so the normal `SerializerFactory` resolution chain keeps control.
- The check mirrors the behavior introduced for `writeReplace` classes in hessian-lite 4.x, scoped to the 3.2 line.

## Verifying this change

- New `Hessian2WriteReplaceSecurityTest`:
  - a non-`Serializable` class with `writeReplace()` is rejected;
  - a `Serializable` class whose `writeReplace()` returns a non-`Serializable` holder is rejected;
  - a `Serializable` class whose `writeReplace()` returns a `String` still serializes (no false positives).
- `mvn -pl dubbo-serialization/dubbo-serialization-hessian2 -am test`: 811 tests, 0 failures.
- `spotless:check` passes; new patch lines are 100% covered.

<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [x] Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [ ] GitHub Actions works fine on your own branch.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
