### PR TITLE
Fix Triple flow control deadlock when a message exceeds the stream window

### DIFF
--- a/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/message/LengthFieldStreamingDecoder.java
+++ b/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/message/LengthFieldStreamingDecoder.java
@@ -79,7 +79,20 @@ public class LengthFieldStreamingDecoder implements StreamingDecoder {
             }
             return;
         }
+        // Bytes must be returned to flow control as soon as they are taken off the wire,
+        // even if the message they belong to is still incomplete: a message larger than
+        // the peer's send window can only complete if the partial frames already received
+        // trigger WINDOW_UPDATE, otherwise both sides wait on each other forever.
+        int numBytes;
+        try {
+            numBytes = inputStream.available();
+        } catch (IOException e) {
+            throw new DecodeException(e);
+        }
         accumulate.addInputStream(inputStream);
+        if (listener != null) {
+            listener.bytesRead(numBytes);
+        }
         deliver();
     }
 
@@ -237,18 +250,9 @@ public class LengthFieldStreamingDecoder implements StreamingDecoder {
     }
 
     private void processBody() throws IOException {
-        // Calculate total bytes read: header (offset + length field) + payload
-        int totalBytesRead = lengthFieldOffset + lengthFieldLength + requiredLength;
-
-        MessageStream messageStream;
-        try {
-            messageStream = readMessageStream(accumulate, requiredLength);
-        } finally {
-            // Notify listener about bytes read for flow control immediately after reading bytes
-            // This must be in finally block to ensure flow control works even if reading fails
-            // Following gRPC's pattern: bytesRead is called as soon as bytes are consumed from input
-            listener.bytesRead(totalBytesRead);
-        }
+        // Flow-control bytes were already returned in decode() when the data was ingested,
+        // so nothing to report per completed message here.
+        MessageStream messageStream = readMessageStream(accumulate, requiredLength);
 
         invokeListener(messageStream.inputStream, messageStream.length);
 

--- a/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/netty4/h2/NettyH2StreamChannel.java
+++ b/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/netty4/h2/NettyH2StreamChannel.java
@@ -128,15 +128,26 @@ public class NettyH2StreamChannel implements H2StreamChannel {
         // Consume bytes to trigger WINDOW_UPDATE frame
         // This must be executed in the event loop thread
         if (http2StreamChannel.eventLoop().inEventLoop()) {
-            localFlowController.consumeBytes(stream, numBytes);
+            consumeBytesAndFlush(localFlowController, stream, numBytes);
         } else {
             http2StreamChannel.eventLoop().execute(() -> {
                 try {
-                    localFlowController.consumeBytes(stream, numBytes);
+                    consumeBytesAndFlush(localFlowController, stream, numBytes);
                 } catch (Exception e) {
                     LOGGER.warn(PROTOCOL_FAILED_RESPONSE, "", "", "Failed to consumeBytes for stream " + streamId, e);
                 }
             });
+        }
+    }
+
+    private void consumeBytesAndFlush(Http2LocalFlowController localFlowController, Http2Stream stream, int numBytes)
+            throws Exception {
+        // The WINDOW_UPDATE written by the flow controller is not flushed by the frame
+        // reading loop when consumption happens outside of it, and flushing the stream
+        // channel itself is a no-op for frames written directly to the connection, so
+        // flush the parent channel, otherwise the peer may wait forever for the window.
+        if (localFlowController.consumeBytes(stream, numBytes)) {
+            http2StreamChannel.parent().flush();
         }
     }
 

--- a/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/h12/http2/Http2TripleClientStream.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/main/java/org/apache/dubbo/rpc/protocol/tri/h12/http2/Http2TripleClientStream.java
@@ -125,18 +125,33 @@ public final class Http2TripleClientStream extends AbstractTripleClientStream {
         // This must be executed in the event loop thread
         if (http2StreamChannel.eventLoop().inEventLoop()) {
             try {
-                localFlowController.consumeBytes(stream, numBytes);
+                consumeBytesAndFlush(localFlowController, http2StreamChannel, stream, numBytes);
             } catch (Exception e) {
                 LOGGER.warn(PROTOCOL_FAILED_RESPONSE, "", "", "Failed to consumeBytes for stream " + streamId, e);
             }
         } else {
             http2StreamChannel.eventLoop().execute(() -> {
                 try {
-                    localFlowController.consumeBytes(stream, numBytes);
+                    consumeBytesAndFlush(localFlowController, http2StreamChannel, stream, numBytes);
                 } catch (Exception e) {
                     LOGGER.warn(PROTOCOL_FAILED_RESPONSE, "", "", "Failed to consumeBytes for stream " + streamId, e);
                 }
             });
+        }
+    }
+
+    private static void consumeBytesAndFlush(
+            Http2LocalFlowController localFlowController,
+            Http2StreamChannel http2StreamChannel,
+            Http2Stream stream,
+            int numBytes)
+            throws Exception {
+        // The WINDOW_UPDATE written by the flow controller is not flushed by the frame
+        // reading loop when consumption happens outside of it, and flushing the stream
+        // channel itself is a no-op for frames written directly to the connection, so
+        // flush the parent channel, otherwise the peer may wait forever for the window.
+        if (localFlowController.consumeBytes(stream, numBytes)) {
+            http2StreamChannel.parent().flush();
         }
     }
 

--- a/dubbo-rpc/dubbo-rpc-triple/src/test/java/org/apache/dubbo/rpc/protocol/tri/TripleFlowControlTest.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/test/java/org/apache/dubbo/rpc/protocol/tri/TripleFlowControlTest.java
@@ -1,0 +1,160 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.rpc.protocol.tri;
+
+import org.apache.dubbo.common.URL;
+import org.apache.dubbo.common.extension.ExtensionLoader;
+import org.apache.dubbo.common.utils.ClassUtils;
+import org.apache.dubbo.common.utils.NetUtils;
+import org.apache.dubbo.config.ProtocolConfig;
+import org.apache.dubbo.config.nested.TripleConfig;
+import org.apache.dubbo.rpc.Constants;
+import org.apache.dubbo.rpc.Exporter;
+import org.apache.dubbo.rpc.Invoker;
+import org.apache.dubbo.rpc.Protocol;
+import org.apache.dubbo.rpc.ProxyFactory;
+import org.apache.dubbo.rpc.model.ApplicationModel;
+import org.apache.dubbo.rpc.model.ConsumerModel;
+import org.apache.dubbo.rpc.model.ModuleServiceRepository;
+import org.apache.dubbo.rpc.model.ProviderModel;
+import org.apache.dubbo.rpc.model.ServiceDescriptor;
+import org.apache.dubbo.rpc.model.ServiceMetadata;
+import org.apache.dubbo.rpc.protocol.tri.support.IGreeter;
+import org.apache.dubbo.rpc.protocol.tri.support.IGreeterImpl;
+import org.apache.dubbo.rpc.protocol.tri.support.MockStreamObserver;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies that a single message larger than the HTTP/2 stream-level flow control window can
+ * still be delivered: the consumer must return WINDOW_UPDATE for the partially received
+ * message, otherwise the peer stalls once the window is exhausted and both sides wait on
+ * each other until the call times out.
+ */
+class TripleFlowControlTest {
+
+    /**
+     * The gRPC response size reported in issue #16427: about 92 KiB, far above the 64 KiB
+     * stream window configured below and far below the default 8 MiB max response body size.
+     */
+    private static final int PAYLOAD_SIZE = 94_486;
+
+    private static final int INITIAL_STREAM_WINDOW_SIZE = 64 * 1024 - 1;
+
+    private ProtocolConfig protocolConfig;
+    private Exporter<IGreeter> export;
+    private IGreeter greeterProxy;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        IGreeterImpl serviceImpl = new IGreeterImpl();
+        int availablePort = NetUtils.getAvailablePort();
+        ApplicationModel applicationModel = ApplicationModel.defaultModel();
+
+        // TripleHttp3ProtocolTest leaks H3_ENABLED=true into the global configuration and
+        // the static Http3Exchanger state; force both back to the plain HTTP/2 path,
+        // otherwise the window size configured below does not apply
+        Map<String, String> settings = new HashMap<>();
+        settings.put(Constants.H3_SETTINGS_HTTP3_ENABLED, "false");
+        applicationModel.modelEnvironment().updateAppConfigMap(settings);
+        applicationModel.getApplicationConfigManager().getSsl().ifPresent(ssl -> applicationModel
+                .getApplicationConfigManager()
+                .removeConfig(ssl));
+        new TripleProtocol(applicationModel.getFrameworkModel());
+
+        protocolConfig = new ProtocolConfig("tri");
+        TripleConfig tripleConfig = new TripleConfig();
+        tripleConfig.setInitialWindowSize(INITIAL_STREAM_WINDOW_SIZE);
+        protocolConfig.setTriple(tripleConfig);
+        applicationModel.getApplicationConfigManager().addProtocol(protocolConfig);
+
+        URL providerUrl = URL.valueOf("tri://127.0.0.1:" + availablePort + "/" + IGreeter.class.getName());
+
+        ModuleServiceRepository serviceRepository =
+                applicationModel.getDefaultModule().getServiceRepository();
+        ServiceDescriptor serviceDescriptor = serviceRepository.registerService(IGreeter.class);
+
+        ProviderModel providerModel = new ProviderModel(
+                providerUrl.getServiceKey(),
+                serviceImpl,
+                serviceDescriptor,
+                new ServiceMetadata(),
+                ClassUtils.getClassLoader(IGreeter.class));
+        serviceRepository.registerProvider(providerModel);
+        providerUrl = providerUrl.setServiceModel(providerModel);
+
+        Protocol protocol = ExtensionLoader.getExtensionLoader(Protocol.class).getExtension("tri");
+
+        ProxyFactory proxy =
+                applicationModel.getExtensionLoader(ProxyFactory.class).getAdaptiveExtension();
+        Invoker<IGreeter> invoker = proxy.getInvoker(serviceImpl, IGreeter.class, providerUrl);
+        export = protocol.export(invoker);
+
+        URL consumerUrl =
+                URL.valueOf("tri://127.0.0.1:" + availablePort + "/" + IGreeter.class.getName() + "?timeout=5000");
+        ConsumerModel consumerModel =
+                new ConsumerModel(consumerUrl.getServiceKey(), null, serviceDescriptor, null, null, null);
+        consumerUrl = consumerUrl.setServiceModel(consumerModel);
+        greeterProxy = proxy.getProxy(protocol.refer(IGreeter.class, consumerUrl));
+        Thread.sleep(1000);
+    }
+
+    @AfterEach
+    void tearDown() {
+        export.unexport();
+        ExtensionLoader.getExtensionLoader(Protocol.class).getExtension("tri").destroy();
+        ApplicationModel.defaultModel()
+                .getDefaultModule()
+                .getServiceRepository()
+                .destroy();
+        ApplicationModel.defaultModel().getApplicationConfigManager().removeConfig(protocolConfig);
+    }
+
+    @Test
+    void testMessageLargerThanStreamWindow() throws Exception {
+        String payload = buildPayload();
+
+        // unary: the request and the response each exceed the window, exercising the
+        // client-to-server and server-to-client directions in one call
+        CompletableFuture<String> reply = CompletableFuture.supplyAsync(() -> greeterProxy.echo(payload));
+        Assertions.assertEquals(payload, reply.get(10, TimeUnit.SECONDS));
+
+        // server stream: a large message delivered to a streaming observer
+        MockStreamObserver responseObserver = new MockStreamObserver();
+        greeterProxy.serverStream(payload, responseObserver);
+        Assertions.assertTrue(responseObserver.getLatch().await(10, TimeUnit.SECONDS), "onNext not delivered");
+        Assertions.assertEquals(payload, responseObserver.getOnNextData());
+        Assertions.assertTrue(responseObserver.isOnCompleted());
+    }
+
+    private static String buildPayload() {
+        StringBuilder builder = new StringBuilder(PAYLOAD_SIZE);
+        int chunk = 0;
+        while (builder.length() < PAYLOAD_SIZE) {
+            builder.append("flow-control-payload-").append(chunk++).append(';');
+        }
+        return builder.toString();
+    }
+}

