### PR TITLE
Validate condition router YAML before parsing

### DIFF
--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/router/condition/config/model/ConditionRuleParser.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/router/condition/config/model/ConditionRuleParser.java
@@ -49,10 +49,15 @@ public class ConditionRuleParser {
 
     private static final ErrorTypeAwareLogger logger = LoggerFactory.getErrorTypeAwareLogger(ConditionRuleParser.class);
 
+    @SuppressWarnings("unchecked")
     public static AbstractRouterRule parse(String rawRule) {
         AbstractRouterRule rule;
         Yaml yaml = new Yaml(new SafeConstructor(new LoaderOptions()));
-        Map<String, Object> map = yaml.load(rawRule);
+        Object parsedRule = yaml.load(rawRule);
+        if (!(parsedRule instanceof Map)) {
+            throw new IllegalArgumentException("Condition router rule must be a YAML mapping.");
+        }
+        Map<String, Object> map = (Map<String, Object>) parsedRule;
         String confVersion = (String) map.get(CONFIG_VERSION_KEY);
 
         if (confVersion != null && confVersion.toLowerCase().startsWith(RULE_VERSION_V31)) {

--- a/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/router/condition/config/ConditionRuleParserTest.java
+++ b/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/router/condition/config/ConditionRuleParserTest.java
@@ -16,9 +16,6 @@
  */
 package org.apache.dubbo.rpc.cluster.router.condition.config;
 
-import org.apache.dubbo.common.URL;
-import org.apache.dubbo.common.config.configcenter.ConfigChangeType;
-import org.apache.dubbo.common.config.configcenter.ConfigChangedEvent;
 import org.apache.dubbo.rpc.cluster.router.condition.config.model.ConditionRuleParser;
 
 import java.util.Arrays;
@@ -35,29 +32,5 @@ public class ConditionRuleParserTest {
                     Assertions.assertThrows(IllegalArgumentException.class, () -> ConditionRuleParser.parse(rawRule));
             Assertions.assertEquals("Condition router rule must be a YAML mapping.", exception.getMessage());
         }
-    }
-
-    @Test
-    public void testCommentOnlyRuleUpdatePreservesPreviousRule() {
-        String rawRule = "configVersion: v3.1\n" + "scope: service\n"
-                + "key: com.foo.BarService\n"
-                + "force: true\n"
-                + "runtime: true\n"
-                + "enabled: true\n"
-                + "conditions:\n"
-                + "  - from:\n"
-                + "      match: env=gray\n"
-                + "    to:\n"
-                + "      - match: env!=gray\n"
-                + "        weight: 100";
-
-        ServiceStateRouter<String> router = new ServiceStateRouter<>(
-                URL.valueOf("consumer://127.0.0.1/com.foo.BarService?env=gray&region=beijing"));
-        router.process(new ConfigChangedEvent("com.foo.BarService", "", rawRule, ConfigChangeType.ADDED));
-        Assertions.assertTrue(router.isForce());
-
-        router.process(new ConfigChangedEvent("com.foo.BarService", "", "# comment", ConfigChangeType.MODIFIED));
-
-        Assertions.assertTrue(router.isForce());
     }
 }

--- a/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/router/condition/config/ConditionRuleParserTest.java
+++ b/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/router/condition/config/ConditionRuleParserTest.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.rpc.cluster.router.condition.config;
+
+import org.apache.dubbo.common.URL;
+import org.apache.dubbo.common.config.configcenter.ConfigChangeType;
+import org.apache.dubbo.common.config.configcenter.ConfigChangedEvent;
+import org.apache.dubbo.rpc.cluster.router.condition.config.model.ConditionRuleParser;
+
+import java.util.Arrays;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class ConditionRuleParserTest {
+
+    @Test
+    public void testRejectNonMappingRule() {
+        for (String rawRule : Arrays.asList("", " ", "# comment", "---", "null", "[]", "condition")) {
+            IllegalArgumentException exception =
+                    Assertions.assertThrows(IllegalArgumentException.class, () -> ConditionRuleParser.parse(rawRule));
+            Assertions.assertEquals("Condition router rule must be a YAML mapping.", exception.getMessage());
+        }
+    }
+
+    @Test
+    public void testCommentOnlyRuleUpdatePreservesPreviousRule() {
+        String rawRule = "configVersion: v3.1\n" + "scope: service\n"
+                + "key: com.foo.BarService\n"
+                + "force: true\n"
+                + "runtime: true\n"
+                + "enabled: true\n"
+                + "conditions:\n"
+                + "  - from:\n"
+                + "      match: env=gray\n"
+                + "    to:\n"
+                + "      - match: env!=gray\n"
+                + "        weight: 100";
+
+        ServiceStateRouter<String> router = new ServiceStateRouter<>(
+                URL.valueOf("consumer://127.0.0.1/com.foo.BarService?env=gray&region=beijing"));
+        router.process(new ConfigChangedEvent("com.foo.BarService", "", rawRule, ConfigChangeType.ADDED));
+        Assertions.assertTrue(router.isForce());
+
+        router.process(new ConfigChangedEvent("com.foo.BarService", "", "# comment", ConfigChangeType.MODIFIED));
+
+        Assertions.assertTrue(router.isForce());
+    }
+}

--- a/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/router/condition/config/ConditionRuleParserTest.java
+++ b/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/router/condition/config/ConditionRuleParserTest.java
@@ -16,6 +16,9 @@
  */
 package org.apache.dubbo.rpc.cluster.router.condition.config;
 
+import org.apache.dubbo.common.URL;
+import org.apache.dubbo.common.config.configcenter.ConfigChangeType;
+import org.apache.dubbo.common.config.configcenter.ConfigChangedEvent;
 import org.apache.dubbo.rpc.cluster.router.condition.config.model.ConditionRuleParser;
 
 import java.util.Arrays;
@@ -32,5 +35,29 @@ public class ConditionRuleParserTest {
                     Assertions.assertThrows(IllegalArgumentException.class, () -> ConditionRuleParser.parse(rawRule));
             Assertions.assertEquals("Condition router rule must be a YAML mapping.", exception.getMessage());
         }
+    }
+
+    @Test
+    public void testCommentOnlyRuleUpdatePreservesPreviousRule() {
+        String rawRule = "configVersion: v3.1\n" + "scope: service\n"
+                + "key: com.foo.BarService\n"
+                + "force: true\n"
+                + "runtime: true\n"
+                + "enabled: true\n"
+                + "conditions:\n"
+                + "  - from:\n"
+                + "      match: env=gray\n"
+                + "    to:\n"
+                + "      - match: env!=gray\n"
+                + "        weight: 100";
+
+        ServiceStateRouter<String> router = new ServiceStateRouter<>(
+                URL.valueOf("consumer://127.0.0.1/com.foo.BarService?env=gray&region=beijing"));
+        router.process(new ConfigChangedEvent("com.foo.BarService", "", rawRule, ConfigChangeType.ADDED));
+        Assertions.assertTrue(router.isForce());
+
+        router.process(new ConfigChangedEvent("com.foo.BarService", "", "# comment", ConfigChangeType.MODIFIED));
+
+        Assertions.assertTrue(router.isForce());
     }
 }

