### PR TITLE
fix: correct MD5 calculation for InputStream and File

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/io/Bytes.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/io/Bytes.java
@@ -909,15 +909,9 @@ public class Bytes {
     private static byte[] getMD5(InputStream is, int bs) throws IOException {
         MessageDigest md = getMessageDigest();
         byte[] buf = new byte[bs];
-        while (is.available() > 0) {
-            int read, total = 0;
-            do {
-                if ((read = is.read(buf, total, bs - total)) <= 0) {
-                    break;
-                }
-                total += read;
-            } while (total < bs);
-            md.update(buf);
+        int read;
+        while ((read = is.read(buf)) != -1) {
+            md.update(buf, 0, read);
         }
         return md.digest();
     }

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/io/BytesTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/io/BytesTest.java
@@ -16,8 +16,10 @@
  */
 package org.apache.dubbo.common.io;
 
+import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -124,7 +126,32 @@ class BytesTest {
     void testMD5ForFile() throws IOException {
         byte[] md5 = Bytes.getMD5(new File(
                 getClass().getClassLoader().getResource("md5.testfile.txt").getFile()));
-        assertThat(md5, is(Bytes.base642bytes("iNZ+5qHafVNPLJxHwLKJ3w==")));
+        assertThat(md5, is(Bytes.base642bytes("/D/5joxqDTCH1RXARz+Gdw==")));
+    }
+
+    @Test
+    void testMD5ForInputStreamBoundaries() throws IOException {
+        int[] lengths = {12, 8191, 8192, 8193};
+        for (int length : lengths) {
+            byte[] source = new byte[length];
+            for (int i = 0; i < source.length; i++) {
+                source[i] = (byte) i;
+            }
+            assertThat(Bytes.getMD5(new ByteArrayInputStream(source)), is(Bytes.getMD5(source)));
+        }
+    }
+
+    @Test
+    void testMD5ForInputStreamWithNoAvailableBytes() throws IOException {
+        byte[] source = "hello world!".getBytes();
+        InputStream inputStream = new ByteArrayInputStream(source) {
+            @Override
+            public int available() {
+                return 0;
+            }
+        };
+
+        assertThat(Bytes.getMD5(inputStream), is(Bytes.getMD5(source)));
     }
 
     @Test


### PR DESCRIPTION
## What is the purpose of the change?


Fix incorrect MD5 calculation in `Bytes.getMD5(InputStream)` and `Bytes.getMD5(File)`.

The previous implementation used `InputStream.available()` to detect EOF and passed the entire buffer to `MessageDigest.update()`. For a final partial read, zero-filled bytes were included in the digest. Streams that report `available() == 0` while still containing readable data were also skipped.

This change reads until `read()` returns `-1` and updates the digest with only the bytes actually read.

GitHub issue:  https://github.com/apache/dubbo/issues/16451



## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Make sure gitHub actions can pass. [Why the workflow is failing and how to fix it?](../CONTRIBUTING.md)
