### PR TITLE
Reject negative data length in ExchangeCodec decode

### DIFF
--- a/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/exchange/codec/ExchangeCodec.java
+++ b/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/exchange/codec/ExchangeCodec.java
@@ -118,6 +118,11 @@ public class ExchangeCodec extends TelnetCodec {
         // get data length.
         int len = Bytes.bytes2int(header, 12);
 
+        // data length can not be negative, see https://github.com/apache/dubbo/issues/16447.
+        if (len < 0) {
+            throw new IOException("Data length can not be negative: " + len);
+        }
+
         // When receiving response, how to exceed the length, then directly construct a response to the client.
         // see more detail from https://github.com/apache/dubbo/issues/7021.
         Object obj = finishRespWhenOverPayload(channel, len, header);

--- a/dubbo-remoting/dubbo-remoting-api/src/test/java/org/apache/dubbo/remoting/codec/DeprecatedExchangeCodec.java
+++ b/dubbo-remoting/dubbo-remoting-api/src/test/java/org/apache/dubbo/remoting/codec/DeprecatedExchangeCodec.java
@@ -104,6 +104,12 @@ final class DeprecatedExchangeCodec extends DeprecatedTelnetCodec implements Cod
 
         // get data length.
         int len = Bytes.bytes2int(header, 12);
+
+        // data length can not be negative, see https://github.com/apache/dubbo/issues/16447.
+        if (len < 0) {
+            throw new IOException("Data length can not be negative: " + len);
+        }
+
         checkPayload(channel, len);
 
         int tt = len + HEADER_LENGTH;

--- a/dubbo-remoting/dubbo-remoting-api/src/test/java/org/apache/dubbo/remoting/codec/ExchangeCodecTest.java
+++ b/dubbo-remoting/dubbo-remoting-api/src/test/java/org/apache/dubbo/remoting/codec/ExchangeCodecTest.java
@@ -214,6 +214,20 @@ class ExchangeCodecTest extends TelnetCodecTest {
     }
 
     @Test
+    void test_Decode_Negative_Data_Length() {
+        // magic dabb, flag c2, id all ff, data length ffffffff (-1)
+        byte[] request =
+                new byte[] {MAGIC_HIGH, MAGIC_LOW, (byte) 0xc2, 0, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1};
+
+        try {
+            decode(request);
+            Assertions.fail();
+        } catch (IOException expected) {
+            Assertions.assertTrue(expected.getMessage().contains("Data length can not be negative: -1"));
+        }
+    }
+
+    @Test
     void test_Decode_Header_Need_Readmore() throws IOException {
         byte[] header = new byte[] {MAGIC_HIGH, MAGIC_LOW, 0, 0, 0, 0, 0, 0, 0, 0, 0};
         testDecode_assertEquals(header, TelnetCodec.DecodeResult.NEED_MORE_INPUT);


### PR DESCRIPTION

## What is the purpose of the change?

Closes #16447

A frame header that declares a negative data length is not a valid frame, and no additional input can make it one. On the 3.3 branch such a header passes every check in ExchangeCodec.decode: finishRespWhenOverPayload only compares against the payload upper bound, and the completeness check readable < len + 16 holds for every negative len. The negative value then reaches the ChannelBufferInputStream constructor, which rejects it with an IllegalArgumentException that escapes decode.

Stack trace from a 16-byte frame with data length ffffffff:

```
java.lang.IllegalArgumentException: length: -1
    at org.apache.dubbo.remoting.buffer.ChannelBufferInputStream.<init>(ChannelBufferInputStream.java:37)
    at org.apache.dubbo.remoting.exchange.codec.ExchangeCodec.decode(ExchangeCodec.java:134)
    at org.apache.dubbo.remoting.exchange.codec.ExchangeCodec.decode(ExchangeCodec.java:92)
```

What this PR does

decode now checks the sign of len right after Bytes.bytes2int(header, 12) and rejects a negative value with an IOException, so an invalid header is handled as a decode-level protocol error at the point the length is read instead of surfacing as an unexpected exception from a stream constructor. On the netty4 transport the connection-level behavior is unchanged: the exception is caught by InternalDecoder, logged, and the connection is closed.

NEED_MORE_INPUT is deliberately not used here. It is only correct when more input can complete the frame, and a negative length can never be completed.

The same guard is added to DeprecatedExchangeCodec in test sources: CodecAdapterTest re-runs the ExchangeCodecTest suite through the old Codec interface, so the copy needs the same behavior to keep the two paths aligned.

Testing

A new test, test_Decode_Negative_Data_Length, feeds the exact 16-byte reproducer from the issue (magic dabb, flag c2, requestId all ff, data length ffffffff) and asserts that decode rejects it with an IOException. Without the fix this test fails with the stack above.

The full dubbo-remoting-api module suite (385 tests) and the dubbo-remoting-netty4 module pass locally.

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Make sure gitHub actions can pass. [Why the workflow is failing and how to fix it?](../CONTRIBUTING.md)
