### PR TITLE
build(deps): upgrade fastjson2 from 2.0.62 to 2.0.64

### DIFF
--- a/dubbo-dependencies-bom/pom.xml
+++ b/dubbo-dependencies-bom/pom.xml
@@ -99,7 +99,7 @@
     <httpclient_version>4.5.14</httpclient_version>
     <httpcore_version>4.4.16</httpcore_version>
     <fastjson_version>1.2.83_noneautotype</fastjson_version>
-    <fastjson2_version>2.0.62</fastjson2_version>
+    <fastjson2_version>2.0.64</fastjson2_version>
     <zookeeper_version>3.7.2</zookeeper_version>
     <curator_version>5.9.0</curator_version>
     <curator_test_version>2.12.0</curator_test_version>


### PR DESCRIPTION
## What is the purpose of the change?

Upgrade `com.alibaba.fastjson2:fastjson2` from `2.0.62` to `2.0.64` through the version property in `dubbo-dependencies-bom/pom.xml`.

This includes the AutoType validation and JSON/JSONB parser hardening published in [2.0.63](https://github.com/alibaba/fastjson2/releases/tag/2.0.63), followed by the serialization/deserialization fixes in [2.0.64](https://github.com/alibaba/fastjson2/releases/tag/2.0.64).

No Java code or serialization configuration changes are included. The separate fastjson 1.x dependency remains at `1.2.83_noneautotype`.

### GitHub_issue

N/A — routine dependency upgrade; no existing Dubbo issue is being closed.

### Validation

- JDK 17: `FastJson2SerializationTest`, `TypeMatchTest`, `FastJsonImplTest`, `FastJson2ImplTest`, and `JsonUtilsTest`: **813 tests passed**, with no failures, errors, or skipped tests.
- JDK 21: BOM Spotless check passed; the BOM and `dubbo-all` build with dependencies passed across **78 reactor modules** (tests skipped for this build).
- Local RPC smoke test on JDK 17: separate provider and consumer JVMs, Nacos service discovery, and `fastjson2` serialization. Both JVMs verified fastjson2 `2.0.64` at runtime. **341 RPC calls and 425 assertions passed**, covering `Date`, primitive/boxed bytes, byte arrays, nulls, and DTOs containing dates, lists, and maps. The smoke harness is external to this one-line dependency change.

Commands for the repository checks:

```sh
mvn -B -ntp -pl dubbo-serialization/dubbo-serialization-fastjson2 -am \
  -Dtest=FastJson2SerializationTest,TypeMatchTest,FastJsonImplTest,FastJson2ImplTest,JsonUtilsTest \
  -Dsurefire.failIfNoSpecifiedTests=false test
mvn -B -ntp -pl dubbo-dependencies-bom spotless:check
mvn -B -ntp -pl dubbo-dependencies-bom,dubbo-distribution/dubbo-all -am \
  -Drevision=3.3.7-fastjson2-2064-pr-SNAPSHOT -Dmaven.test.skip=true install
```

## Checklist

- [x] Include a GitHub_issue field for the change.
- [x] Explain what changes and why.
- [x] Verify the affected behavior with existing tests. No new Java logic or sample is introduced.
- [ ] GitHub Actions passed — pending PR creation and CI execution.