--- a/dubbo-rpc/dubbo-rpc-triple/src/test/java/org/apache/dubbo/rpc/protocol/tri/h12/grpc/GrpcStreamingDecoderTest.java
+++ b/dubbo-rpc/dubbo-rpc-triple/src/test/java/org/apache/dubbo/rpc/protocol/tri/h12/grpc/GrpcStreamingDecoderTest.java
@@ -34,6 +34,42 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 class GrpcStreamingDecoderTest {
 
     @Test
+    void reportsBytesReadForIncompleteMessage() {
+        GrpcStreamingDecoder decoder = new GrpcStreamingDecoder();
+        List<Integer> reported = new ArrayList<>();
+        decoder.setFragmentListener(new StreamingDecoder.FragmentListener() {
+            @Override
+            public void bytesRead(int numBytes) {
+                reported.add(numBytes);
+            }
+
+            @Override
+            public void onFragmentMessage(InputStream rawMessage, int messageLength) {}
+        });
+
+        // a message larger than the peer's send window arrives split across frames and the
+        // first part is buffered while the message is still incomplete: flow control bytes
+        // must be returned for that part, otherwise the peer can never send the rest
+        byte[] message = frame("incomplete");
+        byte[] firstPart = Arrays.copyOf(message, message.length - 1);
+        byte[] lastByte = new byte[] {message[message.length - 1]};
+
+        decoder.decode(new ByteArrayInputStream(firstPart));
+        assertEquals(firstPart.length, sum(reported));
+
+        decoder.decode(new ByteArrayInputStream(lastByte));
+        assertEquals(firstPart.length + lastByte.length, sum(reported));
+    }
+
+    private static int sum(List<Integer> values) {
+        int total = 0;
+        for (int value : values) {
+            total += value;
+        }
+        return total;
+    }
+
+    @Test
     void continueDecodingWithBufferedPartialFrameAfterListenerSwitch() {
         GrpcStreamingDecoder decoder = new GrpcStreamingDecoder();
         List<String> messages = new ArrayList<>();


### PR DESCRIPTION
AI disclosure: this change was prepared with AI coding agents, reviewed and revised line by line by me.

## What is the purpose of the change?

Fixes #16427 (case 1).

When a single gRPC message is larger than the HTTP/2 stream-level flow control window, the call deadlocks until it times out: the sender stops once the window is exhausted and waits for WINDOW_UPDATE, while the receiver buffers the partial message and waits for the remaining bytes. Two defects cause this:

1. `LengthFieldStreamingDecoder` only reported `bytesRead` after a full message was assembled (`processBody`), so bytes buffered inside an incomplete message were never returned to the peer. Now `decode()` reports the ingested bytes as soon as they are taken off the wire, and the per-message report in `processBody()` is dropped to avoid double counting. This matches the grpc-java deframer pattern already referenced in the code comment.
2. `consumeBytes()` (both `NettyH2StreamChannel` on the server side and `Http2TripleClientStream` on the client side) never flushed the WINDOW_UPDATE written by the flow controller: when consumption runs from an executor thread the frame reading loop does not flush it, and flushing the stream channel itself is a no-op for frames written directly to the connection. The frame observed in a frame log sat in the outbound buffer for 5 seconds until a timeout reset flushed it. Both sites now flush the parent channel when `consumeBytes` wrote an update.

Verified both directions on a real localhost tri connection: with a 64 KiB initial stream window and the ~92 KiB message from the issue, the frame log shows the request and the response each delivered as 65535 + 29003 bytes with WINDOW_UPDATE flowing in between, instead of a deadlock until the 5s deadline. The second failure mode from the issue (window exceeded against a PHP gRPC peer) needs a peer that keeps sending beyond the advertised window and did not reproduce between two Netty endpoints, so it is not addressed here.

Tests: `TripleFlowControlTest` (unary and server-stream against a real localhost endpoint, red before the change: DEADLINE_EXCEEDED after 5s, green after), `GrpcStreamingDecoderTest.reportsBytesReadForIncompleteMessage` (partial message reports its bytes, red before: expected 14 but was 0). `mvn -pl dubbo-remoting/dubbo-remoting-http12,dubbo-rpc/dubbo-rpc-triple -am test` passes.

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Make sure gitHub actions can pass. [Why the workflow is failing and how to fix it?](../CONTRIBUTING.md)
