### PR TITLE
fix(rpc): release concurrent count when downstream throws LIMIT_EXCEEDED

### DIFF
--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/filter/ActiveLimitFilter.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/filter/ActiveLimitFilter.java
@@ -46,6 +46,7 @@ import static org.apache.dubbo.rpc.Constants.ACTIVES_KEY;
 public class ActiveLimitFilter implements Filter, Filter.Listener {
 
     private static final String ACTIVE_LIMIT_FILTER_START_TIME = "active_limit_filter_start_time";
+    private static final String ACTIVE_LIMIT_FILTER_COUNTED = "active_limit_filter_counted";
 
     @Override
     public Result invoke(Invoker<?> invoker, Invocation invocation) throws RpcException {
@@ -79,6 +80,7 @@ public class ActiveLimitFilter implements Filter, Filter.Listener {
                 }
             }
         }
+        invocation.put(ACTIVE_LIMIT_FILTER_COUNTED, true);
 
         invocation.put(ACTIVE_LIMIT_FILTER_START_TIME, System.currentTimeMillis());
 
@@ -103,7 +105,11 @@ public class ActiveLimitFilter implements Filter, Filter.Listener {
 
         if (t instanceof RpcException) {
             RpcException rpcException = (RpcException) t;
-            if (rpcException.isLimitExceed()) {
+            if (rpcException.isLimitExceed() && invocation.get(ACTIVE_LIMIT_FILTER_COUNTED) == null) {
+                // This filter itself rejected the invocation before beginCount
+                // succeeded, so there is nothing to release. A LIMIT_EXCEEDED
+                // thrown by a downstream invoker must still release the count
+                // taken in invoke(), otherwise the concurrent slots leak (#16455).
                 return;
             }
         }

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/filter/ExecuteLimitFilter.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/filter/ExecuteLimitFilter.java
@@ -41,6 +41,7 @@ import static org.apache.dubbo.rpc.Constants.EXECUTES_KEY;
 public class ExecuteLimitFilter implements Filter, Filter.Listener {
 
     private static final String EXECUTE_LIMIT_FILTER_START_TIME = "execute_limit_filter_start_time";
+    private static final String EXECUTE_LIMIT_FILTER_COUNTED = "execute_limit_filter_counted";
 
     @Override
     public Result invoke(Invoker<?> invoker, Invocation invocation) throws RpcException {
@@ -54,6 +55,7 @@ public class ExecuteLimitFilter implements Filter, Filter.Listener {
                             + ", cause: The service using threads greater than <dubbo:service executes=\"" + max
                             + "\" /> limited.");
         }
+        invocation.put(EXECUTE_LIMIT_FILTER_COUNTED, true);
 
         invocation.put(EXECUTE_LIMIT_FILTER_START_TIME, System.currentTimeMillis());
         try {
@@ -76,7 +78,12 @@ public class ExecuteLimitFilter implements Filter, Filter.Listener {
     public void onError(Throwable t, Invoker<?> invoker, Invocation invocation) {
         if (t instanceof RpcException) {
             RpcException rpcException = (RpcException) t;
-            if (rpcException.isLimitExceed()) {
+            if (rpcException.isLimitExceed() && invocation.get(EXECUTE_LIMIT_FILTER_COUNTED) == null) {
+                // This filter itself rejected the invocation before beginCount
+                // succeeded, so there is nothing to release. A LIMIT_EXCEEDED
+                // thrown by the business implementation must still release the
+                // count taken in invoke(), otherwise the concurrent slots leak
+                // (#16455).
                 return;
             }
         }

--- a/dubbo-rpc/dubbo-rpc-api/src/test/java/org/apache/dubbo/rpc/filter/ActiveLimitFilterTest.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/test/java/org/apache/dubbo/rpc/filter/ActiveLimitFilterTest.java
@@ -21,12 +21,14 @@ import org.apache.dubbo.rpc.Invocation;
 import org.apache.dubbo.rpc.Invoker;
 import org.apache.dubbo.rpc.Result;
 import org.apache.dubbo.rpc.RpcException;
+import org.apache.dubbo.rpc.RpcInvocation;
 import org.apache.dubbo.rpc.RpcStatus;
 import org.apache.dubbo.rpc.support.BlockMyInvoker;
 import org.apache.dubbo.rpc.support.MockInvocation;
 import org.apache.dubbo.rpc.support.MyInvoker;
 import org.apache.dubbo.rpc.support.RuntimeExceptionInvoker;
 
+import java.util.Collections;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -35,7 +37,12 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
 
 /**
  * ActiveLimitFilterTest.java
@@ -230,5 +237,51 @@ class ActiveLimitFilterTest {
                     afterExceptionActiveCount,
                     "After exception active count should be same");
         }
+    }
+
+    @Test
+    void testOnErrorReleasesCountWhenDownstreamThrowsLimitExceeded() {
+        URL url = URL.valueOf("test://test:11/limit-leak?accesslog=true&group=dubbo&version=1.1&actives=1&timeout=1000");
+        RpcInvocation invocation = new RpcInvocation();
+        invocation.setMethodName("invoke");
+
+        @SuppressWarnings("unchecked")
+        Invoker<ActiveLimitFilterTest> target = mock(Invoker.class);
+        given(target.getUrl()).willReturn(url);
+        given(target.getInterface()).willReturn(ActiveLimitFilterTest.class);
+        given(target.invoke(any(Invocation.class))).willThrow(
+                new RpcException(RpcException.LIMIT_EXCEEDED_EXCEPTION, "downstream rejected"));
+
+        assertThrows(RpcException.class, () -> activeLimitFilter.invoke(target, invocation));
+        // beginCount succeeded in invoke(); the downstream LIMIT_EXCEEDED must
+        // still release the taken slot instead of leaking it.
+        activeLimitFilter.onError(
+                new RpcException(RpcException.LIMIT_EXCEEDED_EXCEPTION, "downstream rejected"),
+                target,
+                invocation);
+
+        assertEquals(0, RpcStatus.getStatus(url, "invoke").getActive());
+    }
+
+    @Test
+    void testOnErrorKeepsCountWhenFilterItselfRejected() {
+        URL url = URL.valueOf("test://test:11/limit-self-reject?accesslog=true&group=dubbo&version=1.1&actives=1&timeout=1");
+        RpcInvocation invocation = new RpcInvocation();
+        invocation.setMethodName("invoke");
+        assertTrue(RpcStatus.beginCount(url, "invoke", 1));
+
+        @SuppressWarnings("unchecked")
+        Invoker<ActiveLimitFilterTest> target = mock(Invoker.class);
+        given(target.getUrl()).willReturn(url);
+        given(target.getInterface()).willReturn(ActiveLimitFilterTest.class);
+
+        // Admission fails inside invoke() before the counted marker is set
+        assertThrows(RpcException.class, () -> activeLimitFilter.invoke(target, invocation));
+        activeLimitFilter.onError(
+                new RpcException(RpcException.LIMIT_EXCEEDED_EXCEPTION, "self rejected"), target, invocation);
+
+        // The slot held by the concurrent invocation stays untouched (no double release)
+        assertEquals(1, RpcStatus.getStatus(url, "invoke").getActive());
+        RpcStatus.endCount(url, "invoke", 0, false);
     }
 }

--- a/dubbo-rpc/dubbo-rpc-api/src/test/java/org/apache/dubbo/rpc/filter/ExecuteLimitFilterTest.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/test/java/org/apache/dubbo/rpc/filter/ExecuteLimitFilterTest.java
@@ -26,6 +26,7 @@ import org.apache.dubbo.rpc.RpcInvocation;
 import org.apache.dubbo.rpc.RpcStatus;
 import org.apache.dubbo.rpc.support.BlockMyInvoker;
 
+import java.util.Collections;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -33,8 +34,13 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 class ExecuteLimitFilterTest {
@@ -132,5 +138,49 @@ class ExecuteLimitFilterTest {
         }
 
         Assertions.assertEquals(totalExecute - maxExecute, failed.get());
+    }
+
+    @Test
+    void testOnErrorReleasesCountWhenBusinessThrowsLimitExceeded() {
+        URL url = URL.valueOf("test://test:11/exec-leak?accesslog=true&group=dubbo&version=1.1&executes=10");
+        RpcInvocation invocation = new RpcInvocation();
+        invocation.setMethodName("invoke");
+
+        @SuppressWarnings("unchecked")
+        Invoker<ExecuteLimitFilterTest> target = mock(Invoker.class);
+        given(target.getUrl()).willReturn(url);
+        given(target.getInterface()).willReturn(ExecuteLimitFilterTest.class);
+        given(target.invoke(any(Invocation.class))).willThrow(
+                new RpcException(RpcException.LIMIT_EXCEEDED_EXCEPTION, "business limit"));
+
+        // beginCount succeeds and the marker is set; the business LIMIT_EXCEEDED
+        // propagates through the filter
+        assertThrows(RpcException.class, () -> executeLimitFilter.invoke(target, invocation));
+        executeLimitFilter.onError(
+                new RpcException(RpcException.LIMIT_EXCEEDED_EXCEPTION, "business limit"), target, invocation);
+
+        assertEquals(0, RpcStatus.getStatus(url, "invoke").getActive());
+    }
+
+    @Test
+    void testOnErrorKeepsCountWhenFilterItselfRejected() {
+        URL url = URL.valueOf("test://test:11/exec-self-reject?accesslog=true&group=dubbo&version=1.1&executes=1");
+        RpcInvocation invocation = new RpcInvocation();
+        invocation.setMethodName("invoke");
+        assertTrue(RpcStatus.beginCount(url, "invoke", 1));
+
+        @SuppressWarnings("unchecked")
+        Invoker<ExecuteLimitFilterTest> target = mock(Invoker.class);
+        given(target.getUrl()).willReturn(url);
+        given(target.getInterface()).willReturn(ExecuteLimitFilterTest.class);
+
+        // Admission fails inside invoke() before the counted marker is set
+        assertThrows(RpcException.class, () -> executeLimitFilter.invoke(target, invocation));
+        executeLimitFilter.onError(
+                new RpcException(RpcException.LIMIT_EXCEEDED_EXCEPTION, "self rejected"), target, invocation);
+
+        // The slot held by the concurrent invocation stays untouched (no double release)
+        assertEquals(1, RpcStatus.getStatus(url, "invoke").getActive());
+        RpcStatus.endCount(url, "invoke", 0, false);
     }
 }


### PR DESCRIPTION
Fixes #16455

## What

`ActiveLimitFilter` and `ExecuteLimitFilter` skipped `RpcStatus.endCount()` whenever `onError` received a `LIMIT_EXCEEDED` `RpcException`. That skip is only correct when the filter itself rejected admission (in that case `beginCount` never succeeded, so there is nothing to release).

When admission **succeeded** and a downstream invoker (client side, `ActiveLimitFilter`) or the business implementation (provider side, `ExecuteLimitFilter`) threw `LIMIT_EXCEEDED` — or a response future completed exceptionally with it — the count taken in `invoke()` leaked. Repeated occurrences exhaust the `actives`/`executes` slots and every subsequent invocation times out until restart.

## Fix

Mark the invocation (`invocation.put(...COUNTED, true)`) as soon as `beginCount` succeeds. `onError` now only skips the release when a `LIMIT_EXCEEDED` arrives **without** that marker (i.e. the filter's own rejection path); every other error — and downstream limit exceptions — release the count as before.

## Tests

Two regression cases per filter in `dubbo-rpc-api`:
- downstream/business `LIMIT_EXCEEDED` after successful admission → the slot is released (`active == 0`); previously it leaked,
- admission rejected by the filter itself → the concurrent count is untouched (no double release).

`ActiveLimitFilterTest` (9) and `ExecuteLimitFilterTest` (6) all pass.