--- a/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/router/condition/config/ConditionStateRouterTestV31.java
+++ b/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/router/condition/config/ConditionStateRouterTestV31.java
@@ -116,39 +116,6 @@ public class ConditionStateRouterTestV31 {
     }
 
     @Test
-    public void testRejectNonMappingRule() {
-        for (String rawRule : Arrays.asList("", " ", "# comment", "---", "null", "[]", "condition")) {
-            IllegalArgumentException exception =
-                    Assertions.assertThrows(IllegalArgumentException.class, () -> ConditionRuleParser.parse(rawRule));
-            Assertions.assertEquals("Condition router rule must be a YAML mapping.", exception.getMessage());
-        }
-    }
-
-    @Test
-    public void testCommentOnlyRuleUpdatePreservesPreviousRule() {
-        String rawRule = "configVersion: v3.1\n" + "scope: service\n"
-                + "key: com.foo.BarService\n"
-                + "force: true\n"
-                + "runtime: true\n"
-                + "enabled: true\n"
-                + "conditions:\n"
-                + "  - from:\n"
-                + "      match: env=gray\n"
-                + "    to:\n"
-                + "      - match: env!=gray\n"
-                + "        weight: 100";
-
-        ServiceStateRouter<String> router = new ServiceStateRouter<>(
-                URL.valueOf("consumer://127.0.0.1/com.foo.BarService?env=gray&region=beijing"));
-        router.process(new ConfigChangedEvent("com.foo.BarService", "", rawRule, ConfigChangeType.ADDED));
-        Assertions.assertTrue(router.isForce());
-
-        router.process(new ConfigChangedEvent("com.foo.BarService", "", "# comment", ConfigChangeType.MODIFIED));
-
-        Assertions.assertTrue(router.isForce());
-    }
-
-    @Test
     public void testMultiplyConditionRoute() {
 
         String rawRule = "configVersion: v3.1\n" + "scope: service\n"

--- a/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/router/condition/config/ConditionStateRouterTestV31.java
+++ b/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/router/condition/config/ConditionStateRouterTestV31.java
@@ -116,6 +116,39 @@ public class ConditionStateRouterTestV31 {
     }
 
     @Test
+    public void testRejectNonMappingRule() {
+        for (String rawRule : Arrays.asList("", " ", "# comment", "---", "null", "[]", "condition")) {
+            IllegalArgumentException exception =
+                    Assertions.assertThrows(IllegalArgumentException.class, () -> ConditionRuleParser.parse(rawRule));
+            Assertions.assertEquals("Condition router rule must be a YAML mapping.", exception.getMessage());
+        }
+    }
+
+    @Test
+    public void testCommentOnlyRuleUpdatePreservesPreviousRule() {
+        String rawRule = "configVersion: v3.1\n" + "scope: service\n"
+                + "key: com.foo.BarService\n"
+                + "force: true\n"
+                + "runtime: true\n"
+                + "enabled: true\n"
+                + "conditions:\n"
+                + "  - from:\n"
+                + "      match: env=gray\n"
+                + "    to:\n"
+                + "      - match: env!=gray\n"
+                + "        weight: 100";
+
+        ServiceStateRouter<String> router = new ServiceStateRouter<>(
+                URL.valueOf("consumer://127.0.0.1/com.foo.BarService?env=gray&region=beijing"));
+        router.process(new ConfigChangedEvent("com.foo.BarService", "", rawRule, ConfigChangeType.ADDED));
+        Assertions.assertTrue(router.isForce());
+
+        router.process(new ConfigChangedEvent("com.foo.BarService", "", "# comment", ConfigChangeType.MODIFIED));
+
+        Assertions.assertTrue(router.isForce());
+    }
+
+    @Test
     public void testMultiplyConditionRoute() {
 
         String rawRule = "configVersion: v3.1\n" + "scope: service\n"


### PR DESCRIPTION
## What is the purpose of the change?
`ConditionRuleParser.parse()` assumes that SnakeYAML always returns a YAML mapping. However, an empty YAML document returns `null`, while a sequence or scalar document returns a non-map value. This can result in a `NullPointerException` or `ClassCastException` instead of a clear validation error.

Some configuration-center adapters filter a Java `null` or an exactly empty string, but that does not cover every input that produces a null SnakeYAML result. Non-empty inputs such as a comment-only document, `---`, or the explicit YAML value `null` can pass string-level checks and still load as `null`.

This change validates the top-level YAML value before parsing it and rejects non-mapping documents with a clear `IllegalArgumentException` instead of relying on incidental `NullPointerException` or `ClassCastException` failures.


**What does this change do?**

- Parse the YAML document into an `Object` before casting it.
- Require the top-level YAML value to be a mapping.
- Report a clear `IllegalArgumentException` for empty, comment-only, sequence, and scalar documents.
- Add regression coverage for null and non-mapping YAML documents.

## Checklist
- [ ] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Make sure gitHub actions can pass. [Why the workflow is failing and how to fix it?](../CONTRIBUTING.md)
