### PR TITLE
fix: avoid leaking accessKey/secretKey in RpcException message

### DIFF
--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/directory/AbstractDirectory.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/directory/AbstractDirectory.java
@@ -205,7 +205,8 @@ public abstract class AbstractDirectory<T> implements Directory<T> {
         if (destroyed) {
             throw new RpcException(
                     "Directory of type " + this.getClass().getSimpleName() + " already destroyed for service "
-                            + getConsumerUrl().getServiceKey() + " from registry " + getUrl());
+                            + getConsumerUrl().getServiceKey() + " from registry "
+                            + getUrl().removeParameters("accessKey", "secretKey"));
         }
 
         BitList<Invoker<T>> availableInvokers;


### PR DESCRIPTION
AbstractDirectory#list() included the raw registry URL in the exception thrown when the directory was already destroyed. When the registry URL carried MSE Nacos accessKey/secretKey parameters, they were exposed in the exception message. Strip these parameters before building the message.

Fixes apache/dubbo#15678

## What is the purpose of the change?


## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Make sure gitHub actions can pass. [Why the workflow is failing and how to fix it?](../CONTRIBUTING.md)
