### PR TITLE
fix(mcp): migrate to MCP SDK 0.18.3 JSON APIs

### DIFF
--- a/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/SysProps.java
+++ b/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/SysProps.java
@@ -27,6 +27,9 @@ public class SysProps {
     private static Map<String, String> map = new LinkedHashMap<String, String>();
 
     public static void reset() {
+        for (String key : map.keySet()) {
+            System.clearProperty(key);
+        }
         map.clear();
     }
 
@@ -36,9 +39,6 @@ public class SysProps {
     }
 
     public static void clear() {
-        for (String key : map.keySet()) {
-            System.clearProperty(key);
-        }
         reset();
     }
 }

--- a/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/SysProps.java
+++ b/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/SysProps.java
@@ -27,6 +27,9 @@ public class SysProps {
     private static Map<String, String> map = new LinkedHashMap<String, String>();
 
     public static void reset() {
+        for (String key : map.keySet()) {
+            System.clearProperty(key);
+        }
         map.clear();
     }
 
@@ -36,9 +39,6 @@ public class SysProps {
     }
 
     public static void clear() {
-        for (String key : map.keySet()) {
-            System.clearProperty(key);
-        }
         reset();
     }
 }

--- a/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/boot/configprops/SpringBootConfigPropsTest.java
+++ b/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/boot/configprops/SpringBootConfigPropsTest.java
@@ -79,6 +79,12 @@ class SpringBootConfigPropsTest {
 
     @BeforeAll
     public static void beforeAll() {
+        // Clear JVM System properties that other tests in the same JVM may have left set to
+        // disable metrics. Dubbo resolves dubbo.metrics.* from the System properties with the
+        // highest precedence, which would otherwise override this test's @SpringBootTest
+        // property dubbo.metrics.protocol=prometheus and fail the assertion below.
+        System.clearProperty("dubbo.metrics.protocol");
+        System.clearProperty("dubbo.metrics.enabled");
         DubboBootstrap.reset();
     }
 

--- a/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/boot/configprops/SpringBootMultipleConfigPropsTest.java
+++ b/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/boot/configprops/SpringBootMultipleConfigPropsTest.java
@@ -80,6 +80,12 @@ class SpringBootMultipleConfigPropsTest {
 
     @BeforeAll
     public static void beforeAll() {
+        // Clear JVM System properties that other tests in the same JVM may have left set to
+        // disable metrics. Dubbo resolves dubbo.metrics.* from the System properties with the
+        // highest precedence, which would otherwise override the prometheus setting expected
+        // by this test.
+        System.clearProperty("dubbo.metrics.protocol");
+        System.clearProperty("dubbo.metrics.enabled");
         DubboBootstrap.reset();
     }
 

--- a/dubbo-plugin/dubbo-mcp/src/main/java/org/apache/dubbo/mcp/tool/DubboOpenApiToolConverter.java
+++ b/dubbo-plugin/dubbo-mcp/src/main/java/org/apache/dubbo/mcp/tool/DubboOpenApiToolConverter.java
@@ -43,6 +43,8 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.modelcontextprotocol.json.McpJsonMapper;
+import io.modelcontextprotocol.json.jackson2.JacksonMcpJsonMapper;
 import io.modelcontextprotocol.spec.McpSchema;
 
 public class DubboOpenApiToolConverter {
@@ -51,6 +53,7 @@ public class DubboOpenApiToolConverter {
             LoggerFactory.getErrorTypeAwareLogger(DubboOpenApiToolConverter.class);
     private final DefaultOpenAPIService openApiService;
     private final ObjectMapper objectMapper = new ObjectMapper();
+    private final McpJsonMapper jsonMapper = new JacksonMcpJsonMapper(objectMapper);
     private final Map<String, Operation> opCache = new ConcurrentHashMap<>();
 
     public DubboOpenApiToolConverter(DefaultOpenAPIService openApiService) {
@@ -120,7 +123,11 @@ public class DubboOpenApiToolConverter {
                     e);
             schemaJson = "{\"type\":\"object\",\"properties\":{}}";
         }
-        return new McpSchema.Tool(toolName, desc, schemaJson);
+        return McpSchema.Tool.builder()
+                .name(toolName)
+                .description(desc)
+                .inputSchema(jsonMapper, schemaJson)
+                .build();
     }
 
     private String generateToolName(Operation op, McpServiceFilter.McpToolConfig toolConfig) {

--- a/dubbo-plugin/dubbo-mcp/src/main/java/org/apache/dubbo/mcp/tool/DubboServiceToolRegistry.java
+++ b/dubbo-plugin/dubbo-mcp/src/main/java/org/apache/dubbo/mcp/tool/DubboServiceToolRegistry.java
@@ -43,6 +43,8 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.BiFunction;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.modelcontextprotocol.json.McpJsonMapper;
+import io.modelcontextprotocol.json.jackson2.JacksonMcpJsonMapper;
 import io.modelcontextprotocol.server.McpAsyncServer;
 import io.modelcontextprotocol.server.McpAsyncServerExchange;
 import io.modelcontextprotocol.server.McpServerFeatures;
@@ -61,6 +63,7 @@ public class DubboServiceToolRegistry {
     private final Map<String, McpServerFeatures.AsyncToolSpecification> registeredTools = new ConcurrentHashMap<>();
     private final Map<String, Set<String>> serviceToToolsMapping = new ConcurrentHashMap<>();
     private final ObjectMapper objectMapper;
+    private final McpJsonMapper jsonMapper;
 
     public DubboServiceToolRegistry(
             McpAsyncServer mcpServer,
@@ -72,6 +75,7 @@ public class DubboServiceToolRegistry {
         this.genericCaller = genericCaller;
         this.mcpServiceFilter = mcpServiceFilter;
         this.objectMapper = new ObjectMapper();
+        this.jsonMapper = new JacksonMcpJsonMapper(objectMapper);
     }
 
     public int registerService(ProviderModel providerModel) {
@@ -191,7 +195,11 @@ public class DubboServiceToolRegistry {
                 description = generateDefaultDescription(method, providerModel);
             }
 
-            McpSchema.Tool mcpTool = new McpSchema.Tool(toolName, description, generateToolSchema(method));
+            McpSchema.Tool mcpTool = McpSchema.Tool.builder()
+                    .name(toolName)
+                    .description(description)
+                    .inputSchema(jsonMapper, generateToolSchema(method))
+                    .build();
 
             McpServerFeatures.AsyncToolSpecification toolSpec =
                     createMethodToolSpecification(mcpTool, providerModel, method, url);

--- a/dubbo-plugin/dubbo-mcp/src/main/java/org/apache/dubbo/mcp/transport/DubboMcpSseTransportProvider.java
+++ b/dubbo-plugin/dubbo-mcp/src/main/java/org/apache/dubbo/mcp/transport/DubboMcpSseTransportProvider.java
@@ -37,8 +37,10 @@ import org.apache.dubbo.rpc.model.ApplicationModel;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.modelcontextprotocol.json.McpJsonMapper;
+import io.modelcontextprotocol.json.TypeRef;
+import io.modelcontextprotocol.json.jackson2.JacksonMcpJsonMapper;
 import io.modelcontextprotocol.spec.McpError;
 import io.modelcontextprotocol.spec.McpSchema;
 import io.modelcontextprotocol.spec.McpServerSession;
@@ -66,7 +68,7 @@ public class DubboMcpSseTransportProvider implements McpServerTransportProvider 
 
     private McpServerSession.Factory sessionFactory;
 
-    private final ObjectMapper objectMapper;
+    private final McpJsonMapper jsonMapper;
 
     /**
      * session cache, default expire time is 60 seconds
@@ -82,7 +84,7 @@ public class DubboMcpSseTransportProvider implements McpServerTransportProvider 
             expireSeconds = 60;
         }
         sessions = new ExpiringMap<>(expireSeconds, 30);
-        this.objectMapper = objectMapper;
+        this.jsonMapper = new JacksonMcpJsonMapper(objectMapper);
         sessions.getExpireThread().startExpiryIfNotStarted();
     }
 
@@ -147,7 +149,7 @@ public class DubboMcpSseTransportProvider implements McpServerTransportProvider 
         refreshSessionExpire(session);
         try {
             McpSchema.JSONRPCMessage message = McpSchema.deserializeJsonRpcMessage(
-                    objectMapper, IOUtils.read(request.inputStream(), String.valueOf(StandardCharsets.UTF_8)));
+                    jsonMapper, IOUtils.read(request.inputStream(), String.valueOf(StandardCharsets.UTF_8)));
             session.handle(message).block();
             response.setStatus(HttpStatus.OK.getCode());
         } catch (IOException e) {
@@ -159,8 +161,7 @@ public class DubboMcpSseTransportProvider implements McpServerTransportProvider 
     private void handleSseConnection(StreamObserver<ServerSentEvent<String>> responseObserver) {
         // Handle the SSE connection
         // This is where you would set up the SSE stream and send events to the client
-        DubboMcpSessionTransport dubboMcpSessionTransport =
-                new DubboMcpSessionTransport(responseObserver, objectMapper);
+        DubboMcpSessionTransport dubboMcpSessionTransport = new DubboMcpSessionTransport(responseObserver, jsonMapper);
         McpServerSession mcpServerSession = sessionFactory.create(dubboMcpSessionTransport);
         sessions.put(mcpServerSession.getId(), mcpServerSession);
         Configuration conf = ConfigurationUtils.getGlobalConfiguration(ApplicationModel.defaultModel());
@@ -179,14 +180,14 @@ public class DubboMcpSseTransportProvider implements McpServerTransportProvider 
 
     private static class DubboMcpSessionTransport implements McpServerTransport {
 
-        private final ObjectMapper JSON;
+        private final McpJsonMapper jsonMapper;
 
         private final StreamObserver<ServerSentEvent<String>> responseObserver;
 
         public DubboMcpSessionTransport(
-                StreamObserver<ServerSentEvent<String>> responseObserver, ObjectMapper objectMapper) {
+                StreamObserver<ServerSentEvent<String>> responseObserver, McpJsonMapper jsonMapper) {
             this.responseObserver = responseObserver;
-            this.JSON = objectMapper;
+            this.jsonMapper = jsonMapper;
         }
 
         @Override
@@ -203,7 +204,7 @@ public class DubboMcpSseTransportProvider implements McpServerTransportProvider 
         public Mono<Void> sendMessage(McpSchema.JSONRPCMessage message) {
             return Mono.fromRunnable(() -> {
                 try {
-                    String jsonText = JSON.writeValueAsString(message);
+                    String jsonText = jsonMapper.writeValueAsString(message);
                     responseObserver.onNext(ServerSentEvent.<String>builder()
                             .event(MESSAGE_EVENT_TYPE)
                             .data(jsonText)
@@ -215,8 +216,8 @@ public class DubboMcpSseTransportProvider implements McpServerTransportProvider 
         }
 
         @Override
-        public <T> T unmarshalFrom(Object data, TypeReference<T> typeRef) {
-            return JSON.convertValue(data, typeRef);
+        public <T> T unmarshalFrom(Object data, TypeRef<T> typeRef) {
+            return jsonMapper.convertValue(data, typeRef);
         }
     }
 }

--- a/dubbo-plugin/dubbo-mcp/src/main/java/org/apache/dubbo/mcp/transport/DubboMcpStreamableTransportProvider.java
+++ b/dubbo-plugin/dubbo-mcp/src/main/java/org/apache/dubbo/mcp/transport/DubboMcpStreamableTransportProvider.java
@@ -39,8 +39,10 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.modelcontextprotocol.json.McpJsonMapper;
+import io.modelcontextprotocol.json.TypeRef;
+import io.modelcontextprotocol.json.jackson2.JacksonMcpJsonMapper;
 import io.modelcontextprotocol.spec.McpError;
 import io.modelcontextprotocol.spec.McpSchema;
 import io.modelcontextprotocol.spec.McpStreamableServerSession;
@@ -64,6 +66,8 @@ public class DubboMcpStreamableTransportProvider implements McpStreamableServerT
     private Factory sessionFactory;
 
     private final ObjectMapper objectMapper;
+
+    private final McpJsonMapper jsonMapper;
 
     public static final String SESSION_ID_HEADER = "mcp-session-id";
 
@@ -89,6 +93,7 @@ public class DubboMcpStreamableTransportProvider implements McpStreamableServerT
         }
         sessions = new ExpiringMap<>(expireSeconds, 30);
         this.objectMapper = objectMapper;
+        this.jsonMapper = new JacksonMcpJsonMapper(objectMapper);
         sessions.getExpireThread().startExpiryIfNotStarted();
     }
 
@@ -296,7 +301,7 @@ public class DubboMcpStreamableTransportProvider implements McpStreamableServerT
 
             // Read and deserialize JSON-RPC message from request body
             String requestBody = IOUtils.read(request.inputStream(), StandardCharsets.UTF_8.name());
-            McpSchema.JSONRPCMessage message = McpSchema.deserializeJsonRpcMessage(objectMapper, requestBody);
+            McpSchema.JSONRPCMessage message = McpSchema.deserializeJsonRpcMessage(jsonMapper, requestBody);
 
             // Check if it's an initialization request
             if (message instanceof McpSchema.JSONRPCRequest
@@ -318,8 +323,8 @@ public class DubboMcpStreamableTransportProvider implements McpStreamableServerT
                 }
 
                 // Create new session
-                McpSchema.InitializeRequest initializeRequest = objectMapper.convertValue(
-                        ((McpSchema.JSONRPCRequest) message).params(), new TypeReference<>() {});
+                McpSchema.InitializeRequest initializeRequest =
+                        jsonMapper.convertValue(((McpSchema.JSONRPCRequest) message).params(), new TypeRef<>() {});
 
                 McpStreamableServerSession.McpStreamableServerSessionInit init =
                         sessionFactory.startSession(initializeRequest);
@@ -427,8 +432,7 @@ public class DubboMcpStreamableTransportProvider implements McpStreamableServerT
                 response.setHeader("Access-Control-Allow-Origin", "*");
 
                 // Handle request stream
-                DubboMcpSessionTransport sessionTransport =
-                        new DubboMcpSessionTransport(responseObserver, objectMapper);
+                DubboMcpSessionTransport sessionTransport = new DubboMcpSessionTransport(responseObserver, jsonMapper);
                 session.responseStream((McpSchema.JSONRPCRequest) message, sessionTransport)
                         .block();
             } else {
@@ -528,14 +532,14 @@ public class DubboMcpStreamableTransportProvider implements McpStreamableServerT
 
     private static class DubboMcpSessionTransport implements McpStreamableServerTransport {
 
-        private final ObjectMapper JSON;
+        private final McpJsonMapper jsonMapper;
 
         private final StreamObserver<ServerSentEvent<byte[]>> responseObserver;
 
         public DubboMcpSessionTransport(
-                StreamObserver<ServerSentEvent<byte[]>> responseObserver, ObjectMapper objectMapper) {
+                StreamObserver<ServerSentEvent<byte[]>> responseObserver, McpJsonMapper jsonMapper) {
             this.responseObserver = responseObserver;
-            this.JSON = objectMapper;
+            this.jsonMapper = jsonMapper;
         }
 
         @Override
@@ -555,7 +559,7 @@ public class DubboMcpStreamableTransportProvider implements McpStreamableServerT
             return Mono.fromRunnable(() -> {
                 try {
                     if (responseObserver != null) {
-                        String jsonText = JSON.writeValueAsString(message);
+                        String jsonText = jsonMapper.writeValueAsString(message);
                         responseObserver.onNext(ServerSentEvent.<byte[]>builder()
                                 .event("message")
                                 .data(jsonText.getBytes(StandardCharsets.UTF_8))
@@ -572,7 +576,7 @@ public class DubboMcpStreamableTransportProvider implements McpStreamableServerT
             return Mono.fromRunnable(() -> {
                 try {
                     if (responseObserver != null) {
-                        String jsonText = JSON.writeValueAsString(message);
+                        String jsonText = jsonMapper.writeValueAsString(message);
                         ServerSentEvent<byte[]> event = ServerSentEvent.<byte[]>builder()
                                 .event("message")
                                 .data(jsonText.getBytes(StandardCharsets.UTF_8))
@@ -587,8 +591,8 @@ public class DubboMcpStreamableTransportProvider implements McpStreamableServerT
         }
 
         @Override
-        public <T> T unmarshalFrom(Object data, TypeReference<T> typeRef) {
-            return JSON.convertValue(data, typeRef);
+        public <T> T unmarshalFrom(Object data, TypeRef<T> typeRef) {
+            return jsonMapper.convertValue(data, typeRef);
         }
     }
 }

--- a/dubbo-plugin/dubbo-mcp/src/test/java/org/apache/dubbo/mcp/tool/DubboServiceToolRegistryTest.java
+++ b/dubbo-plugin/dubbo-mcp/src/test/java/org/apache/dubbo/mcp/tool/DubboServiceToolRegistryTest.java
@@ -201,8 +201,10 @@ class DubboServiceToolRegistryTest {
 
     private java.util.Map<String, io.modelcontextprotocol.spec.McpSchema.Tool> createMockTools() {
         java.util.Map<String, io.modelcontextprotocol.spec.McpSchema.Tool> tools = new java.util.HashMap<>();
-        io.modelcontextprotocol.spec.McpSchema.Tool tool =
-                new io.modelcontextprotocol.spec.McpSchema.Tool("testTool", "Test description", "{}");
+        io.modelcontextprotocol.spec.McpSchema.Tool tool = io.modelcontextprotocol.spec.McpSchema.Tool.builder()
+                .name("testTool")
+                .description("Test description")
+                .build();
         tools.put("testTool", tool);
         return tools;
     }

--- a/dubbo-plugin/dubbo-mcp/src/test/java/org/apache/dubbo/mcp/transport/DubboMcpSseTransportProviderTest.java
+++ b/dubbo-plugin/dubbo-mcp/src/test/java/org/apache/dubbo/mcp/transport/DubboMcpSseTransportProviderTest.java
@@ -37,7 +37,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -76,7 +75,6 @@ class DubboMcpSseTransportProviderTest {
 
     private MockedStatic<RpcContext> rpcContextMockedStatic;
 
-    @InjectMocks
     private DubboMcpSseTransportProvider transportProvider;
 
     private final ObjectMapper objectMapper = new ObjectMapper();

--- a/dubbo-test/dubbo-test-common/src/main/java/org/apache/dubbo/test/common/SysProps.java
+++ b/dubbo-test/dubbo-test-common/src/main/java/org/apache/dubbo/test/common/SysProps.java
@@ -27,6 +27,9 @@ public class SysProps {
     private static Map<String, String> map = new LinkedHashMap<>();
 
     public static void reset() {
+        for (String key : map.keySet()) {
+            System.clearProperty(key);
+        }
         map.clear();
     }
 
@@ -36,9 +39,6 @@ public class SysProps {
     }
 
     public static void clear() {
-        for (String key : map.keySet()) {
-            System.clearProperty(key);
-        }
         reset();
     }
 }


### PR DESCRIPTION
## What is the purpose of the change?

This companion PR completes the MCP SDK 0.18.3 upgrade in #16342. The SDK replaced its Jackson-specific APIs with `McpJsonMapper`/`TypeRef` and removed the deprecated string-schema `Tool` constructors, leaving the Dependabot head unable to compile.

The change:

- adapts Dubbo's existing `ObjectMapper` instances through the SDK-provided `JacksonMcpJsonMapper`;
- uses the SDK's new `TypeRef` transport contract;
- migrates tool creation to the mapper-aware builder, preserving the previous JSON Schema parsing behavior;
- removes a redundant Mockito `@InjectMocks` path that constructed the SSE provider with a null mapper before the test's explicit setup; and
- carries the already merged test-isolation fix from #16420 onto this older Dependabot branch. Without that fix, all five unit-test jobs fail because leaked `dubbo.metrics.*` System properties override the Spring test's Prometheus configuration.

No public API or MCP wire behavior is intentionally changed.

## Verification

- Reproduced 8 Java compilation errors on exact Dependabot head `09795dcd58e0137c63ea5307b025893cd1aa0c48` with `./mvnw -pl dubbo-plugin/dubbo-mcp -DskipTests compile`.
- Confirmed the five red GitHub jobs all fail at `SpringBootConfigPropsTest` with `expected: <prometheus> but was: <disabled>`, then traced the exact defect to the maintainer-approved and merged #16420.
- Ran `SpringBootConfigPropsTest` and `SpringBootMultipleConfigPropsTest` while deliberately injecting `-Ddubbo.metrics.protocol=disabled -Ddubbo.metrics.enabled=false`; both passed with the accepted isolation fix.
- `./mvnw -T 4 -pl dubbo-plugin/dubbo-mcp -am clean install -DskipTests ...` — all 53 reactor modules compiled, packaged, and installed successfully on JDK 17.
- `./mvnw -pl dubbo-plugin/dubbo-mcp clean test verify -Pjacoco,...` — all 89 MCP tests passed and the JaCoCo report was generated on JDK 17.
- `git diff --check` passed.

## Checklist

- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change. (Dependency-upgrade context: #16342.)
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction. Existing transport and tool-schema tests exercise the migrated paths; the SDK-dependent fixture was updated.
- [x] Make sure GitHub Actions can pass. [Why the workflow is failing and how to fix it?](../CONTRIBUTING.md)
