### PR TITLE
fix: release concurrency slots on downstream limit exceptions

### DIFF
--- a/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/filter/LimitFilterSlotReleaseTest.java
+++ b/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/filter/LimitFilterSlotReleaseTest.java
@@ -83,6 +83,20 @@ class LimitFilterSlotReleaseTest {
 
     @ParameterizedTest
     @ValueSource(strings = {"actives", "executes"})
+    void downstreamTimeoutExceptionReleasesSlot(String limit) {
+        setup(limit);
+        RpcException timeout = new RpcException(RpcException.TIMEOUT_EXCEPTION, "downstream timed out");
+        when(target.invoke(any())).thenThrow(timeout).thenAnswer(call -> success(call.getArgument(0)));
+
+        assertSame(timeout, assertThrows(RpcException.class, () -> chain.invoke(invocation())));
+        assertCounts(0, 1);
+        assertEquals("ok", chain.invoke(invocation()).getValue());
+        assertCounts(0, 1);
+        verify(target, times(2)).invoke(any());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"actives", "executes"})
     void asynchronousLimitExceptionReleasesSlot(String limit) {
         setup(limit);
         CompletableFuture<AppResponse> pending = new CompletableFuture<>();

--- a/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/filter/LimitFilterSlotReleaseTest.java
+++ b/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/filter/LimitFilterSlotReleaseTest.java
@@ -1,0 +1,194 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.rpc.cluster.filter;
+
+import org.apache.dubbo.common.URL;
+import org.apache.dubbo.rpc.AppResponse;
+import org.apache.dubbo.rpc.AsyncRpcResult;
+import org.apache.dubbo.rpc.Filter;
+import org.apache.dubbo.rpc.Invoker;
+import org.apache.dubbo.rpc.Result;
+import org.apache.dubbo.rpc.RpcContext;
+import org.apache.dubbo.rpc.RpcException;
+import org.apache.dubbo.rpc.RpcInvocation;
+import org.apache.dubbo.rpc.RpcStatus;
+import org.apache.dubbo.rpc.filter.ActiveLimitFilter;
+import org.apache.dubbo.rpc.filter.ExecuteLimitFilter;
+
+import java.util.Collections;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Verifies limit-filter accounting through the production listener lifecycle.
+ *
+ * @date 2026-09-08
+ */
+class LimitFilterSlotReleaseTest {
+
+    private URL url;
+    private Invoker<Object> target;
+    private Invoker<Object> chain;
+
+    @AfterEach
+    void cleanup() {
+        RpcContext.removeContext();
+        if (url != null) {
+            RpcStatus.removeStatus(url, "invoke");
+            RpcStatus.removeStatus(url);
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"actives", "executes"})
+    void downstreamLimitExceptionReleasesSlot(String limit) {
+        setup(limit);
+        RpcException rejection = new RpcException(RpcException.LIMIT_EXCEEDED_EXCEPTION, "downstream rejected");
+        when(target.invoke(any())).thenThrow(rejection).thenAnswer(call -> success(call.getArgument(0)));
+
+        assertSame(rejection, assertThrows(RpcException.class, () -> chain.invoke(invocation())));
+        assertCounts(0, 1);
+        assertEquals("ok", chain.invoke(invocation()).getValue());
+        assertCounts(0, 1);
+        verify(target, times(2)).invoke(any());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"actives", "executes"})
+    void asynchronousLimitExceptionReleasesSlot(String limit) {
+        setup(limit);
+        CompletableFuture<AppResponse> pending = new CompletableFuture<>();
+        when(target.invoke(any())).thenAnswer(call -> new AsyncRpcResult(pending, call.getArgument(0)));
+        chain.invoke(invocation());
+        assertCounts(1, 0);
+
+        pending.completeExceptionally(new RpcException(RpcException.LIMIT_EXCEEDED_EXCEPTION, "downstream rejected"));
+
+        assertCounts(0, 1);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"actives", "executes"})
+    void localRejectionDoesNotReleaseAnotherCallsSlot(String limit) {
+        setup(limit);
+        CompletableFuture<AppResponse> pending = new CompletableFuture<>();
+        when(target.invoke(any())).thenAnswer(call -> new AsyncRpcResult(pending, call.getArgument(0)));
+        chain.invoke(invocation());
+
+        assertTrue(assertThrows(RpcException.class, () -> chain.invoke(invocation()))
+                .isLimitExceed());
+        assertCounts(1, 0);
+        verify(target).invoke(any());
+
+        pending.complete(new AppResponse("ok"));
+        assertCounts(0, 0);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"actives", "executes"})
+    void reusedInvocationDoesNotRetainPreviousAdmission(String limit) {
+        setup(limit);
+        CompletableFuture<AppResponse> pending = new CompletableFuture<>();
+        when(target.invoke(any()))
+                .thenAnswer(call -> success(call.getArgument(0)))
+                .thenAnswer(call -> new AsyncRpcResult(pending, call.getArgument(0)));
+        RpcInvocation reused = invocation();
+        chain.invoke(reused);
+        chain.invoke(invocation());
+
+        assertTrue(assertThrows(RpcException.class, () -> chain.invoke(reused)).isLimitExceed());
+        assertCounts(1, 0);
+        verify(target, times(2)).invoke(any());
+
+        pending.complete(new AppResponse("ok"));
+        assertCounts(0, 0);
+    }
+
+    @SuppressWarnings("unchecked")
+    private void setup(String limit) {
+        url = URL.valueOf("test://localhost:12345/" + UUID.randomUUID() + "?" + limit + "=1&timeout=1");
+        target = mock(Invoker.class);
+        when(target.getUrl()).thenReturn(url);
+        when(target.getInterface()).thenReturn(Object.class);
+        Filter filter = "actives".equals(limit) ? new ActiveLimitFilter() : new ExecuteLimitFilter();
+        chain = new FilterChainBuilder.CallbackRegistrationInvoker<>(
+                new FilterChainBuilder.CopyOfFilterChainNode<>(target, target, filter),
+                Collections.singletonList(filter));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"actives", "executes"})
+    void sharedInvocationKeepsAdmissionSeparateForEachTarget(String limit) {
+        setup(limit);
+        URL admittedUrl = url;
+        CompletableFuture<AppResponse> pending = new CompletableFuture<>();
+        when(target.invoke(any())).thenAnswer(call -> new AsyncRpcResult(pending, call.getArgument(0)));
+        RpcInvocation shared = invocation();
+        chain.invoke(shared);
+
+        setup(limit);
+        assertTrue(RpcStatus.beginCount(url, "invoke", 1));
+        try {
+            assertTrue(
+                    assertThrows(RpcException.class, () -> chain.invoke(shared)).isLimitExceed());
+            assertCounts(1, 0);
+
+            pending.completeExceptionally(
+                    new RpcException(RpcException.LIMIT_EXCEEDED_EXCEPTION, "downstream rejected"));
+
+            assertEquals(0, RpcStatus.getStatus(admittedUrl).getActive());
+            assertEquals(0, RpcStatus.getStatus(admittedUrl, "invoke").getActive());
+            assertEquals(1, RpcStatus.getStatus(admittedUrl, "invoke").getFailed());
+            assertCounts(1, 0);
+        } finally {
+            pending.complete(new AppResponse("ok"));
+            RpcStatus.endCount(url, "invoke", 0, true);
+            RpcStatus.removeStatus(admittedUrl, "invoke");
+            RpcStatus.removeStatus(admittedUrl);
+        }
+    }
+
+    private RpcInvocation invocation() {
+        RpcInvocation invocation = new RpcInvocation();
+        invocation.setMethodName("invoke");
+        return invocation;
+    }
+
+    private Result success(RpcInvocation invocation) {
+        return AsyncRpcResult.newDefaultAsyncResult("ok", invocation);
+    }
+
+    private void assertCounts(int active, int failed) {
+        assertEquals(active, RpcStatus.getStatus(url).getActive());
+        assertEquals(active, RpcStatus.getStatus(url, "invoke").getActive());
+        assertEquals(failed, RpcStatus.getStatus(url, "invoke").getFailed());
+    }
+}

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/filter/ActiveLimitFilter.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/filter/ActiveLimitFilter.java
@@ -47,9 +47,14 @@ public class ActiveLimitFilter implements Filter, Filter.Listener {
 
     private static final String ACTIVE_LIMIT_FILTER_START_TIME = "active_limit_filter_start_time";
 
+    private static final String ACTIVE_LIMIT_FILTER_COUNTED = "active_limit_filter_counted";
+
     @Override
     public Result invoke(Invoker<?> invoker, Invocation invocation) throws RpcException {
         URL url = invoker.getUrl();
+        // Forking calls can share an invocation across different provider URLs.
+        String countKey = ACTIVE_LIMIT_FILTER_COUNTED + url.toIdentityString();
+        invocation.put(countKey, false);
         String methodName = RpcUtils.getMethodName(invocation);
         int max = invoker.getUrl().getMethodParameter(methodName, ACTIVES_KEY, 0);
         final RpcStatus rpcStatus = RpcStatus.getStatus(invoker.getUrl(), RpcUtils.getMethodName(invocation));
@@ -80,6 +85,7 @@ public class ActiveLimitFilter implements Filter, Filter.Listener {
             }
         }
 
+        invocation.put(countKey, true);
         invocation.put(ACTIVE_LIMIT_FILTER_START_TIME, System.currentTimeMillis());
 
         return invoker.invoke(invocation);
@@ -103,7 +109,9 @@ public class ActiveLimitFilter implements Filter, Filter.Listener {
 
         if (t instanceof RpcException) {
             RpcException rpcException = (RpcException) t;
-            if (rpcException.isLimitExceed()) {
+            // A downstream rejection still needs to release this filter's acquired slot.
+            if (rpcException.isLimitExceed()
+                    && !Boolean.TRUE.equals(invocation.get(ACTIVE_LIMIT_FILTER_COUNTED + url.toIdentityString()))) {
                 return;
             }
         }

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/filter/ExecuteLimitFilter.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/filter/ExecuteLimitFilter.java
@@ -42,9 +42,13 @@ public class ExecuteLimitFilter implements Filter, Filter.Listener {
 
     private static final String EXECUTE_LIMIT_FILTER_START_TIME = "execute_limit_filter_start_time";
 
+    private static final String EXECUTE_LIMIT_FILTER_COUNTED = "execute_limit_filter_counted";
+
     @Override
     public Result invoke(Invoker<?> invoker, Invocation invocation) throws RpcException {
         URL url = invoker.getUrl();
+        String countKey = EXECUTE_LIMIT_FILTER_COUNTED + url.toIdentityString();
+        invocation.put(countKey, false);
         String methodName = RpcUtils.getMethodName(invocation);
         int max = url.getMethodParameter(methodName, EXECUTES_KEY, 0);
         if (!RpcStatus.beginCount(url, methodName, max)) {
@@ -55,6 +59,7 @@ public class ExecuteLimitFilter implements Filter, Filter.Listener {
                             + "\" /> limited.");
         }
 
+        invocation.put(countKey, true);
         invocation.put(EXECUTE_LIMIT_FILTER_START_TIME, System.currentTimeMillis());
         try {
             return invoker.invoke(invocation);
@@ -76,7 +81,10 @@ public class ExecuteLimitFilter implements Filter, Filter.Listener {
     public void onError(Throwable t, Invoker<?> invoker, Invocation invocation) {
         if (t instanceof RpcException) {
             RpcException rpcException = (RpcException) t;
-            if (rpcException.isLimitExceed()) {
+            // A downstream rejection still needs to release this filter's acquired slot.
+            if (rpcException.isLimitExceed()
+                    && !Boolean.TRUE.equals(invocation.get(
+                            EXECUTE_LIMIT_FILTER_COUNTED + invoker.getUrl().toIdentityString()))) {
                 return;
             }
         }


### PR DESCRIPTION
## What is the purpose of the change?

Fixes #16455.

`ActiveLimitFilter` and `ExecuteLimitFilter` skip error accounting for every `LIMIT_EXCEEDED_EXCEPTION`. If a downstream invoker throws that exception after admission, or completes its result future exceptionally with it, the acquired concurrency slot is never released. At a limit of 1, later calls can time out or be rejected despite no call remaining in flight.

Track whether each filter acquired a slot during the current invocation attempt. Only locally rejected limit exceptions skip accounting; downstream limit exceptions release the slot through the existing error callback. Scope each marker by the target URL identity (also used by RpcStatus), since forking calls can share an Invocation across providers. Reset the marker on entry so sequential reuse does not reuse a previous admission decision. Existing timing, wakeup, successful-response, and non-limit-error handling are preserved.

The regression tests use the production `CopyOfFilterChainNode` and `CallbackRegistrationInvoker` lifecycle with local mock invokers and controllable futures. For both filters they verify synchronous downstream rejection, asynchronous exceptional completion, local rejection while another call remains active, sequential invocation reuse, and target isolation when two invokers share the same Invocation.

## Verification

JDK 17.0.17, Maven 3.9.4, Windows; the project's Java 8 artifact target is unchanged.

```shell
./mvnw -B -pl dubbo-cluster -am \
  -Dtest=LimitFilterSlotReleaseTest,ActiveLimitFilterTest,ExecuteLimitFilterTest,RpcStatusTest,DefaultFilterChainBuilderTest \
  -Dsurefire.failIfNoSpecifiedTests=false test
./mvnw -B -pl dubbo-cluster -am -Pcheckstyle \
  -Dcheckstyle_unix.skip=true '-DspotlessFiles=.*Limit.*java' validate spotless:check
```

- Before the fix on `dab47b7843`: 8 new regression cases, 4 assertion failures, 0 errors. Both filters retain an active count of 1 after synchronous/asynchronous downstream limit errors. The local-rejection controls pass.
- After the final fix and coverage follow-up: all 28 selected tests pass, including 12 new cases; 0 failures, errors, or skips. These include target isolation for a shared Invocation and non-limit RPC timeout handling for both filters.
- Java Checkstyle reports 0 violations across the selected reactor; Spotless reports no changes needed for the checked limit-related files, and git diff --check is clean.

On this Windows checkout, the initial Unix resource-line-ending check reports 59 pre-existing CRLF resource files due to core.autocrlf=true. The separate Unix check was disabled locally for subsequent validation; no unrelated resources were modified. All three changed Java files use LF. The final test run also enabled Java Checkstyle and applied Spotless without further changes.

The regression targets exceptions delivered to `onError`, not business exceptions carried inside a normally completed `AppResponse`. No registry or external RPC service is required. The full repository test suite was not run.

AI assistance was used for investigation, code, and tests. The failing behavior was reproduced locally before applying the production fix.

### Coverage follow-up

Added two non-limit RPC timeout cases (consumer and provider filters). Each verifies that the original exception propagates, the admitted slot is released, failure accounting increments, and the next invocation succeeds. Production code is unchanged by this follow-up.

The local JaCoCo 0.8.15 report, generated from the same 28 selected tests using CI's `jacoco,jdk15ge-simple,!jdk15ge-add-open` profiles, covers all **11 executable lines added by this PR** with **zero missed instructions or branches**. In particular, the `isLimitExceed()` false branch is exercised. This is 100% local patch coverage, not whole-project coverage. Java Checkstyle and Spotless checks also pass with the same previously disclosed Windows Unix-resource-check exception. Remote CI and Codecov must rerun on the new commit; their previous success applies to the earlier commit only.

## Checklist

- [x] A GitHub issue describes the change: #16455.
- [x] The description explains the problem, behavior, and implementation.
- [x] Regression tests cover the fix and admission controls.
- [ ] GitHub Actions pass (pending upstream execution).
